### PR TITLE
fix: Automatically add resource req for custom ops

### DIFF
--- a/src/builder/circuit.rs
+++ b/src/builder/circuit.rs
@@ -132,6 +132,7 @@ mod test {
     use super::*;
     use cool_asserts::assert_matches;
 
+    use crate::extension::ExtensionSet;
     use crate::{
         builder::{
             test::{build_main, NAT, QB},
@@ -179,12 +180,18 @@ mod test {
                 "MyOp",
                 "unknown op".to_string(),
                 vec![],
-                Some(FunctionType::new(vec![QB, NAT], vec![QB])),
+                Some(
+                    FunctionType::new(vec![QB, NAT], vec![QB]).with_extension_delta(
+                        &ExtensionSet::singleton(&"MissingRsrc".try_into().unwrap()),
+                    ),
+                ),
             ))
             .into(),
         );
         let build_res = build_main(
-            FunctionType::new(type_row![QB, QB, NAT], type_row![QB, QB, BOOL_T]).pure(),
+            FunctionType::new(type_row![QB, QB, NAT], type_row![QB, QB, BOOL_T])
+                .with_extension_delta(&ExtensionSet::singleton(&"MissingRsrc".try_into().unwrap()))
+                .pure(),
             |mut f_build| {
                 let [q0, q1, angle]: [Wire; 3] = f_build.input_wires_arr();
 


### PR DESCRIPTION
Closes #388

This fix is blocked by extension inference.
The failing test in `builder::circuit::test::with_nonlinear_and_outputs` constructs this diagram:

![image](https://github.com/CQCL-DEV/hugr/assets/121866228/d34cc430-a753-4a55-b0ba-8668db7ce84c)

Where `MissingRsrc.MyOp` now requires `MissingRsrc`. The output node has that extension in `input_resources`, but the rest of the operations in the region need to define it too. (And I think we'll require a lift node for qubit 1?)