### PR TITLE
[Refactor] Tidy some CFG structuring code, require RootHandle=CfgID

### DIFF
--- a/src/algorithm/half_node.rs
+++ b/src/algorithm/half_node.rs
@@ -2,8 +2,9 @@ use std::hash::Hash;
 
 use super::nest_cfgs::CfgNodeMap;
 
-use crate::hugr::views::HugrView;
+use crate::hugr::RootTagged;
 
+use crate::ops::handle::CfgID;
 use crate::ops::{OpTag, OpTrait};
 
 use crate::{Direction, Node};
@@ -30,7 +31,7 @@ struct HalfNodeView<H> {
     exit: Node,
 }
 
-impl<H: HugrView> HalfNodeView<H> {
+impl<H: RootTagged<RootHandle = CfgID>> HalfNodeView<H> {
     #[allow(unused)]
     pub(crate) fn new(h: H) -> Self {
         let (entry, exit) = {
@@ -62,7 +63,7 @@ impl<H: HugrView> HalfNodeView<H> {
     }
 }
 
-impl<H: HugrView> CfgNodeMap<HalfNode> for HalfNodeView<H> {
+impl<H: RootTagged<RootHandle = CfgID>> CfgNodeMap<HalfNode> for HalfNodeView<H> {
     type Iterator<'c> = <Vec<HalfNode> as IntoIterator>::IntoIter where Self: 'c;
     fn entry_node(&self) -> HalfNode {
         HalfNode::N(self.entry)
@@ -97,6 +98,7 @@ mod test {
     use super::super::nest_cfgs::{test::*, EdgeClassifier};
     use super::{HalfNode, HalfNodeView};
     use crate::builder::BuildError;
+    use crate::hugr::views::RootChecked;
     use crate::ops::handle::NodeHandle;
 
     use itertools::Itertools;
@@ -116,7 +118,7 @@ mod test {
         //               \---<---<---<---<---<---<---<---<---<---/
         // Allowing to identify two nested regions (and fixing the problem with an IdentityCfgMap on the same example)
 
-        let v = HalfNodeView::new(&h);
+        let v = HalfNodeView::new(RootChecked::try_new(&h).unwrap());
 
         let edge_classes = EdgeClassifier::get_edge_classes(&v);
         let HalfNodeView { h: _, entry, exit } = v;

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -625,10 +625,10 @@ pub(crate) mod test {
         cfg_builder.branch(&tail, 0, &exit)?;
 
         let mut h = cfg_builder.finish_prelude_hugr()?;
-        let mut m = IdentityCfgMap::new(RootChecked::<_, CfgID>::try_new(&mut h).unwrap());
+        let rc = RootChecked::<_, CfgID>::try_new(&mut h).unwrap();
         let (entry, exit) = (entry.node(), exit.node());
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
-        let edge_classes = EdgeClassifier::get_edge_classes(&m);
+        let edge_classes = EdgeClassifier::get_edge_classes(&IdentityCfgMap::new(rc.borrow()));
         let [&left, &right] = edge_classes
             .keys()
             .filter(|(s, _)| *s == split)
@@ -649,7 +649,7 @@ pub(crate) mod test {
                 sorted([(entry, split), (merge, head), (tail, exit)]), // Two regions, conditional and then loop.
             ])
         );
-        transform_cfg_to_nested(&mut m);
+        transform_cfg_to_nested(&mut IdentityCfgMap::new(rc));
         h.validate(&PRELUDE_REGISTRY).unwrap();
         assert_eq!(1, depth(&h, entry));
         assert_eq!(1, depth(&h, exit));

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -356,7 +356,7 @@ struct UndirectedDFSTree<T> {
 }
 
 impl<T: Copy + Clone + PartialEq + Eq + Hash> UndirectedDFSTree<T> {
-    pub fn new(cfg: &impl CfgNodeMap<T>) -> Self {
+    fn new(cfg: &impl CfgNodeMap<T>) -> Self {
         //1. Traverse backwards-only from exit building bitset of reachable nodes
         let mut reachable = HashSet::new();
         {

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -158,9 +158,7 @@ pub fn transform_cfg_to_nested<T: Copy + Eq + Hash + std::fmt::Debug>(
 pub fn transform_all_cfgs(h: &mut Hugr) {
     let mut node_stack = Vec::from([h.root()]);
     while let Some(n) = node_stack.pop() {
-        if h.get_optype(n).tag() == OpTag::Cfg {
-            // We've checked the optype so this should be fine
-            let s = SiblingMut::<CfgID>::try_new(h, n).unwrap();
+        if let Ok(s) = SiblingMut::<CfgID>::try_new(h, n) {
             transform_cfg_to_nested(&mut IdentityCfgMap::new(s));
         }
         node_stack.extend(h.children(n))

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -9,6 +9,7 @@ use super::{check_tag, RootTagged};
 
 /// A view of the whole Hugr.
 /// (Just provides static checking of the type of the root node)
+#[derive(Clone)]
 pub struct RootChecked<H, Root = Node>(H, PhantomData<Root>);
 
 impl<H: RootTagged + AsRef<Hugr>, Root: NodeHandle> RootChecked<H, Root> {

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -38,6 +38,13 @@ impl<Root> RootChecked<Hugr, Root> {
     }
 }
 
+impl<Root> RootChecked<&mut Hugr, Root> {
+    /// Allows immutably borrowing the underlying mutable reference
+    pub fn borrow(&self) -> RootChecked<&Hugr, Root> {
+        RootChecked(&*self.0, PhantomData)
+    }
+}
+
 impl<H: AsRef<Hugr>, Root: NodeHandle> RootTagged for RootChecked<H, Root> {
     type RootHandle = Root;
 }


### PR DESCRIPTION
* IdentityCfgMap and HalfNodeView require RootTagged w/ CfgID rather than just HugrView
* Derive `Clone` for RootHandle
* implement a `fn borrow` (returning `RootHandle<&Hugr>`) for `RootHandle<&mut Hugr`
* Avoid some redundant checks and unwraps, remove a misleading `pub` (the structure it's on isn't pub)