### PR TITLE
fix(Inference): Don't add constraints between static edges

### DIFF
--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -328,9 +328,7 @@ impl UnificationContext {
             for port in hugr.node_inputs(tgt_node).filter(|src_port| {
                 matches!(
                     sig.port_kind(*src_port),
-                    Some(EdgeKind::Value(_))
-                        | Some(EdgeKind::Static(_))
-                        | Some(EdgeKind::ControlFlow)
+                    Some(EdgeKind::Value(_)) | Some(EdgeKind::ControlFlow)
                 )
             }) {
                 let m_tgt = *self

--- a/src/hugr/rewrite/replace.rs
+++ b/src/hugr/rewrite/replace.rs
@@ -482,7 +482,7 @@ mod test {
             FunctionType::new_linear(just_list.clone()).with_extension_delta(&exset),
         )?;
 
-        let pred_const = cfg.add_constant(ops::Const::unary_unit_sum(), None)?;
+        let pred_const = cfg.add_constant(ops::Const::unary_unit_sum(), exset)?;
 
         let entry = single_node_block(&mut cfg, pop, &pred_const, true)?;
         let bb2 = single_node_block(&mut cfg, push, &pred_const, false)?;


### PR DESCRIPTION
As mentioned in #688, ([here](https://github.com/CQCL/hugr/pull/688#discussion_r1393404921)) don't require that both sides of a static edge have the same extension requirements, since the static edge often has the empty set.