### PR TITLE
Alternative start to automatically including extension-reqs

### DIFF
--- a/src/builder/circuit.rs
+++ b/src/builder/circuit.rs
@@ -137,17 +137,22 @@ mod test {
             test::{build_main, NAT, QB},
             Dataflow, DataflowSubContainer, Wire,
         },
-        extension::prelude::BOOL_T,
+        extension::{
+            prelude::{BOOL_T, PRELUDE_ID},
+            ExtensionSet,
+        },
         ops::{custom::OpaqueOp, LeafOp},
         type_row,
         types::FunctionType,
-        utils::test_quantum_extension::{cx_gate, h_gate, measure},
+        utils::test_quantum_extension::{self, cx_gate, h_gate, measure},
     };
 
     #[test]
     fn simple_linear() {
         let build_res = build_main(
-            FunctionType::new(type_row![QB, QB], type_row![QB, QB]).pure(),
+            FunctionType::new(type_row![QB, QB], type_row![QB, QB]).with_input_extensions(
+                ExtensionSet::from_iter([PRELUDE_ID, test_quantum_extension::EXTENSION_ID]),
+            ),
             |mut f_build| {
                 let wires = f_build.input_wires().collect();
 

--- a/src/builder/circuit.rs
+++ b/src/builder/circuit.rs
@@ -189,7 +189,10 @@ mod test {
             .into(),
         );
         let build_res = build_main(
-            FunctionType::new(type_row![QB, QB, NAT], type_row![QB, QB, BOOL_T]).pure(),
+            FunctionType::new(type_row![QB, QB, NAT], type_row![QB, QB, BOOL_T])
+                .with_input_extensions(ExtensionSet::singleton(
+                    &test_quantum_extension::EXTENSION_ID,
+                )),
             |mut f_build| {
                 let [q0, q1, angle]: [Wire; 3] = f_build.input_wires_arr();
 

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -220,7 +220,7 @@ pub(crate) mod test {
     use crate::std_extensions::logic;
     use crate::std_extensions::logic::test::and_op;
     use crate::types::Type;
-    use crate::utils::test_quantum_extension::h_gate;
+    use crate::utils::test_quantum_extension::{self, h_gate};
     use crate::{
         builder::{
             test::{n_identity, BIT, NAT, QB},
@@ -240,7 +240,10 @@ pub(crate) mod test {
             let _f_id = {
                 let mut func_builder = module_builder.define_function(
                     "main",
-                    FunctionType::new(type_row![NAT, QB], type_row![NAT, QB]).pure(),
+                    FunctionType::new(type_row![NAT, QB], type_row![NAT, QB])
+                        .with_input_extensions(ExtensionSet::singleton(
+                            &test_quantum_extension::EXTENSION_ID,
+                        )),
                 )?;
 
                 let [int, qb] = func_builder.input_wires_arr();

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -217,6 +217,7 @@ pub(crate) mod test {
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::ops::{handle::NodeHandle, LeafOp, OpTag};
 
+    use crate::std_extensions::logic;
     use crate::std_extensions::logic::test::and_op;
     use crate::types::Type;
     use crate::utils::test_quantum_extension::h_gate;
@@ -273,7 +274,8 @@ pub(crate) mod test {
 
             let f_build = module_builder.define_function(
                 "main",
-                FunctionType::new(type_row![BOOL_T], type_row![BOOL_T, BOOL_T]).pure(),
+                FunctionType::new(type_row![BOOL_T], type_row![BOOL_T, BOOL_T])
+                    .with_input_extensions(ExtensionSet::singleton(&logic::EXTENSION_ID)),
             )?;
 
             f(f_build)?;

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -189,10 +189,8 @@ impl OpDef {
             }
         };
 
-        let res = pf.instantiate(args, exts)?;
-        // TODO bring this assert back once resource inference is done?
-        // https://github.com/CQCL-DEV/hugr/issues/425
-        // assert!(res.contains(self.extension()));
+        let mut res = pf.instantiate(args, exts)?;
+        res.extension_reqs.insert(self.extension());
         Ok(res)
     }
 


### PR DESCRIPTION
Intended to fix #388, alternative approach to #389.

However, the tiny fix for #388 breaks many tests. Some (4) are updated+fixed here, but many more still failing. At least some of these are due to #673 which will need fixing first