### PR TITLE
refactor: rename accidentally-changed Extension::add_node_xxx back to add_op

### DIFF
--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -270,7 +270,7 @@ impl Extension {
     }
 
     /// Create an OpDef with custom binary code to compute the signature
-    pub fn add_node_custom_sig(
+    pub fn add_op_custom_sig(
         &mut self,
         name: SmolStr,
         description: String,
@@ -291,14 +291,14 @@ impl Extension {
 
     /// Create an OpDef with custom binary code to compute the signature, and no "misc" or "lowering
     /// functions" defined.
-    pub fn add_node_custom_sig_simple(
+    pub fn add_op_custom_sig_simple(
         &mut self,
         name: SmolStr,
         description: String,
         params: Vec<TypeParam>,
         signature_func: impl CustomSignatureFunc + 'static,
     ) -> Result<&OpDef, ExtensionBuildError> {
-        self.add_node_custom_sig(
+        self.add_op_custom_sig(
             name,
             description,
             params,
@@ -310,7 +310,7 @@ impl Extension {
 
     /// Create an OpDef with a signature (inputs+outputs) read from the
     /// declarative YAML
-    pub fn add_node_decl_sig(
+    pub fn add_op_decl_sig(
         &mut self,
         name: SmolStr,
         description: String,

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -41,7 +41,7 @@ lazy_static! {
             .unwrap();
 
         prelude
-            .add_node_custom_sig_simple(
+            .add_op_custom_sig_simple(
                 SmolStr::new_inline(NEW_ARRAY_OP_ID),
                 "Create a new array from elements".to_string(),
                 vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],

--- a/src/std_extensions/arithmetic/conversions.rs
+++ b/src/std_extensions/arithmetic/conversions.rs
@@ -44,7 +44,7 @@ pub fn extension() -> Extension {
     );
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "trunc_u".into(),
             "float to unsigned int".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -52,7 +52,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "trunc_s".into(),
             "float to signed int".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -60,7 +60,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "convert_u".into(),
             "unsigned int to float".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -68,7 +68,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "convert_s".into(),
             "signed int to float".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],

--- a/src/std_extensions/arithmetic/float_ops.rs
+++ b/src/std_extensions/arithmetic/float_ops.rs
@@ -41,16 +41,16 @@ pub fn extension() -> Extension {
     );
 
     extension
-        .add_node_custom_sig_simple("feq".into(), "equality test".to_owned(), vec![], fcmp_sig)
+        .add_op_custom_sig_simple("feq".into(), "equality test".to_owned(), vec![], fcmp_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple("fne".into(), "inequality test".to_owned(), vec![], fcmp_sig)
+        .add_op_custom_sig_simple("fne".into(), "inequality test".to_owned(), vec![], fcmp_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple("flt".into(), "\"less than\"".to_owned(), vec![], fcmp_sig)
+        .add_op_custom_sig_simple("flt".into(), "\"less than\"".to_owned(), vec![], fcmp_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "fgt".into(),
             "\"greater than\"".to_owned(),
             vec![],
@@ -58,7 +58,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "fle".into(),
             "\"less than or equal\"".to_owned(),
             vec![],
@@ -66,7 +66,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "fge".into(),
             "\"greater than or equal\"".to_owned(),
             vec![],
@@ -74,22 +74,22 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple("fmax".into(), "maximum".to_owned(), vec![], fbinop_sig)
+        .add_op_custom_sig_simple("fmax".into(), "maximum".to_owned(), vec![], fbinop_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple("fmin".into(), "minimum".to_owned(), vec![], fbinop_sig)
+        .add_op_custom_sig_simple("fmin".into(), "minimum".to_owned(), vec![], fbinop_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple("fadd".into(), "addition".to_owned(), vec![], fbinop_sig)
+        .add_op_custom_sig_simple("fadd".into(), "addition".to_owned(), vec![], fbinop_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple("fsub".into(), "subtraction".to_owned(), vec![], fbinop_sig)
+        .add_op_custom_sig_simple("fsub".into(), "subtraction".to_owned(), vec![], fbinop_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple("fneg".into(), "negation".to_owned(), vec![], funop_sig)
+        .add_op_custom_sig_simple("fneg".into(), "negation".to_owned(), vec![], funop_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "fabs".into(),
             "absolute value".to_owned(),
             vec![],
@@ -97,7 +97,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "fmul".into(),
             "multiplication".to_owned(),
             vec![],
@@ -105,13 +105,13 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple("fdiv".into(), "division".to_owned(), vec![], fbinop_sig)
+        .add_op_custom_sig_simple("fdiv".into(), "division".to_owned(), vec![], fbinop_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple("ffloor".into(), "floor".to_owned(), vec![], funop_sig)
+        .add_op_custom_sig_simple("ffloor".into(), "floor".to_owned(), vec![], funop_sig)
         .unwrap();
     extension
-        .add_node_custom_sig_simple("fceil".into(), "ceiling".to_owned(), vec![], funop_sig)
+        .add_op_custom_sig_simple("fceil".into(), "ceiling".to_owned(), vec![], funop_sig)
         .unwrap();
 
     extension

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -144,7 +144,7 @@ pub fn extension() -> Extension {
     );
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "iwiden_u".into(),
             "widen an unsigned integer to a wider one with the same value".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -152,7 +152,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "iwiden_s".into(),
             "widen a signed integer to a wider one with the same value".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -160,7 +160,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "inarrow_u".into(),
             "narrow an unsigned integer to a narrower one with the same value if possible"
                 .to_owned(),
@@ -169,7 +169,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "inarrow_s".into(),
             "narrow a signed integer to a narrower one with the same value if possible".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -177,7 +177,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "itobool".into(),
             "convert to bool (1 is true, 0 is false)".to_owned(),
             vec![],
@@ -185,7 +185,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ifrombool".into(),
             "convert from bool (1 is true, 0 is false)".to_owned(),
             vec![],
@@ -193,7 +193,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ieq".into(),
             "equality test".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -201,7 +201,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ine".into(),
             "inequality test".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -209,7 +209,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ilt_u".into(),
             "\"less than\" as unsigned integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -217,7 +217,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ilt_s".into(),
             "\"less than\" as signed integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -225,7 +225,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "igt_u".into(),
             "\"greater than\" as unsigned integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -233,7 +233,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "igt_s".into(),
             "\"greater than\" as signed integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -241,7 +241,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ile_u".into(),
             "\"less than or equal\" as unsigned integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -249,7 +249,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ile_s".into(),
             "\"less than or equal\" as signed integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -257,7 +257,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ige_u".into(),
             "\"greater than or equal\" as unsigned integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -265,7 +265,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ige_s".into(),
             "\"greater than or equal\" as signed integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -273,7 +273,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "imax_u".into(),
             "maximum of unsigned integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -281,7 +281,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "imax_s".into(),
             "maximum of signed integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -289,7 +289,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "imin_u".into(),
             "minimum of unsigned integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -297,7 +297,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "imin_s".into(),
             "minimum of signed integers".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -305,7 +305,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "iadd".into(),
             "addition modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -313,7 +313,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "isub".into(),
             "subtraction modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -321,7 +321,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ineg".into(),
             "negation modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -329,7 +329,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "imul".into(),
             "multiplication modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -337,7 +337,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "idivmod_checked_u".into(),
             "given unsigned integers 0 <= n < 2^N, 0 <= m < 2^M, generates unsigned q, r where \
             q*m+r=n, 0<=r<m (m=0 is an error)"
@@ -347,7 +347,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "idivmod_u".into(),
             "given unsigned integers 0 <= n < 2^N, 0 <= m < 2^M, generates unsigned q, r where \
             q*m+r=n, 0<=r<m (m=0 will call panic)"
@@ -357,7 +357,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "idivmod_checked_s".into(),
             "given signed integer -2^{N-1} <= n < 2^{N-1} and unsigned 0 <= m < 2^M, generates \
             signed q and unsigned r where q*m+r=n, 0<=r<m (m=0 is an error)"
@@ -367,7 +367,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "idivmod_s".into(),
             "given signed integer -2^{N-1} <= n < 2^{N-1} and unsigned 0 <= m < 2^M, generates \
             signed q and unsigned r where q*m+r=n, 0<=r<m (m=0 will call panic)"
@@ -377,7 +377,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "idiv_checked_u".into(),
             "as idivmod_checked_u but discarding the second output".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -385,7 +385,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "idiv_u".into(),
             "as idivmod_u but discarding the second output".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -393,7 +393,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "imod_checked_u".into(),
             "as idivmod_checked_u but discarding the first output".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -401,7 +401,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "imod_u".into(),
             "as idivmod_u but discarding the first output".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -409,7 +409,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "idiv_checked_s".into(),
             "as idivmod_checked_s but discarding the second output".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -417,7 +417,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "idiv_s".into(),
             "as idivmod_s but discarding the second output".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -425,7 +425,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "imod_checked_s".into(),
             "as idivmod_checked_s but discarding the first output".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -433,7 +433,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "imod_s".into(),
             "as idivmod_s but discarding the first output".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
@@ -441,7 +441,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "iabs".into(),
             "convert signed to unsigned by taking absolute value".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -449,7 +449,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "iand".into(),
             "bitwise AND".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -457,7 +457,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ior".into(),
             "bitwise OR".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -465,7 +465,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ixor".into(),
             "bitwise XOR".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -473,7 +473,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "inot".into(),
             "bitwise NOT".to_owned(),
             vec![LOG_WIDTH_TYPE_PARAM],
@@ -481,7 +481,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ishl".into(),
             "shift first input left by k bits where k is unsigned interpretation of second input \
             (leftmost bits dropped, rightmost bits set to zero"
@@ -491,7 +491,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "ishr".into(),
             "shift first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits dropped, leftmost bits set to zero)"
@@ -501,7 +501,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "irotl".into(),
             "rotate first input left by k bits where k is unsigned interpretation of second input \
             (leftmost bits replace rightmost bits)"
@@ -511,7 +511,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "irotr".into(),
             "rotate first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits replace leftmost bits)"

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -72,12 +72,10 @@ fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_custom_sig(
+        .add_op_custom_sig_simple(
             POP_NAME,
             "Pop from back of list".into(),
             vec![TypeParam::Type(TypeBound::Any)],
-            Default::default(),
-            vec![],
             move |args: &[TypeArg]| {
                 let (list_type, element_type) = list_types(args)?;
                 Ok(FunctionType {
@@ -89,12 +87,10 @@ fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_custom_sig(
+        .add_op_custom_sig_simple(
             PUSH_NAME,
             "Push to back of list".into(),
             vec![TypeParam::Type(TypeBound::Any)],
-            Default::default(),
-            vec![],
             move |args: &[TypeArg]| {
                 let (list_type, element_type) = list_types(args)?;
                 Ok(FunctionType {

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -72,7 +72,7 @@ fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig(
+        .add_op_custom_sig(
             POP_NAME,
             "Pop from back of list".into(),
             vec![TypeParam::Type(TypeBound::Any)],
@@ -89,7 +89,7 @@ fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig(
+        .add_op_custom_sig(
             PUSH_NAME,
             "Push to back of list".into(),
             vec![TypeParam::Type(TypeBound::Any)],

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -34,7 +34,7 @@ fn extension() -> Extension {
     let mut extension = Extension::new(EXTENSION_ID);
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             SmolStr::new_inline(NOT_NAME),
             "logical 'not'".into(),
             vec![],
@@ -43,7 +43,7 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             SmolStr::new_inline(AND_NAME),
             "logical 'and'".into(),
             vec![H_INT],
@@ -68,7 +68,7 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             SmolStr::new_inline(OR_NAME),
             "logical 'or'".into(),
             vec![H_INT],

--- a/src/std_extensions/quantum.rs
+++ b/src/std_extensions/quantum.rs
@@ -199,7 +199,7 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "atrunc".into(),
             "truncate an angle to one with a lower log-denominator with the same value, rounding \
             down in [0, 2π) if necessary"
@@ -210,7 +210,7 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "aconvert".into(),
             "convert an angle to one with another log-denominator having the same value, if \
             possible, otherwise return an error"
@@ -221,7 +221,7 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "aadd".into(),
             "addition of angles".to_owned(),
             vec![LOG_DENOM_TYPE_PARAM],
@@ -230,7 +230,7 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "asub".into(),
             "subtraction of the second angle from the first".to_owned(),
             vec![LOG_DENOM_TYPE_PARAM],
@@ -239,7 +239,7 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             "aneg".into(),
             "negation of an angle".to_owned(),
             vec![LOG_DENOM_TYPE_PARAM],
@@ -248,7 +248,7 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             SmolStr::new_inline("H"),
             "Hadamard".into(),
             vec![],
@@ -256,7 +256,7 @@ fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             SmolStr::new_inline("RzF64"),
             "Rotation specified by float".into(),
             vec![],
@@ -270,11 +270,11 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(SmolStr::new_inline("CX"), "CX".into(), vec![], two_qb_func)
+        .add_op_custom_sig_simple(SmolStr::new_inline("CX"), "CX".into(), vec![], two_qb_func)
         .unwrap();
 
     extension
-        .add_node_custom_sig_simple(
+        .add_op_custom_sig_simple(
             SmolStr::new_inline("Measure"),
             "Measure a qubit, returning the qubit and the measurement result.".into(),
             vec![],


### PR DESCRIPTION
Ooops, these were accidentally hit by renaming in #642 .

Driveby: change a couple of `add_op_custom_sig`'s in extension.rs to use the `custom_sig_simple` variant