### PR TITLE
refactor!: Rename `new_linear()` to `new_endo()`.

### DIFF
--- a/src/extension/infer/test.rs
+++ b/src/extension/infer/test.rs
@@ -883,7 +883,7 @@ fn simple_cfg_loop() -> Result<(), Box<dyn Error>> {
 fn plus_on_self() -> Result<(), Box<dyn std::error::Error>> {
     let ext = ExtensionId::new("unknown1").unwrap();
     let delta = ExtensionSet::singleton(&ext);
-    let ft = FunctionType::new_linear(type_row![QB_T, QB_T]).with_extension_delta(&delta);
+    let ft = FunctionType::new_endo(type_row![QB_T, QB_T]).with_extension_delta(&delta);
     let mut dfg = DFGBuilder::new(ft.clone())?;
 
     // While https://github.com/CQCL-DEV/hugr/issues/388 is unsolved,
@@ -897,7 +897,7 @@ fn plus_on_self() -> Result<(), Box<dyn std::error::Error>> {
         Some(ft),
     ))
     .into();
-    let unary_sig = FunctionType::new_linear(type_row![QB_T])
+    let unary_sig = FunctionType::new_endo(type_row![QB_T])
         .with_extension_delta(&ExtensionSet::singleton(&ext));
     let unop: LeafOp = ExternalOp::Opaque(OpaqueOp::new(
         ext,

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -379,14 +379,14 @@ mod test {
         const OP_NAME: SmolStr = SmolStr::new_inline("Reverse");
         let type_scheme = PolyFuncType::new_validated(
             vec![TP],
-            FunctionType::new_linear(vec![list_of_var]),
+            FunctionType::new_endo(vec![list_of_var]),
             &reg1,
         )?;
         e.add_op_type_scheme(OP_NAME, "".into(), Default::default(), vec![], type_scheme)?;
 
         let list_usize =
             Type::new_extension(list_def.instantiate(vec![TypeArg::Type { ty: USIZE_T }])?);
-        let mut dfg = DFGBuilder::new(FunctionType::new_linear(vec![list_usize]))?;
+        let mut dfg = DFGBuilder::new(FunctionType::new_endo(vec![list_usize]))?;
         let rev = dfg.add_dataflow_op(
             LeafOp::from(ExternalOp::Extension(
                 e.instantiate_extension_op(&OP_NAME, vec![TypeArg::Type { ty: USIZE_T }], &reg1)

--- a/src/hugr/rewrite/replace.rs
+++ b/src/hugr/rewrite/replace.rs
@@ -479,7 +479,7 @@ mod test {
         let intermed = TypeRow::from(vec![listy.clone(), USIZE_T]);
 
         let mut cfg = CFGBuilder::new(
-            FunctionType::new_linear(just_list.clone()).with_extension_delta(&exset),
+            FunctionType::new_endo(just_list.clone()).with_extension_delta(&exset),
         )?;
 
         let pred_const = cfg.add_constant(ops::Const::unary_unit_sum(), None)?;
@@ -516,7 +516,7 @@ mod test {
         // Replacement: one BB with two DFGs inside.
         // Use Hugr rather than Builder because DFGs must be empty (not even Input/Output).
         let mut replacement = Hugr::new(NodeType::new_open(ops::CFG {
-            signature: FunctionType::new_linear(just_list.clone()),
+            signature: FunctionType::new_endo(just_list.clone()),
         }));
         let r_bb = replacement.add_node_with_parent(
             replacement.root(),
@@ -644,7 +644,7 @@ mod test {
 
     #[test]
     fn test_invalid() -> Result<(), Box<dyn std::error::Error>> {
-        let utou = FunctionType::new_linear(vec![USIZE_T]);
+        let utou = FunctionType::new_endo(vec![USIZE_T]);
         let mk_op = |s| {
             LeafOp::from(ExternalOp::Opaque(OpaqueOp::new(
                 ExtensionId::new("unknown_ext").unwrap(),

--- a/src/hugr/validate/test.rs
+++ b/src/hugr/validate/test.rs
@@ -139,7 +139,7 @@ fn leaf_root() {
 #[test]
 fn dfg_root() {
     let dfg_op: OpType = ops::DFG {
-        signature: FunctionType::new_linear(type_row![BOOL_T]),
+        signature: FunctionType::new_endo(type_row![BOOL_T]),
     }
     .into();
 
@@ -366,7 +366,7 @@ fn test_ext_edge() -> Result<(), HugrError> {
     let sub_dfg = h.add_node_with_parent(
         h.root(),
         ops::DFG {
-            signature: FunctionType::new_linear(type_row![BOOL_T]),
+            signature: FunctionType::new_endo(type_row![BOOL_T]),
         },
     )?;
     // this Xor has its 2nd input unconnected

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -731,7 +731,7 @@ mod tests {
         let mut mod_builder = ModuleBuilder::new();
         let func = mod_builder.declare(
             "test",
-            FunctionType::new_linear(type_row![QB_T, QB_T, QB_T]).pure(),
+            FunctionType::new_endo(type_row![QB_T, QB_T, QB_T]).pure(),
         )?;
         let func_id = {
             let mut dfg = mod_builder.define_declaration(&func)?;
@@ -747,8 +747,7 @@ mod tests {
 
     fn build_3not_hugr() -> Result<(Hugr, Node), BuildError> {
         let mut mod_builder = ModuleBuilder::new();
-        let func =
-            mod_builder.declare("test", FunctionType::new_linear(type_row![BOOL_T]).pure())?;
+        let func = mod_builder.declare("test", FunctionType::new_endo(type_row![BOOL_T]).pure())?;
         let func_id = {
             let mut dfg = mod_builder.define_declaration(&func)?;
             let outs1 = dfg.add_dataflow_op(not_op(), dfg.input_wires())?;
@@ -806,7 +805,7 @@ mod tests {
         let sub = SiblingSubgraph::try_new_dataflow_subgraph(&func)?;
 
         let empty_dfg = {
-            let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T, QB_T])).unwrap();
+            let builder = DFGBuilder::new(FunctionType::new_endo(type_row![QB_T, QB_T])).unwrap();
             let inputs = builder.input_wires();
             builder.finish_prelude_hugr_with_outputs(inputs).unwrap()
         };
@@ -831,7 +830,7 @@ mod tests {
         // the first two qubits.
         assert_eq!(
             sub.signature(&func),
-            FunctionType::new_linear(type_row![QB_T, QB_T])
+            FunctionType::new_endo(type_row![QB_T, QB_T])
         );
         Ok(())
     }
@@ -843,7 +842,7 @@ mod tests {
         let sub = SiblingSubgraph::from_sibling_graph(&func)?;
 
         let empty_dfg = {
-            let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T])).unwrap();
+            let builder = DFGBuilder::new(FunctionType::new_endo(type_row![QB_T])).unwrap();
             let inputs = builder.input_wires();
             builder.finish_prelude_hugr_with_outputs(inputs).unwrap()
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,11 @@
 //!     use lazy_static::lazy_static;
 //!
 //!     fn one_qb_func() -> PolyFuncType {
-//!         FunctionType::new_linear(type_row![QB_T]).into()
+//!         FunctionType::new_endo(type_row![QB_T]).into()
 //!     }
 //!
 //!     fn two_qb_func() -> PolyFuncType {
-//!         FunctionType::new_linear(type_row![QB_T, QB_T]).into()
+//!         FunctionType::new_endo(type_row![QB_T, QB_T]).into()
 //!     }
 //!     /// The extension identifier.
 //!     pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("mini.quantum");

--- a/src/types.rs
+++ b/src/types.rs
@@ -215,7 +215,7 @@ impl TypeEnum {
 /// ```
 /// # use hugr::types::{Type, TypeBound, FunctionType};
 ///
-/// let func_type = Type::new_function(FunctionType::new_linear(vec![]));
+/// let func_type = Type::new_function(FunctionType::new_endo(vec![]));
 /// assert_eq!(func_type.least_upper_bound(), TypeBound::Copyable);
 ///
 /// ```
@@ -428,7 +428,7 @@ pub(crate) mod test {
     fn construct() {
         let t: Type = Type::new_tuple(vec![
             USIZE_T,
-            Type::new_function(FunctionType::new_linear(vec![])),
+            Type::new_function(FunctionType::new_endo(vec![])),
             Type::new_extension(CustomType::new(
                 "my_custom",
                 [],

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -66,7 +66,7 @@ mod test {
 
     #[test]
     fn serialize_types_roundtrip() {
-        let g: Type = Type::new_function(FunctionType::new_linear(vec![]));
+        let g: Type = Type::new_function(FunctionType::new_endo(vec![]));
 
         assert_eq!(ser_roundtrip(&g), g);
 

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -109,7 +109,7 @@ impl FunctionType {
         }
     }
     /// Create a new signature with the same input and output types.
-    pub fn new_linear(linear: impl Into<TypeRow>) -> Self {
+    pub fn new_endo(linear: impl Into<TypeRow>) -> Self {
         let linear = linear.into();
         Self::new(linear.clone(), linear)
     }

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -109,7 +109,8 @@ impl FunctionType {
             extension_reqs: ExtensionSet::new(),
         }
     }
-    /// Create a new signature with the same input and output types.
+    /// Create a new signature with the same input and output types (signature of an endomorphic
+    /// function).
     pub fn new_endo(linear: impl Into<TypeRow>) -> Self {
         let linear = linear.into();
         Self::new(linear.clone(), linear)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,11 +46,11 @@ pub(crate) mod test_quantum_extension {
     use lazy_static::lazy_static;
 
     fn one_qb_func() -> PolyFuncType {
-        FunctionType::new_linear(type_row![QB_T]).into()
+        FunctionType::new_endo(type_row![QB_T]).into()
     }
 
     fn two_qb_func() -> PolyFuncType {
-        FunctionType::new_linear(type_row![QB_T, QB_T]).into()
+        FunctionType::new_endo(type_row![QB_T, QB_T]).into()
     }
     /// The extension identifier.
     pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("test.quantum");

--- a/src/values.rs
+++ b/src/values.rs
@@ -266,7 +266,7 @@ pub(crate) mod test {
             hugr: Box::new(simple_dfg_hugr),
         };
 
-        let correct_type = Type::new_function(FunctionType::new_linear(type_row![
+        let correct_type = Type::new_function(FunctionType::new_endo(type_row![
             crate::extension::prelude::BOOL_T
         ]));
 


### PR DESCRIPTION
Closes #664 .

BREAKING_CHANGES: `FunctionType::new_linear()` renamed to `FunctionType::new_endo()`.