### PR TITLE
feat: port.as_directed to match on either direction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ petgraph = { version = "0.6.3", default-features = false }
 context-iterators = "0.2.0"
 serde_json = "1.0.97"
 delegate = "0.10.0"
-either = "1.9.0"
 
 [features]
 pyo3 = ["dep:pyo3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ petgraph = { version = "0.6.3", default-features = false }
 context-iterators = "0.2.0"
 serde_json = "1.0.97"
 delegate = "0.10.0"
+either = "1.9.0"
 
 [features]
 pyo3 = ["dep:pyo3"]

--- a/src/core.rs
+++ b/src/core.rs
@@ -4,6 +4,7 @@
 
 use derive_more::From;
 
+use either::Either::{self, Left, Right};
 #[cfg(feature = "pyo3")]
 use pyo3::pyclass;
 
@@ -92,34 +93,31 @@ impl Port {
     /// [HugrError::InvalidPortDirection]
     #[inline]
     pub fn as_incoming(&self) -> Result<IncomingPort, HugrError> {
-        match self.direction() {
-            Direction::Incoming => Ok(IncomingPort {
-                index: self.index() as u16,
-            }),
-            dir @ Direction::Outgoing => Err(HugrError::InvalidPortDirection(dir)),
-        }
+        self.as_directed()
+            .left()
+            .ok_or(HugrError::InvalidPortDirection(self.direction()))
     }
 
     /// Converts to an [OutgoingPort] if this port is one; else fails with
     /// [HugrError::InvalidPortDirection]
     #[inline]
     pub fn as_outgoing(&self) -> Result<OutgoingPort, HugrError> {
+        self.as_directed()
+            .right()
+            .ok_or(HugrError::InvalidPortDirection(self.direction()))
+    }
+
+    /// Converts to either an [IncomingPort] or an [OutgoingPort], as appropriate.
+    #[inline]
+    pub fn as_directed(&self) -> Either<IncomingPort, OutgoingPort> {
         match self.direction() {
-            Direction::Outgoing => Ok(OutgoingPort {
+            Direction::Incoming => Left(IncomingPort {
                 index: self.index() as u16,
             }),
-            dir @ Direction::Incoming => Err(HugrError::InvalidPortDirection(dir)),
+            Direction::Outgoing => Right(OutgoingPort {
+                index: self.index() as u16,
+            }),
         }
-    }
-    /// Creates a new outgoing port.
-    #[inline]
-    pub fn try_new_outgoing(port: impl TryInto<OutgoingPort>) -> Result<Self, HugrError> {
-        let Ok(port) = port.try_into() else {
-            return Err(HugrError::InvalidPortDirection(Direction::Incoming));
-        };
-        Ok(Self {
-            offset: portgraph::PortOffset::new_outgoing(port.index()),
-        })
     }
 
     /// Returns the direction of the port.

--- a/src/core.rs
+++ b/src/core.rs
@@ -2,9 +2,11 @@
 //!
 //! These types are re-exported in the root of the crate.
 
-use derive_more::From;
+pub use itertools::Either;
 
-use either::Either::{self, Left, Right};
+use derive_more::From;
+use itertools::Either::{Left, Right};
+
 #[cfg(feature = "pyo3")]
 use pyo3::pyclass;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 
 pub mod algorithm;
 pub mod builder;
-mod core;
+pub mod core;
 pub mod extension;
 pub mod hugr;
 pub mod macros;


### PR DESCRIPTION
This replaces boilerplate like
```rust
match port.direction() {
    Direction::Incoming => {
        let incoming = port.as_incoming().unwrap();
        ...
    }
    Direction::Outgoing => {
        let outgoing = port.as_outgoing().unwrap();
        ...
    }
}
```
with
```rust
match port.as_directed() {
    Left(incoming) => ...
    Right(outgoing) => ...
}
```

drive-by: Drop leftover `Port::try_new_outgoing`.