### PR TITLE
Add RootChecked to guarantee root node type

### DIFF
--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 #[cfg(feature = "pyo3")]
 use pyo3::{create_exception, exceptions::PyException, pyclass, PyErr};
 
-pub use self::views::HugrView;
+pub use self::views::{HugrView, RootTagged};
 use crate::extension::{
     infer_extensions, ExtensionRegistry, ExtensionSet, ExtensionSolution, InferExtensionError,
 };
@@ -619,7 +619,6 @@ mod test {
     #[test]
     fn io_node() {
         use crate::builder::test::simple_dfg_hugr;
-        use crate::hugr::views::HugrView;
         use cool_asserts::assert_matches;
 
         let hugr = simple_dfg_hugr();

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -570,7 +570,9 @@ pub enum HugrError {
     #[error("Invalid node {0:?}.")]
     InvalidNode(Node),
     /// The node was not of the required [OpTag]
-    /// (e.g. to conform to a [HugrView::RootHandle])
+    /// (e.g. to conform to the [RootTagged::RootHandle] of a [HugrView])
+    ///
+    /// [RootTagged::RootHandle]: crate::hugr::views::RootTagged::RootHandle
     #[error("Invalid tag: required a tag in {required} but found {actual}")]
     #[allow(missing_docs)]
     InvalidTag { required: OpTag, actual: OpTag },

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -571,8 +571,6 @@ pub enum HugrError {
     InvalidNode(Node),
     /// The node was not of the required [OpTag]
     /// (e.g. to conform to the [RootTagged::RootHandle] of a [HugrView])
-    ///
-    /// [RootTagged::RootHandle]: crate::hugr::views::RootTagged::RootHandle
     #[error("Invalid tag: required a tag in {required} but found {actual}")]
     #[allow(missing_docs)]
     InvalidTag { required: OpTag, actual: OpTag },

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -216,8 +216,7 @@ impl InsertionResult {
 }
 
 /// Impl for non-wrapped Hugrs. Overwrites the recursive default-impls to directly use the hugr.
-impl<T: HugrView + AsMut<Hugr>> HugrMut for T
-{
+impl<T: HugrView + AsMut<Hugr>> HugrMut for T {
     fn add_node_with_parent(&mut self, parent: Node, node: NodeType) -> Result<Node, HugrError> {
         let node = self.as_mut().add_node(node);
         self.as_mut()
@@ -516,8 +515,7 @@ pub(crate) mod sealed {
     }
 
     /// Impl for non-wrapped Hugrs. Overwrites the recursive default-impls to directly use the hugr.
-    impl<T: HugrView + AsMut<Hugr>> HugrMutInternals for T
-    {
+    impl<T: HugrView + AsMut<Hugr>> HugrMutInternals for T {
         fn hugr_mut(&mut self) -> &mut Hugr {
             self.as_mut()
         }

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -571,7 +571,12 @@ pub(crate) mod sealed {
         }
 
         fn replace_op(&mut self, node: Node, op: NodeType) -> Result<NodeType, HugrError> {
-            // No possibility of failure here since Self::RootHandle == Any
+            if node == self.root() && !Self::RootHandle::TAG.is_superset(op.tag()) {
+                return Err(HugrError::InvalidTag {
+                    required: Self::RootHandle::TAG,
+                    actual: op.tag(),
+                });
+            }
             let cur = self.hugr_mut().op_types.get_mut(node.index);
             Ok(std::mem::replace(cur, op))
         }

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -216,9 +216,7 @@ impl InsertionResult {
 }
 
 /// Impl for non-wrapped Hugrs. Overwrites the recursive default-impls to directly use the hugr.
-impl<T> HugrMut for T
-where
-    T: HugrView + AsMut<Hugr>,
+impl<T: HugrView + AsMut<Hugr>> HugrMut for T
 {
     fn add_node_with_parent(&mut self, parent: Node, node: NodeType) -> Result<Node, HugrError> {
         let node = self.as_mut().add_node(node);
@@ -518,9 +516,7 @@ pub(crate) mod sealed {
     }
 
     /// Impl for non-wrapped Hugrs. Overwrites the recursive default-impls to directly use the hugr.
-    impl<T> HugrMutInternals for T
-    where
-        T: HugrView + AsMut<Hugr>,
+    impl<T: HugrView + AsMut<Hugr>> HugrMutInternals for T
     {
         fn hugr_mut(&mut self) -> &mut Hugr {
             self.as_mut()

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -436,13 +436,12 @@ fn insert_subgraph_internal(
 
 pub(crate) mod sealed {
     use super::*;
-    use crate::ops::handle::NodeHandle;
 
     /// Trait for accessing the mutable internals of a Hugr(Mut).
     ///
     /// Specifically, this trait lets you apply arbitrary modifications that may
     /// invalidate the HUGR.
-    pub trait HugrMutInternals: RootTagged {
+    pub trait HugrMutInternals: HugrView {
         /// Returns the Hugr at the base of a chain of views.
         fn hugr_mut(&mut self) -> &mut Hugr;
 
@@ -502,20 +501,11 @@ pub(crate) mod sealed {
         /// # Errors
         /// Returns a [`HugrError::InvalidTag`] if this would break the bound
         /// ([`Self::RootHandle`]) on the root node's [OpTag]
-        fn replace_op(&mut self, node: Node, op: NodeType) -> Result<NodeType, HugrError> {
-            self.valid_node(node)?;
-            if node == self.root() && !Self::RootHandle::TAG.is_superset(op.tag()) {
-                return Err(HugrError::InvalidTag {
-                    required: Self::RootHandle::TAG,
-                    actual: op.tag(),
-                });
-            }
-            self.hugr_mut().replace_op(node, op)
-        }
+        fn replace_op(&mut self, node: Node, op: NodeType) -> Result<NodeType, HugrError>;
     }
 
     /// Impl for non-wrapped Hugrs. Overwrites the recursive default-impls to directly use the hugr.
-    impl<T: RootTagged + AsMut<Hugr>> HugrMutInternals for T {
+    impl<T: HugrView + AsMut<Hugr>> HugrMutInternals for T {
         fn hugr_mut(&mut self) -> &mut Hugr {
             self.as_mut()
         }
@@ -571,7 +561,7 @@ pub(crate) mod sealed {
         }
 
         fn replace_op(&mut self, node: Node, op: NodeType) -> Result<NodeType, HugrError> {
-            // No possibility of failure here since Self::RootHandle == Any
+            // No possibility of failure here since there is no Self::RootHandle
             let cur = self.hugr_mut().op_types.get_mut(node.index);
             Ok(std::mem::replace(cur, op))
         }

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -216,7 +216,7 @@ impl InsertionResult {
 }
 
 /// Impl for non-wrapped Hugrs. Overwrites the recursive default-impls to directly use the hugr.
-impl<T: RootTagged + AsMut<Hugr>> HugrMut for T {
+impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
     fn add_node_with_parent(&mut self, parent: Node, node: NodeType) -> Result<Node, HugrError> {
         let node = self.as_mut().add_node(node);
         self.as_mut()
@@ -515,7 +515,7 @@ pub(crate) mod sealed {
     }
 
     /// Impl for non-wrapped Hugrs. Overwrites the recursive default-impls to directly use the hugr.
-    impl<T: RootTagged + AsMut<Hugr>> HugrMutInternals for T {
+    impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMutInternals for T {
         fn hugr_mut(&mut self) -> &mut Hugr {
             self.as_mut()
         }
@@ -571,12 +571,7 @@ pub(crate) mod sealed {
         }
 
         fn replace_op(&mut self, node: Node, op: NodeType) -> Result<NodeType, HugrError> {
-            if node == self.root() && !Self::RootHandle::TAG.is_superset(op.tag()) {
-                return Err(HugrError::InvalidTag {
-                    required: Self::RootHandle::TAG,
-                    actual: op.tag(),
-                });
-            }
+            // We know RootHandle=Node here so no need to check
             let cur = self.hugr_mut().op_types.get_mut(node.index);
             Ok(std::mem::replace(cur, op))
         }

--- a/src/hugr/rewrite/insert_identity.rs
+++ b/src/hugr/rewrite/insert_identity.rs
@@ -110,7 +110,7 @@ mod tests {
         algorithm::nest_cfgs::test::build_conditional_in_loop_cfg,
         extension::{prelude::QB_T, PRELUDE_REGISTRY},
         ops::handle::NodeHandle,
-        Hugr,
+        Hugr, HugrView,
     };
 
     #[rstest]

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -335,6 +335,8 @@ impl<H: AsRef<Hugr>, Root: NodeHandle> RootTagged for RootChecked<H, Root> {
     type RootHandle = Root;
 }
 
+// Note do not implement AsMut<Hugr> - that would get us the impl HugrMut
+// for unwrapped Hugrs, which would not check the root node OpTag.
 impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
     fn as_ref(&self) -> &Hugr {
         self.0.as_ref()

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -335,7 +335,7 @@ impl<H: AsRef<Hugr>, Root: NodeHandle> RootTagged for RootChecked<H, Root> {
     type RootHandle = Root;
 }
 
-// Note do not implement AsMut<Hugr> - that would get us the impl HugrMut
+// Note do not implement AsMut<Hugr> - that would get us the `impl HugrMutInternals`
 // for unwrapped Hugrs, which would not check the root node OpTag.
 impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
     fn as_ref(&self) -> &Hugr {

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -344,17 +344,6 @@ impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
 impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> hugrmut::sealed::HugrMutInternals
     for RootChecked<H, Root>
 {
-    fn replace_op(&mut self, node: Node, op: NodeType) -> Result<NodeType, HugrError> {
-        self.valid_node(node)?;
-        if node == self.root() && !<Self as RootTagged>::RootHandle::TAG.is_superset(op.tag()) {
-            return Err(HugrError::InvalidTag {
-                required: <Self as RootTagged>::RootHandle::TAG,
-                actual: op.tag(),
-            });
-        }
-        self.hugr_mut().replace_op(node, op)
-    }
-
     fn hugr_mut(&mut self) -> &mut Hugr {
         self.0.as_mut()
     }

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -2,16 +2,16 @@
 
 pub mod descendants;
 pub mod petgraph;
+mod root_checked;
 pub mod sibling;
 pub mod sibling_subgraph;
 
 #[cfg(test)]
 mod tests;
 
-use std::marker::PhantomData;
-
 pub use self::petgraph::PetgraphWrapper;
 pub use descendants::DescendantsGraph;
+pub use root_checked::RootChecked;
 pub use sibling::SiblingGraph;
 pub use sibling_subgraph::SiblingSubgraph;
 
@@ -309,45 +309,6 @@ pub trait RootTagged: HugrView {
     type RootHandle: NodeHandle;
 }
 
-/// A view of the whole Hugr.
-/// (Just provides static checking of the type of the root node)
-pub struct RootChecked<H, Root = Node>(H, PhantomData<Root>);
-
-impl<H: HugrView, Root: NodeHandle> RootChecked<H, Root> {
-    /// Create a hierarchical view of a whole HUGR
-    ///
-    /// # Errors
-    /// Returns [`HugrError::InvalidTag`] if the root isn't a node of the required [`OpTag`]
-    pub fn try_new(hugr: H) -> Result<Self, HugrError> {
-        check_tag::<Root>(&hugr, hugr.root())?;
-        Ok(Self(hugr, PhantomData))
-    }
-}
-
-impl<Root> RootChecked<Hugr, Root> {
-    /// Extracts the underlying (owned) Hugr
-    pub fn into_hugr(self) -> Hugr {
-        self.0
-    }
-}
-
-impl<H: AsRef<Hugr>, Root: NodeHandle> RootTagged for RootChecked<H, Root> {
-    type RootHandle = Root;
-}
-
-impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
-    fn as_ref(&self) -> &Hugr {
-        self.0.as_ref()
-    }
-}
-
-impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> AsMut<Hugr> for RootChecked<H, Root> {
-    #[inline(always)]
-    fn as_mut(&mut self) -> &mut Hugr {
-        self.0.as_mut()
-    }
-}
-
 /// A common trait for views of a HUGR hierarchical subgraph.
 pub trait HierarchyView<'a>: RootTagged + Sized {
     /// Create a hierarchical view of a HUGR given a root node.
@@ -520,60 +481,5 @@ pub(crate) mod sealed {
         fn root_node(&self) -> Node {
             self.as_ref().root.into()
         }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::{NodeType, RootChecked};
-    use crate::extension::ExtensionSet;
-    use crate::hugr::hugrmut::sealed::HugrMutInternals;
-    use crate::hugr::{HugrError, HugrMut};
-    use crate::ops::handle::{CfgID, DataflowParentID, DfgID};
-    use crate::ops::{BasicBlock, LeafOp, OpTag};
-    use crate::{ops, type_row, types::FunctionType, Hugr, HugrView};
-
-    #[test]
-    fn root_checked() {
-        let root_type = NodeType::pure(ops::DFG {
-            signature: FunctionType::new(vec![], vec![]),
-        });
-        let mut h = Hugr::new(root_type.clone());
-        let cfg_v = RootChecked::<&Hugr, CfgID>::try_new(&h);
-        assert_eq!(
-            cfg_v.err(),
-            Some(HugrError::InvalidTag {
-                required: OpTag::Cfg,
-                actual: OpTag::Dfg
-            })
-        );
-        let mut dfg_v = RootChecked::<&mut Hugr, DfgID>::try_new(&mut h).unwrap();
-        // That is a HugrMutInternal, so we can try:
-        let root = dfg_v.root();
-        let bb = NodeType::pure(BasicBlock::DFB {
-            inputs: type_row![],
-            other_outputs: type_row![],
-            predicate_variants: vec![type_row![]],
-            extension_delta: ExtensionSet::new(),
-        });
-        let r = dfg_v.replace_op(root, bb.clone());
-        assert_eq!(
-            r,
-            Err(HugrError::InvalidTag {
-                required: OpTag::Dfg,
-                actual: ops::OpTag::BasicBlock
-            })
-        );
-        // That didn't do anything:
-        assert_eq!(dfg_v.get_nodetype(root), &root_type);
-
-        let mut dfp_v = RootChecked::<&mut Hugr, DataflowParentID>::try_new(&mut h).unwrap();
-        let r = dfp_v.replace_op(root, bb.clone());
-        assert_eq!(r, Ok(root_type));
-        assert_eq!(dfp_v.get_nodetype(root), &bb);
-
-        // And it's a HugrMut:
-        let nodetype = NodeType::pure(LeafOp::MakeTuple { tys: type_row![] });
-        dfp_v.add_node_with_parent(dfp_v.root(), nodetype).unwrap();
     }
 }

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -314,7 +314,7 @@ impl<'a, Root: NodeHandle> TryFrom<&'a Hugr> for WholeHugrView<'a, Root> {
     /// Create a hierarchical view of a whole HUGR
     ///
     /// # Errors
-    /// Returns [`HugrError::InvalidNode`] if the root isn't a node of the required [OpTag]
+    /// Returns [`HugrError::InvalidNode`] if the root isn't a node of the required [`OpTag`]
     fn try_from(hugr: &'a Hugr) -> Result<Self, HugrError> {
         if !Root::TAG.is_superset(hugr.root_type().tag()) {
             return Err(HugrError::InvalidNode(hugr.root()));

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -508,7 +508,7 @@ pub(crate) mod sealed {
         fn root_node(&self) -> Node;
     }
 
-    impl<T: AsRef<super::Hugr>> HugrInternals for T {
+    impl<T: AsRef<Hugr>> HugrInternals for T {
         type Portgraph<'p> = &'p MultiPortGraph where Self: 'p;
 
         #[inline]

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -399,9 +399,7 @@ fn check_tag<Required: NodeHandle>(hugr: &impl HugrView, node: Node) -> Result<(
     Ok(())
 }
 
-impl<T> HugrView for T
-where
-    T: AsRef<Hugr>,
+impl<T: AsRef<Hugr>> HugrView for T
 {
     type RootHandle = Node;
 
@@ -528,9 +526,7 @@ pub(crate) mod sealed {
         fn root_node(&self) -> Node;
     }
 
-    impl<T> HugrInternals for T
-    where
-        T: AsRef<super::Hugr>,
+    impl<T: AsRef<super::Hugr>> HugrInternals for T
     {
         type Portgraph<'p> = &'p MultiPortGraph where Self: 'p;
 

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -307,9 +307,9 @@ pub trait HugrView: sealed::HugrInternals {
 
 /// A view of the whole Hugr.
 /// (Just provides static checking of the type of the root node)
-pub struct WholeHugrView<H, Root = Node>(H, PhantomData<Root>);
+pub struct RootTagged<H, Root = Node>(H, PhantomData<Root>);
 
-impl<H: HugrView, Root: NodeHandle> WholeHugrView<H, Root> {
+impl<H: HugrView, Root: NodeHandle> RootTagged<H, Root> {
     /// Create a hierarchical view of a whole HUGR
     ///
     /// # Errors
@@ -322,20 +322,20 @@ impl<H: HugrView, Root: NodeHandle> WholeHugrView<H, Root> {
     }
 }
 
-impl<Root> WholeHugrView<Hugr, Root> {
+impl<Root> RootTagged<Hugr, Root> {
     /// Extracts the underlying (owned) Hugr
     pub fn into_hugr(self) -> Hugr {
         self.0
     }
 }
 
-impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for WholeHugrView<H, Root> {
+impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootTagged<H, Root> {
     fn as_ref(&self) -> &Hugr {
         self.0.as_ref()
     }
 }
 
-impl<H: AsMut<Hugr>, Root> AsMut<Hugr> for WholeHugrView<H, Root> {
+impl<H: AsMut<Hugr>, Root> AsMut<Hugr> for RootTagged<H, Root> {
     fn as_mut(&mut self) -> &mut Hugr {
         self.0.as_mut()
     }
@@ -504,21 +504,21 @@ pub(crate) mod sealed {
 
 #[cfg(test)]
 mod test {
-    use super::{NodeType, WholeHugrView};
+    use super::{NodeType, RootTagged};
     use crate::hugr::{HugrError, HugrMut};
     use crate::ops::handle::{CfgID, DfgID};
     use crate::ops::LeafOp;
     use crate::{ops, type_row, types::FunctionType, Hugr, HugrView};
 
     #[test]
-    fn whole_hugr_view() {
+    fn root_tagged() {
         let mut h = Hugr::new(NodeType::pure(ops::DFG {
             signature: FunctionType::new(vec![], vec![]),
         }));
-        let cfg_v = WholeHugrView::<&Hugr, CfgID>::try_new(&h);
+        let cfg_v = RootTagged::<&Hugr, CfgID>::try_new(&h);
         assert_eq!(cfg_v.err(), Some(HugrError::InvalidNode(h.root())));
-        let mut dfg_v = WholeHugrView::<&mut Hugr, DfgID>::try_new(&mut h).unwrap();
-        // Just to check that WholeHugrView is a HugrMut:
+        let mut dfg_v = RootTagged::<&mut Hugr, DfgID>::try_new(&mut h).unwrap();
+        // Just to check that RootTagged is a HugrMut:
         dfg_v
             .add_node_with_parent(
                 dfg_v.root(),

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -502,8 +502,11 @@ mod test {
         }));
         let cfg_v = WholeHugrView::<CfgID>::try_new(&h);
         assert_eq!(cfg_v.err(), Some(HugrError::InvalidNode(h.root())));
-        let dfg_v = WholeHugrView::<DfgID>::try_new(h).unwrap();
+        let dfg_v = WholeHugrView::<DfgID>::try_new(&h).unwrap();
         // Just to check that WholeHugrView is a HugrView:
-        assert_eq!(dfg_v.all_neighbours(dfg_v.root()).collect(), vec![]);
+        assert_eq!(
+            dfg_v.all_neighbours(dfg_v.root()).collect::<Vec<_>>(),
+            vec![]
+        );
     }
 }

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -20,7 +20,7 @@ use itertools::{Itertools, MapInto};
 use portgraph::dot::{DotFormat, EdgeStyle, NodeStyle, PortStyle};
 use portgraph::{multiportgraph, LinkView, MultiPortGraph, PortView};
 
-use super::{hugrmut, Hugr, HugrError, HugrMut, NodeMetadata, NodeType, DEFAULT_NODETYPE};
+use super::{Hugr, HugrError, NodeMetadata, NodeType, DEFAULT_NODETYPE};
 use crate::ops::handle::NodeHandle;
 use crate::ops::{FuncDecl, FuncDefn, OpName, OpTag, OpTrait, OpType, DFG};
 use crate::types::{EdgeKind, FunctionType};
@@ -335,23 +335,18 @@ impl<H: AsRef<Hugr>, Root: NodeHandle> RootTagged for RootChecked<H, Root> {
     type RootHandle = Root;
 }
 
-// Note do not implement AsMut<Hugr> - that would get us the `impl HugrMutInternals`
-// for unwrapped Hugrs, which would not check the root node OpTag.
 impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
     fn as_ref(&self) -> &Hugr {
         self.0.as_ref()
     }
 }
 
-impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> hugrmut::sealed::HugrMutInternals
-    for RootChecked<H, Root>
-{
-    fn hugr_mut(&mut self) -> &mut Hugr {
+impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> AsMut<Hugr> for RootChecked<H, Root> {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut Hugr {
         self.0.as_mut()
     }
 }
-
-impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> HugrMut for RootChecked<H, Root> {}
 
 /// A common trait for views of a HUGR hierarchical subgraph.
 pub trait HierarchyView<'a>: RootTagged + Sized {

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -344,6 +344,17 @@ impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
 impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> hugrmut::sealed::HugrMutInternals
     for RootChecked<H, Root>
 {
+    fn replace_op(&mut self, node: Node, op: NodeType) -> Result<NodeType, HugrError> {
+        self.valid_node(node)?;
+        if node == self.root() && !<Self as RootTagged>::RootHandle::TAG.is_superset(op.tag()) {
+            return Err(HugrError::InvalidTag {
+                required: <Self as RootTagged>::RootHandle::TAG,
+                actual: op.tag(),
+            });
+        }
+        self.hugr_mut().replace_op(node, op)
+    }
+
     fn hugr_mut(&mut self) -> &mut Hugr {
         self.0.as_mut()
     }

--- a/src/hugr/views/descendants.rs
+++ b/src/hugr/views/descendants.rs
@@ -39,9 +39,6 @@ pub struct DescendantsGraph<'g, Root = Node> {
     /// The operation handle of the root node.
     _phantom: std::marker::PhantomData<Root>,
 }
-impl<'g, Root: NodeHandle> RootTagged for DescendantsGraph<'g, Root> {
-    type RootHandle = Root;
-}
 impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
     type Nodes<'a> = MapInto<<RegionGraph<'g> as PortView>::Nodes<'a>, Node>
     where
@@ -150,6 +147,9 @@ impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
     fn all_neighbours(&self, node: Node) -> Self::Neighbours<'_> {
         self.graph.all_neighbours(node.index).map_into()
     }
+}
+impl<'g, Root: NodeHandle> RootTagged for DescendantsGraph<'g, Root> {
+    type RootHandle = Root;
 }
 
 impl<'a, Root> HierarchyView<'a> for DescendantsGraph<'a, Root>

--- a/src/hugr/views/descendants.rs
+++ b/src/hugr/views/descendants.rs
@@ -9,7 +9,7 @@ use crate::hugr::HugrError;
 use crate::ops::handle::NodeHandle;
 use crate::{Direction, Hugr, Node, Port};
 
-use super::{check_tag, sealed::HugrInternals, HierarchyView, HugrView};
+use super::{check_tag, sealed::HugrInternals, HierarchyView, HugrView, RootTagged};
 
 type RegionGraph<'g> = portgraph::view::Region<'g, &'g MultiPortGraph>;
 
@@ -39,13 +39,10 @@ pub struct DescendantsGraph<'g, Root = Node> {
     /// The operation handle of the root node.
     _phantom: std::marker::PhantomData<Root>,
 }
-
-impl<'g, Root> HugrView for DescendantsGraph<'g, Root>
-where
-    Root: NodeHandle,
-{
+impl<'g, Root: NodeHandle> RootTagged for DescendantsGraph<'g, Root> {
     type RootHandle = Root;
-
+}
+impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
     type Nodes<'a> = MapInto<<RegionGraph<'g> as PortView>::Nodes<'a>, Node>
     where
         Self: 'a;

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -11,7 +11,7 @@ use super::{check_tag, RootTagged};
 /// (Just provides static checking of the type of the root node)
 pub struct RootChecked<H, Root = Node>(H, PhantomData<Root>);
 
-impl<H: RootTagged, Root: NodeHandle> RootChecked<H, Root> {
+impl<H: RootTagged + AsRef<Hugr>, Root: NodeHandle> RootChecked<H, Root> {
     /// Create a hierarchical view of a whole HUGR
     ///
     /// # Errors

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -47,7 +47,10 @@ impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
     }
 }
 
-impl<H: HugrMutInternals + AsRef<Hugr>, Root: NodeHandle> HugrMutInternals for RootChecked<H, Root> {
+impl<H: HugrMutInternals + AsRef<Hugr>, Root> HugrMutInternals for RootChecked<H, Root>
+where
+    Root: NodeHandle,
+{
     #[inline(always)]
     fn hugr_mut(&mut self) -> &mut Hugr {
         self.0.hugr_mut()
@@ -62,7 +65,7 @@ mod test {
     use crate::extension::ExtensionSet;
     use crate::hugr::hugrmut::sealed::HugrMutInternals;
     use crate::hugr::{HugrError, HugrMut, NodeType};
-    use crate::ops::handle::{CfgID, DataflowParentID, DfgID, BasicBlockID};
+    use crate::ops::handle::{BasicBlockID, CfgID, DataflowParentID, DfgID};
     use crate::ops::{BasicBlock, LeafOp, OpTag};
     use crate::{ops, type_row, types::FunctionType, Hugr, HugrView};
 

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
-use crate::hugr::HugrError;
+use crate::hugr::hugrmut::sealed::HugrMutInternals;
+use crate::hugr::{HugrError, HugrMut};
 use crate::ops::handle::NodeHandle;
 use crate::{Hugr, Node};
 
@@ -46,12 +47,14 @@ impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
     }
 }
 
-impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> AsMut<Hugr> for RootChecked<H, Root> {
+impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> HugrMutInternals for RootChecked<H, Root> {
     #[inline(always)]
-    fn as_mut(&mut self) -> &mut Hugr {
+    fn hugr_mut(&mut self) -> &mut Hugr {
         self.0.as_mut()
     }
 }
+
+impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> HugrMut for RootChecked<H, Root> {}
 
 #[cfg(test)]
 mod test {

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -1,0 +1,103 @@
+use std::marker::PhantomData;
+
+use crate::hugr::HugrError;
+use crate::ops::handle::NodeHandle;
+use crate::{Hugr, HugrView, Node};
+
+use super::{check_tag, RootTagged};
+
+/// A view of the whole Hugr.
+/// (Just provides static checking of the type of the root node)
+pub struct RootChecked<H, Root = Node>(H, PhantomData<Root>);
+
+impl<H: HugrView, Root: NodeHandle> RootChecked<H, Root> {
+    /// Create a hierarchical view of a whole HUGR
+    ///
+    /// # Errors
+    /// Returns [`HugrError::InvalidTag`] if the root isn't a node of the required [`OpTag`]
+    ///
+    /// [`OpTag`]: crate::ops::OpTag
+    pub fn try_new(hugr: H) -> Result<Self, HugrError> {
+        check_tag::<Root>(&hugr, hugr.root())?;
+        Ok(Self(hugr, PhantomData))
+    }
+}
+
+impl<Root> RootChecked<Hugr, Root> {
+    /// Extracts the underlying (owned) Hugr
+    pub fn into_hugr(self) -> Hugr {
+        self.0
+    }
+}
+
+impl<H: AsRef<Hugr>, Root: NodeHandle> RootTagged for RootChecked<H, Root> {
+    type RootHandle = Root;
+}
+
+impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
+    fn as_ref(&self) -> &Hugr {
+        self.0.as_ref()
+    }
+}
+
+impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> AsMut<Hugr> for RootChecked<H, Root> {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut Hugr {
+        self.0.as_mut()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::RootChecked;
+    use crate::extension::ExtensionSet;
+    use crate::hugr::hugrmut::sealed::HugrMutInternals;
+    use crate::hugr::{HugrError, HugrMut, NodeType};
+    use crate::ops::handle::{CfgID, DataflowParentID, DfgID};
+    use crate::ops::{BasicBlock, LeafOp, OpTag};
+    use crate::{ops, type_row, types::FunctionType, Hugr, HugrView};
+
+    #[test]
+    fn root_checked() {
+        let root_type = NodeType::pure(ops::DFG {
+            signature: FunctionType::new(vec![], vec![]),
+        });
+        let mut h = Hugr::new(root_type.clone());
+        let cfg_v = RootChecked::<&Hugr, CfgID>::try_new(&h);
+        assert_eq!(
+            cfg_v.err(),
+            Some(HugrError::InvalidTag {
+                required: OpTag::Cfg,
+                actual: OpTag::Dfg
+            })
+        );
+        let mut dfg_v = RootChecked::<&mut Hugr, DfgID>::try_new(&mut h).unwrap();
+        // That is a HugrMutInternal, so we can try:
+        let root = dfg_v.root();
+        let bb = NodeType::pure(BasicBlock::DFB {
+            inputs: type_row![],
+            other_outputs: type_row![],
+            predicate_variants: vec![type_row![]],
+            extension_delta: ExtensionSet::new(),
+        });
+        let r = dfg_v.replace_op(root, bb.clone());
+        assert_eq!(
+            r,
+            Err(HugrError::InvalidTag {
+                required: OpTag::Dfg,
+                actual: ops::OpTag::BasicBlock
+            })
+        );
+        // That didn't do anything:
+        assert_eq!(dfg_v.get_nodetype(root), &root_type);
+
+        let mut dfp_v = RootChecked::<&mut Hugr, DataflowParentID>::try_new(&mut h).unwrap();
+        let r = dfp_v.replace_op(root, bb.clone());
+        assert_eq!(r, Ok(root_type));
+        assert_eq!(dfp_v.get_nodetype(root), &bb);
+
+        // And it's a HugrMut:
+        let nodetype = NodeType::pure(LeafOp::MakeTuple { tys: type_row![] });
+        dfp_v.add_node_with_parent(dfp_v.root(), nodetype).unwrap();
+    }
+}

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
-use crate::hugr::HugrError;
+use crate::hugr::hugrmut::sealed::HugrMutInternals;
+use crate::hugr::{HugrError, HugrMut};
 use crate::ops::handle::NodeHandle;
 use crate::{Hugr, Node};
 
@@ -43,12 +44,14 @@ impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
     }
 }
 
-impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> AsMut<Hugr> for RootChecked<H, Root> {
+impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> HugrMutInternals for RootChecked<H, Root> {
     #[inline(always)]
-    fn as_mut(&mut self) -> &mut Hugr {
+    fn hugr_mut(&mut self) -> &mut Hugr {
         self.0.as_mut()
     }
 }
+
+impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> HugrMut for RootChecked<H, Root> {}
 
 #[cfg(test)]
 mod test {

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::hugr::hugrmut::sealed::HugrMutInternals;
-use crate::hugr::{HugrError, HugrMut};
+use crate::hugr::HugrError;
 use crate::ops::handle::NodeHandle;
 use crate::{Hugr, Node};
 
@@ -44,14 +43,12 @@ impl<H: AsRef<Hugr>, Root> AsRef<Hugr> for RootChecked<H, Root> {
     }
 }
 
-impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> HugrMutInternals for RootChecked<H, Root> {
+impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> AsMut<Hugr> for RootChecked<H, Root> {
     #[inline(always)]
-    fn hugr_mut(&mut self) -> &mut Hugr {
+    fn as_mut(&mut self) -> &mut Hugr {
         self.0.as_mut()
     }
 }
-
-impl<H: AsMut<Hugr> + AsRef<Hugr>, Root: NodeHandle> HugrMut for RootChecked<H, Root> {}
 
 #[cfg(test)]
 mod test {

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::hugr::HugrError;
 use crate::ops::handle::NodeHandle;
-use crate::{Hugr, HugrView, Node};
+use crate::{Hugr, Node};
 
 use super::{check_tag, RootTagged};
 
@@ -10,7 +10,10 @@ use super::{check_tag, RootTagged};
 /// (Just provides static checking of the type of the root node)
 pub struct RootChecked<H, Root = Node>(H, PhantomData<Root>);
 
-impl<H: HugrView, Root: NodeHandle> RootChecked<H, Root> {
+// The restriction on RootHandle here is because RootChecked would bypass
+// any root-tag-checking done by the inner struct and go straight to the
+// &mut Hugr (which has RootHandle=Node). So ensure no checking gets bypassed.
+impl<H: RootTagged<RootHandle = Node>, Root: NodeHandle> RootChecked<H, Root> {
     /// Create a hierarchical view of a whole HUGR
     ///
     /// # Errors

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -95,10 +95,6 @@ macro_rules! impl_base_members {
     };
 }
 
-impl<'g, Root: NodeHandle> RootTagged for SiblingGraph<'g, Root> {
-    type RootHandle = Root;
-}
-
 impl<'g, Root: NodeHandle> HugrView for SiblingGraph<'g, Root> {
     type Neighbours<'a> = MapInto<<FlatRegionGraph<'g> as LinkView>::Neighbours<'a>, Node>
     where
@@ -174,6 +170,9 @@ impl<'g, Root: NodeHandle> HugrView for SiblingGraph<'g, Root> {
     fn all_neighbours(&self, node: Node) -> Self::Neighbours<'_> {
         self.graph.all_neighbours(node.index).map_into()
     }
+}
+impl<'g, Root: NodeHandle> RootTagged for SiblingGraph<'g, Root> {
+    type RootHandle = Root;
 }
 
 impl<'a, Root: NodeHandle> SiblingGraph<'a, Root> {
@@ -275,9 +274,6 @@ impl<'g, Root: NodeHandle> HugrInternals for SiblingMut<'g, Root> {
     }
 }
 
-impl<'g, Root: NodeHandle> RootTagged for SiblingMut<'g, Root> {
-    type RootHandle = Root;
-}
 impl<'g, Root: NodeHandle> HugrView for SiblingMut<'g, Root> {
     type Neighbours<'a> = <Vec<Node> as IntoIterator>::IntoIter
     where
@@ -349,7 +345,9 @@ impl<'g, Root: NodeHandle> HugrView for SiblingMut<'g, Root> {
             .into_iter()
     }
 }
-
+impl<'g, Root: NodeHandle> RootTagged for SiblingMut<'g, Root> {
+    type RootHandle = Root;
+}
 impl<'g, Root: NodeHandle> HugrMutInternals for SiblingMut<'g, Root> {
     fn hugr_mut(&mut self) -> &mut Hugr {
         self.hugr

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -7,7 +7,7 @@ use itertools::{Itertools, MapInto};
 use portgraph::{LinkView, MultiPortGraph, PortIndex, PortView};
 
 use crate::hugr::hugrmut::sealed::HugrMutInternals;
-use crate::hugr::{HugrError, HugrMut};
+use crate::hugr::{HugrError, HugrMut, NodeType};
 use crate::ops::handle::NodeHandle;
 use crate::{Direction, Hugr, Node, Port};
 
@@ -349,6 +349,17 @@ impl<'g, Root: NodeHandle> RootTagged for SiblingMut<'g, Root> {
     type RootHandle = Root;
 }
 impl<'g, Root: NodeHandle> HugrMutInternals for SiblingMut<'g, Root> {
+    fn replace_op(&mut self, node: Node, op: NodeType) -> Result<NodeType, HugrError> {
+        self.valid_node(node)?;
+        if node == self.root() && !<Self as RootTagged>::RootHandle::TAG.is_superset(op.tag()) {
+            return Err(HugrError::InvalidTag {
+                required: <Self as RootTagged>::RootHandle::TAG,
+                actual: op.tag(),
+            });
+        }
+        self.hugr_mut().replace_op(node, op)
+    }
+
     fn hugr_mut(&mut self) -> &mut Hugr {
         self.hugr
     }

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -11,7 +11,7 @@ use crate::hugr::{HugrError, HugrMut};
 use crate::ops::handle::NodeHandle;
 use crate::{Direction, Hugr, Node, Port};
 
-use super::{check_tag, sealed::HugrInternals, HierarchyView, HugrView};
+use super::{check_tag, sealed::HugrInternals, HierarchyView, HugrView, RootTagged};
 
 type FlatRegionGraph<'g> = portgraph::view::FlatRegion<'g, &'g MultiPortGraph>;
 
@@ -95,12 +95,11 @@ macro_rules! impl_base_members {
     };
 }
 
-impl<'g, Root> HugrView for SiblingGraph<'g, Root>
-where
-    Root: NodeHandle,
-{
+impl<'g, Root: NodeHandle> RootTagged for SiblingGraph<'g, Root> {
     type RootHandle = Root;
+}
 
+impl<'g, Root: NodeHandle> HugrView for SiblingGraph<'g, Root> {
     type Neighbours<'a> = MapInto<<FlatRegionGraph<'g> as LinkView>::Neighbours<'a>, Node>
     where
         Self: 'a;
@@ -276,9 +275,10 @@ impl<'g, Root: NodeHandle> HugrInternals for SiblingMut<'g, Root> {
     }
 }
 
-impl<'g, Root: NodeHandle> HugrView for SiblingMut<'g, Root> {
+impl<'g, Root: NodeHandle> RootTagged for SiblingMut<'g, Root> {
     type RootHandle = Root;
-
+}
+impl<'g, Root: NodeHandle> HugrView for SiblingMut<'g, Root> {
     type Neighbours<'a> = <Vec<Node> as IntoIterator>::IntoIter
     where
         Self: 'a;

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -7,7 +7,7 @@ use itertools::{Itertools, MapInto};
 use portgraph::{LinkView, MultiPortGraph, PortIndex, PortView};
 
 use crate::hugr::hugrmut::sealed::HugrMutInternals;
-use crate::hugr::{HugrError, HugrMut, NodeType};
+use crate::hugr::{HugrError, HugrMut};
 use crate::ops::handle::NodeHandle;
 use crate::{Direction, Hugr, Node, Port};
 
@@ -349,17 +349,6 @@ impl<'g, Root: NodeHandle> RootTagged for SiblingMut<'g, Root> {
     type RootHandle = Root;
 }
 impl<'g, Root: NodeHandle> HugrMutInternals for SiblingMut<'g, Root> {
-    fn replace_op(&mut self, node: Node, op: NodeType) -> Result<NodeType, HugrError> {
-        self.valid_node(node)?;
-        if node == self.root() && !<Self as RootTagged>::RootHandle::TAG.is_superset(op.tag()) {
-            return Err(HugrError::InvalidTag {
-                required: <Self as RootTagged>::RootHandle::TAG,
-                actual: op.tag(),
-            });
-        }
-        self.hugr_mut().replace_op(node, op)
-    }
-
     fn hugr_mut(&mut self) -> &mut Hugr {
         self.hugr
     }

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -29,7 +29,7 @@ use crate::{
     Hugr, Node, Port, SimpleReplacement,
 };
 
-use super::HugrView;
+use super::{HugrView, RootTagged};
 
 #[cfg(feature = "pyo3")]
 use pyo3::{create_exception, exceptions::PyException, PyErr};
@@ -97,7 +97,7 @@ impl SiblingSubgraph {
     /// subgraph is empty.
     pub fn try_new_dataflow_subgraph<H, Root>(dfg_graph: &H) -> Result<Self, InvalidSubgraph>
     where
-        H: Clone + HugrView<RootHandle = Root>,
+        H: Clone + RootTagged<RootHandle = Root>,
         Root: ContainerHandle<ChildrenHandle = DataflowOpID>,
     {
         let parent = dfg_graph.root();


### PR DESCRIPTION
* Factor out RootTagged as a subtrait of HugrView to allow separate implementation. Most things can still just use HugrView (as it happens everything that implements HugrView also implements RootTagged, but this is not required).
    * HugrMut a subtrait of RootTagged not just HugrView
* Then add a new RootChecked struct storing any `AsRef<Hugr>` with a fixed RootHandle.
     * It allows `.as_ref()`, throwing away the extra information in the RootHandle
     * If the underlying view is a HugrMut then it is too
     * Use trait-default implementations of Hugr(View,(Mut)Internals), as the latter check that `replace_op` does not break the bound on root-type
     * But do not provide `.as_mut()` as that would allow bypassing and invalidating the extra info in the RootHandle
     * Like SiblingMut, check that nested instances only narrow the bound.
* Change the overridden-for-&(mut) Hugr impls of Hugr(Mut)Internals to only work for `RootHandle=Node` to ensure the lack of checking in replace_op there is safe.