### PR TITLE
refactor: Remove add_op/node_after and move_after

### DIFF
--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -303,12 +303,6 @@ impl Hugr {
         }
     }
 
-    /// Add a node to the graph, with the default conversion from OpType to NodeType
-    pub(crate) fn add_op(&mut self, op: impl Into<OpType>) -> Node {
-        // TODO: Default to `NodeType::open_extensions` once we can infer extensions
-        self.add_node(NodeType::pure(op))
-    }
-
     /// Add a node to the graph.
     pub(crate) fn add_node(&mut self, nodetype: NodeType) -> Node {
         let node = self

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -439,18 +439,6 @@ pub(crate) mod sealed {
             self.hugr_mut().set_parent(node, parent)
         }
 
-        /// Move a node in the hierarchy to be the subsequent sibling of another
-        /// node.
-        ///
-        /// The sibling node's parent becomes the new node's parent.
-        ///
-        /// The node becomes the parent's last child.
-        fn move_after_sibling(&mut self, node: Node, after: Node) -> Result<(), HugrError> {
-            self.valid_non_root(node)?;
-            self.valid_non_root(after)?;
-            self.hugr_mut().move_after_sibling(node, after)
-        }
-
         /// Move a node in the hierarchy to be the prior sibling of another node.
         ///
         /// The sibling node's parent becomes the new node's parent.
@@ -519,14 +507,6 @@ pub(crate) mod sealed {
             self.hugr_mut()
                 .hierarchy
                 .push_child(node.index, parent.index)?;
-            Ok(())
-        }
-
-        fn move_after_sibling(&mut self, node: Node, after: Node) -> Result<(), HugrError> {
-            self.hugr_mut().hierarchy.detach(node.index);
-            self.hugr_mut()
-                .hierarchy
-                .insert_after(node.index, after.index)?;
             Ok(())
         }
 

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -75,20 +75,6 @@ pub trait HugrMut: HugrMutInternals {
         self.hugr_mut().add_node_before(sibling, nodetype)
     }
 
-    /// Add a node to the graph as the next sibling of another node.
-    ///
-    /// The sibling node's parent becomes the new node's parent.
-    ///
-    /// # Errors
-    ///
-    ///  - If the sibling node does not have a parent.
-    ///  - If the attachment would introduce a cycle.
-    #[inline]
-    fn add_op_after(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
-        self.valid_non_root(sibling)?;
-        self.hugr_mut().add_op_after(sibling, op)
-    }
-
     /// Remove a node from the graph.
     ///
     /// # Panics
@@ -224,14 +210,6 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
         self.as_mut()
             .hierarchy
             .insert_before(node.index, sibling.index)?;
-        Ok(node)
-    }
-
-    fn add_op_after(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
-        let node = self.as_mut().add_op(op);
-        self.as_mut()
-            .hierarchy
-            .insert_after(node.index, sibling.index)?;
         Ok(node)
     }
 

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -99,12 +99,11 @@ impl Rewrite for SimpleReplacement {
             .collect::<Vec<Node>>();
         // slice of nodes omitting Input and Output:
         let replacement_inner_nodes = &replacement_nodes[2..];
-        let self_output_node = h.children(parent).nth(1).unwrap();
         let replacement_output_node = *replacement_nodes.get(1).unwrap();
         for &node in replacement_inner_nodes {
             // Add the nodes.
             let op: &OpType = self.replacement.get_optype(node);
-            let new_node = h.add_op_after(self_output_node, op.clone()).unwrap();
+            let new_node = h.add_op_with_parent(parent, op.clone()).unwrap();
             index_map.insert(node, new_node);
 
             // Move the metadata

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -273,7 +273,7 @@ pub mod test {
 
     use super::*;
     use crate::extension::{EMPTY_REG, PRELUDE_REGISTRY};
-    use crate::hugr::hugrmut::sealed::HugrMutInternals;
+
     use crate::{
         builder::{
             test::closed_dfg_root_hugr, Container, DFGBuilder, Dataflow, DataflowHugr,
@@ -465,10 +465,11 @@ pub mod test {
         hugr.connect(old_in, 0, out, 0).unwrap();
 
         // Now add a new input
-        let new_in = hugr.add_op(Input::new([QB].to_vec()));
+        let new_in = hugr
+            .add_op_before(old_in, Input::new([QB].to_vec()))
+            .unwrap();
         hugr.disconnect(old_in, Port::new_outgoing(0)).unwrap();
         hugr.connect(new_in, 0, out, 0).unwrap();
-        hugr.move_before_sibling(new_in, old_in).unwrap();
         hugr.remove_node(old_in).unwrap();
         hugr.update_validate(&PRELUDE_REGISTRY).unwrap();
 

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -1039,8 +1039,8 @@ mod test {
 
         // Add an internal exit node
         let exit2 = b
-            .add_op_after(
-                exit,
+            .add_op_with_parent(
+                cfg,
                 ops::BasicBlock::Exit {
                     cfg_outputs: type_row![BOOL_T],
                 },

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -845,7 +845,7 @@ mod test {
         assert_eq!(b.validate(&EMPTY_REG), Ok(()));
 
         // Add another hierarchy root
-        let other = b.add_op(ops::Module);
+        let other = b.add_node(NodeType::pure(ops::Module));
         assert_matches!(
             b.validate(&EMPTY_REG),
             Err(ValidationError::NoParent { node }) => assert_eq!(node, other)


### PR DESCRIPTION
We only use these in a couple of places, and we never need to - we're always adding after the last sibling of a parent that we have handy anyway.

The `_before` versions are much more widely used, but maybe we only need one rather than both?

Note [this run](https://github.com/CQCL/hugr/actions/runs/6614791644/job/17965516726) without the last commit: `clippy --all-targets` complains that `add_op` is unused, even though it *is* used. But it's not that hard to remove...