### PR TITLE
Resolve opaque ops during validation (no mutation)

### DIFF
--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -700,10 +700,7 @@ mod test {
 
     use super::*;
     use crate::builder::test::closed_dfg_root_hugr;
-    use crate::extension::{
-        prelude::{PRELUDE_ID, PRELUDE_REGISTRY},
-        ExtensionSet,
-    };
+    use crate::extension::{prelude::PRELUDE_REGISTRY, ExtensionSet};
     use crate::hugr::{validate::ValidationError, Hugr, HugrMut, HugrView, NodeType};
     use crate::macros::const_extension_ids;
     use crate::ops::{self, dataflow::IOTrait, handle::NodeHandle, OpTrait};
@@ -720,6 +717,7 @@ mod test {
         const A: ExtensionId = "A";
         const B: ExtensionId = "B";
         const C: ExtensionId = "C";
+        const UNKNOWN_EXTENSION: ExtensionId = "Unknown";
     }
 
     #[test]
@@ -1183,7 +1181,7 @@ mod test {
             predicate_variants,
             extension_delta,
         };
-        let op = make_opaque(PRELUDE_ID, dfb_sig.clone());
+        let op = make_opaque(UNKNOWN_EXTENSION, dfb_sig.clone());
 
         let [bb, bb_in, bb_out] = create_with_io(hugr, bb_parent, dfb, dfb_sig)?;
 
@@ -1385,7 +1383,7 @@ mod test {
         let entry_mid = hugr.add_node_with_parent(
             entry,
             NodeType::open_extensions(make_opaque(
-                PRELUDE_ID,
+                UNKNOWN_EXTENSION,
                 FunctionType::new(vec![NAT], twoway(NAT)),
             )),
         )?;
@@ -1474,7 +1472,7 @@ mod test {
         let entry_dfg = hugr.add_node_with_parent(
             entry,
             NodeType::open_extensions(make_opaque(
-                PRELUDE_ID,
+                UNKNOWN_EXTENSION,
                 FunctionType::new(vec![NAT], oneway(NAT)).with_extension_delta(&entry_ext),
             )),
         )?;
@@ -1555,7 +1553,7 @@ mod test {
         let entry_mid = hugr.add_node_with_parent(
             entry,
             NodeType::open_extensions(make_opaque(
-                PRELUDE_ID,
+                UNKNOWN_EXTENSION,
                 FunctionType::new(vec![NAT], oneway(NAT)),
             )),
         )?;

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -185,16 +185,6 @@ impl OpDef {
         self.check_args_impl(args)
     }
 
-    /// Check [`OpaqueOp`] is a valid instantiation of this definition.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if the type of the instance does not
-    /// match the definition.
-    pub fn check_opaque(&self, opaque: &OpaqueOp) -> Result<(), SignatureError> {
-        self.check_concrete_impl(opaque)
-    }
-
     /// Instantiate a concrete [`OpaqueOp`] by providing type arguments.
     ///
     /// # Errors

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -180,7 +180,6 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
             };
             // If successful, check TypeArgs are valid for the declared TypeParams
             if let Some(ext_op) = ext_op {
-                // WTF looks like check_opaque might be duplicating some of this?!
                 ext_op
                     .def()
                     .check_args(ext_op.args())

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -18,6 +18,8 @@ use crate::extension::{
     ExtensionRegistry, ExtensionSolution, InferExtensionError,
 };
 
+use crate::ops::custom::CustomOpError;
+use crate::ops::custom::{resolve_opaque_op, ExtensionOp, ExternalOp};
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::{OpTag, OpTrait, OpType, ValidateOp};
 use crate::types::{EdgeKind, Type};
@@ -159,12 +161,29 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
             }
         }
 
-        // Check operation-specific constraints. Firstly that type args are correct
-        // (Good to call `resolve_extension_ops` immediately before this
-        //   - see https://github.com/CQCL-DEV/hugr/issues/508 )
+        // Check operation-specific constraints.
         if let OpType::LeafOp(crate::ops::LeafOp::CustomOp(b)) = op_type {
+            // Check TypeArgs are valid (in themselves, not necessarily wrt the TypeParams)
             for arg in b.args() {
                 arg.validate(self.extension_registry)
+                    .map_err(|cause| ValidationError::SignatureError { node, cause })?;
+            }
+            // Try to resolve serialized names to actual OpDefs in Extensions.
+            let e: Option<ExtensionOp>;
+            let ext_op = match &**b {
+                ExternalOp::Opaque(op) => {
+                    // If resolve_extension_ops has been called first, this would always return Ok(None)
+                    e = resolve_opaque_op(node, op, self.extension_registry)?;
+                    e.as_ref()
+                }
+                ExternalOp::Extension(ext) => Some(ext),
+            };
+            // If successful, check TypeArgs are valid for the declared TypeParams
+            if let Some(ext_op) = ext_op {
+                // WTF looks like check_opaque might be duplicating some of this?!
+                ext_op
+                    .def()
+                    .check_args(ext_op.args())
                     .map_err(|cause| ValidationError::SignatureError { node, cause })?;
             }
         }
@@ -634,6 +653,12 @@ pub enum ValidationError {
     /// Error in a node signature
     #[error("Error in signature of node {node:?}: {cause}")]
     SignatureError { node: Node, cause: SignatureError },
+    /// Error in a [CustomOp] serialized as an [Opaque]
+    ///
+    /// [CustomOp]: crate::ops::LeafOp::CustomOp
+    /// [Opaque]: crate::ops::custom::ExternalOp::Opaque
+    #[error(transparent)]
+    CustomOpError(#[from] CustomOpError),
 }
 
 #[cfg(feature = "pyo3")]

--- a/src/ops/custom.rs
+++ b/src/ops/custom.rs
@@ -291,7 +291,7 @@ pub fn resolve_opaque_op(
 
 /// Errors that arise after loading a Hugr containing opaque ops (serialized just as their names)
 /// when trying to resolve the serialized names against a registry of known Extensions.
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum CustomOpError {
     /// Extension not found, and no signature
     #[error("Unable to resolve operation {0} for node {1:?} with no saved signature")]


### PR DESCRIPTION
* Refactor `resolve_extension_ops` to allow resolving, one node at a time, without mutation
* Use this in validation, to check OpaqueOp's are correct
* Improve the CustomOpError structure a bit
* Remove `check_opaque` - we've just done it properly, and it has no callers
* Update `infer.rs` tests - opaque operations must be from an unknown extension 