### PR TITLE
Static checking of Port

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -60,7 +60,7 @@ pub trait Container {
     /// [`other_outputs`]: crate::ops::OpTrait::other_output
     fn add_other_wire(&mut self, src: Node, dst: Node) -> Result<Wire, BuildError> {
         let (src_port, _) = self.hugr_mut().add_other_edge(src, dst)?;
-        Ok(Wire::new(src, src_port.as_outgoing().unwrap()))
+        Ok(Wire::new(src, src_port))
     }
 
     /// Add a constant value to the container and return a handle to it.

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -1,7 +1,7 @@
 use crate::hugr::hugrmut::InsertionResult;
 use crate::hugr::validate::InterGraphEdgeError;
 use crate::hugr::views::HugrView;
-use crate::hugr::{IncomingPort, Node, NodeMetadata, OutgoingPort, Port, ValidationError};
+use crate::hugr::{IncomingPort, Node, NodeMetadata, OutgoingPort, ValidationError};
 use crate::ops::{self, LeafOp, OpTrait, OpType};
 
 use std::iter;
@@ -60,7 +60,7 @@ pub trait Container {
     /// [`other_outputs`]: crate::ops::OpTrait::other_output
     fn add_other_wire(&mut self, src: Node, dst: Node) -> Result<Wire, BuildError> {
         let (src_port, _) = self.hugr_mut().add_other_edge(src, dst)?;
-        Ok(Wire::new(src, src_port))
+        Ok(Wire::new(src, src_port.as_outgoing().unwrap()))
     }
 
     /// Add a constant value to the container and return a handle to it.
@@ -368,7 +368,7 @@ pub trait Dataflow: Container {
                 input_extensions,
             ),
             // Constant wire from the constant value node
-            vec![Wire::new(const_node, Port::new_outgoing(0))],
+            vec![Wire::new(const_node, OutgoingPort::from(0))],
         )?;
 
         Ok(load_n.out_wire(0))
@@ -658,12 +658,12 @@ fn wire_up_inputs<T: Dataflow + ?Sized>(
 fn wire_up<T: Dataflow + ?Sized>(
     data_builder: &mut T,
     src: Node,
-    src_port: impl TryInto<OutgoingPort>,
+    src_port: impl Into<OutgoingPort>,
     dst: Node,
-    dst_port: impl TryInto<IncomingPort>,
+    dst_port: impl Into<IncomingPort>,
 ) -> Result<bool, BuildError> {
-    let src_port = Port::try_new_outgoing(src_port)?;
-    let dst_port = Port::try_new_incoming(dst_port)?;
+    let src_port: OutgoingPort = src_port.into();
+    let dst_port: IncomingPort = dst_port.into();
     let base = data_builder.hugr_mut();
 
     let src_parent = base.get_parent(src);
@@ -675,9 +675,9 @@ fn wire_up<T: Dataflow + ?Sized>(
             if !typ.copyable() {
                 let val_err: ValidationError = InterGraphEdgeError::NonCopyableData {
                     from: src,
-                    from_offset: src_port,
+                    from_offset: src_port.into(),
                     to: dst,
-                    to_offset: dst_port,
+                    to_offset: dst_port.into(),
                     ty: EdgeKind::Value(typ),
                 }
                 .into();
@@ -693,9 +693,9 @@ fn wire_up<T: Dataflow + ?Sized>(
             else {
                 let val_err: ValidationError = InterGraphEdgeError::NoRelation {
                     from: src,
-                    from_offset: src_port,
+                    from_offset: src_port.into(),
                     to: dst,
-                    to_offset: dst_port,
+                    to_offset: dst_port.into(),
                 }
                 .into();
                 return Err(val_err.into());

--- a/src/builder/handle.rs
+++ b/src/builder/handle.rs
@@ -1,11 +1,11 @@
 //! Handles to nodes in HUGR used during the building phase.
 //!
 use crate::{
+    hugr::OutgoingPort,
     ops::{
         handle::{BasicBlockID, CaseID, DfgID, FuncID, NodeHandle, TailLoopID},
         OpTag,
     },
-    Port,
 };
 use crate::{Node, Wire};
 
@@ -64,7 +64,7 @@ impl<T: NodeHandle> BuildHandle<T> {
     /// Retrieve a [`Wire`] corresponding to the given offset.
     /// Does not check whether such a wire is valid for this node.
     pub fn out_wire(&self, offset: usize) -> Wire {
-        Wire::new(self.node(), Port::new_outgoing(offset))
+        Wire::new(self.node(), OutgoingPort::from(offset))
     }
 
     #[inline]
@@ -124,14 +124,12 @@ impl Iterator for Outputs {
     fn next(&mut self) -> Option<Self::Item> {
         self.range
             .next()
-            .map(|offset| Wire::new(self.node, Port::new_outgoing(offset)))
+            .map(|offset| Wire::new(self.node, OutgoingPort::from(offset)))
     }
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range
-            .nth(n)
-            .map(|offset| Wire::new(self.node, Port::new_outgoing(offset)))
+        self.range.nth(n).map(|offset| Wire::new(self.node, offset))
     }
 
     #[inline]
@@ -157,7 +155,7 @@ impl DoubleEndedIterator for Outputs {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.range
             .next_back()
-            .map(|offset| Wire::new(self.node, Port::new_outgoing(offset)))
+            .map(|offset| Wire::new(self.node, offset))
     }
 }
 

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -511,13 +511,13 @@ impl NodeIndex for Node {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A DataFlow wire, defined by a Value-kind output port of a node
 // Stores node and offset to output port
-pub struct Wire(Node, usize);
+pub struct Wire(Node, OutgoingPort);
 
 impl Wire {
     /// Create a new wire from a node and a port.
     #[inline]
     pub fn new(node: Node, port: impl Into<OutgoingPort>) -> Self {
-        Self(node, Port::new_outgoing(port).index())
+        Self(node, port.into())
     }
 
     /// The node that this wire is connected to.
@@ -529,7 +529,7 @@ impl Wire {
     /// The output port that this wire is connected to.
     #[inline]
     pub fn source(&self) -> OutgoingPort {
-        OutgoingPort::from(self.1)
+        self.1
     }
 }
 

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -136,8 +136,11 @@ pub trait HugrMut: HugrMutInternals {
     ///
     /// [`OpTrait::other_input`]: crate::ops::OpTrait::other_input
     /// [`OpTrait::other_output`]: crate::ops::OpTrait::other_output
-    // TODO make this return (OutgoingPort, IncomingPort)
-    fn add_other_edge(&mut self, src: Node, dst: Node) -> Result<(Port, Port), HugrError> {
+    fn add_other_edge(
+        &mut self,
+        src: Node,
+        dst: Node,
+    ) -> Result<(OutgoingPort, IncomingPort), HugrError> {
         self.valid_node(src)?;
         self.valid_node(dst)?;
         self.hugr_mut().add_other_edge(src, dst)
@@ -276,7 +279,11 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
         Ok(())
     }
 
-    fn add_other_edge(&mut self, src: Node, dst: Node) -> Result<(Port, Port), HugrError> {
+    fn add_other_edge(
+        &mut self,
+        src: Node,
+        dst: Node,
+    ) -> Result<(OutgoingPort, IncomingPort), HugrError> {
         let src_port = self
             .get_optype(src)
             .other_port_index(Direction::Outgoing)
@@ -288,7 +295,7 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
             .expect("Destination operation has no non-dataflow incoming edges")
             .as_incoming()?;
         self.connect(src, src_port, dst, dst_port)?;
-        Ok((src_port.into(), dst_port.into()))
+        Ok((src_port, dst_port))
     }
 
     fn insert_hugr(&mut self, root: Node, mut other: Hugr) -> Result<InsertionResult, HugrError> {

--- a/src/hugr/rewrite/insert_identity.rs
+++ b/src/hugr/rewrite/insert_identity.rs
@@ -18,6 +18,7 @@ pub struct IdentityInsertion {
     /// The node following the identity to be inserted.
     pub post_node: Node,
     /// The port following the identity to be inserted.
+    // TODO: make this an IncomingPort
     pub post_port: Port,
 }
 
@@ -96,11 +97,16 @@ impl Rewrite for IdentityInsertion {
         let new_node = h
             .add_op_with_parent(parent, LeafOp::Noop { ty })
             .expect("Parent validity already checked.");
-        h.connect(pre_node, pre_port, new_node, 0)
+        h.connect(pre_node, pre_port.as_outgoing().unwrap(), new_node, 0)
             .expect("Should only fail if ports don't exist.");
 
-        h.connect(new_node, 0, self.post_node, self.post_port)
-            .expect("Should only fail if ports don't exist.");
+        h.connect(
+            new_node,
+            0,
+            self.post_node,
+            self.post_port.as_incoming().unwrap(),
+        )
+        .expect("Should only fail if ports don't exist.");
         Ok(new_node)
     }
 

--- a/src/hugr/rewrite/insert_identity.rs
+++ b/src/hugr/rewrite/insert_identity.rs
@@ -77,7 +77,7 @@ impl Rewrite for IdentityInsertion {
         };
 
         let (pre_node, pre_port) = h
-            .linked_ports(self.post_node, self.post_port)
+            .linked_outputs(self.post_node, self.post_port)
             .exactly_one()
             .ok()
             .expect("Value kind input can only have one connection.");
@@ -92,7 +92,7 @@ impl Rewrite for IdentityInsertion {
         let new_node = h
             .add_op_with_parent(parent, LeafOp::Noop { ty })
             .expect("Parent validity already checked.");
-        h.connect(pre_node, pre_port.as_outgoing().unwrap(), new_node, 0)
+        h.connect(pre_node, pre_port, new_node, 0)
             .expect("Should only fail if ports don't exist.");
 
         h.connect(new_node, 0, self.post_node, self.post_port)

--- a/src/hugr/rewrite/insert_identity.rs
+++ b/src/hugr/rewrite/insert_identity.rs
@@ -5,7 +5,7 @@ use std::iter;
 use crate::hugr::{HugrMut, IncomingPort, Node};
 use crate::ops::{LeafOp, OpTag, OpTrait};
 use crate::types::EdgeKind;
-use crate::{Direction, HugrView, Port};
+use crate::HugrView;
 
 use super::Rewrite;
 
@@ -132,7 +132,7 @@ mod tests {
 
         let final_node_port = h.node_inputs(final_node).next().unwrap();
 
-        let rw = IdentityInsertion::new(final_node, final_node_port.as_incoming().unwrap());
+        let rw = IdentityInsertion::new(final_node, final_node_port);
 
         let noop_node = h.apply_rewrite(rw).unwrap();
 
@@ -153,7 +153,7 @@ mod tests {
 
         let final_node_input = h.node_inputs(final_node).next().unwrap();
 
-        let rw = IdentityInsertion::new(final_node, final_node_input.as_incoming().unwrap());
+        let rw = IdentityInsertion::new(final_node, final_node_input);
 
         let apply_result = h.apply_rewrite(rw);
         assert_eq!(

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -162,7 +162,8 @@ impl Rewrite for OutlineCfg {
         for (pred, br) in preds {
             if !self.blocks.contains(&pred) {
                 h.disconnect(pred, br).unwrap();
-                h.connect(pred, br, new_block, 0).unwrap();
+                h.connect(pred, br.as_outgoing().unwrap(), new_block, 0)
+                    .unwrap();
             }
         }
         if entry == outer_entry {
@@ -211,7 +212,9 @@ impl Rewrite for OutlineCfg {
             SiblingMut::try_new(h, new_block).unwrap();
         let mut in_cfg_view: SiblingMut<'_, CfgID> =
             SiblingMut::try_new(&mut in_bb_view, cfg_node).unwrap();
-        in_cfg_view.connect(exit, exit_port, inner_exit, 0).unwrap();
+        in_cfg_view
+            .connect(exit, exit_port.as_outgoing().unwrap(), inner_exit, 0)
+            .unwrap();
 
         Ok((new_block, cfg_node))
     }

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -212,9 +212,7 @@ impl Rewrite for OutlineCfg {
             SiblingMut::try_new(h, new_block).unwrap();
         let mut in_cfg_view: SiblingMut<'_, CfgID> =
             SiblingMut::try_new(&mut in_bb_view, cfg_node).unwrap();
-        in_cfg_view
-            .connect(exit, exit_port.as_outgoing().unwrap(), inner_exit, 0)
-            .unwrap();
+        in_cfg_view.connect(exit, exit_port, inner_exit, 0).unwrap();
 
         Ok((new_block, cfg_node))
     }

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -116,11 +116,17 @@ impl Rewrite for SimpleReplacement {
         for &node in replacement_inner_nodes {
             let new_node = index_map.get(&node).unwrap();
             for outport in self.replacement.node_outputs(node) {
+                let outport = outport.as_outgoing().unwrap();
                 for target in self.replacement.linked_ports(node, outport) {
                     if self.replacement.get_optype(target.0).tag() != OpTag::Output {
                         let new_target = index_map.get(&target.0).unwrap();
-                        h.connect(*new_node, outport, *new_target, target.1)
-                            .unwrap();
+                        h.connect(
+                            *new_node,
+                            outport,
+                            *new_target,
+                            target.1.as_incoming().unwrap(),
+                        )
+                        .unwrap();
                     }
                 }
             }
@@ -139,9 +145,9 @@ impl Rewrite for SimpleReplacement {
                 let new_inp_node = index_map.get(rep_inp_node).unwrap();
                 h.connect(
                     rem_inp_pred_node,
-                    rem_inp_pred_port,
+                    rem_inp_pred_port.as_outgoing().unwrap(),
                     *new_inp_node,
-                    *rep_inp_port,
+                    rep_inp_port.as_incoming().unwrap(),
                 )
                 .unwrap();
             }
@@ -159,9 +165,9 @@ impl Rewrite for SimpleReplacement {
                 h.disconnect(*rem_out_node, *rem_out_port).unwrap();
                 h.connect(
                     *new_out_node,
-                    rep_out_pred_port,
+                    rep_out_pred_port.as_outgoing().unwrap(),
                     *rem_out_node,
-                    *rem_out_port,
+                    rem_out_port.as_incoming().unwrap(),
                 )
                 .unwrap();
             }
@@ -181,9 +187,9 @@ impl Rewrite for SimpleReplacement {
                 h.disconnect(*rem_out_node, *rem_out_port).unwrap();
                 h.connect(
                     rem_inp_pred_node,
-                    rem_inp_pred_port,
+                    rem_inp_pred_port.as_outgoing().unwrap(),
                     *rem_out_node,
-                    *rem_out_port,
+                    rem_out_port.as_incoming().unwrap(),
                 )
                 .unwrap();
             }

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -116,7 +116,6 @@ impl Rewrite for SimpleReplacement {
         for &node in replacement_inner_nodes {
             let new_node = index_map.get(&node).unwrap();
             for outport in self.replacement.node_outputs(node) {
-                let outport = outport.as_outgoing().unwrap();
                 for target in self.replacement.linked_ports(node, outport) {
                     if self.replacement.get_optype(target.0).tag() != OpTag::Output {
                         let new_target = index_map.get(&target.0).unwrap();
@@ -476,10 +475,13 @@ pub(in crate::hugr::rewrite) mod test {
         // 3.4. Construct the maps
         let mut nu_inp: HashMap<(Node, Port), (Node, Port)> = HashMap::new();
         let mut nu_out: HashMap<(Node, Port), Port> = HashMap::new();
-        nu_inp.insert((n_node_output, n_port_0), (h_node_cx, h_port_0));
-        nu_inp.insert((n_node_h, n_port_2), (h_node_cx, h_port_1));
-        nu_out.insert((h_node_h0, h_port_2), n_port_0);
-        nu_out.insert((h_node_h1, h_port_3), n_port_1);
+        nu_inp.insert(
+            (n_node_output, n_port_0.into()),
+            (h_node_cx, h_port_0.into()),
+        );
+        nu_inp.insert((n_node_h, n_port_2.into()), (h_node_cx, h_port_1.into()));
+        nu_out.insert((h_node_h0, h_port_2), n_port_0.into());
+        nu_out.insert((h_node_h1, h_port_3), n_port_1.into());
         // 4. Define the replacement
         let r = SimpleReplacement {
             subgraph: SiblingSubgraph::try_from_nodes(s, &h).unwrap(),
@@ -525,6 +527,7 @@ pub(in crate::hugr::rewrite) mod test {
         let outputs = h
             .node_inputs(output)
             .filter(|&p| h.get_optype(output).signature().get(p).is_some())
+            .map_into()
             .map(|p| ((output, p), p))
             .collect();
         h.apply_rewrite(SimpleReplacement::new(
@@ -577,6 +580,7 @@ pub(in crate::hugr::rewrite) mod test {
         let outputs = repl
             .node_inputs(repl_output)
             .filter(|&p| repl.get_optype(repl_output).signature().get(p).is_some())
+            .map_into()
             .map(|p| ((repl_output, p), p))
             .collect();
 

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -133,18 +133,19 @@ impl Rewrite for SimpleReplacement {
         // 3.2. For each p = self.nu_inp[q] such that q is not an Output port, add an edge from the
         // predecessor of p to (the new copy of) q.
         for ((rep_inp_node, rep_inp_port), (rem_inp_node, rem_inp_port)) in &self.nu_inp {
+            let rem_inp_port = rem_inp_port.as_incoming().unwrap();
             if self.replacement.get_optype(*rep_inp_node).tag() != OpTag::Output {
                 // add edge from predecessor of (s_inp_node, s_inp_port) to (new_inp_node, n_inp_port)
                 let (rem_inp_pred_node, rem_inp_pred_port) = h
-                    .linked_ports(*rem_inp_node, *rem_inp_port)
+                    .linked_outputs(*rem_inp_node, rem_inp_port)
                     .exactly_one()
                     .ok() // PortLinks does not implement Debug
                     .unwrap();
-                h.disconnect(*rem_inp_node, *rem_inp_port).unwrap();
+                h.disconnect(*rem_inp_node, rem_inp_port).unwrap();
                 let new_inp_node = index_map.get(rep_inp_node).unwrap();
                 h.connect(
                     rem_inp_pred_node,
-                    rem_inp_pred_port.as_outgoing().unwrap(),
+                    rem_inp_pred_port,
                     *new_inp_node,
                     rep_inp_port.as_incoming().unwrap(),
                 )

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -149,6 +149,7 @@ pub trait HugrView: sealed::HugrInternals {
 
     /// Iterator over output ports of node.
     /// Shorthand for [`node_ports`][HugrView::node_ports]`(node, Direction::Outgoing)`.
+    // TODO: make this return an iterator of OutgoingPort
     #[inline]
     fn node_outputs(&self, node: Node) -> Self::NodePorts<'_> {
         self.node_ports(node, Direction::Outgoing)
@@ -156,6 +157,7 @@ pub trait HugrView: sealed::HugrInternals {
 
     /// Iterator over inputs ports of node.
     /// Shorthand for [`node_ports`][HugrView::node_ports]`(node, Direction::Incoming)`.
+    // TODO: make this return an iterator of IncomingPort
     #[inline]
     fn node_inputs(&self, node: Node) -> Self::NodePorts<'_> {
         self.node_ports(node, Direction::Incoming)
@@ -165,13 +167,13 @@ pub trait HugrView: sealed::HugrInternals {
     fn all_node_ports(&self, node: Node) -> Self::NodePorts<'_>;
 
     /// Iterator over the nodes and ports connected to a port.
-    fn linked_ports(&self, node: Node, port: Port) -> Self::PortLinks<'_>;
+    fn linked_ports(&self, node: Node, port: impl Into<Port>) -> Self::PortLinks<'_>;
 
     /// Iterator the links between two nodes.
     fn node_connections(&self, node: Node, other: Node) -> Self::NodeConnections<'_>;
 
     /// Returns whether a port is connected.
-    fn is_linked(&self, node: Node, port: Port) -> bool {
+    fn is_linked(&self, node: Node, port: impl Into<Port>) -> bool {
         self.linked_ports(node, port).next().is_some()
     }
 
@@ -391,7 +393,8 @@ impl<T: AsRef<Hugr>> HugrView for T {
     }
 
     #[inline]
-    fn linked_ports(&self, node: Node, port: Port) -> Self::PortLinks<'_> {
+    fn linked_ports(&self, node: Node, port: impl Into<Port>) -> Self::PortLinks<'_> {
+        let port = port.into();
         let hugr = self.as_ref();
         let port = hugr.graph.port_index(node.index, port.offset).unwrap();
         hugr.graph

--- a/src/hugr/views/descendants.rs
+++ b/src/hugr/views/descendants.rs
@@ -100,8 +100,11 @@ impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
         self.graph.all_port_offsets(node.index).map_into()
     }
 
-    fn linked_ports(&self, node: Node, port: Port) -> Self::PortLinks<'_> {
-        let port = self.graph.port_index(node.index, port.offset).unwrap();
+    fn linked_ports(&self, node: Node, port: impl Into<Port>) -> Self::PortLinks<'_> {
+        let port = self
+            .graph
+            .port_index(node.index, port.into().offset)
+            .unwrap();
         self.graph
             .port_links(port)
             .with_context(self)

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -131,8 +131,11 @@ impl<'g, Root: NodeHandle> HugrView for SiblingGraph<'g, Root> {
         self.graph.all_port_offsets(node.index).map_into()
     }
 
-    fn linked_ports(&self, node: Node, port: Port) -> Self::PortLinks<'_> {
-        let port = self.graph.port_index(node.index, port.offset).unwrap();
+    fn linked_ports(&self, node: Node, port: impl Into<Port>) -> Self::PortLinks<'_> {
+        let port = self
+            .graph
+            .port_index(node.index, port.into().offset)
+            .unwrap();
         self.graph
             .port_links(port)
             .with_context(self)
@@ -313,7 +316,7 @@ impl<'g, Root: NodeHandle> HugrView for SiblingMut<'g, Root> {
         }
     }
 
-    fn linked_ports(&self, node: Node, port: Port) -> Self::PortLinks<'_> {
+    fn linked_ports(&self, node: Node, port: impl Into<Port>) -> Self::PortLinks<'_> {
         // Need to filter only to links inside the sibling graph
         SiblingGraph::<'_, Node>::new_unchecked(self.hugr, self.root)
             .linked_ports(node, port)

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -432,15 +432,19 @@ impl SiblingSubgraph {
             .node_ports(inp, Direction::Outgoing)
             .zip(self.inputs.iter())
         {
+            let inp_port = inp_port.as_outgoing().unwrap();
             for (repl_node, repl_port) in repl_ports {
-                extracted.connect(inp, inp_port, node_map[repl_node], *repl_port)?;
+                let repl_port = repl_port.as_incoming().unwrap();
+                extracted.connect(inp, inp_port, node_map[repl_node], repl_port)?;
             }
         }
         for (out_port, (repl_node, repl_port)) in extracted
             .node_ports(out, Direction::Incoming)
+            .map(|p| p.as_incoming().unwrap())
             .zip(self.outputs.iter())
         {
-            extracted.connect(node_map[repl_node], *repl_port, out, out_port)?;
+            let repl_port = repl_port.as_outgoing().unwrap();
+            extracted.connect(node_map[repl_node], repl_port, out, out_port)?;
         }
 
         Ok(extracted)

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -585,9 +585,8 @@ fn get_input_output_ports<H: HugrView>(hugr: &H) -> (IncomingPorts, OutgoingPort
     let inputs = dfg_inputs
         .into_iter()
         .map(|p| {
-            hugr.linked_ports(inp, p)
+            hugr.linked_inputs(inp, p)
                 .filter(|&(n, _)| n != out)
-                .map(|(n, p)| (n, p.as_incoming().unwrap()))
                 .collect_vec()
         })
         .filter(|v| !v.is_empty())
@@ -596,8 +595,7 @@ fn get_input_output_ports<H: HugrView>(hugr: &H) -> (IncomingPorts, OutgoingPort
     // direct wires to the input.
     let outputs = dfg_outputs
         .into_iter()
-        .filter_map(|p| hugr.linked_ports(out, p).find(|&(n, _)| n != inp))
-        .map(|(n, p)| (n, p.as_outgoing().unwrap()))
+        .filter_map(|p| hugr.linked_outputs(out, p).find(|&(n, _)| n != inp))
         .collect();
     (inputs, outputs)
 }
@@ -894,17 +892,12 @@ mod tests {
         SiblingSubgraph::try_new(
             hugr.node_outputs(inp)
                 .take(2)
-                .map(|p| {
-                    hugr.linked_ports(inp, p)
-                        .map(|(n, p)| (n, p.as_incoming().unwrap()))
-                        .collect_vec()
-                })
+                .map(|p| hugr.linked_inputs(inp, p).collect_vec())
                 .filter(|ps| !ps.is_empty())
                 .collect(),
             hugr.node_inputs(out)
                 .take(2)
-                .filter_map(|p| hugr.linked_ports(out, p).exactly_one().ok())
-                .map(|(n, p)| (n, p.as_outgoing().unwrap()))
+                .filter_map(|p| hugr.linked_outputs(out, p).exactly_one().ok())
                 .collect(),
             &func,
         )

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -9,7 +9,7 @@ use smol_str::SmolStr;
 
 use std::fmt::{self, Display, Write};
 
-use crate::hugr::{Direction, PortIndex};
+use crate::hugr::{Direction, IncomingPort, OutgoingPort, PortIndex};
 
 use super::{Type, TypeRow};
 
@@ -103,7 +103,8 @@ impl FunctionType {
     /// Returns the type of a value [`Port`]. Returns `None` if the port is out
     /// of bounds.
     #[inline]
-    pub fn get(&self, port: Port) -> Option<&Type> {
+    pub fn get(&self, port: impl Into<Port>) -> Option<&Type> {
+        let port = port.into();
         match port.direction() {
             Direction::Incoming => self.input.get(port),
             Direction::Outgoing => self.output.get(port),
@@ -201,14 +202,16 @@ impl FunctionType {
 
     /// Returns the incoming `Port`s in the signature.
     #[inline]
-    pub fn input_ports(&self) -> impl Iterator<Item = Port> {
+    pub fn input_ports(&self) -> impl Iterator<Item = IncomingPort> {
         self.ports(Direction::Incoming)
+            .map(|p| p.as_incoming().unwrap())
     }
 
     /// Returns the outgoing `Port`s in the signature.
     #[inline]
-    pub fn output_ports(&self) -> impl Iterator<Item = Port> {
+    pub fn output_ports(&self) -> impl Iterator<Item = OutgoingPort> {
         self.ports(Direction::Outgoing)
+            .map(|p| p.as_outgoing().unwrap())
     }
 }
 


### PR DESCRIPTION
A bunch of code used to go via `Port::try_new_incoming` (and similarly `try_new_outgoing`), allowing to use both existing Ports (failing at runtime if direction incorrect) as well as ints etc.

Instead, separate out the only fallible case (Port -> IncomingPort/OutgoingPort) - add fallible methods `Port::as_incoming` and `Port::as_outgoing` to perform those conversions. APIs that want to enforce a direction now take `Into<IncomingPort>` (rather than TryInto).

This is generally not too painful, indeed in some cases quite the opposite, the key part was to extend directionality further - e.g. `Wire` stores an `OutgoingPort`, `HugrView::node_inputs`/`node_outputs` return iterators over that element type, etc. - and new methods `linked_inputs` and `linked_outputs` propagate the knowledge that IncomingPorts are only connected to OutgoingPorts, etc.