### PR TITLE
tests: strength "failing_sccs_test", rename to "sccs" as it's not failing!

### DIFF
--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -687,7 +687,7 @@ impl UnificationContext {
                         });
 
                 let (rs, other_ms): (Vec<_>, Vec<_>) = plus_constraints.unzip();
-                let solution = rs.iter().fold(ExtensionSet::new(), |e1, e2| e1.union(e2));
+                let solution = rs.iter().fold(ExtensionSet::new(), ExtensionSet::union);
                 let unresolved_metas = other_ms
                     .into_iter()
                     .filter(|other_m| m != *other_m)

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -705,9 +705,8 @@ impl UnificationContext {
         println!("{:?}", relations.node_map);
         println!("{:?}", relations.graph);
 
-        // Process the strongly-connected components. We need to deal with these
-        // depended-upon before depender. ccs() gives them back in some order
-        // - this might need to be reversed????
+        // Process the strongly-connected components. petgraph/sccs() returns these
+        // depended-upon before depender, as we need.
         for cc in relations.sccs() {
             // Strongly connected components are looping constraint dependencies.
             // This means that each metavariable in the CC has the same solution.

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -1672,7 +1672,7 @@ mod test {
         let m2 = ctx.fresh_meta();
         let m3 = ctx.fresh_meta();
         ctx.add_constraint(m1, Constraint::Plus(ExtensionSet::singleton(&A), m3));
-        ctx.add_constraint(m2, Constraint::Plus(ExtensionSet::singleton(&A), m1));
+        ctx.add_constraint(m2, Constraint::Plus(ExtensionSet::singleton(&UNKNOWN_EXTENSION), m1));
         ctx.add_constraint(m3, Constraint::Plus(ExtensionSet::singleton(&A), m2));
         // And a second scc
         let m4 = ctx.fresh_meta();
@@ -1684,10 +1684,10 @@ mod test {
         ctx.variables.insert(m1);
         ctx.variables.insert(m4);
         ctx.instantiate_variables();
-        assert_eq!(ctx.get_solution(&m1), Some(&ExtensionSet::singleton(&A)));
+        assert_eq!(ctx.get_solution(&m1), Some(&ExtensionSet::from_iter([A, UNKNOWN_EXTENSION])));
         assert_eq!(
             ctx.get_solution(&m4),
-            Some(&ExtensionSet::from_iter([A, B, C]))
+            Some(&ExtensionSet::from_iter([A, B, C, UNKNOWN_EXTENSION]))
         );
     }
 }

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -1664,7 +1664,7 @@ mod test {
     // Test that logic for dealing with self-referential constraints doesn't
     // fall over when a self-referencing group of metas also references a meta
     // outside the group
-    fn failing_sccs_test() {
+    fn sccs() {
         let hugr = Hugr::default();
         let mut ctx = UnificationContext::new(&hugr);
         let m1 = ctx.fresh_meta();
@@ -1677,9 +1677,10 @@ mod test {
         ctx.add_constraint(m2, Constraint::Plus(ExtensionSet::singleton(&A), m1));
         ctx.add_constraint(m3, Constraint::Plus(ExtensionSet::singleton(&A), m2));
         // This other meta is outside the loop, but depended on by one of the loop metas
-        ctx.add_constraint(m2, Constraint::Plus(ExtensionSet::singleton(&A), m_other));
+        ctx.add_constraint(m2, Constraint::Plus(ExtensionSet::singleton(&B), m_other));
         ctx.variables.insert(m1);
         ctx.variables.insert(m_other);
         ctx.instantiate_variables();
+        assert_eq!(ctx.get_solution(&m1), Some(&ExtensionSet::from_iter([A,B])));
     }
 }


### PR DESCRIPTION
* Include situation with two loops
* Using four extensions, finally obtained a version where the iteration order of the `sccs()` mattered. Turns out its correct now (but reversing it breaks the test - many simpler tests worked in both orders).
* Driveby switch a lambda `|a,b| a.union(b)` to just `ExtensionSet::union`