### PR TITLE
refactor: insert_subgraph just return HashMap, make InsertionResult new_root compulsory

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -231,7 +231,7 @@ pub trait Dataflow: Container {
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
         let num_outputs = hugr.get_optype(hugr.root()).signature().output_count();
-        let node = self.add_hugr(hugr)?.new_root.unwrap();
+        let node = self.add_hugr(hugr)?.new_root;
 
         let inputs = input_wires.into_iter().collect();
         wire_up_inputs(inputs, node, self)?;
@@ -252,7 +252,7 @@ pub trait Dataflow: Container {
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
         let num_outputs = hugr.get_optype(hugr.root()).signature().output_count();
-        let node = self.add_hugr_view(hugr)?.new_root.unwrap();
+        let node = self.add_hugr_view(hugr)?.new_root;
 
         let inputs = input_wires.into_iter().collect();
         wire_up_inputs(inputs, node, self)?;

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -150,7 +150,7 @@ impl Rewrite for OutlineCfg {
                 .insert_hugr(outer_cfg, new_block_bldr.hugr().clone())
                 .unwrap();
             (
-                ins_res.new_root.unwrap(),
+                ins_res.new_root,
                 *ins_res.node_map.get(&cfg.node()).unwrap(),
             )
         };

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -424,9 +424,7 @@ impl SiblingSubgraph {
         // Take the unfinished Hugr from the builder, to avoid unnecessary
         // validation checks that require connecting the inputs and outputs.
         let mut extracted = mem::take(builder.hugr_mut());
-        let node_map = extracted
-            .insert_subgraph(extracted.root(), hugr, self)?
-            .node_map;
+        let node_map = extracted.insert_subgraph(extracted.root(), hugr, self)?;
 
         // Connect the inserted nodes in-between the input and output nodes.
         let [inp, out] = extracted.get_io(extracted.root()).unwrap();


### PR DESCRIPTION
insert_subgraph reused InsertionResult by making new_root into an Option. The "reuse" is trivial - what's left is a single field - so this avoids confusion as to when `new_root` is or is not None and thus a bunch of unwraps.