### PR TITLE
refactor!: More exception handling for SimpleReplacement

### DIFF
--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -362,12 +362,7 @@ impl SiblingSubgraph {
             })
             .collect();
 
-        Ok(SimpleReplacement::new(
-            self.clone(),
-            replacement,
-            nu_inp,
-            nu_out,
-        ))
+        Ok(SimpleReplacement::try_new(self.clone(), replacement, nu_inp, nu_out).unwrap())
     }
 }
 


### PR DESCRIPTION
I needed this for debbuging in tket2, so I thought we might as well merge it in.

BREAKING CHANGE: `SimpleReplacement::new` is now `SimpleReplacement::try_new`.