### PR TITLE
Replace API: add mu_new, tighten wellformedness

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1220,9 +1220,6 @@ It contains the following fields:
   - `TgtPos`: (for `Value` and `Static` edges only) the desired position among
     the incoming ports to the new node.
 
-Note that in a `NewEdgeSpec` one of `SrcNode` and `TgtNode` is an existing node
-in the hugr and the other is a new node.
-
 The `Replace` method takes as input:
   - the ID of a container node $P$ in $\Gamma$;
   - a set $S$ of IDs of nodes that are children of $P$
@@ -1239,8 +1236,13 @@ The `Replace` method takes as input:
   - a list $\mu\_\textrm{inp}$ of `NewEdgeSpec` which all have their `TgtNode`in
     $G$ and `SrcNode` in $\Gamma \setminus R$;
   - a list $\mu\_\textrm{out}$ of `NewEdgeSpec` which all have their `SrcNode`in
-    $G$ and `TgtNode` in $\Gamma \setminus R$ (where `TgtNode` and `TgtPos` describe
-    an existing incoming edge of that kind from a node in $R$).
+    $G$ and `TgtNode` in $\Gamma \setminus R$, where `TgtNode` and `TgtPos` describe
+    an existing incoming edge of that kind from a node in $R$.
+  - a list $\mu\_\textrm{new}$ of `NewEdgeSpec` which all have both `SrcNode` and `TgtNode`
+    in $\Gamma \setminus R$, where `TgtNode` and `TgtPos` describe an existing incoming
+    edge of that kind from a node in $R$.
+
+Note that for `NewEdgeSpec`s with `EdgeKind` == `Value`, the `TgtNode` + `TgtPos`s will all be unique when considering all three lists together, and similarly for `EdgeKind` == `Static`.
 
 The well-formedness requirements of Hugr imply that $\mu\_\textrm{inp}$ and $\mu\_\textrm{out}$ may only contain `NewEdgeSpec`s with certain `EdgeKind`s, depending on $P$:
    - if $P$ is a dataflow container, `EdgeKind`s may be `Order`, `Value` or `Static` only (no `ControlFlow`)


### PR DESCRIPTION
Sometimes a replacement can remove nodes on a path from the rest of the hugr, through the replacement, and to the outside, without adding any new nodes on that path. In these cases we would expect the nodes to be elided, but may nonetheless require adding a new edge to retain the path (from the original source outside the removed nodes, to the target also outside the removed nodes).

In the case of SimpleReplace, such a path can only be exist for Value edges, and we do this by adding an edge from the replacement's `Input` node directly to its `Output`. (These nodes are not added into the resulting Hugr but the edge is added.)

For Replace this doesn't work: firstly, we do not expect the replacement to contain `Input` or `Output` nodes (*all* nodes from the replacement are added). Secondly, it's not really clear that such a mechanism would work for e.g. Order edges, where we might have/need multiple edges if we are removing all nodes from multiple (parallel) Order paths.

So, add a new list of `NewEdgeSpec`s. (The alternative would be to allow SrcPos to specify which Hugr - existing or replacement - it referred to; we *could* do this in the spec but not in the code if we think it's clearer! But in code I'm pretty sure this makes more sense.)

Also clarify the rules about the targets of these edges.