### PR TITLE
refactor: Replace NodeType::signature() with io_extensions()

### DIFF
--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -261,7 +261,7 @@ impl UnificationContext {
     where
         T: HugrView,
     {
-        if hugr.root_type().signature().is_none() {
+        if hugr.root_type().input_extensions().is_none() {
             let m_input = self.make_or_get_meta(hugr.root(), Direction::Incoming);
             self.variables.insert(m_input);
         }
@@ -302,7 +302,7 @@ impl UnificationContext {
                 self.add_constraint(m_output, Constraint::Equal(m_exit));
             }
 
-            match node_type.signature() {
+            match node_type.io_extensions() {
                 // Input extensions are open
                 None => {
                     let c = if let Some(sig) = node_type.op_signature() {
@@ -318,9 +318,9 @@ impl UnificationContext {
                     self.add_constraint(m_output, c);
                 }
                 // We have a solution for everything!
-                Some(sig) => {
-                    self.add_solution(m_output, sig.output_extensions());
-                    self.add_solution(m_input, sig.input_extensions);
+                Some((input_exts, output_exts)) => {
+                    self.add_solution(m_input, input_exts.clone());
+                    self.add_solution(m_output, output_exts);
                 }
             }
         }

--- a/src/extension/infer/test.rs
+++ b/src/extension/infer/test.rs
@@ -253,26 +253,10 @@ fn dangling_src() -> Result<(), Box<dyn Error>> {
 
     let closure = hugr.infer_extensions()?;
     assert!(closure.is_empty());
+    assert_eq!(hugr.get_nodetype(src.node()).io_extensions().unwrap().1, rs);
     assert_eq!(
-        hugr.get_nodetype(src.node())
-            .signature()
-            .unwrap()
-            .output_extensions(),
-        rs
-    );
-    assert_eq!(
-        hugr.get_nodetype(mult.node())
-            .signature()
-            .unwrap()
-            .input_extensions,
-        rs
-    );
-    assert_eq!(
-        hugr.get_nodetype(mult.node())
-            .signature()
-            .unwrap()
-            .output_extensions(),
-        rs
+        hugr.get_nodetype(mult.node()).io_extensions().unwrap(),
+        (&rs.clone(), rs)
     );
     Ok(())
 }
@@ -385,18 +369,12 @@ fn test_conditional_inference() -> Result<(), Box<dyn Error>> {
 
     for node in [case0_node, case1_node, conditional_node] {
         assert_eq!(
-            hugr.get_nodetype(node)
-                .signature()
-                .unwrap()
-                .input_extensions,
-            ExtensionSet::new()
+            hugr.get_nodetype(node).io_extensions().unwrap().0,
+            &ExtensionSet::new()
         );
         assert_eq!(
-            hugr.get_nodetype(node)
-                .signature()
-                .unwrap()
-                .input_extensions,
-            ExtensionSet::new()
+            hugr.get_nodetype(node).io_extensions().unwrap().0,
+            &ExtensionSet::new()
         );
     }
     Ok(())

--- a/src/extension/validate.rs
+++ b/src/extension/validate.rs
@@ -50,13 +50,15 @@ impl ExtensionValidator {
     /// extension requirements for all of its input and output edges, then put
     /// those requirements in the extension validation context.
     fn gather_extensions(&mut self, node: &Node, node_type: &NodeType) {
-        if let Some(sig) = node_type.signature() {
-            for dir in Direction::BOTH {
-                assert!(self
-                    .extensions
-                    .insert((*node, dir), sig.get_extension(&dir))
-                    .is_none());
-            }
+        if let Some((input_exts, output_exts)) = node_type.io_extensions() {
+            let prev_i = self
+                .extensions
+                .insert((*node, Direction::Incoming), input_exts.clone());
+            assert!(prev_i.is_none());
+            let prev_o = self
+                .extensions
+                .insert((*node, Direction::Outgoing), output_exts);
+            assert!(prev_o.is_none());
         }
     }
 

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -27,7 +27,7 @@ pub struct FunctionType {
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-/// A concrete signature, which has been instantiated with a set of input extensions
+/// A combination of a FunctionType and a set of input extensions, used for declaring functions
 pub struct Signature {
     /// The underlying signature
     pub signature: FunctionType,
@@ -243,15 +243,6 @@ impl FunctionType {
 }
 
 impl Signature {
-    /// Returns a reference to the extension set for the ports of the
-    /// signature in a given direction
-    pub fn get_extension(&self, dir: &Direction) -> ExtensionSet {
-        match dir {
-            Direction::Incoming => self.input_extensions.clone(),
-            Direction::Outgoing => self.output_extensions(),
-        }
-    }
-
     delegate! {
         to self.signature {
             /// Inputs of the function type


### PR DESCRIPTION
The signature() method on NodeType basically only existed so the caller could get both the input and output extensions (Signature providing the `.output_extensions()` method). Instead, provide `nodetype.io_extensions()` returning the same information.

This does leave Signature itself, which is a bit of a carbuncle.