### PR TITLE
fix: Serialise dynamically computed opaqueOp signatures

### DIFF
--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -198,8 +198,8 @@ impl OpDef {
 
     pub(crate) fn should_serialize_signature(&self) -> bool {
         match self.signature_func {
-            SignatureFunc::TypeScheme { .. } => true,
-            SignatureFunc::CustomFunc { .. } => false,
+            SignatureFunc::TypeScheme { .. } => false,
+            SignatureFunc::CustomFunc { .. } => true,
         }
     }
 


### PR DESCRIPTION
These were the wrong way around.

Closes #683