### PR TITLE
refactor: Constraint::Plus stores an ExtensionSet, which is a BTreeSet

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -306,7 +306,7 @@ pub struct ExtensionSet(BTreeSet<ExtensionId>);
 
 impl ExtensionSet {
     /// Creates a new empty extension set.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(BTreeSet::new())
     }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -6,7 +6,7 @@
 use std::collections::hash_map::{DefaultHasher, Entry};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
-use std::hash::{BuildHasher, BuildHasherDefault};
+use std::hash::{BuildHasher, BuildHasherDefault, Hasher};
 use std::sync::Arc;
 
 use smol_str::SmolStr;
@@ -313,7 +313,11 @@ impl std::hash::Hash for ExtensionSet {
         let item_h = BuildHasherDefault::<DefaultHasher>::default();
         self.0
             .iter()
-            .map(|e_id| item_h.hash_one(e_id))
+            .map(|e_id| {
+                let mut h = item_h.build_hasher();
+                e_id.hash(&mut h);
+                h.finish()
+            })
             .fold(0, |a, b| a ^ b)
             .hash(state);
     }

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -328,11 +328,6 @@ impl ExtensionSet {
         Self(HashSet::new())
     }
 
-    /// Creates a new extension set from some extensions.
-    pub fn new_from_extensions(extensions: impl Into<HashSet<ExtensionId>>) -> Self {
-        Self(extensions.into())
-    }
-
     /// Adds a extension to the set.
     pub fn insert(&mut self, extension: &ExtensionId) {
         self.0.insert(extension.clone());

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -3,10 +3,9 @@
 //! TODO: YAML declaration and parsing. This should be similar to a plugin
 //! system (outside the `types` module), which also parses nested [`OpDef`]s.
 
-use std::collections::hash_map::{DefaultHasher, Entry};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::hash_map::Entry;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::{Debug, Display, Formatter};
-use std::hash::Hasher;
 use std::sync::Arc;
 
 use smol_str::SmolStr;
@@ -302,30 +301,13 @@ pub enum ExtensionBuildError {
 }
 
 /// A set of extensions identified by their unique [`ExtensionId`].
-#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct ExtensionSet(HashSet<ExtensionId>);
-
-impl std::hash::Hash for ExtensionSet {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        // Hash each item individually and combine with a *weak* hash combiner
-        // (i.e. that is associative and commutative, hence item iteration order doesn't matter).
-        // Here we just use xor.
-        self.0
-            .iter()
-            .map(|e_id| {
-                let mut h = DefaultHasher::new();
-                e_id.hash(&mut h);
-                h.finish()
-            })
-            .fold(0, |a, b| a ^ b)
-            .hash(state);
-    }
-}
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ExtensionSet(BTreeSet<ExtensionId>);
 
 impl ExtensionSet {
     /// Creates a new empty extension set.
     pub fn new() -> Self {
-        Self(HashSet::new())
+        Self(BTreeSet::new())
     }
 
     /// Adds a extension to the set.
@@ -385,6 +367,6 @@ impl Display for ExtensionSet {
 
 impl FromIterator<ExtensionId> for ExtensionSet {
     fn from_iter<I: IntoIterator<Item = ExtensionId>>(iter: I) -> Self {
-        Self(HashSet::from_iter(iter))
+        Self(BTreeSet::from_iter(iter))
     }
 }

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -372,6 +372,11 @@ impl ExtensionSet {
     pub fn iter(&self) -> impl Iterator<Item = &ExtensionId> {
         self.0.iter()
     }
+
+    /// True if this set contains no [ExtensionId]s
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl Display for ExtensionSet {

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -363,7 +363,7 @@ impl ExtensionSet {
 
     /// The things in other which are in not in self
     pub fn missing_from(&self, other: &Self) -> Self {
-        ExtensionSet(HashSet::from_iter(other.0.difference(&self.0).cloned()))
+        ExtensionSet::from_iter(other.0.difference(&self.0).cloned())
     }
 
     /// Iterate over the contained ExtensionIds

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -6,7 +6,7 @@
 use std::collections::hash_map::{DefaultHasher, Entry};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
-use std::hash::{BuildHasher, BuildHasherDefault, Hasher};
+use std::hash::Hasher;
 use std::sync::Arc;
 
 use smol_str::SmolStr;
@@ -310,11 +310,10 @@ impl std::hash::Hash for ExtensionSet {
         // Hash each item individually and combine with a *weak* hash combiner
         // (i.e. that is associative and commutative, hence item iteration order doesn't matter).
         // Here we just use xor.
-        let item_h = BuildHasherDefault::<DefaultHasher>::default();
         self.0
             .iter()
             .map(|e_id| {
-                let mut h = item_h.build_hasher();
+                let mut h = DefaultHasher::new();
                 e_id.hash(&mut h);
                 h.finish()
             })

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -233,7 +233,7 @@ impl UnificationContext {
     fn gen_union_constraint(&mut self, input: Meta, output: Meta, delta: ExtensionSet) {
         self.add_constraint(
             output,
-            if delta.is_subset(&ExtensionSet::new()) {
+            if delta.is_empty() {
                 Constraint::Equal(input)
             } else {
                 Constraint::Plus(delta, input)

--- a/src/std_extensions/arithmetic/conversions.rs
+++ b/src/std_extensions/arithmetic/conversions.rs
@@ -1,7 +1,5 @@
 //! Conversions between integer and floating-point values.
 
-use std::collections::HashSet;
-
 use crate::{
     extension::{ExtensionId, ExtensionSet, SignatureError},
     type_row,
@@ -39,10 +37,10 @@ fn itof_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
 pub fn extension() -> Extension {
     let mut extension = Extension::new_with_reqs(
         EXTENSION_ID,
-        ExtensionSet::new_from_extensions(HashSet::from_iter(vec![
+        ExtensionSet::from_iter(vec![
             super::int_types::EXTENSION_ID,
             super::float_types::EXTENSION_ID,
-        ])),
+        ]),
     );
 
     extension


### PR DESCRIPTION
* Convert ExtensionSet from HashSet to BTreeSe => trivially derive Hash
* Constraint::Plus stores an ExtensionSet, rather than a single Extension => gen_union_constraint avoids long chains of metas
* Inline gen_union_constraint (no longer recursive)