### PR TITLE
refactor!: rename predicate to TupleSum/UnitSum

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -345,8 +345,8 @@ not. That is, Conditional-nodes act as "if-then-else" followed by a
 control-flow merge.
 
 A **TupleSum(T0, T1…TN)** type is an algebraic “sum of products” type,
-defined as `Sum(Tuple(#t0), Tuple(#t1), ...Tuple(#tn))` (see [type
-system](#type-system)), where `#ti` is the *i*th Row defining it.
+defined as `Sum(Tuple(#T0), Tuple(#T1), ...Tuple(#Tn))` (see [type
+system](#type-system)), where `#Ti` is the *i*th Row defining it.
 
 ```mermaid
 flowchart
@@ -424,7 +424,7 @@ output of each of these is a sum type, whose arity is the number of outgoing
 control edges; the remaining outputs are those that are passed to all
 succeeding nodes.
 
-The three nodes labelled "Const" are simply generating a choice with one empty
+The three nodes labelled "Const" are simply generating a TupleSum with one empty
 value to pass to the Output node.
 
 ```mermaid

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -335,16 +335,16 @@ express control flow, i.e. conditional or repeated evaluation.
 ##### `Conditional` nodes
 
 These are parents to multiple `Case` nodes; the children have no edges.
-The first input to the Conditional-node is of Predicate type (see below), whose
+The first input to the Conditional-node is of Choice type (see below), whose
 arity matches the number of children of the Conditional-node. At runtime
 the constructor (tag) selects which child to execute; the unpacked
-contents of the Predicate with all remaining inputs to Conditional
+contents of the Choice with all remaining inputs to Conditional
 appended are sent to this child, and all outputs of the child are the
 outputs of the Conditional; that child is evaluated, but the others are
 not. That is, Conditional-nodes act as "if-then-else" followed by a
 control-flow merge.
 
-A **Predicate(T0, T1…TN)** type is an algebraic “sum of products” type,
+A **Choice(T0, T1…TN)** type is an algebraic “sum of products” type,
 defined as `Sum(Tuple(#t0), Tuple(#t1), ...Tuple(#tn))` (see [type
 system](#type-system)), where `#ti` is the *i*th Row defining it.
 
@@ -362,7 +362,7 @@ flowchart
         end
         Case0 ~~~ Case1
     end
-    Pred["case 0 inputs | case 1 inputs"] --> Conditional
+    Choice["case 0 inputs | case 1 inputs"] --> Conditional
     OI["other inputs"] --> Conditional
     Conditional --> outputs
 ```
@@ -370,7 +370,7 @@ flowchart
 ##### `TailLoop` nodes
 
 These provide tail-controlled loops: the data sibling graph within the
-TailLoop-node computes a value of 2-ary `Predicate(#i, #o)`; the first
+TailLoop-node computes a value of 2-ary `Choice(#i, #o)`; the first
 variant means to repeat the loop with the values of the tuple unpacked
 and “fed” in at at the top; the second variant means to exit the loop
 with those values unpacked. The graph may additionally take in a row
@@ -398,7 +398,7 @@ The first child is the entry block and must be a `DFB`, with inputs the same as 
 The remaining children are either `DFB`s or [scoped definitions](#scoped-definitions).
 
 The first output of the DSG contained in a `BasicBlock` has type
-`Predicate(#t0,...#t(n-1))`, where the node has `n` successors, and the
+`Choice(#t0,...#t(n-1))`, where the node has `n` successors, and the
 remaining outputs are a row `#x`. `#ti` with `#x` appended matches the
 inputs of successor `i`.
 
@@ -424,7 +424,7 @@ output of each of these is a sum type, whose arity is the number of outgoing
 control edges; the remaining outputs are those that are passed to all
 succeeding nodes.
 
-The three nodes labelled "Const" are simply generating a predicate with one empty
+The three nodes labelled "Const" are simply generating a choice with one empty
 value to pass to the Output node.
 
 ```mermaid
@@ -1376,8 +1376,8 @@ use an empty node in the replacement and have B map this node to the old
 one.
 
 We can, for example, implement “turning a Conditional-node with known
-predicate into a DFG-node” by a `Replace` where the Conditional (and its
-preceding predicate) is replaced by an empty DFG and the map B specifies
+Choice into a DFG-node” by a `Replace` where the Conditional (and its
+preceding Choice) is replaced by an empty DFG and the map B specifies
 the “good” child of the Conditional as the surrogate parent of the new
 DFG’s children. (If the good child was just an Op, we could either
 remove it and include it in the replacement, or – to avoid this overhead

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1,4 +1,4 @@
-# HUGR design document, Draft 3
+# HUGR design document
 
 The Hierarchical Unified Graph Representation (HUGR, pronounced *hugger* 
 🫂) is a proposed new
@@ -335,16 +335,16 @@ express control flow, i.e. conditional or repeated evaluation.
 ##### `Conditional` nodes
 
 These are parents to multiple `Case` nodes; the children have no edges.
-The first input to the Conditional-node is of Choice type (see below), whose
+The first input to the Conditional-node is of TupleSum type (see below), whose
 arity matches the number of children of the Conditional-node. At runtime
 the constructor (tag) selects which child to execute; the unpacked
-contents of the Choice with all remaining inputs to Conditional
+contents of the TupleSum with all remaining inputs to Conditional
 appended are sent to this child, and all outputs of the child are the
 outputs of the Conditional; that child is evaluated, but the others are
 not. That is, Conditional-nodes act as "if-then-else" followed by a
 control-flow merge.
 
-A **Choice(T0, T1…TN)** type is an algebraic “sum of products” type,
+A **TupleSum(T0, T1…TN)** type is an algebraic “sum of products” type,
 defined as `Sum(Tuple(#t0), Tuple(#t1), ...Tuple(#tn))` (see [type
 system](#type-system)), where `#ti` is the *i*th Row defining it.
 
@@ -362,7 +362,7 @@ flowchart
         end
         Case0 ~~~ Case1
     end
-    Choice["case 0 inputs | case 1 inputs"] --> Conditional
+    TupleSum["case 0 inputs | case 1 inputs"] --> Conditional
     OI["other inputs"] --> Conditional
     Conditional --> outputs
 ```
@@ -370,7 +370,7 @@ flowchart
 ##### `TailLoop` nodes
 
 These provide tail-controlled loops: the data sibling graph within the
-TailLoop-node computes a value of 2-ary `Choice(#i, #o)`; the first
+TailLoop-node computes a value of 2-ary `TupleSum(#i, #o)`; the first
 variant means to repeat the loop with the values of the tuple unpacked
 and “fed” in at at the top; the second variant means to exit the loop
 with those values unpacked. The graph may additionally take in a row
@@ -398,7 +398,7 @@ The first child is the entry block and must be a `DFB`, with inputs the same as 
 The remaining children are either `DFB`s or [scoped definitions](#scoped-definitions).
 
 The first output of the DSG contained in a `BasicBlock` has type
-`Choice(#t0,...#t(n-1))`, where the node has `n` successors, and the
+`TupleSum(#t0,...#t(n-1))`, where the node has `n` successors, and the
 remaining outputs are a row `#x`. `#ti` with `#x` appended matches the
 inputs of successor `i`.
 
@@ -1143,12 +1143,6 @@ is itself in S.
 The meaning of “convex” is: if A and B are nodes in the convex set S,
 then any sibling node on a path from A to B is also in S.
 
-Given a set S of nodes in a hugr, let S\* be the set of all nodes
-descended from nodes in S, including S itself.
-
-Call two nodes a, b in Γ *separated* if a is not in {b}\* and b is not
-in {a}\* (i.e. there is no hierarchy relation between them).
-
 #### API methods
 
 There are the following primitive operations.
@@ -1177,15 +1171,20 @@ The method takes as input:
     Ext edges;
   - a hugr $H$ whose root is a DFG node $R$ with only leaf nodes as children --
     let $T$ be the set of children of $R$;
-  - a map $\nu\_\textrm{inp}: \textrm{inp}\_H(T \setminus \\{\texttt{Input}\\}) \to \textrm{inp}\_{\Gamma}(S)$;
-  - a map $\nu_\textrm{out}: \textrm{out}_{\Gamma}(S) \to \textrm{out}_H(T \setminus \\{\texttt{Output}\\})$.
+  - a map $\nu\_\textrm{inp}: \textrm{inp}\_H(T \setminus \\{\texttt{Input}\\}) \to \textrm{inp}\_{\Gamma}(S)$; note that
+      * $\nu\_\textrm{inp}: \textrm{inp}\_H(T \setminus \\{\texttt{Input}\\})$ is just "the successors of $\texttt{Input}$", so could be expressed as outputs of the $\texttt{Input}$ node
+      * in order to produce a valid Hugr, all possible keys must be present; and all possible values must be present exactly once unless Copyable);
+  - a map $\nu_\textrm{out}: \textrm{out}_{\Gamma}(S) \to \textrm{out}_H(T \setminus \\{\texttt{Output}\\})$; again note that
+      * $\textrm{out}_H(T \setminus \\{\texttt{Output}\\})$ is just the input ports to the $\texttt{Output}$ node (their source must all be in $H$)
+      * in order to produce a valid hugr, all keys $\textrm{out}_{\Gamma}(S)$ must be present
+      * ...and each possible value must be either Copyable and/or present exactly once. Any that is absent could just be omitted from $H$....
   
 The new hugr is then derived as follows:
   
   1. Make a copy in $\Gamma$ of all children of $R$, excluding Input and Output,
      and all edges between them. Make all the newly added nodes children of $P$.
-     Notation: if $p$ is a port of a node in $R$, write $p^*$ for the copy of
-     the port in $\Gamma$.
+     Notation: for each port $p$ of a node in $R$ of which a copy is made, write
+     $p^*$ for the copy of the port in $\Gamma$.
   2. For each $(q, p = \nu_\textrm{inp}(q))$ such that $q \notin \texttt{Output}$,
      add an edge from $p^-$ to $q^*$.
   3. For each $(p, q = \nu_\textrm{out}(p))$ such that $q^- \notin \texttt{Input}$,
@@ -1199,20 +1198,9 @@ The new hugr is then derived as follows:
 
 This is the general subgraph-replacement method.
 
-A _partial hugr_ is a graph formed by a subset of nodes of a valid hugr together
-with a subset of their adjoining edges. It must not include a `Module` node.
-
-Given a partial hugr $G$, let
-
-  - $\top(G)$ be the set of nodes in $G$ without an incoming hierarchy edge;
-  - $\bot(G)$ be the set of container nodes in $G$ without an outgoing hierarchy edge.
-
 Given a set $S$ of nodes in a hugr, let $S^\*$ be the set of all nodes
 descended from nodes in $S$ (i.e. reachable from $S$ by following hierarchy edges),
 including $S$ itself.
-
-Call two nodes $a, b \in \Gamma$ _separated_ if $a \notin \\{b\\}^\*$ and
-$b \notin \\{a\\}^\*$ (i.e. there is no hierarchy relation between them).
 
 A `NewEdgeSpec` specifies an edge inserted between an existing node and a new node.
 It contains the following fields:
@@ -1229,22 +1217,34 @@ Note that in a `NewEdgeSpec` one of `SrcNode` and `TgtNode` is an existing node
 in the hugr and the other is a new node.
 
 The `Replace` method takes as input:
-
-  - a set $S$ of mutually-separated nodes in $\Gamma$;
-  - a partial hugr $G$;
-  - a map $T : \top(G) \to \Gamma \setminus S^*$ whose image consists of container nodes;
-  - a map $B : \bot(G) \to S^\*$ whose image consists of container nodes, such that $B(x)$
-    is separated from $B(y)$ unless $x = y$. Let $X$ be the set of children
-    of nodes in the image of $B$, and $R = S^\* \setminus X^\*$.
+  - the ID of a container node $P$ in $\Gamma$;
+  - a set $S$ of IDs of nodes that are children of $P$
+  - a Hugr $G$ whose root is a node of the same type as $P$.
+    Note this Hugr need not be valid, in that it may be missing:
+      * edges to/from some ports (i.e. it may have unconnected ports)---not just Copyable dataflow outputs, which may occur even in valid Hugrs, but also incoming and/or non-Copyable dataflow ports, and ControlFlow ports,
+      * all children for some container nodes strictly beneath the root (i.e. it may have container nodes with no outgoing hierarchy edges)
+      * some children of the root, for container nodes that require particular children (e.g.
+        $\mathtt{Input}$ and/or $\mathtt{Output}$ if $P$ is a dataflow container, the exit node
+        of a CFG, the required number of children of a conditional)
+  - a map $B$ *from* container nodes in $G$ that have no children *to* container nodes in $S^\*$
+    none of which is an ancestor of another.
+    Let $X$ be the set of children of nodes in the image of $B$, and $R = S^\* \setminus X^\*$.
   - a list $\mu\_\textrm{inp}$ of `NewEdgeSpec` which all have their `TgtNode`in
-    $G$ and `SrcNode` in $\Gamma \setminus S^*$;
+    $G$ and `SrcNode` in $\Gamma \setminus R$;
   - a list $\mu\_\textrm{out}$ of `NewEdgeSpec` which all have their `SrcNode`in
-    $G$ and `TgtNode` in $\Gamma \setminus S^*$ (and `TgtNode` has an existing
-    incoming edge from a node in $R$).
+    $G$ and `TgtNode` in $\Gamma \setminus R$ (where `TgtNode` and `TgtPos` describe
+    an existing incoming edge of that kind from a node in $R$).
+
+The well-formedness requirements of Hugr imply that $\mu\_\textrm{inp}$ and $\mu\_\textrm{out}$ may only contain `NewEdgeSpec`s with certain `EdgeKind`s, depending on $P$:
+   - if $P$ is a dataflow container, `EdgeKind`s may be `Order`, `Value` or `Static` only (no `ControlFlow`)
+   - if $P$ is a CFG node, `EdgeKind`s may be `ControlFlow`, `Value`, or `Static` only (no `Order`)
+   - if $P$ is a Module node, there may be `Value` or `Static` only (no `Order`).
+(in the case of $P$ being a CFG or Module node, any `Value` edges will be nonlocal, like Static edges.)
 
 The new hugr is then derived as follows:
 
-1.  Make a copy in $\Gamma$ of all the nodes in $G$, and all edges between them.
+1.  Make a copy in $\Gamma$ of all the nodes in $G$ *except the root*, and all edges except
+    hierarchy edges from the root.
 2.  For each $\sigma\_\mathrm{inp} \in \mu\_\textrm{inp}$, insert a new edge going into the new
     copy of the `TgtNode` of $\sigma\_\mathrm{inp}$ according to the specification $\sigma\_\mathrm{inp}$.
     Where these edges are from ports that currently have edges to nodes in $R$,
@@ -1253,8 +1253,10 @@ The new hugr is then derived as follows:
     copy of the `SrcNode` of $\sigma\_\mathrm{out}$ according to the specification $\sigma\_\mathrm{out}$.
     The target port must have an existing edge whose source is in $R$; this edge
     is removed.
-4.  For each $(n, t = T(n))$, append the copy of $n$ to the list
-    of children of $t$ (adding a hierachy edge from $t$ to $n$).
+4.  Let $N$ be the ordered list of the copies made in $\Gamma$ of the children of the root node of $G$.
+    For each child $C$ of $P$ (in order), if $C \in S$, redirect the hierarchy edge $P \rightarrow C$ to
+    target the next node in $N$. Stop if there are no more nodes in $N$.
+    Add any remaining nodes in $N$ to the end of $P$'s list of children.
 5.  For each node $(n, b = B(n))$ and for each child $m$ of $b$, replace the
     hierarchy edge from $b$ to $m$ with a hierarchy edge from the new copy of
     $n$ to $m$ (preserving the order).
@@ -1351,13 +1353,12 @@ it (and its incoming value and Order edges) from the hugr.
 
 ###### `InsertConst`
 
-Given a `Const<T>` node `c` and a DSG `P`, add `c` as a child of `P`,
-inserting an Order edge from the Input under `P` to `c`.
+Given a `Const<T>` node `c` and a container node `P` (either a `Module`,
+ a `CFG` node or a dataflow container), add `c` as a child of `P`.
 
 ###### `RemoveConst`
 
-Given a `Const<T>` node `c` having no outgoing edges, remove `c`
-together with its incoming `Order` edge.
+Given a `Const<T>` node `c` having no outgoing edges, remove `c`.
 
 #### Usage
 
@@ -1376,8 +1377,8 @@ use an empty node in the replacement and have B map this node to the old
 one.
 
 We can, for example, implement “turning a Conditional-node with known
-Choice into a DFG-node” by a `Replace` where the Conditional (and its
-preceding Choice) is replaced by an empty DFG and the map B specifies
+TupleSum into a DFG-node” by a `Replace` where the Conditional (and its
+preceding TupleSum) is replaced by an empty DFG and the map B specifies
 the “good” child of the Conditional as the surrogate parent of the new
 DFG’s children. (If the good child was just an Op, we could either
 remove it and include it in the replacement, or – to avoid this overhead

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -428,10 +428,9 @@ pub(crate) mod test {
         //               \-> right -/             \-<--<-/
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
 
-        let pred_const =
-            cfg_builder.add_constant(Const::simple_predicate(0, 2), ExtensionSet::new())?; // Nothing here cares which
+        let pred_const = cfg_builder.add_constant(Const::unit_choice(0, 2), ExtensionSet::new())?; // Nothing here cares which
         let const_unit =
-            cfg_builder.add_constant(Const::simple_unary_predicate(), ExtensionSet::new())?;
+            cfg_builder.add_constant(Const::unary_unit_choice(), ExtensionSet::new())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,
@@ -677,10 +676,9 @@ pub(crate) mod test {
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
-        let pred_const =
-            cfg_builder.add_constant(Const::simple_predicate(0, 2), ExtensionSet::new())?; // Nothing here cares which
+        let pred_const = cfg_builder.add_constant(Const::unit_choice(0, 2), ExtensionSet::new())?; // Nothing here cares which
         let const_unit =
-            cfg_builder.add_constant(Const::simple_unary_predicate(), ExtensionSet::new())?;
+            cfg_builder.add_constant(Const::unary_unit_choice(), ExtensionSet::new())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 2, ExtensionSet::new())?,
@@ -721,10 +719,9 @@ pub(crate) mod test {
         cfg_builder: &mut CFGBuilder<T>,
         separate_headers: bool,
     ) -> Result<(BasicBlockID, BasicBlockID), BuildError> {
-        let pred_const =
-            cfg_builder.add_constant(Const::simple_predicate(0, 2), ExtensionSet::new())?; // Nothing here cares which
+        let pred_const = cfg_builder.add_constant(Const::unit_choice(0, 2), ExtensionSet::new())?; // Nothing here cares which
         let const_unit =
-            cfg_builder.add_constant(Const::simple_unary_predicate(), ExtensionSet::new())?;
+            cfg_builder.add_constant(Const::unary_unit_choice(), ExtensionSet::new())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -605,9 +605,8 @@ pub(crate) mod test {
         //               \-> right -/             \-<--<-/
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
 
-        let pred_const = cfg_builder.add_constant(Const::unit_choice(0, 2), ExtensionSet::new())?; // Nothing here cares which
-        let const_unit =
-            cfg_builder.add_constant(Const::unary_unit_choice(), ExtensionSet::new())?;
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2), ExtensionSet::new())?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::unary_unit_sum(), ExtensionSet::new())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,
@@ -888,9 +887,8 @@ pub(crate) mod test {
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
-        let pred_const = cfg_builder.add_constant(Const::unit_choice(0, 2), ExtensionSet::new())?; // Nothing here cares which
-        let const_unit =
-            cfg_builder.add_constant(Const::unary_unit_choice(), ExtensionSet::new())?;
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2), ExtensionSet::new())?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::unary_unit_sum(), ExtensionSet::new())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 2, ExtensionSet::new())?,
@@ -931,9 +929,8 @@ pub(crate) mod test {
         cfg_builder: &mut CFGBuilder<T>,
         separate_headers: bool,
     ) -> Result<(BasicBlockID, BasicBlockID), BuildError> {
-        let pred_const = cfg_builder.add_constant(Const::unit_choice(0, 2), ExtensionSet::new())?; // Nothing here cares which
-        let const_unit =
-            cfg_builder.add_constant(Const::unary_unit_choice(), ExtensionSet::new())?;
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2), ExtensionSet::new())?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::unary_unit_sum(), ExtensionSet::new())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -421,8 +421,8 @@ pub trait Dataflow: Container {
     }
 
     /// Return a builder for a [`crate::ops::Conditional`] node.
-    /// `predicate_inputs` and `predicate_wire` define the type of the predicate
-    /// variants and the wire carrying the predicate respectively.
+    /// `choice_inputs` and `choice_wire` define the type of the Choice
+    /// variants and the wire carrying the Choice respectively.
     ///
     /// The `other_inputs` must be an iterable over pairs of the type of the input and
     /// the corresponding wire.
@@ -434,24 +434,24 @@ pub trait Dataflow: Container {
     /// the Conditional node.
     fn conditional_builder(
         &mut self,
-        (predicate_inputs, predicate_wire): (impl IntoIterator<Item = TypeRow>, Wire),
+        (choice_inputs, choice_wire): (impl IntoIterator<Item = TypeRow>, Wire),
         other_inputs: impl IntoIterator<Item = (Type, Wire)>,
         output_types: TypeRow,
         extension_delta: ExtensionSet,
     ) -> Result<ConditionalBuilder<&mut Hugr>, BuildError> {
-        let mut input_wires = vec![predicate_wire];
+        let mut input_wires = vec![choice_wire];
         let (input_types, rest_input_wires): (Vec<Type>, Vec<Wire>) =
             other_inputs.into_iter().unzip();
 
         input_wires.extend(rest_input_wires);
         let inputs: TypeRow = input_types.into();
-        let predicate_inputs: Vec<_> = predicate_inputs.into_iter().collect();
-        let n_cases = predicate_inputs.len();
+        let choice_inputs: Vec<_> = choice_inputs.into_iter().collect();
+        let n_cases = choice_inputs.len();
         let n_out_wires = output_types.len();
 
         let conditional_id = self.add_dataflow_op(
             ops::Conditional {
-                predicate_inputs,
+                choice_inputs,
                 other_inputs: inputs,
                 outputs: output_types,
                 extension_delta,
@@ -534,15 +534,15 @@ pub trait Dataflow: Container {
     }
 
     /// Add [`LeafOp::MakeTuple`] and [`LeafOp::Tag`] nodes to construct the
-    /// `tag` variant of a predicate (sum-of-tuples) type.
-    fn make_predicate(
+    /// `tag` variant of a Choice (sum-of-tuples) type.
+    fn make_choice(
         &mut self,
         tag: usize,
-        predicate_variants: impl IntoIterator<Item = TypeRow>,
+        choice_variants: impl IntoIterator<Item = TypeRow>,
         values: impl IntoIterator<Item = Wire>,
     ) -> Result<Wire, BuildError> {
         let tuple = self.make_tuple(values)?;
-        let variants = crate::types::predicate_variants_row(predicate_variants);
+        let variants = crate::types::choice_variant_row(choice_variants);
         let make_op = self.add_dataflow_op(LeafOp::Tag { tag, variants }, vec![tuple])?;
         Ok(make_op.out_wire(0))
     }
@@ -561,7 +561,7 @@ pub trait Dataflow: Container {
         tail_loop: ops::TailLoop,
         values: impl IntoIterator<Item = Wire>,
     ) -> Result<Wire, BuildError> {
-        self.make_predicate(0, [tail_loop.just_inputs, tail_loop.just_outputs], values)
+        self.make_choice(0, [tail_loop.just_inputs, tail_loop.just_outputs], values)
     }
 
     /// Use the wires in `values` to return a wire corresponding to the
@@ -578,7 +578,7 @@ pub trait Dataflow: Container {
         loop_op: ops::TailLoop,
         values: impl IntoIterator<Item = Wire>,
     ) -> Result<Wire, BuildError> {
-        self.make_predicate(1, [loop_op.just_inputs, loop_op.just_outputs], values)
+        self.make_choice(1, [loop_op.just_inputs, loop_op.just_outputs], values)
     }
 
     /// Add a [`ops::Call`] node, calling `function`, with inputs

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -103,8 +103,8 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
     }
 
     /// Return a builder for a non-entry [`BasicBlock::DFB`] child graph with `inputs`
-    /// and `outputs` and the variants of the branching Choice Sum value
-    /// specified by `choice_variants`.
+    /// and `outputs` and the variants of the branching TupleSum value
+    /// specified by `tuple_sum_rows`.
     ///
     /// # Errors
     ///
@@ -112,13 +112,13 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
     pub fn block_builder(
         &mut self,
         inputs: TypeRow,
-        choice_variants: Vec<TypeRow>,
+        tuple_sum_rows: impl IntoIterator<Item = TypeRow>,
         extension_delta: ExtensionSet,
         other_outputs: TypeRow,
     ) -> Result<BlockBuilder<&mut Hugr>, BuildError> {
         self.any_block_builder(
             inputs,
-            choice_variants,
+            tuple_sum_rows,
             other_outputs,
             extension_delta,
             false,
@@ -128,15 +128,16 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
     fn any_block_builder(
         &mut self,
         inputs: TypeRow,
-        choice_variants: Vec<TypeRow>,
+        tuple_sum_rows: impl IntoIterator<Item = TypeRow>,
         other_outputs: TypeRow,
         extension_delta: ExtensionSet,
         entry: bool,
     ) -> Result<BlockBuilder<&mut Hugr>, BuildError> {
+        let tuple_sum_rows: Vec<_> = tuple_sum_rows.into_iter().collect();
         let op = OpType::BasicBlock(BasicBlock::DFB {
             inputs: inputs.clone(),
             other_outputs: other_outputs.clone(),
-            choice_variants: choice_variants.clone(),
+            tuple_sum_rows: tuple_sum_rows.clone(),
             extension_delta,
         });
         let parent = self.container_node();
@@ -152,14 +153,14 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
         BlockBuilder::create(
             self.hugr_mut(),
             block_n,
-            choice_variants,
+            tuple_sum_rows,
             other_outputs,
             inputs,
         )
     }
 
     /// Return a builder for a non-entry [`BasicBlock::DFB`] child graph with `inputs`
-    /// and `outputs` and a unit Choice type: a Sum of `n_cases` unit types.
+    /// and `outputs` and a UnitSum type: a Sum of `n_cases` unit types.
     ///
     /// # Errors
     ///
@@ -178,15 +179,15 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
     }
 
     /// Return a builder for the entry [`BasicBlock::DFB`] child graph with `inputs`
-    /// and `outputs` and the variants of the branching Choice Sum value
-    /// specified by `choice_variants`.
+    /// and `outputs` and the variants of the branching TupleSum value
+    /// specified by `tuple_sum_rows`.
     ///
     /// # Errors
     ///
     /// This function will return an error if an entry block has already been built.
     pub fn entry_builder(
         &mut self,
-        choice_variants: Vec<TypeRow>,
+        tuple_sum_rows: impl IntoIterator<Item = TypeRow>,
         other_outputs: TypeRow,
         extension_delta: ExtensionSet,
     ) -> Result<BlockBuilder<&mut Hugr>, BuildError> {
@@ -194,17 +195,11 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
             .inputs
             .take()
             .ok_or(BuildError::EntryBuiltError(self.cfg_node))?;
-        self.any_block_builder(
-            inputs,
-            choice_variants,
-            other_outputs,
-            extension_delta,
-            true,
-        )
+        self.any_block_builder(inputs, tuple_sum_rows, other_outputs, extension_delta, true)
     }
 
     /// Return a builder for the entry [`BasicBlock::DFB`] child graph with `inputs`
-    /// and `outputs` and a unit Choice type: a Sum of `n_cases` unit types.
+    /// and `outputs` and a UnitSum type: a Sum of `n_cases` unit types.
     ///
     /// # Errors
     ///
@@ -244,8 +239,8 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
 pub type BlockBuilder<B> = DFGWrapper<B, BasicBlockID>;
 
 impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
-    /// Set the outputs of the block, with `branch_wire` being the value of the
-    /// Choice.  `outputs` are the remaining outputs.
+    /// Set the outputs of the block, with `branch_wire` carrying  the value of the
+    /// branch controlling TupleSum value.  `outputs` are the remaining outputs.
     pub fn set_outputs(
         &mut self,
         branch_wire: Wire,
@@ -256,13 +251,13 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
     fn create(
         base: B,
         block_n: Node,
-        choice_variants: Vec<TypeRow>,
+        tuple_sum_rows: impl IntoIterator<Item = TypeRow>,
         other_outputs: TypeRow,
         inputs: TypeRow,
     ) -> Result<Self, BuildError> {
-        // The node outputs a Choice before the data outputs of the block node
-        let choice_type = Type::new_choice(choice_variants);
-        let mut node_outputs = vec![choice_type];
+        // The node outputs a TupleSum before the data outputs of the block node
+        let tuple_sum_type = Type::new_tuple_sum(tuple_sum_rows);
+        let mut node_outputs = vec![tuple_sum_type];
         node_outputs.extend_from_slice(&other_outputs);
         let signature = FunctionType::new(inputs, TypeRow::from(node_outputs));
         let inp_ex = base
@@ -293,23 +288,23 @@ impl BlockBuilder<Hugr> {
     pub fn new(
         inputs: impl Into<TypeRow>,
         input_extensions: impl Into<Option<ExtensionSet>>,
-        choice_variants: impl IntoIterator<Item = TypeRow>,
+        tuple_sum_rows: impl IntoIterator<Item = TypeRow>,
         other_outputs: impl Into<TypeRow>,
         extension_delta: ExtensionSet,
     ) -> Result<Self, BuildError> {
         let inputs = inputs.into();
-        let choice_variants: Vec<_> = choice_variants.into_iter().collect();
+        let tuple_sum_rows: Vec<_> = tuple_sum_rows.into_iter().collect();
         let other_outputs = other_outputs.into();
         let op = BasicBlock::DFB {
             inputs: inputs.clone(),
             other_outputs: other_outputs.clone(),
-            choice_variants: choice_variants.clone(),
+            tuple_sum_rows: tuple_sum_rows.clone(),
             extension_delta,
         };
 
         let base = Hugr::new(NodeType::new(op, input_extensions));
         let root = base.root();
-        Self::create(base, root, choice_variants, other_outputs, inputs)
+        Self::create(base, root, tuple_sum_rows, other_outputs, inputs)
     }
 
     /// [Set outputs](BlockBuilder::set_outputs) and [finish_hugr](`BlockBuilder::finish_hugr`).
@@ -382,14 +377,13 @@ mod test {
         let entry = {
             let [inw] = entry_b.input_wires_arr();
 
-            let sum = entry_b.make_choice(1, sum2_variants, [inw])?;
+            let sum = entry_b.make_tuple_sum(1, sum2_variants, [inw])?;
             entry_b.finish_with_outputs(sum, [])?
         };
         let mut middle_b = cfg_builder
             .simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?;
         let middle = {
-            let c =
-                middle_b.add_load_const(ops::Const::unary_unit_choice(), ExtensionSet::new())?;
+            let c = middle_b.add_load_const(ops::Const::unary_unit_sum(), ExtensionSet::new())?;
             let [inw] = middle_b.input_wires_arr();
             middle_b.finish_with_outputs(c, [inw])?
         };

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -159,7 +159,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
     }
 
     /// Return a builder for a non-entry [`BasicBlock::DFB`] child graph with `inputs`
-    /// and `outputs` and a unit choice type: a Sum of `n_cases` unit types.
+    /// and `outputs` and a unit Choice type: a Sum of `n_cases` unit types.
     ///
     /// # Errors
     ///
@@ -204,7 +204,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
     }
 
     /// Return a builder for the entry [`BasicBlock::DFB`] child graph with `inputs`
-    /// and `outputs` and a unit choice type: a Sum of `n_cases` unit types.
+    /// and `outputs` and a unit Choice type: a Sum of `n_cases` unit types.
     ///
     /// # Errors
     ///

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -158,20 +158,20 @@ impl HugrBuilder for ConditionalBuilder<Hugr> {
 impl ConditionalBuilder<Hugr> {
     /// Initialize a Conditional rooted HUGR builder
     pub fn new(
-        predicate_inputs: impl IntoIterator<Item = TypeRow>,
+        choice_inputs: impl IntoIterator<Item = TypeRow>,
         other_inputs: impl Into<TypeRow>,
         outputs: impl Into<TypeRow>,
         extension_delta: ExtensionSet,
     ) -> Result<Self, BuildError> {
-        let predicate_inputs: Vec<_> = predicate_inputs.into_iter().collect();
+        let choice_inputs: Vec<_> = choice_inputs.into_iter().collect();
         let other_inputs = other_inputs.into();
         let outputs = outputs.into();
 
         let n_out_wires = outputs.len();
-        let n_cases = predicate_inputs.len();
+        let n_cases = choice_inputs.len();
 
         let op = ops::Conditional {
-            predicate_inputs,
+            choice_inputs,
             other_inputs,
             outputs,
             extension_delta,
@@ -222,9 +222,9 @@ mod test {
 
     #[test]
     fn basic_conditional() -> Result<(), BuildError> {
-        let predicate_inputs = vec![type_row![]; 2];
+        let choice_inputs = vec![type_row![]; 2];
         let mut conditional_b = ConditionalBuilder::new(
-            predicate_inputs,
+            choice_inputs,
             type_row![NAT],
             type_row![NAT],
             ExtensionSet::new(),
@@ -248,11 +248,11 @@ mod test {
                 let const_wire = fbuild.load_const(&tru_const)?;
                 let [int] = fbuild.input_wires_arr();
                 let conditional_id = {
-                    let predicate_inputs = vec![type_row![]; 2];
+                    let choice_inputs = vec![type_row![]; 2];
                     let other_inputs = vec![(NAT, int)];
                     let outputs = vec![NAT].into();
                     let mut conditional_b = fbuild.conditional_builder(
-                        (predicate_inputs, const_wire),
+                        (choice_inputs, const_wire),
                         other_inputs,
                         outputs,
                         ExtensionSet::new(),
@@ -276,13 +276,9 @@ mod test {
 
     #[test]
     fn test_not_all_cases() -> Result<(), BuildError> {
-        let predicate_inputs = vec![type_row![]; 2];
-        let mut builder = ConditionalBuilder::new(
-            predicate_inputs,
-            type_row![],
-            type_row![],
-            ExtensionSet::new(),
-        )?;
+        let choice_inputs = vec![type_row![]; 2];
+        let mut builder =
+            ConditionalBuilder::new(choice_inputs, type_row![], type_row![], ExtensionSet::new())?;
         n_identity(builder.case_builder(0)?)?;
         assert_matches!(
             builder.finish_sub_container().map(|_| ()),
@@ -295,13 +291,9 @@ mod test {
 
     #[test]
     fn test_case_already_built() -> Result<(), BuildError> {
-        let predicate_inputs = vec![type_row![]; 2];
-        let mut builder = ConditionalBuilder::new(
-            predicate_inputs,
-            type_row![],
-            type_row![],
-            ExtensionSet::new(),
-        )?;
+        let choice_inputs = vec![type_row![]; 2];
+        let mut builder =
+            ConditionalBuilder::new(choice_inputs, type_row![], type_row![], ExtensionSet::new())?;
         n_identity(builder.case_builder(0)?)?;
         assert_matches!(
             builder.case_builder(0).map(|_| ()),

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -158,20 +158,20 @@ impl HugrBuilder for ConditionalBuilder<Hugr> {
 impl ConditionalBuilder<Hugr> {
     /// Initialize a Conditional rooted HUGR builder
     pub fn new(
-        choice_inputs: impl IntoIterator<Item = TypeRow>,
+        tuple_sum_rows: impl IntoIterator<Item = TypeRow>,
         other_inputs: impl Into<TypeRow>,
         outputs: impl Into<TypeRow>,
         extension_delta: ExtensionSet,
     ) -> Result<Self, BuildError> {
-        let choice_inputs: Vec<_> = choice_inputs.into_iter().collect();
+        let tuple_sum_rows: Vec<_> = tuple_sum_rows.into_iter().collect();
         let other_inputs = other_inputs.into();
         let outputs = outputs.into();
 
         let n_out_wires = outputs.len();
-        let n_cases = choice_inputs.len();
+        let n_cases = tuple_sum_rows.len();
 
         let op = ops::Conditional {
-            choice_inputs,
+            tuple_sum_rows,
             other_inputs,
             outputs,
             extension_delta,
@@ -222,9 +222,8 @@ mod test {
 
     #[test]
     fn basic_conditional() -> Result<(), BuildError> {
-        let choice_inputs = vec![type_row![]; 2];
         let mut conditional_b = ConditionalBuilder::new(
-            choice_inputs,
+            [type_row![], type_row![]],
             type_row![NAT],
             type_row![NAT],
             ExtensionSet::new(),
@@ -248,11 +247,10 @@ mod test {
                 let const_wire = fbuild.load_const(&tru_const)?;
                 let [int] = fbuild.input_wires_arr();
                 let conditional_id = {
-                    let choice_inputs = vec![type_row![]; 2];
                     let other_inputs = vec![(NAT, int)];
                     let outputs = vec![NAT].into();
                     let mut conditional_b = fbuild.conditional_builder(
-                        (choice_inputs, const_wire),
+                        ([type_row![], type_row![]], const_wire),
                         other_inputs,
                         outputs,
                         ExtensionSet::new(),
@@ -276,9 +274,12 @@ mod test {
 
     #[test]
     fn test_not_all_cases() -> Result<(), BuildError> {
-        let choice_inputs = vec![type_row![]; 2];
-        let mut builder =
-            ConditionalBuilder::new(choice_inputs, type_row![], type_row![], ExtensionSet::new())?;
+        let mut builder = ConditionalBuilder::new(
+            [type_row![], type_row![]],
+            type_row![],
+            type_row![],
+            ExtensionSet::new(),
+        )?;
         n_identity(builder.case_builder(0)?)?;
         assert_matches!(
             builder.finish_sub_container().map(|_| ()),
@@ -291,9 +292,12 @@ mod test {
 
     #[test]
     fn test_case_already_built() -> Result<(), BuildError> {
-        let choice_inputs = vec![type_row![]; 2];
-        let mut builder =
-            ConditionalBuilder::new(choice_inputs, type_row![], type_row![], ExtensionSet::new())?;
+        let mut builder = ConditionalBuilder::new(
+            [type_row![], type_row![]],
+            type_row![],
+            type_row![],
+            ExtensionSet::new(),
+        )?;
         n_identity(builder.case_builder(0)?)?;
         assert_matches!(
             builder.case_builder(0).map(|_| ()),

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -26,7 +26,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
         Ok(TailLoopBuilder::from_dfg_builder(dfg_build))
     }
     /// Set the outputs of the [`ops::TailLoop`], with `out_variant` as the value of the
-    /// termination Choice, and `rest` being the remaining outputs
+    /// termination TupleSum, and `rest` being the remaining outputs
     pub fn set_outputs(
         &mut self,
         out_variant: Wire,
@@ -48,7 +48,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
         }
     }
 
-    /// The output types of the child graph, including the Choice as the first.
+    /// The output types of the child graph, including the TupleSum as the first.
     pub fn internal_output_row(&self) -> Result<TypeRow, BuildError> {
         self.loop_signature().map(ops::TailLoop::body_output_row)
     }
@@ -152,10 +152,9 @@ mod test {
                     let [const_wire] = lift_node.outputs_arr();
                     let [b1] = loop_b.input_wires_arr();
                     let conditional_id = {
-                        let choice_inputs = vec![type_row![]; 2];
                         let output_row = loop_b.internal_output_row()?;
                         let mut conditional_b = loop_b.conditional_builder(
-                            (choice_inputs, const_wire),
+                            ([type_row![], type_row![]], const_wire),
                             vec![(BIT, b1)],
                             output_row,
                             ExtensionSet::new(),

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -26,7 +26,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
         Ok(TailLoopBuilder::from_dfg_builder(dfg_build))
     }
     /// Set the outputs of the [`ops::TailLoop`], with `out_variant` as the value of the
-    /// termination predicate, and `rest` being the remaining outputs
+    /// termination Choice, and `rest` being the remaining outputs
     pub fn set_outputs(
         &mut self,
         out_variant: Wire,
@@ -48,7 +48,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
         }
     }
 
-    /// The output types of the child graph, including the predicate as the first.
+    /// The output types of the child graph, including the Choice as the first.
     pub fn internal_output_row(&self) -> Result<TypeRow, BuildError> {
         self.loop_signature().map(ops::TailLoop::body_output_row)
     }
@@ -152,10 +152,10 @@ mod test {
                     let [const_wire] = lift_node.outputs_arr();
                     let [b1] = loop_b.input_wires_arr();
                     let conditional_id = {
-                        let predicate_inputs = vec![type_row![]; 2];
+                        let choice_inputs = vec![type_row![]; 2];
                         let output_row = loop_b.internal_output_row()?;
                         let mut conditional_b = loop_b.conditional_builder(
-                            (predicate_inputs, const_wire),
+                            (choice_inputs, const_wire),
                             vec![(BIT, b1)],
                             output_row,
                             ExtensionSet::new(),

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -1028,14 +1028,14 @@ mod test {
             Ok(case)
         }
 
-        let predicate_inputs = vec![type_row![]; 2];
+        let choice_inputs = vec![type_row![]; 2];
         let rs = ExtensionSet::from_iter([A, B]);
 
         let inputs = type_row![NAT];
         let outputs = type_row![NAT];
 
         let op = ops::Conditional {
-            predicate_inputs,
+            choice_inputs,
             other_inputs: inputs.clone(),
             outputs: outputs.clone(),
             extension_delta: rs.clone(),

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -1050,14 +1050,14 @@ mod test {
             Ok(case)
         }
 
-        let choice_inputs = vec![type_row![]; 2];
+        let tuple_sum_rows = vec![type_row![]; 2];
         let rs = ExtensionSet::from_iter([A, B]);
 
         let inputs = type_row![NAT];
         let outputs = type_row![NAT];
 
         let op = ops::Conditional {
-            choice_inputs,
+            tuple_sum_rows,
             other_inputs: inputs.clone(),
             outputs: outputs.clone(),
             extension_delta: rs.clone(),
@@ -1171,16 +1171,17 @@ mod test {
         hugr: &mut Hugr,
         bb_parent: Node,
         inputs: TypeRow,
-        choice_variants: Vec<TypeRow>,
+        tuple_sum_rows: impl IntoIterator<Item = TypeRow>,
         extension_delta: ExtensionSet,
     ) -> Result<Node, Box<dyn Error>> {
-        let choice_type = Type::new_choice(choice_variants.clone());
-        let dfb_sig = FunctionType::new(inputs.clone(), vec![choice_type])
+        let tuple_sum_rows: Vec<_> = tuple_sum_rows.into_iter().collect();
+        let tuple_sum_type = Type::new_tuple_sum(tuple_sum_rows.clone());
+        let dfb_sig = FunctionType::new(inputs.clone(), vec![tuple_sum_type])
             .with_extension_delta(&extension_delta.clone());
         let dfb = ops::BasicBlock::DFB {
             inputs,
             other_outputs: type_row![],
-            choice_variants,
+            tuple_sum_rows,
             extension_delta,
         };
         let op = make_opaque(PRELUDE_ID, dfb_sig.clone());
@@ -1196,11 +1197,11 @@ mod test {
     }
 
     fn oneway(ty: Type) -> Vec<Type> {
-        vec![Type::new_choice([vec![ty]])]
+        vec![Type::new_tuple_sum([vec![ty]])]
     }
 
     fn twoway(ty: Type) -> Vec<Type> {
-        vec![Type::new_choice([vec![ty.clone()], vec![ty]])]
+        vec![Type::new_tuple_sum([vec![ty.clone()], vec![ty]])]
     }
 
     fn create_entry_exit(
@@ -1211,11 +1212,11 @@ mod test {
         entry_extensions: ExtensionSet,
         exit_types: impl Into<TypeRow>,
     ) -> Result<([Node; 3], Node), Box<dyn Error>> {
-        let entry_predicate_type = Type::new_choice(entry_predicates.clone());
+        let entry_predicate_type = Type::new_tuple_sum(entry_predicates.clone());
         let dfb = ops::BasicBlock::DFB {
             inputs: inputs.clone(),
             other_outputs: type_row![],
-            choice_variants: entry_predicates,
+            tuple_sum_rows: entry_predicates,
             extension_delta: entry_extensions,
         };
 

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -1206,15 +1206,15 @@ mod test {
         hugr: &mut Hugr,
         root: Node,
         inputs: TypeRow,
-        entry_predicates: Vec<TypeRow>,
+        entry_variants: Vec<TypeRow>,
         entry_extensions: ExtensionSet,
         exit_types: impl Into<TypeRow>,
     ) -> Result<([Node; 3], Node), Box<dyn Error>> {
-        let entry_predicate_type = Type::new_tuple_sum(entry_predicates.clone());
+        let entry_tuple_sum = Type::new_tuple_sum(entry_variants.clone());
         let dfb = ops::BasicBlock::DFB {
             inputs: inputs.clone(),
             other_outputs: type_row![],
-            tuple_sum_rows: entry_predicates,
+            tuple_sum_rows: entry_variants,
             extension_delta: entry_extensions,
         };
 
@@ -1233,7 +1233,7 @@ mod test {
         let entry_out = hugr.add_node_with_parent(
             entry,
             NodeType::open_extensions(ops::Output {
-                types: vec![entry_predicate_type].into(),
+                types: vec![entry_tuple_sum].into(),
             }),
         )?;
 

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -86,7 +86,7 @@ pub const QB_T: Type = Type::new_extension(QB_CUSTOM_T);
 /// Unsigned size type.
 pub const USIZE_T: Type = Type::new_extension(USIZE_CUSTOM_T);
 /// Boolean type - Sum of two units.
-pub const BOOL_T: Type = Type::new_unit_choice(2);
+pub const BOOL_T: Type = Type::new_unit_sum(2);
 
 /// Initialize a new array of element type `element_ty` of length `size`
 pub fn array_type(element_ty: Type, size: u64) -> Type {

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -86,7 +86,7 @@ pub const QB_T: Type = Type::new_extension(QB_CUSTOM_T);
 /// Unsigned size type.
 pub const USIZE_T: Type = Type::new_extension(USIZE_CUSTOM_T);
 /// Boolean type - Sum of two units.
-pub const BOOL_T: Type = Type::new_simple_predicate(2);
+pub const BOOL_T: Type = Type::new_unit_choice(2);
 
 /// Initialize a new array of element type `element_ty` of length `size`
 pub fn array_type(element_ty: Type, size: u64) -> Type {

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -135,10 +135,10 @@ impl Rewrite for OutlineCfg {
                 .cfg_builder(wires_in, input_extensions, outputs, extension_delta)
                 .unwrap();
             let cfg = cfg.finish_sub_container().unwrap();
-            let predicate = new_block_bldr
-                .add_constant(ops::Const::simple_unary_predicate(), ExtensionSet::new())
+            let choice = new_block_bldr
+                .add_constant(ops::Const::unary_unit_choice(), ExtensionSet::new())
                 .unwrap();
-            let pred_wire = new_block_bldr.load_const(&predicate).unwrap();
+            let pred_wire = new_block_bldr.load_const(&choice).unwrap();
             new_block_bldr
                 .set_outputs(pred_wire, cfg.outputs())
                 .unwrap();

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -139,10 +139,10 @@ impl Rewrite for OutlineCfg {
                 .cfg_builder(wires_in, input_extensions, outputs, extension_delta)
                 .unwrap();
             let cfg = cfg.finish_sub_container().unwrap();
-            let choice = new_block_bldr
-                .add_constant(ops::Const::unary_unit_choice(), ExtensionSet::new())
+            let unit_sum = new_block_bldr
+                .add_constant(ops::Const::unary_unit_sum(), ExtensionSet::new())
                 .unwrap();
-            let pred_wire = new_block_bldr.load_const(&choice).unwrap();
+            let pred_wire = new_block_bldr.load_const(&unit_sum).unwrap();
             new_block_bldr
                 .set_outputs(pred_wire, cfg.outputs())
                 .unwrap();

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -776,18 +776,18 @@ mod test {
         (input, copy, output)
     }
 
-    /// Adds an input{BOOL_T}, tag_constant(0, BOOL_T^pred_size), tag(BOOL_T^pred_size), and
-    /// output{Sum{unit^pred_size}, BOOL_T} operation to a dataflow container.
+    /// Adds an input{BOOL_T}, tag_constant(0, BOOL_T^tuple_sum_size), tag(BOOL_T^tuple_sum_size), and
+    /// output{Sum{unit^tuple_sum_size}, BOOL_T} operation to a dataflow container.
     /// Intended to be used to populate a BasicBlock node in a CFG.
     ///
     /// Returns the node indices of each of the operations.
     fn add_block_children(
         b: &mut Hugr,
         parent: Node,
-        choice_size: usize,
+        tuple_sum_size: usize,
     ) -> (Node, Node, Node, Node) {
-        let const_op = ops::Const::unit_choice(0, choice_size as u8);
-        let tag_type = Type::new_unit_choice(choice_size as u8);
+        let const_op = ops::Const::unit_sum(0, tuple_sum_size as u8);
+        let tag_type = Type::new_unit_sum(tuple_sum_size as u8);
 
         let input = b
             .add_op_with_parent(parent, ops::Input::new(type_row![BOOL_T]))
@@ -993,7 +993,7 @@ mod test {
                 cfg,
                 ops::BasicBlock::DFB {
                     inputs: type_row![BOOL_T],
-                    choice_variants: vec![type_row![]],
+                    tuple_sum_rows: vec![type_row![]],
                     other_outputs: type_row![BOOL_T],
                     extension_delta: ExtensionSet::new(),
                 },
@@ -1034,7 +1034,7 @@ mod test {
             block,
             NodeType::pure(ops::BasicBlock::DFB {
                 inputs: type_row![Q],
-                choice_variants: vec![type_row![]],
+                tuple_sum_rows: vec![type_row![]],
                 other_outputs: type_row![Q],
                 extension_delta: ExtensionSet::new(),
             }),
@@ -1047,7 +1047,7 @@ mod test {
             .unwrap();
         b.replace_op(
             block_output,
-            NodeType::pure(ops::Output::new(type_row![Type::new_unit_choice(1), Q])),
+            NodeType::pure(ops::Output::new(type_row![Type::new_unit_sum(1), Q])),
         )
         .unwrap();
         assert_matches!(

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -784,10 +784,10 @@ mod test {
     fn add_block_children(
         b: &mut Hugr,
         parent: Node,
-        predicate_size: usize,
+        choice_size: usize,
     ) -> (Node, Node, Node, Node) {
-        let const_op = ops::Const::simple_predicate(0, predicate_size as u8);
-        let tag_type = Type::new_simple_predicate(predicate_size as u8);
+        let const_op = ops::Const::unit_choice(0, choice_size as u8);
+        let tag_type = Type::new_unit_choice(choice_size as u8);
 
         let input = b
             .add_op_with_parent(parent, ops::Input::new(type_row![BOOL_T]))
@@ -988,7 +988,7 @@ mod test {
                 cfg,
                 ops::BasicBlock::DFB {
                     inputs: type_row![BOOL_T],
-                    predicate_variants: vec![type_row![]],
+                    choice_variants: vec![type_row![]],
                     other_outputs: type_row![BOOL_T],
                     extension_delta: ExtensionSet::new(),
                 },
@@ -1029,7 +1029,7 @@ mod test {
             block,
             NodeType::pure(ops::BasicBlock::DFB {
                 inputs: type_row![Q],
-                predicate_variants: vec![type_row![]],
+                choice_variants: vec![type_row![]],
                 other_outputs: type_row![Q],
                 extension_delta: ExtensionSet::new(),
             }),
@@ -1040,10 +1040,7 @@ mod test {
         b.replace_op(block_input, NodeType::pure(ops::Input::new(type_row![Q])));
         b.replace_op(
             block_output,
-            NodeType::pure(ops::Output::new(type_row![
-                Type::new_simple_predicate(1),
-                Q
-            ])),
+            NodeType::pure(ops::Output::new(type_row![Type::new_unit_choice(1), Q])),
         );
         assert_matches!(
             b.validate(&EMPTY_REG),

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -97,7 +97,7 @@ mod test {
         let bb = NodeType::pure(BasicBlock::DFB {
             inputs: type_row![],
             other_outputs: type_row![],
-            choice_variants: vec![type_row![]],
+            tuple_sum_rows: vec![type_row![]],
             extension_delta: ExtensionSet::new(),
         });
         let r = dfg_v.replace_op(root, bb.clone());

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -34,7 +34,7 @@ impl Const {
         &self.typ
     }
 
-    /// Sum of Tuples, used  for branching.
+    /// Sum of Tuples, used for branching.
     /// Tuple rows are defined in order by input rows.
     pub fn tuple_sum(
         tag: usize,

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -55,10 +55,7 @@ impl Const {
 
     /// Constant Sum over units, with only one variant.
     pub fn unary_unit_choice() -> Self {
-        Self {
-            value: Value::unary_unit_choice(),
-            typ: Type::new_unit_choice(1),
-        }
+        Self::unit_choice(0, 1)
     }
 
     /// Constant "true" value, i.e. the second variant of Sum((), ()).

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -36,36 +36,36 @@ impl Const {
 
     /// Sum of Tuples, used  for branching.
     /// Tuple rows are defined in order by input rows.
-    pub fn choice(
+    pub fn tuple_sum(
         tag: usize,
         value: Value,
         variant_rows: impl IntoIterator<Item = TypeRow>,
     ) -> Result<Self, ConstTypeError> {
-        let typ = Type::new_choice(variant_rows);
+        let typ = Type::new_tuple_sum(variant_rows);
         Self::new(Value::sum(tag, value), typ)
     }
 
     /// Constant Sum over units, used as branching values.
-    pub fn unit_choice(tag: usize, size: u8) -> Self {
+    pub fn unit_sum(tag: usize, size: u8) -> Self {
         Self {
-            value: Value::unit_choice(tag),
-            typ: Type::new_unit_choice(size),
+            value: Value::unit_sum(tag),
+            typ: Type::new_unit_sum(size),
         }
     }
 
     /// Constant Sum over units, with only one variant.
-    pub fn unary_unit_choice() -> Self {
-        Self::unit_choice(0, 1)
+    pub fn unary_unit_sum() -> Self {
+        Self::unit_sum(0, 1)
     }
 
     /// Constant "true" value, i.e. the second variant of Sum((), ()).
     pub fn true_val() -> Self {
-        Self::unit_choice(1, 2)
+        Self::unit_sum(1, 2)
     }
 
     /// Constant "false" value, i.e. the first variant of Sum((), ()).
     pub fn false_val() -> Self {
-        Self::unit_choice(0, 2)
+        Self::unit_sum(0, 2)
     }
 
     /// Tuple of values
@@ -139,17 +139,17 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_choice() -> Result<(), BuildError> {
+    fn test_tuple_sum() -> Result<(), BuildError> {
         use crate::builder::Container;
         let pred_rows = vec![type_row![USIZE_T, FLOAT64_TYPE], type_row![]];
-        let pred_ty = Type::new_choice(pred_rows.clone());
+        let pred_ty = Type::new_tuple_sum(pred_rows.clone());
 
         let mut b = DFGBuilder::new(FunctionType::new(
             type_row![],
             TypeRow::from(vec![pred_ty.clone()]),
         ))?;
         let c = b.add_constant(
-            Const::choice(
+            Const::tuple_sum(
                 0,
                 Value::tuple([CustomTestValue(TypeBound::Eq).into(), serialized_float(5.1)]),
                 pred_rows.clone(),
@@ -161,7 +161,7 @@ mod test {
 
         let mut b = DFGBuilder::new(FunctionType::new(type_row![], TypeRow::from(vec![pred_ty])))?;
         let c = b.add_constant(
-            Const::choice(1, Value::unit(), pred_rows)?,
+            Const::tuple_sum(1, Value::unit(), pred_rows)?,
             ExtensionSet::new(),
         )?;
         let w = b.load_const(&c)?;
@@ -171,10 +171,10 @@ mod test {
     }
 
     #[test]
-    fn test_bad_choice() {
+    fn test_bad_tuple_sum() {
         let pred_rows = [type_row![USIZE_T, FLOAT64_TYPE], type_row![]];
 
-        let res = Const::choice(0, Value::tuple([]), pred_rows);
+        let res = Const::tuple_sum(0, Value::tuple([]), pred_rows);
         assert_matches!(res, Err(ConstTypeError::TupleWrongLength));
     }
 

--- a/src/ops/controlflow.rs
+++ b/src/ops/controlflow.rs
@@ -32,7 +32,7 @@ impl DataflowOpTrait for TailLoop {
 
     fn signature(&self) -> FunctionType {
         let [inputs, outputs] =
-            [&self.just_inputs, &self.just_outputs].map(|row| choice_first(row, &self.rest));
+            [&self.just_inputs, &self.just_outputs].map(|row| tuple_sum_first(row, &self.rest));
         FunctionType::new(inputs, outputs)
     }
 }
@@ -40,23 +40,24 @@ impl DataflowOpTrait for TailLoop {
 impl TailLoop {
     /// Build the output TypeRow of the child graph of a TailLoop node.
     pub(crate) fn body_output_row(&self) -> TypeRow {
-        let choice = Type::new_choice([self.just_inputs.clone(), self.just_outputs.clone()]);
-        let mut outputs = vec![choice];
+        let tuple_sum_type =
+            Type::new_tuple_sum([self.just_inputs.clone(), self.just_outputs.clone()]);
+        let mut outputs = vec![tuple_sum_type];
         outputs.extend_from_slice(&self.rest);
         outputs.into()
     }
 
     /// Build the input TypeRow of the child graph of a TailLoop node.
     pub(crate) fn body_input_row(&self) -> TypeRow {
-        choice_first(&self.just_inputs, &self.rest)
+        tuple_sum_first(&self.just_inputs, &self.rest)
     }
 }
 
 /// Conditional operation, defined by child `Case` nodes for each branch.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Conditional {
-    /// The possible rows of the Choice input
-    pub choice_inputs: Vec<TypeRow>,
+    /// The possible rows of the TupleSum input
+    pub tuple_sum_rows: Vec<TypeRow>,
     /// Remaining input types
     pub other_inputs: TypeRow,
     /// Output types
@@ -77,7 +78,7 @@ impl DataflowOpTrait for Conditional {
         let mut inputs = self.other_inputs.clone();
         inputs
             .to_mut()
-            .insert(0, Type::new_choice(self.choice_inputs.clone()));
+            .insert(0, Type::new_tuple_sum(self.tuple_sum_rows.clone()));
         FunctionType::new(inputs, self.outputs.clone()).with_extension_delta(&self.extension_delta)
     }
 }
@@ -85,8 +86,8 @@ impl DataflowOpTrait for Conditional {
 impl Conditional {
     /// Build the input TypeRow of the nth child graph of a Conditional node.
     pub(crate) fn case_input_row(&self, case: usize) -> Option<TypeRow> {
-        Some(choice_first(
-            self.choice_inputs.get(case)?,
+        Some(tuple_sum_first(
+            self.tuple_sum_rows.get(case)?,
             &self.other_inputs,
         ))
     }
@@ -122,7 +123,7 @@ pub enum BasicBlock {
     DFB {
         inputs: TypeRow,
         other_outputs: TypeRow,
-        choice_variants: Vec<TypeRow>,
+        tuple_sum_rows: Vec<TypeRow>,
         extension_delta: ExtensionSet,
     },
     /// The single exit node of the CFG, has no children,
@@ -192,10 +193,10 @@ impl BasicBlock {
     pub fn successor_input(&self, successor: usize) -> Option<TypeRow> {
         match self {
             BasicBlock::DFB {
-                choice_variants,
+                tuple_sum_rows,
                 other_outputs: outputs,
                 ..
-            } => Some(choice_first(choice_variants.get(successor)?, outputs)),
+            } => Some(tuple_sum_first(tuple_sum_rows.get(successor)?, outputs)),
             BasicBlock::Exit { .. } => panic!("Exit should have no successors"),
         }
     }
@@ -240,9 +241,9 @@ impl Case {
     }
 }
 
-fn choice_first(choice: &TypeRow, rest: &TypeRow) -> TypeRow {
+fn tuple_sum_first(tuple_sum_row: &TypeRow, rest: &TypeRow) -> TypeRow {
     TypeRow::from(
-        choice
+        tuple_sum_row
             .iter()
             .cloned()
             .chain(rest.iter().cloned())

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -93,10 +93,10 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_value(FALSE_NAME, ops::Const::unit_choice(0, 2))
+        .add_value(FALSE_NAME, ops::Const::unit_sum(0, 2))
         .unwrap();
     extension
-        .add_value(TRUE_NAME, ops::Const::unit_choice(1, 2))
+        .add_value(TRUE_NAME, ops::Const::unit_sum(1, 2))
         .unwrap();
     extension
 }

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -93,10 +93,10 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_value(FALSE_NAME, ops::Const::simple_predicate(0, 2))
+        .add_value(FALSE_NAME, ops::Const::unit_choice(0, 2))
         .unwrap();
     extension
-        .add_value(TRUE_NAME, ops::Const::simple_predicate(1, 2))
+        .add_value(TRUE_NAME, ops::Const::unit_choice(1, 2))
         .unwrap();
     extension
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -254,7 +254,7 @@ impl Type {
         Self::new_sum(choice_variant_row(variant_rows))
     }
 
-    /// New unit choice with empty Tuple variants
+    /// New unit Choice with empty Tuple variants
     pub const fn new_unit_choice(size: u8) -> Self {
         // should be the only way to avoid going through SumType::new
         Self(TypeEnum::Sum(SumType::Simple { size }), TypeBound::Eq)

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -80,7 +80,7 @@ mod test {
         let t = Type::new_sum(vec![USIZE_T, FLOAT64_TYPE]);
         assert_eq!(ser_roundtrip(&t), t);
 
-        // A unit choice
+        // A unit Choice
         let t = Type::new_unit_choice(4);
         assert_eq!(ser_roundtrip(&t), t);
     }

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -80,8 +80,8 @@ mod test {
         let t = Type::new_sum(vec![USIZE_T, FLOAT64_TYPE]);
         assert_eq!(ser_roundtrip(&t), t);
 
-        // A simple predicate
-        let t = Type::new_simple_predicate(4);
+        // A unit choice
+        let t = Type::new_unit_choice(4);
         assert_eq!(ser_roundtrip(&t), t);
     }
 }

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -80,8 +80,7 @@ mod test {
         let t = Type::new_sum(vec![USIZE_T, FLOAT64_TYPE]);
         assert_eq!(ser_roundtrip(&t), t);
 
-        // A unit Choice
-        let t = Type::new_unit_choice(4);
+        let t = Type::new_unit_sum(4);
         assert_eq!(ser_roundtrip(&t), t);
     }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -97,13 +97,13 @@ impl Value {
     }
 
     /// Constant Sum of a unit value, used to control branches.
-    pub fn unit_choice(tag: usize) -> Self {
+    pub fn unit_sum(tag: usize) -> Self {
         Self::sum(tag, Self::unit())
     }
 
     /// Constant Sum with just one variant of unit type
-    pub fn unary_unit_choice() -> Self {
-        Self::unit_choice(0)
+    pub fn unary_unit_sum() -> Self {
+        Self::unit_sum(0)
     }
 
     /// Tuple of values.
@@ -113,7 +113,7 @@ impl Value {
         }
     }
 
-    /// Sum value (could be of any compatible type - e.g., if `value` was a Tuple, a Choice type)
+    /// Sum value (could be of any compatible type - e.g., if `value` was a Tuple, a TupleSum type)
     pub fn sum(tag: usize, value: Value) -> Self {
         Self::Sum {
             tag,

--- a/src/values.rs
+++ b/src/values.rs
@@ -96,14 +96,14 @@ impl Value {
         Self::Tuple { vs: vec![] }
     }
 
-    /// Constant Sum over units, used as predicates.
-    pub fn simple_predicate(tag: usize) -> Self {
+    /// Constant Sum over units, used as branching values.
+    pub fn unit_choice(tag: usize) -> Self {
         Self::sum(tag, Self::unit())
     }
 
     /// Constant Sum over Tuples with just one variant of unit type
-    pub fn simple_unary_predicate() -> Self {
-        Self::simple_predicate(0)
+    pub fn unary_unit_choice() -> Self {
+        Self::unit_choice(0)
     }
 
     /// Tuple of values.
@@ -113,7 +113,7 @@ impl Value {
         }
     }
 
-    /// Sum value (could be of any compatible type, e.g. a predicate)
+    /// Sum value (could be of any compatible type, e.g. a Choice)
     pub fn sum(tag: usize, value: Value) -> Self {
         Self::Sum {
             tag,

--- a/src/values.rs
+++ b/src/values.rs
@@ -96,12 +96,12 @@ impl Value {
         Self::Tuple { vs: vec![] }
     }
 
-    /// Constant Sum over units, used as branching values.
+    /// Constant Sum of a unit value, used to control branches.
     pub fn unit_choice(tag: usize) -> Self {
         Self::sum(tag, Self::unit())
     }
 
-    /// Constant Sum over Tuples with just one variant of unit type
+    /// Constant Sum with just one variant of unit type
     pub fn unary_unit_choice() -> Self {
         Self::unit_choice(0)
     }
@@ -113,7 +113,7 @@ impl Value {
         }
     }
 
-    /// Sum value (could be of any compatible type, e.g. a Choice)
+    /// Sum value (could be of any compatible type - e.g., if `value` was a Tuple, a Choice type)
     pub fn sum(tag: usize, value: Value) -> Self {
         Self::Sum {
             tag,


### PR DESCRIPTION
Closes #448

BREAKING CHANGE: previous uses of type/value constructor methods for "predicates" will need updating