### PR TITLE
refactor: NodeType constructors, adding new_auto

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -146,7 +146,7 @@ pub(crate) mod test {
     /// inference. Using DFGBuilder will default to a root node with an open
     /// extension variable
     pub(crate) fn closed_dfg_root_hugr(signature: FunctionType) -> Hugr {
-        let mut hugr = Hugr::new(NodeType::pure(ops::DFG {
+        let mut hugr = Hugr::new(NodeType::new_pure(ops::DFG {
             signature: signature.clone(),
         }));
         hugr.add_op_with_parent(

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -200,7 +200,7 @@ pub trait Dataflow: Container {
         op: impl Into<OpType>,
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
-        self.add_dataflow_node(NodeType::new_open(op), input_wires)
+        self.add_dataflow_node(NodeType::new_default(op), input_wires)
     }
 
     /// Add a dataflow [`NodeType`] to the sibling graph, wiring up the `input_wires` to the
@@ -628,7 +628,7 @@ fn add_op_with_wires<T: Dataflow + ?Sized>(
     optype: impl Into<OpType>,
     inputs: Vec<Wire>,
 ) -> Result<(Node, usize), BuildError> {
-    add_node_with_wires(data_builder, NodeType::new_open(optype), inputs)
+    add_node_with_wires(data_builder, NodeType::new_default(optype), inputs)
 }
 
 fn add_node_with_wires<T: Dataflow + ?Sized>(

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -200,7 +200,7 @@ pub trait Dataflow: Container {
         op: impl Into<OpType>,
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
-        self.add_dataflow_node(NodeType::new_default(op), input_wires)
+        self.add_dataflow_node(NodeType::new_auto(op), input_wires)
     }
 
     /// Add a dataflow [`NodeType`] to the sibling graph, wiring up the `input_wires` to the
@@ -628,7 +628,7 @@ fn add_op_with_wires<T: Dataflow + ?Sized>(
     optype: impl Into<OpType>,
     inputs: Vec<Wire>,
 ) -> Result<(Node, usize), BuildError> {
-    add_node_with_wires(data_builder, NodeType::new_default(optype), inputs)
+    add_node_with_wires(data_builder, NodeType::new_auto(optype), inputs)
 }
 
 fn add_node_with_wires<T: Dataflow + ?Sized>(

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -200,7 +200,7 @@ pub trait Dataflow: Container {
         op: impl Into<OpType>,
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
-        self.add_dataflow_node(NodeType::open_extensions(op), input_wires)
+        self.add_dataflow_node(NodeType::new_open(op), input_wires)
     }
 
     /// Add a dataflow [`NodeType`] to the sibling graph, wiring up the `input_wires` to the
@@ -628,7 +628,7 @@ fn add_op_with_wires<T: Dataflow + ?Sized>(
     optype: impl Into<OpType>,
     inputs: Vec<Wire>,
 ) -> Result<(Node, usize), BuildError> {
-    add_node_with_wires(data_builder, NodeType::open_extensions(optype), inputs)
+    add_node_with_wires(data_builder, NodeType::new_open(optype), inputs)
 }
 
 fn add_node_with_wires<T: Dataflow + ?Sized>(

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -62,7 +62,7 @@ impl CFGBuilder<Hugr> {
             signature: signature.clone(),
         };
 
-        let base = Hugr::new(NodeType::open_extensions(cfg_op));
+        let base = Hugr::new(NodeType::new_open(cfg_op));
         let cfg_node = base.root();
         CFGBuilder::create(base, cfg_node, signature.input, signature.output)
     }

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -176,7 +176,7 @@ impl ConditionalBuilder<Hugr> {
             extension_delta,
         };
         // TODO: Allow input extensions to be specified
-        let base = Hugr::new(NodeType::open_extensions(op));
+        let base = Hugr::new(NodeType::new_open(op));
         let conditional_node = base.root();
 
         Ok(ConditionalBuilder {
@@ -194,7 +194,7 @@ impl CaseBuilder<Hugr> {
         let op = ops::Case {
             signature: signature.clone(),
         };
-        let base = Hugr::new(NodeType::open_extensions(op));
+        let base = Hugr::new(NodeType::new_open(op));
         let root = base.root();
         let dfg_builder = DFGBuilder::create_with_io(base, root, signature, None)?;
 

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -79,7 +79,7 @@ impl DFGBuilder<Hugr> {
         let dfg_op = ops::DFG {
             signature: signature.clone(),
         };
-        let base = Hugr::new(NodeType::open_extensions(dfg_op));
+        let base = Hugr::new(NodeType::new_open(dfg_op));
         let root = base.root();
         DFGBuilder::create_with_io(base, root, signature, None)
     }

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -90,7 +90,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         };
         self.hugr_mut().replace_op(
             f_node,
-            NodeType::pure(ops::FuncDefn {
+            NodeType::new_pure(ops::FuncDefn {
                 name,
                 signature: signature.clone(),
             }),

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -82,7 +82,7 @@ impl TailLoopBuilder<Hugr> {
             rest: inputs_outputs.into(),
         };
         // TODO: Allow input extensions to be specified
-        let base = Hugr::new(NodeType::open_extensions(tail_loop.clone()));
+        let base = Hugr::new(NodeType::new_open(tail_loop.clone()));
         let root = base.root();
         Self::create_with_io(base, root, &tail_loop)
     }

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -723,7 +723,7 @@ mod test {
             signature: main_sig,
         };
 
-        let root_node = NodeType::open_extensions(op);
+        let root_node = NodeType::new_open(op);
         let mut hugr = Hugr::new(root_node);
 
         let input = ops::Input::new(type_row![NAT, NAT]);
@@ -1084,7 +1084,7 @@ mod test {
     fn extension_adding_sequence() -> Result<(), Box<dyn Error>> {
         let df_sig = FunctionType::new(type_row![NAT], type_row![NAT]);
 
-        let mut hugr = Hugr::new(NodeType::open_extensions(ops::DFG {
+        let mut hugr = Hugr::new(NodeType::new_open(ops::DFG {
             signature: df_sig
                 .clone()
                 .with_extension_delta(&ExtensionSet::from_iter([A, B])),
@@ -1255,7 +1255,7 @@ mod test {
         let b = ExtensionSet::singleton(&B);
         let c = ExtensionSet::singleton(&C);
 
-        let mut hugr = Hugr::new(NodeType::open_extensions(ops::CFG {
+        let mut hugr = Hugr::new(NodeType::new_open(ops::CFG {
             signature: FunctionType::new(type_row![NAT], type_row![NAT]).with_extension_delta(&abc),
         }));
 
@@ -1353,7 +1353,7 @@ mod test {
     ///             +--------------------+
     #[test]
     fn multi_entry() -> Result<(), Box<dyn Error>> {
-        let mut hugr = Hugr::new(NodeType::open_extensions(ops::CFG {
+        let mut hugr = Hugr::new(NodeType::new_open(ops::CFG {
             signature: FunctionType::new(type_row![NAT], type_row![NAT]), // maybe add extensions?
         }));
         let cfg = hugr.root();
@@ -1436,7 +1436,7 @@ mod test {
     ) -> Result<Hugr, Box<dyn Error>> {
         let hugr_delta = entry_ext.clone().union(&bb1_ext).union(&bb2_ext);
 
-        let mut hugr = Hugr::new(NodeType::open_extensions(ops::CFG {
+        let mut hugr = Hugr::new(NodeType::new_open(ops::CFG {
             signature: FunctionType::new(type_row![NAT], type_row![NAT])
                 .with_extension_delta(&hugr_delta),
         }));

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -316,10 +316,7 @@ impl UnificationContext {
                         m_output,
                         node_type.op_signature().extension_reqs,
                     );
-                    if matches!(
-                        node_type.tag(),
-                        OpTag::Alias | OpTag::Function | OpTag::FuncDefn
-                    ) {
+                    if OpTag::ModuleOp.is_superset(node_type.tag()) {
                         self.add_solution(m_input, ExtensionSet::new());
                     }
                 }

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -833,21 +833,21 @@ mod test {
     // This generates a solution that causes validation to fail
     // because of a missing lift node
     fn missing_lift_node() -> Result<(), Box<dyn Error>> {
-        let mut hugr = Hugr::new(NodeType::pure(ops::DFG {
+        let mut hugr = Hugr::new(NodeType::new_pure(ops::DFG {
             signature: FunctionType::new(type_row![NAT], type_row![NAT])
                 .with_extension_delta(&ExtensionSet::singleton(&A)),
         }));
 
         let input = hugr.add_node_with_parent(
             hugr.root(),
-            NodeType::pure(ops::Input {
+            NodeType::new_pure(ops::Input {
                 types: type_row![NAT],
             }),
         )?;
 
         let output = hugr.add_node_with_parent(
             hugr.root(),
-            NodeType::pure(ops::Output {
+            NodeType::new_pure(ops::Output {
                 types: type_row![NAT],
             }),
         )?;
@@ -1049,7 +1049,7 @@ mod test {
             extension_delta: rs.clone(),
         };
 
-        let mut hugr = Hugr::new(NodeType::pure(op));
+        let mut hugr = Hugr::new(NodeType::new_pure(op));
         let conditional_node = hugr.root();
 
         let case_op = ops::Case {

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -316,9 +316,6 @@ impl UnificationContext {
                         m_output,
                         node_type.op_signature().extension_reqs,
                     );
-                    if OpTag::ModuleOp.is_superset(node_type.tag()) {
-                        self.add_solution(m_input, ExtensionSet::new());
-                    }
                 }
                 // We have a solution for everything!
                 Some(sig) => {

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -82,7 +82,7 @@ impl NodeType {
     }
 
     /// Instantiate an OpType with no input extensions
-    pub fn pure(op: impl Into<OpType>) -> Self {
+    pub fn new_pure(op: impl Into<OpType>) -> Self {
         NodeType {
             op: op.into(),
             input_extensions: Some(ExtensionSet::new()),
@@ -153,7 +153,7 @@ impl OpType {
 
 impl Default for Hugr {
     fn default() -> Self {
-        Self::new(NodeType::pure(crate::ops::Module))
+        Self::new(NodeType::new_pure(crate::ops::Module))
     }
 }
 

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -91,7 +91,7 @@ impl NodeType {
 
     /// Instantiate an OpType with an unknown set of input extensions
     /// (to be inferred later)
-    pub fn open_extensions(op: impl Into<OpType>) -> Self {
+    pub fn new_open(op: impl Into<OpType>) -> Self {
         NodeType {
             op: op.into(),
             input_extensions: None,
@@ -239,7 +239,7 @@ impl Hugr {
 
     /// Add a node to the graph, with the default conversion from OpType to NodeType
     pub(crate) fn add_op(&mut self, op: impl Into<OpType>) -> Node {
-        self.add_node(NodeType::open_extensions(op))
+        self.add_node(NodeType::new_open(op))
     }
 
     /// Add a node to the graph.

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -98,6 +98,17 @@ impl NodeType {
         }
     }
 
+    /// Instantiate an [OpType] with the default set of input extensions
+    /// for that OpType.
+    pub fn new_default(op: impl Into<OpType>) -> Self {
+        let op = op.into();
+        if OpTag::ModuleOp.is_superset(op.tag()) {
+            Self::new_pure(op)
+        } else {
+            Self::new_open(op)
+        }
+    }
+
     /// Use the input extensions to calculate the concrete signature of the node
     pub fn signature(&self) -> Option<Signature> {
         self.input_extensions
@@ -237,7 +248,7 @@ impl Hugr {
 
     /// Add a node to the graph, with the default conversion from OpType to NodeType
     pub(crate) fn add_op(&mut self, op: impl Into<OpType>) -> Node {
-        self.add_node(NodeType::new_open(op))
+        self.add_node(NodeType::new_default(op))
     }
 
     /// Add a node to the graph.

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -119,9 +119,7 @@ impl NodeType {
     pub fn input_extensions(&self) -> Option<&ExtensionSet> {
         self.input_extensions.as_ref()
     }
-}
 
-impl NodeType {
     /// Gets the underlying [OpType] i.e. without any [input_extensions]
     ///
     /// [input_extensions]: NodeType::input_extensions

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -100,7 +100,7 @@ impl NodeType {
 
     /// Instantiate an [OpType] with the default set of input extensions
     /// for that OpType.
-    pub fn new_default(op: impl Into<OpType>) -> Self {
+    pub fn new_auto(op: impl Into<OpType>) -> Self {
         let op = op.into();
         if OpTag::ModuleOp.is_superset(op.tag()) {
             Self::new_pure(op)
@@ -248,7 +248,7 @@ impl Hugr {
 
     /// Add a node to the graph, with the default conversion from OpType to NodeType
     pub(crate) fn add_op(&mut self, op: impl Into<OpType>) -> Node {
-        self.add_node(NodeType::new_default(op))
+        self.add_node(NodeType::new_auto(op))
     }
 
     /// Add a node to the graph.

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -620,7 +620,7 @@ mod test {
 
         {
             let f_in = hugr
-                .add_node_with_parent(f, NodeType::pure(ops::Input::new(type_row![NAT])))
+                .add_node_with_parent(f, NodeType::new_pure(ops::Input::new(type_row![NAT])))
                 .unwrap();
             let f_out = hugr
                 .add_op_with_parent(f, ops::Output::new(type_row![NAT, NAT]))

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -37,7 +37,7 @@ pub trait HugrMut: HugrMutInternals {
         parent: Node,
         op: impl Into<OpType>,
     ) -> Result<Node, HugrError> {
-        self.add_node_with_parent(parent, NodeType::new_default(op))
+        self.add_node_with_parent(parent, NodeType::new_auto(op))
     }
 
     /// Add a node to the graph with a parent in the hierarchy.
@@ -217,7 +217,7 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
     }
 
     fn add_op_before(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
-        self.add_node_before(sibling, NodeType::new_default(op))
+        self.add_node_before(sibling, NodeType::new_auto(op))
     }
 
     fn add_node_before(&mut self, sibling: Node, nodetype: NodeType) -> Result<Node, HugrError> {

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -37,7 +37,7 @@ pub trait HugrMut: HugrMutInternals {
         parent: Node,
         op: impl Into<OpType>,
     ) -> Result<Node, HugrError> {
-        self.add_node_with_parent(parent, NodeType::new_open(op))
+        self.add_node_with_parent(parent, NodeType::new_default(op))
     }
 
     /// Add a node to the graph with a parent in the hierarchy.
@@ -217,7 +217,7 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
     }
 
     fn add_op_before(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
-        self.add_node_before(sibling, NodeType::new_open(op))
+        self.add_node_before(sibling, NodeType::new_default(op))
     }
 
     fn add_node_before(&mut self, sibling: Node, nodetype: NodeType) -> Result<Node, HugrError> {

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -37,7 +37,7 @@ pub trait HugrMut: HugrMutInternals {
         parent: Node,
         op: impl Into<OpType>,
     ) -> Result<Node, HugrError> {
-        self.add_node_with_parent(parent, NodeType::open_extensions(op))
+        self.add_node_with_parent(parent, NodeType::new_open(op))
     }
 
     /// Add a node to the graph with a parent in the hierarchy.
@@ -217,7 +217,7 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
     }
 
     fn add_op_before(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
-        self.add_node_before(sibling, NodeType::open_extensions(op))
+        self.add_node_before(sibling, NodeType::new_open(op))
     }
 
     fn add_node_before(&mut self, sibling: Node, nodetype: NodeType) -> Result<Node, HugrError> {

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -336,7 +336,7 @@ pub mod test {
 
         for n in [a, b, c] {
             h.push_child(n, root).unwrap();
-            op_types[n] = NodeType::pure(gen_optype(&g, n));
+            op_types[n] = NodeType::new_pure(gen_optype(&g, n));
         }
 
         let hg = Hugr {

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -223,7 +223,7 @@ impl TryFrom<SerHugrV0> for Hugr {
             hugr.add_node_with_parent(
                 node_ser.parent,
                 match node_ser.input_extensions {
-                    None => NodeType::open_extensions(node_ser.op),
+                    None => NodeType::new_open(node_ser.op),
                     Some(rs) => NodeType::new(node_ser.op, rs),
                 },
             )?;
@@ -332,7 +332,7 @@ pub mod test {
         let mut h = Hierarchy::new();
         let mut op_types = UnmanagedDenseMap::new();
 
-        op_types[root] = NodeType::open_extensions(gen_optype(&g, root));
+        op_types[root] = NodeType::new_open(gen_optype(&g, root));
 
         for n in [a, b, c] {
             h.push_child(n, root).unwrap();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -222,10 +222,7 @@ impl TryFrom<SerHugrV0> for Hugr {
         for node_ser in nodes {
             hugr.add_node_with_parent(
                 node_ser.parent,
-                match node_ser.input_extensions {
-                    None => NodeType::new_open(node_ser.op),
-                    Some(rs) => NodeType::new(node_ser.op, rs),
-                },
+                NodeType::new(node_ser.op, node_ser.input_extensions),
             )?;
         }
 

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -79,7 +79,7 @@ mod test {
 
     #[test]
     fn root_checked() {
-        let root_type = NodeType::pure(ops::DFG {
+        let root_type = NodeType::new_pure(ops::DFG {
             signature: FunctionType::new(vec![], vec![]),
         });
         let mut h = Hugr::new(root_type.clone());
@@ -94,7 +94,7 @@ mod test {
         let mut dfg_v = RootChecked::<&mut Hugr, DfgID>::try_new(&mut h).unwrap();
         // That is a HugrMutInternal, so we can try:
         let root = dfg_v.root();
-        let bb = NodeType::pure(BasicBlock::DFB {
+        let bb = NodeType::new_pure(BasicBlock::DFB {
             inputs: type_row![],
             other_outputs: type_row![],
             tuple_sum_rows: vec![type_row![]],
@@ -129,7 +129,7 @@ mod test {
         let mut bb_v = RootChecked::<_, BasicBlockID>::try_new(dfp_v).unwrap();
 
         // And it's a HugrMut:
-        let nodetype = NodeType::pure(LeafOp::MakeTuple { tys: type_row![] });
+        let nodetype = NodeType::new_pure(LeafOp::MakeTuple { tys: type_row![] });
         bb_v.add_node_with_parent(bb_v.root(), nodetype).unwrap();
     }
 }

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -454,7 +454,7 @@ mod test {
         );
 
         let mut sib_mut = SiblingMut::<DfgID>::try_new(&mut simple_dfg_hugr, root).unwrap();
-        let bad_nodetype = NodeType::open_extensions(crate::ops::CFG { signature });
+        let bad_nodetype = NodeType::new_open(crate::ops::CFG { signature });
         assert_eq!(
             sib_mut.replace_op(sib_mut.root(), bad_nodetype.clone()),
             Err(HugrError::InvalidTag {
@@ -471,7 +471,7 @@ mod test {
     #[rstest]
     fn sibling_mut_covariance(mut simple_dfg_hugr: Hugr) {
         let root = simple_dfg_hugr.root();
-        let case_nodetype = NodeType::open_extensions(crate::ops::Case {
+        let case_nodetype = NodeType::new_open(crate::ops::Case {
             signature: simple_dfg_hugr.root_type().op_signature(),
         });
         let mut sib_mut = SiblingMut::<DfgID>::try_new(&mut simple_dfg_hugr, root).unwrap();


### PR DESCRIPTION
* Rename NodeType::open_extensions to NodeType::new_open
* Rename NodeType::pure to NodeType::new_pure
* Add NodeType::new_auto, which uses Pure for module-ops and Open for others
* Remove special-case in infer.rs solving some module-ops to empty set
* Switch builder/HugrMut methods from new_open to new_auto