### PR TITLE
ci: Better name for the daily coverage notif workflow

### DIFF
--- a/.github/workflows/notify-coverage.yml
+++ b/.github/workflows/notify-coverage.yml
@@ -1,4 +1,8 @@
-name: Coverage
+name: Notify coverage changes
+
+# Daily notification for coverage changes in `main`.
+#
+# PR coverage diffs are computed directly in the `Continuous Integration` workflow.
 
 on:
   schedule:


### PR DESCRIPTION
Renames the workflow to better indicate its purpose, so it doesn't get mixed up with the PR coverage reports.