### PR TITLE
refactor: infer.rs 'fn results'

### DIFF
--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -440,7 +440,7 @@ impl UnificationContext {
                     continue;
                 }
 
-                if let Some(cs) = self.constraints.get(m) {
+                if let Some(cs) = self.constraints.remove(m) {
                     for c in cs
                         .iter()
                         .filter(|c| !matches!(c, Constraint::Equal(_)))
@@ -450,7 +450,6 @@ impl UnificationContext {
                     {
                         self.add_constraint(combined_meta, c.clone());
                     }
-                    self.constraints.remove(m).unwrap();
                     merged.insert(*m);
                     // Record a new meta the first time that we use it; don't
                     // bother recording a new meta if we don't add any


### PR DESCRIPTION
* No need for `&self` to be mutable
* Make control-flow more obvious
* Also, in merge_equal_metas(), do if contains ... remove.unwrap in one step

No change to semantics.