### PR TITLE
chore(deps)!: Update portgraph 0.10 and pyo3 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ path = "src/lib.rs"
 
 [dependencies]
 thiserror = "1.0.28"
-portgraph = { version = "0.9.0", features = ["serde", "petgraph"] }
-pyo3 = { version = "0.19.0", optional = true, features = [
+portgraph = { version = "0.10.0", features = ["serde", "petgraph"] }
+pyo3 = { version = "0.20.0", optional = true, features = [
     "multiple-pymethods",
 ] }
 regex = "1.9.5"
@@ -34,7 +34,8 @@ num-rational = { version = "0.4.1", features = ["serde"] }
 downcast-rs = "1.2.0"
 serde = { version = "1.0", features = [
     # Rc used here for Extension, but unfortunately we must turn the feature on globally
-    "derive", "rc",
+    "derive",
+    "rc",
 ] }
 serde_yaml = "0.9.19"
 typetag = "0.2.7"
@@ -45,7 +46,7 @@ html-escape = "0.2.13"
 bitvec = { version = "1.0.1", features = ["serde"] }
 enum_dispatch = "0.3.11"
 lazy_static = "1.4.0"
-petgraph = { version="0.6.3", default-features = false}
+petgraph = { version = "0.6.3", default-features = false }
 context-iterators = "0.2.0"
 serde_json = "1.0.97"
 delegate = "0.10.0"

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -166,8 +166,8 @@ impl SiblingSubgraph {
         outgoing: OutgoingPorts,
         hugr: &impl HugrView,
     ) -> Result<Self, InvalidSubgraph> {
-        let mut checker = ConvexChecker::new(hugr);
-        Self::try_new_with_checker(incoming, outgoing, hugr, &mut checker)
+        let checker = ConvexChecker::new(hugr);
+        Self::try_new_with_checker(incoming, outgoing, hugr, &checker)
     }
 
     /// Create a new convex sibling subgraph from input and output boundaries.
@@ -182,7 +182,7 @@ impl SiblingSubgraph {
         inputs: IncomingPorts,
         outputs: OutgoingPorts,
         hugr: &'h H,
-        checker: &'c mut ConvexChecker<'h, H>,
+        checker: &'c ConvexChecker<'h, H>,
     ) -> Result<Self, InvalidSubgraph> {
         let pg = hugr.portgraph();
 
@@ -201,7 +201,7 @@ impl SiblingSubgraph {
         let nodes = subpg.nodes_iter().map_into().collect_vec();
         validate_subgraph(hugr, &nodes, &inputs, &outputs)?;
 
-        if !subpg.is_convex_with_checker(&mut checker.0) {
+        if !subpg.is_convex_with_checker(&checker.0) {
             return Err(InvalidSubgraph::NotConvex);
         }
 
@@ -231,8 +231,8 @@ impl SiblingSubgraph {
         nodes: impl Into<Vec<Node>>,
         hugr: &impl HugrView,
     ) -> Result<Self, InvalidSubgraph> {
-        let mut checker = ConvexChecker::new(hugr);
-        Self::try_from_nodes_with_checker(nodes, hugr, &mut checker)
+        let checker = ConvexChecker::new(hugr);
+        Self::try_from_nodes_with_checker(nodes, hugr, &checker)
     }
 
     /// Create a subgraph from a set of nodes.
@@ -246,7 +246,7 @@ impl SiblingSubgraph {
     pub fn try_from_nodes_with_checker<'c, 'h: 'c, H: HugrView>(
         nodes: impl Into<Vec<Node>>,
         hugr: &'h H,
-        checker: &'c mut ConvexChecker<'h, H>,
+        checker: &'c ConvexChecker<'h, H>,
     ) -> Result<Self, InvalidSubgraph> {
         let nodes = nodes.into();
         let nodes_set = nodes.iter().copied().collect::<HashSet<_>>();


### PR DESCRIPTION
- Update to `portgraph` `0.10`. Replaces `&mut ConvexChecker` parameters with `&`.
- Update to `pyo3` `0.20`.

BREAKING CHANGE: `pyo3` updated to `0.20`. Dependencies must have matching pyo3 versions since it links with python libs.