### PR TITLE
perf: O(1) optag superset checks

### DIFF
--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -5,4 +5,5 @@ use criterion::criterion_main;
 
 criterion_main! {
     benchmarks::hugr::benches,
+    benchmarks::tag::benches,
 }

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -1,1 +1,2 @@
 pub mod hugr;
+pub mod tag;

--- a/benches/benchmarks/tag.rs
+++ b/benches/benchmarks/tag.rs
@@ -1,0 +1,27 @@
+#![allow(clippy::unit_arg)] // Required for black_box uses
+
+use criterion::{black_box, criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration};
+use hugr::ops::OpTag;
+
+/// Run `OpTag::is_superset`.
+fn bench_superset(c: &mut Criterion) {
+    let mut group = c.benchmark_group("it_works");
+    group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+
+    let tag = OpTag::Const;
+    let parent = OpTag::Any;
+    group.bench_with_input(
+        BenchmarkId::new("tag_superset", format!("{:?}", (tag, parent))),
+        &(tag, parent),
+        |b, &(t, p)| b.iter(|| t.is_superset(p)),
+    );
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets =
+        bench_superset,
+}

--- a/benches/benchmarks/tag.rs
+++ b/benches/benchmarks/tag.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::unit_arg)] // Required for black_box uses
 
-use criterion::{black_box, criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration};
+use criterion::{criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration};
 use hugr::ops::OpTag;
 
 /// Run `OpTag::is_superset`.
 fn bench_superset(c: &mut Criterion) {
-    let mut group = c.benchmark_group("it_works");
+    let mut group = c.benchmark_group("optag");
     group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
     let tag = OpTag::Const;


### PR DESCRIPTION
Pre-computes a superset matrix, so the checks can be done in a single operation.

Adds a benchmark to see the change.
Before the changes:
```
optag/tag_superset/(Const, Any)
                        time:   [1.2409 ns 1.2595 ns 1.2802 ns]
```
After the changes:
```
optag/tag_superset/(Const, Any)
                        time:   [129.44 ps 130.92 ps 132.46 ps]
                        change: [-89.435% -89.267% -89.098%] (p = 0.00 < 0.05)
```