### PR TITLE
refactor: change &NodeType->&OpType conversion into op() accessor

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -354,8 +354,8 @@ pub trait Dataflow: Container {
         let const_node = cid.node();
         let nodetype = self.hugr().get_nodetype(const_node);
         let input_extensions = nodetype.input_extensions().cloned();
-        let op: &OpType = nodetype.into();
-        let op: ops::Const = op
+        let op: ops::Const = nodetype
+            .op()
             .clone()
             .try_into()
             .expect("ConstID does not refer to Const op.");

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -14,7 +14,7 @@ use super::{ExtensionId, ExtensionSet};
 use crate::{
     hugr::views::HugrView,
     hugr::Node,
-    ops::{OpTag, OpTrait, OpType},
+    ops::{OpTag, OpTrait},
     types::EdgeKind,
     Direction,
 };
@@ -328,7 +328,7 @@ impl UnificationContext {
         // Separate loop so that we can assume that a metavariable has been
         // added for every (Node, Direction) in the graph already.
         for tgt_node in hugr.nodes() {
-            let sig: &OpType = hugr.get_nodetype(tgt_node).into();
+            let sig = hugr.get_nodetype(tgt_node).op();
             // Incoming ports with an edge that should mean equal extension reqs
             for port in hugr.node_inputs(tgt_node).filter(|src_port| {
                 matches!(
@@ -695,6 +695,7 @@ mod test {
     use crate::extension::{prelude::PRELUDE_REGISTRY, ExtensionSet};
     use crate::hugr::{validate::ValidationError, Hugr, HugrMut, HugrView, NodeType};
     use crate::macros::const_extension_ids;
+    use crate::ops::OpType;
     use crate::ops::{self, dataflow::IOTrait, handle::NodeHandle, OpTrait};
     use crate::type_row;
     use crate::types::{FunctionType, Type, TypeRow};

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -121,6 +121,13 @@ impl NodeType {
 }
 
 impl NodeType {
+    /// Gets the underlying [OpType] i.e. without any [input_extensions]
+    ///
+    /// [input_extensions]: NodeType::input_extensions
+    pub fn op(&self) -> &OpType {
+        &self.op
+    }
+
     delegate! {
         to self.op {
             /// Tag identifying the operation.
@@ -130,12 +137,6 @@ impl NodeType {
             /// Returns the number of outputs ports for the operation.
             pub fn output_count(&self) -> usize;
         }
-    }
-}
-
-impl<'a> From<&'a NodeType> for &'a OpType {
-    fn from(nt: &'a NodeType) -> Self {
-        &nt.op
     }
 }
 


### PR DESCRIPTION
* Remove `impl From<&NodeType> for &OpType`
* Add new NodeType `fn op(&self) -> &OpType`