### PR TITLE
feat!: simplify `SignatureFunc` and add custom arg validation.

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -22,7 +22,7 @@ mod infer;
 pub use infer::{infer_extensions, ExtensionSolution, InferExtensionError};
 
 mod op_def;
-pub use op_def::{CustomSignatureFunc, CustomValidator, OpDef};
+pub use op_def::{CustomSignatureFunc, CustomValidator, OpDef, ValidateTypeArgs};
 mod type_def;
 pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -22,7 +22,10 @@ mod infer;
 pub use infer::{infer_extensions, ExtensionSolution, InferExtensionError};
 
 mod op_def;
-pub use op_def::{CustomSignatureFunc, CustomValidator, OpDef, ValidateTypeArgs};
+pub use op_def::{
+    CustomSignatureFunc, CustomValidator, OpDef, SignatureFromArgs, ValidateJustArgs,
+    ValidateTypeArgs,
+};
 mod type_def;
 pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -22,7 +22,7 @@ mod infer;
 pub use infer::{infer_extensions, ExtensionSolution, InferExtensionError};
 
 mod op_def;
-pub use op_def::{CustomFunc, OpDef};
+pub use op_def::{CustomFunc, CustomValidate, OpDef};
 mod type_def;
 pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -22,7 +22,7 @@ mod infer;
 pub use infer::{infer_extensions, ExtensionSolution, InferExtensionError};
 
 mod op_def;
-pub use op_def::{CustomFunc, CustomSignatureFunc, OpDef};
+pub use op_def::{CustomFunc, OpDef};
 mod type_def;
 pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -22,7 +22,7 @@ mod infer;
 pub use infer::{infer_extensions, ExtensionSolution, InferExtensionError};
 
 mod op_def;
-pub use op_def::{CustomFunc, CustomValidate, OpDef};
+pub use op_def::{CustomSignatureFunc, CustomValidator, OpDef};
 mod type_def;
 pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -22,7 +22,7 @@ mod infer;
 pub use infer::{infer_extensions, ExtensionSolution, InferExtensionError};
 
 mod op_def;
-pub use op_def::{CustomSignatureFunc, OpDef};
+pub use op_def::{CustomFunc, CustomSignatureFunc, OpDef};
 mod type_def;
 pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -153,7 +153,7 @@ impl CustomValidator {
 /// or a custom binary which computes a polymorphic function type given values
 /// for its static type parameters.
 #[derive(serde::Deserialize, serde::Serialize)]
-enum SignatureFunc {
+pub enum SignatureFunc {
     // Note: except for serialization, we could have type schemes just implement the same
     // CustomSignatureFunc trait too, and replace this enum with Box<dyn CustomSignatureFunc>.
     // However instead we treat all CustomFunc's as non-serializable.
@@ -402,7 +402,6 @@ impl Extension {
     /// (defined by a [`PolyFuncType`]), a type scheme along with binary
     /// validation for type arguments ([`CustomValidator`]), or a custom binary
     /// function for computing the signature given type arguments (`impl [CustomSignatureFunc]`).
-    #[allow(private_bounds)] // docstring outlines all valid inputs.
     pub fn add_op(
         &mut self,
         name: SmolStr,
@@ -428,7 +427,6 @@ impl Extension {
 
     /// Create an OpDef with `PolyFuncType`, `impl CustomSignatureFunc` or `CustomValidator`
     /// ; and no "misc" or "lowering functions" defined.
-    #[allow(private_bounds)] // docstring outlines all valid inputs.
     pub fn add_op_simple(
         &mut self,
         name: SmolStr,

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -26,7 +26,7 @@ impl SignatureFromArgs for ArrayOpCustom {
         let elem_ty_var = Type::new_var_use(0, TypeBound::Any);
 
         let var_arg_row = vec![elem_ty_var.clone(); n as usize];
-        let other_row = vec![array_type(elem_ty_var.clone(), TypeArg::BoundedNat { n })];
+        let other_row = vec![array_type(TypeArg::BoundedNat { n }, elem_ty_var.clone())];
 
         Ok(PolyFuncType::new(
             vec![TypeParam::Type(TypeBound::Any)],
@@ -111,7 +111,7 @@ pub const USIZE_T: Type = Type::new_extension(USIZE_CUSTOM_T);
 pub const BOOL_T: Type = Type::new_unit_sum(2);
 
 /// Initialize a new array of element type `element_ty` of length `size`
-pub fn array_type(element_ty: Type, size: TypeArg) -> Type {
+pub fn array_type(size: TypeArg, element_ty: Type) -> Type {
     let array_def = PRELUDE.get_type("array").unwrap();
     let custom_t = array_def
         .instantiate(vec![size, TypeArg::Type { ty: element_ty }])
@@ -201,7 +201,7 @@ mod test {
     fn test_new_array() {
         let mut b = DFGBuilder::new(FunctionType::new(
             vec![QB_T, QB_T],
-            vec![array_type(QB_T, TypeArg::BoundedNat { n: 2 })],
+            vec![array_type(TypeArg::BoundedNat { n: 2 }, QB_T)],
         ))
         .unwrap();
 

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -4,17 +4,46 @@ use lazy_static::lazy_static;
 use smol_str::SmolStr;
 
 use crate::{
-    extension::{op_def::CustomSignatureFunc, ExtensionId, TypeDefBound},
+    extension::{ExtensionId, TypeDefBound},
     ops::LeafOp,
     types::{
         type_param::{TypeArg, TypeParam},
-        CustomCheckFailure, CustomType, FunctionType, Type, TypeBound,
+        CustomCheckFailure, CustomType, FunctionType, PolyFuncType, Type, TypeBound,
     },
     values::{CustomConst, KnownTypeConst},
     Extension,
 };
 
-use super::ExtensionRegistry;
+use super::{CustomSignatureFunc, ExtensionRegistry, SignatureError};
+struct ArrayOpCustom;
+
+const MAX: &[TypeParam; 1] = &[TypeParam::max_nat()];
+impl CustomSignatureFunc for ArrayOpCustom {
+    fn compute_signature(
+        &self,
+        _name: &SmolStr,
+        arg_values: &[TypeArg],
+        _misc: &std::collections::HashMap<String, serde_yaml::Value>,
+        _extension_registry: &ExtensionRegistry,
+    ) -> Result<PolyFuncType, SignatureError> {
+        let [TypeArg::BoundedNat { n }] = *arg_values else {
+            panic!("Should have been checked already.")
+        };
+        let elem_ty_var = Type::new_var_use(0, TypeBound::Any);
+
+        let var_arg_row = vec![elem_ty_var.clone(); n as usize];
+        let other_row = vec![array_type(elem_ty_var.clone(), TypeArg::BoundedNat { n })];
+
+        Ok(PolyFuncType::new(
+            vec![TypeParam::Type(TypeBound::Any)],
+            FunctionType::new(var_arg_row, other_row),
+        ))
+    }
+
+    fn static_params(&self) -> &[TypeParam] {
+        MAX
+    }
+}
 
 /// Name of prelude extension.
 pub const PRELUDE_ID: ExtensionId = ExtensionId::new_unchecked("prelude");
@@ -34,26 +63,16 @@ lazy_static! {
         prelude
             .add_type(
                 SmolStr::new_inline("array"),
-                vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
+                vec![ TypeParam::max_nat(),TypeParam::Type(TypeBound::Any)],
                 "array".into(),
-                TypeDefBound::FromParams(vec![0]),
+                TypeDefBound::FromParams(vec![1]),
             )
             .unwrap();
-
         prelude
             .add_op_simple(
                 SmolStr::new_inline(NEW_ARRAY_OP_ID),
                 "Create a new array from elements".to_string(),
-                CustomSignatureFunc::from_function(vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
-                |args: &[TypeArg]| {
-                    let [TypeArg::Type { ty }, TypeArg::BoundedNat { n }] = args else {
-                        panic!("should have been checked already.")
-                    };
-                    Ok(FunctionType::new(
-                        vec![ty.clone(); *n as usize],
-                        vec![array_type(ty.clone(), *n)],
-                    ))
-                }),
+                ArrayOpCustom,
             )
             .unwrap();
 
@@ -98,13 +117,10 @@ pub const USIZE_T: Type = Type::new_extension(USIZE_CUSTOM_T);
 pub const BOOL_T: Type = Type::new_unit_sum(2);
 
 /// Initialize a new array of element type `element_ty` of length `size`
-pub fn array_type(element_ty: Type, size: u64) -> Type {
+pub fn array_type(element_ty: Type, size: TypeArg) -> Type {
     let array_def = PRELUDE.get_type("array").unwrap();
     let custom_t = array_def
-        .instantiate(vec![
-            TypeArg::Type { ty: element_ty },
-            TypeArg::BoundedNat { n: size },
-        ])
+        .instantiate(vec![size, TypeArg::Type { ty: element_ty }])
         .unwrap();
     Type::new_extension(custom_t)
 }
@@ -118,8 +134,8 @@ pub fn new_array_op(element_ty: Type, size: u64) -> LeafOp {
         .instantiate_extension_op(
             NEW_ARRAY_OP_ID,
             vec![
-                TypeArg::Type { ty: element_ty },
                 TypeArg::BoundedNat { n: size },
+                TypeArg::Type { ty: element_ty },
             ],
             &PRELUDE_REGISTRY,
         )
@@ -179,7 +195,10 @@ impl KnownTypeConst for ConstUsize {
 
 #[cfg(test)]
 mod test {
-    use crate::builder::{DFGBuilder, Dataflow, DataflowHugr};
+    use crate::{
+        builder::{DFGBuilder, Dataflow, DataflowHugr},
+        types::FunctionType,
+    };
 
     use super::*;
 
@@ -188,7 +207,7 @@ mod test {
     fn test_new_array() {
         let mut b = DFGBuilder::new(FunctionType::new(
             vec![QB_T, QB_T],
-            vec![array_type(QB_T, 2)],
+            vec![array_type(QB_T, TypeArg::BoundedNat { n: 2 })],
         ))
         .unwrap();
 

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use smol_str::SmolStr;
 
 use crate::{
-    extension::{ExtensionId, TypeDefBound},
+    extension::{op_def::CustomFunc, ExtensionId, TypeDefBound},
     ops::LeafOp,
     types::{
         type_param::{TypeArg, TypeParam},
@@ -44,7 +44,7 @@ lazy_static! {
             .add_op_custom_sig_simple(
                 SmolStr::new_inline(NEW_ARRAY_OP_ID),
                 "Create a new array from elements".to_string(),
-                vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
+                CustomFunc::from_closure(vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
                 |args: &[TypeArg]| {
                     let [TypeArg::Type { ty }, TypeArg::BoundedNat { n }] = args else {
                         panic!("should have been checked already.")
@@ -53,7 +53,7 @@ lazy_static! {
                         vec![ty.clone(); *n as usize],
                         vec![array_type(ty.clone(), *n)],
                     ))
-                },
+                }),
             )
             .unwrap();
 

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -44,7 +44,7 @@ lazy_static! {
             .add_op_simple(
                 SmolStr::new_inline(NEW_ARRAY_OP_ID),
                 "Create a new array from elements".to_string(),
-                CustomSignatureFunc::from_closure(vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
+                CustomSignatureFunc::from_function(vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
                 |args: &[TypeArg]| {
                     let [TypeArg::Type { ty }, TypeArg::BoundedNat { n }] = args else {
                         panic!("should have been checked already.")

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use smol_str::SmolStr;
 
 use crate::{
-    extension::{op_def::CustomFunc, ExtensionId, TypeDefBound},
+    extension::{op_def::CustomSignatureFunc, ExtensionId, TypeDefBound},
     ops::LeafOp,
     types::{
         type_param::{TypeArg, TypeParam},
@@ -44,7 +44,7 @@ lazy_static! {
             .add_op_simple(
                 SmolStr::new_inline(NEW_ARRAY_OP_ID),
                 "Create a new array from elements".to_string(),
-                CustomFunc::from_closure(vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
+                CustomSignatureFunc::from_closure(vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
                 |args: &[TypeArg]| {
                     let [TypeArg::Type { ty }, TypeArg::BoundedNat { n }] = args else {
                         panic!("should have been checked already.")

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -14,16 +14,15 @@ use crate::{
     Extension,
 };
 
-use super::{CustomSignatureFunc, ExtensionRegistry, SignatureError};
+use super::{CustomSignatureFunc, ExtensionRegistry, OpDef, SignatureError};
 struct ArrayOpCustom;
 
 const MAX: &[TypeParam; 1] = &[TypeParam::max_nat()];
 impl CustomSignatureFunc for ArrayOpCustom {
-    fn compute_signature(
-        &self,
-        _name: &SmolStr,
+    fn compute_signature<'o, 'a: 'o>(
+        &'a self,
         arg_values: &[TypeArg],
-        _misc: &std::collections::HashMap<String, serde_yaml::Value>,
+        _def: &'o OpDef,
         _extension_registry: &ExtensionRegistry,
     ) -> Result<PolyFuncType, SignatureError> {
         let [TypeArg::BoundedNat { n }] = *arg_values else {

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -14,16 +14,14 @@ use crate::{
     Extension,
 };
 
-use super::{CustomSignatureFunc, ExtensionRegistry, OpDef, SignatureError};
+use super::{ExtensionRegistry, SignatureError, SignatureFromArgs};
 struct ArrayOpCustom;
 
 const MAX: &[TypeParam; 1] = &[TypeParam::max_nat()];
-impl CustomSignatureFunc for ArrayOpCustom {
+impl SignatureFromArgs for ArrayOpCustom {
     fn compute_signature<'o, 'a: 'o>(
         &'a self,
         arg_values: &[TypeArg],
-        _def: &'o OpDef,
-        _extension_registry: &ExtensionRegistry,
     ) -> Result<PolyFuncType, SignatureError> {
         let [TypeArg::BoundedNat { n }] = *arg_values else {
             panic!("Should have been checked already.")

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -41,7 +41,7 @@ lazy_static! {
             .unwrap();
 
         prelude
-            .add_op_custom_sig_simple(
+            .add_op_simple(
                 SmolStr::new_inline(NEW_ARRAY_OP_ID),
                 "Create a new array from elements".to_string(),
                 CustomFunc::from_closure(vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -21,7 +21,7 @@ const MAX: &[TypeParam; 1] = &[TypeParam::max_nat()];
 impl SignatureFromArgs for ArrayOpCustom {
     fn compute_signature(&self, arg_values: &[TypeArg]) -> Result<PolyFuncType, SignatureError> {
         let [TypeArg::BoundedNat { n }] = *arg_values else {
-            panic!("Should have been checked already.")
+            return Err(SignatureError::InvalidTypeArgs);
         };
         let elem_ty_var = Type::new_var_use(0, TypeBound::Any);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,18 +62,18 @@
 //!         let mut extension = Extension::new(EXTENSION_ID);
 //!
 //!         extension
-//!             .add_op_type_scheme_simple(SmolStr::new_inline("H"), "Hadamard".into(), one_qb_func())
+//!             .add_op_simple(SmolStr::new_inline("H"), "Hadamard".into(), one_qb_func())
 //!             .unwrap();
 //!
 //!         extension
-//!             .add_op_type_scheme_simple(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
+//!             .add_op_simple(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
 //!             .unwrap();
 //!
 //!         extension
-//!             .add_op_type_scheme_simple(
+//!             .add_op_simple(
 //!                 SmolStr::new_inline("Measure"),
 //!                 "Measure a qubit, returning the qubit and the measurement result.".into(),
-//!                 FunctionType::new(type_row![QB_T], type_row![QB_T, BOOL_T]).into(),
+//!                 FunctionType::new(type_row![QB_T], type_row![QB_T, BOOL_T]),
 //!             )
 //!             .unwrap();
 //!

--- a/src/std_extensions/arithmetic/conversions.rs
+++ b/src/std_extensions/arithmetic/conversions.rs
@@ -36,24 +36,24 @@ pub fn extension() -> Extension {
         ]),
     );
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "trunc_u".into(),
             "float to unsigned int".to_owned(),
             ftoi_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple("trunc_s".into(), "float to signed int".to_owned(), ftoi_sig)
+        .add_op_simple("trunc_s".into(), "float to signed int".to_owned(), ftoi_sig)
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "convert_u".into(),
             "unsigned int to float".to_owned(),
             itof_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "convert_s".into(),
             "signed int to float".to_owned(),
             itof_sig,

--- a/src/std_extensions/arithmetic/float_ops.rs
+++ b/src/std_extensions/arithmetic/float_ops.rs
@@ -29,72 +29,72 @@ pub fn extension() -> Extension {
     let funop_sig: PolyFuncType =
         FunctionType::new(type_row![FLOAT64_TYPE], type_row![FLOAT64_TYPE]).into();
     extension
-        .add_op_type_scheme_simple("feq".into(), "equality test".to_owned(), fcmp_sig.clone())
+        .add_op_simple("feq".into(), "equality test".to_owned(), fcmp_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("fne".into(), "inequality test".to_owned(), fcmp_sig.clone())
+        .add_op_simple("fne".into(), "inequality test".to_owned(), fcmp_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("flt".into(), "\"less than\"".to_owned(), fcmp_sig.clone())
+        .add_op_simple("flt".into(), "\"less than\"".to_owned(), fcmp_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "fgt".into(),
             "\"greater than\"".to_owned(),
             fcmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "fle".into(),
             "\"less than or equal\"".to_owned(),
             fcmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "fge".into(),
             "\"greater than or equal\"".to_owned(),
             fcmp_sig,
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple("fmax".into(), "maximum".to_owned(), fbinop_sig.clone())
+        .add_op_simple("fmax".into(), "maximum".to_owned(), fbinop_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("fmin".into(), "minimum".to_owned(), fbinop_sig.clone())
+        .add_op_simple("fmin".into(), "minimum".to_owned(), fbinop_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("fadd".into(), "addition".to_owned(), fbinop_sig.clone())
+        .add_op_simple("fadd".into(), "addition".to_owned(), fbinop_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("fsub".into(), "subtraction".to_owned(), fbinop_sig.clone())
+        .add_op_simple("fsub".into(), "subtraction".to_owned(), fbinop_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("fneg".into(), "negation".to_owned(), funop_sig.clone())
+        .add_op_simple("fneg".into(), "negation".to_owned(), funop_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "fabs".into(),
             "absolute value".to_owned(),
             funop_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "fmul".into(),
             "multiplication".to_owned(),
             fbinop_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple("fdiv".into(), "division".to_owned(), fbinop_sig)
+        .add_op_simple("fdiv".into(), "division".to_owned(), fbinop_sig)
         .unwrap();
     extension
-        .add_op_type_scheme_simple("ffloor".into(), "floor".to_owned(), funop_sig.clone())
+        .add_op_simple("ffloor".into(), "floor".to_owned(), funop_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("fceil".into(), "ceiling".to_owned(), funop_sig)
+        .add_op_simple("fceil".into(), "ceiling".to_owned(), funop_sig)
         .unwrap();
 
     extension

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -2,7 +2,7 @@
 
 use super::int_types::{get_log_width, int_type_var, LOG_WIDTH_TYPE_PARAM};
 use crate::extension::prelude::{sum_with_error, BOOL_T};
-use crate::extension::{CustomValidator, ValidateTypeArgs};
+use crate::extension::{CustomValidator, ValidateJustArgs};
 use crate::type_row;
 use crate::types::{FunctionType, PolyFuncType};
 use crate::utils::collect_array;
@@ -22,13 +22,8 @@ struct IOValidator {
     f_gt_s: bool,
 }
 
-impl ValidateTypeArgs for IOValidator {
-    fn validate<'o, 'a: 'o>(
-        &self,
-        arg_values: &[TypeArg],
-        _def: &'o crate::extension::OpDef,
-        _extension_registry: &crate::extension::ExtensionRegistry,
-    ) -> Result<(), SignatureError> {
+impl ValidateJustArgs for IOValidator {
+    fn validate<'o, 'a: 'o>(&self, arg_values: &[TypeArg]) -> Result<(), SignatureError> {
         let [arg0, arg1] = collect_array(arg_values);
         let i: u8 = get_log_width(arg0)?;
         let o: u8 = get_log_width(arg1)?;

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -2,7 +2,7 @@
 
 use super::int_types::{get_log_width, int_type_var, LOG_WIDTH_TYPE_PARAM};
 use crate::extension::prelude::{sum_with_error, BOOL_T};
-use crate::extension::CustomValidate;
+use crate::extension::CustomValidator;
 use crate::type_row;
 use crate::types::{FunctionType, PolyFuncType};
 use crate::utils::collect_array;
@@ -118,7 +118,7 @@ fn extension() -> Extension {
         .add_op_simple(
             "iwiden_u".into(),
             "widen an unsigned integer to a wider one with the same value".to_owned(),
-            CustomValidate::new_with_validator(widen_poly.clone(), iwiden_sig_validate),
+            CustomValidator::new_with_validator(widen_poly.clone(), iwiden_sig_validate),
         )
         .unwrap();
 
@@ -126,7 +126,7 @@ fn extension() -> Extension {
         .add_op_simple(
             "iwiden_s".into(),
             "widen a signed integer to a wider one with the same value".to_owned(),
-            CustomValidate::new_with_validator(widen_poly, iwiden_sig_validate),
+            CustomValidator::new_with_validator(widen_poly, iwiden_sig_validate),
         )
         .unwrap();
     extension
@@ -134,14 +134,14 @@ fn extension() -> Extension {
             "inarrow_u".into(),
             "narrow an unsigned integer to a narrower one with the same value if possible"
                 .to_owned(),
-            CustomValidate::new_with_validator(narrow_poly.clone(), inarrow_sig_validate),
+            CustomValidator::new_with_validator(narrow_poly.clone(), inarrow_sig_validate),
         )
         .unwrap();
     extension
         .add_op_simple(
             "inarrow_s".into(),
             "narrow a signed integer to a narrower one with the same value if possible".to_owned(),
-            CustomValidate::new_with_validator(narrow_poly, inarrow_sig_validate),
+            CustomValidator::new_with_validator(narrow_poly, inarrow_sig_validate),
         )
         .unwrap();
     extension

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -113,7 +113,7 @@ pub fn extension() -> Extension {
     );
 
     extension
-        .add_op_custom_sig_simple(
+        .add_op_simple(
             "iwiden_u".into(),
             "widen an unsigned integer to a wider one with the same value".to_owned(),
             CustomFunc::from_closure(vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM], iwiden_sig),
@@ -121,14 +121,14 @@ pub fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_op_custom_sig_simple(
+        .add_op_simple(
             "iwiden_s".into(),
             "widen a signed integer to a wider one with the same value".to_owned(),
             CustomFunc::from_closure(vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM], iwiden_sig),
         )
         .unwrap();
     extension
-        .add_op_custom_sig_simple(
+        .add_op_simple(
             "inarrow_u".into(),
             "narrow an unsigned integer to a narrower one with the same value if possible"
                 .to_owned(),
@@ -139,7 +139,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_custom_sig_simple(
+        .add_op_simple(
             "inarrow_s".into(),
             "narrow a signed integer to a narrower one with the same value if possible".to_owned(),
             CustomFunc::from_closure(
@@ -149,139 +149,139 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "itobool".into(),
             "convert to bool (1 is true, 0 is false)".to_owned(),
             itob_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ifrombool".into(),
             "convert from bool (1 is true, 0 is false)".to_owned(),
             btoi_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple("ieq".into(), "equality test".to_owned(), icmp_sig.clone())
+        .add_op_simple("ieq".into(), "equality test".to_owned(), icmp_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("ine".into(), "inequality test".to_owned(), icmp_sig.clone())
+        .add_op_simple("ine".into(), "inequality test".to_owned(), icmp_sig.clone())
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ilt_u".into(),
             "\"less than\" as unsigned integers".to_owned(),
             icmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ilt_s".into(),
             "\"less than\" as signed integers".to_owned(),
             icmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "igt_u".into(),
             "\"greater than\" as unsigned integers".to_owned(),
             icmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "igt_s".into(),
             "\"greater than\" as signed integers".to_owned(),
             icmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ile_u".into(),
             "\"less than or equal\" as unsigned integers".to_owned(),
             icmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ile_s".into(),
             "\"less than or equal\" as signed integers".to_owned(),
             icmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ige_u".into(),
             "\"greater than or equal\" as unsigned integers".to_owned(),
             icmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ige_s".into(),
             "\"greater than or equal\" as signed integers".to_owned(),
             icmp_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "imax_u".into(),
             "maximum of unsigned integers".to_owned(),
             ibinop_sig(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "imax_s".into(),
             "maximum of signed integers".to_owned(),
             ibinop_sig(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "imin_u".into(),
             "minimum of unsigned integers".to_owned(),
             ibinop_sig(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "imin_s".into(),
             "minimum of signed integers".to_owned(),
             ibinop_sig(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "iadd".into(),
             "addition modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
             ibinop_sig(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "isub".into(),
             "subtraction modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
             ibinop_sig(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ineg".into(),
             "negation modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
             iunop_sig(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "imul".into(),
             "multiplication modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
             ibinop_sig(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "idivmod_checked_u".into(),
             "given unsigned integers 0 <= n < 2^N, 0 <= m < 2^M, generates unsigned q, r where \
             q*m+r=n, 0<=r<m (m=0 is an error)"
@@ -290,7 +290,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "idivmod_u".into(),
             "given unsigned integers 0 <= n < 2^N, 0 <= m < 2^M, generates unsigned q, r where \
             q*m+r=n, 0<=r<m (m=0 will call panic)"
@@ -299,7 +299,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "idivmod_checked_s".into(),
             "given signed integer -2^{N-1} <= n < 2^{N-1} and unsigned 0 <= m < 2^M, generates \
             signed q and unsigned r where q*m+r=n, 0<=r<m (m=0 is an error)"
@@ -308,7 +308,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "idivmod_s".into(),
             "given signed integer -2^{N-1} <= n < 2^{N-1} and unsigned 0 <= m < 2^M, generates \
             signed q and unsigned r where q*m+r=n, 0<=r<m (m=0 will call panic)"
@@ -317,82 +317,82 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "idiv_checked_u".into(),
             "as idivmod_checked_u but discarding the second output".to_owned(),
             idiv_checked_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "idiv_u".into(),
             "as idivmod_u but discarding the second output".to_owned(),
             idiv_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "imod_checked_u".into(),
             "as idivmod_checked_u but discarding the first output".to_owned(),
             imod_checked_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "imod_u".into(),
             "as idivmod_u but discarding the first output".to_owned(),
             imod_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "idiv_checked_s".into(),
             "as idivmod_checked_s but discarding the second output".to_owned(),
             idiv_checked_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "idiv_s".into(),
             "as idivmod_s but discarding the second output".to_owned(),
             idiv_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "imod_checked_s".into(),
             "as idivmod_checked_s but discarding the first output".to_owned(),
             imod_checked_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "imod_s".into(),
             "as idivmod_s but discarding the first output".to_owned(),
             imod_sig.clone(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "iabs".into(),
             "convert signed to unsigned by taking absolute value".to_owned(),
             iunop_sig(),
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple("iand".into(), "bitwise AND".to_owned(), ibinop_sig())
+        .add_op_simple("iand".into(), "bitwise AND".to_owned(), ibinop_sig())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("ior".into(), "bitwise OR".to_owned(), ibinop_sig())
+        .add_op_simple("ior".into(), "bitwise OR".to_owned(), ibinop_sig())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("ixor".into(), "bitwise XOR".to_owned(), ibinop_sig())
+        .add_op_simple("ixor".into(), "bitwise XOR".to_owned(), ibinop_sig())
         .unwrap();
     extension
-        .add_op_type_scheme_simple("inot".into(), "bitwise NOT".to_owned(), iunop_sig())
+        .add_op_simple("inot".into(), "bitwise NOT".to_owned(), iunop_sig())
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ishl".into(),
             "shift first input left by k bits where k is unsigned interpretation of second input \
             (leftmost bits dropped, rightmost bits set to zero"
@@ -401,7 +401,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "ishr".into(),
             "shift first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits dropped, leftmost bits set to zero)"
@@ -410,7 +410,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "irotl".into(),
             "rotate first input left by k bits where k is unsigned interpretation of second input \
             (leftmost bits replace rightmost bits)"
@@ -419,7 +419,7 @@ pub fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             "irotr".into(),
             "rotate first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits replace leftmost bits)"

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -2,6 +2,7 @@
 
 use super::int_types::{get_log_width, int_type, int_type_var, LOG_WIDTH_TYPE_PARAM};
 use crate::extension::prelude::{sum_with_error, BOOL_T};
+use crate::extension::CustomFunc;
 use crate::type_row;
 use crate::types::{FunctionType, PolyFuncType};
 use crate::utils::collect_array;
@@ -115,16 +116,15 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iwiden_u".into(),
             "widen an unsigned integer to a wider one with the same value".to_owned(),
-            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
-            iwiden_sig,
+            CustomFunc::from_closure(vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM], iwiden_sig),
         )
         .unwrap();
+
     extension
         .add_op_custom_sig_simple(
             "iwiden_s".into(),
             "widen a signed integer to a wider one with the same value".to_owned(),
-            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
-            iwiden_sig,
+            CustomFunc::from_closure(vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM], iwiden_sig),
         )
         .unwrap();
     extension
@@ -132,16 +132,20 @@ pub fn extension() -> Extension {
             "inarrow_u".into(),
             "narrow an unsigned integer to a narrower one with the same value if possible"
                 .to_owned(),
-            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
-            inarrow_sig,
+            CustomFunc::from_closure(
+                vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
+                inarrow_sig,
+            ),
         )
         .unwrap();
     extension
         .add_op_custom_sig_simple(
             "inarrow_s".into(),
             "narrow a signed integer to a narrower one with the same value if possible".to_owned(),
-            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
-            inarrow_sig,
+            CustomFunc::from_closure(
+                vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
+                inarrow_sig,
+            ),
         )
         .unwrap();
     extension

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -84,7 +84,7 @@ fn extension() -> Extension {
 
     let (l, e) = list_and_elem_type(list_type_def);
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             POP_NAME,
             "Pop from back of list".into(),
             PolyFuncType::new(
@@ -94,7 +94,7 @@ fn extension() -> Extension {
         )
         .unwrap();
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             PUSH_NAME,
             "Push to back of list".into(),
             PolyFuncType::new(vec![TP], FunctionType::new(vec![l.clone(), e], vec![l])),

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -3,7 +3,7 @@
 use smol_str::SmolStr;
 
 use crate::{
-    extension::{prelude::BOOL_T, ExtensionId, SignatureFromArgs},
+    extension::{prelude::BOOL_T, ExtensionId, SignatureError, SignatureFromArgs},
     ops, type_row,
     types::{
         type_param::{TypeArg, TypeParam},
@@ -35,9 +35,10 @@ fn logic_op_sig() -> impl SignatureFromArgs {
         fn compute_signature(
             &self,
             arg_values: &[TypeArg],
-        ) -> Result<crate::types::PolyFuncType, crate::extension::SignatureError> {
+        ) -> Result<crate::types::PolyFuncType, SignatureError> {
+            // get the number of input booleans.
             let [TypeArg::BoundedNat { n }] = *arg_values else {
-                panic!("Should have been checked already.")
+                return Err(SignatureError::InvalidTypeArgs);
             };
             let var_arg_row = vec![BOOL_T; n as usize];
             Ok(FunctionType::new(var_arg_row, vec![BOOL_T]).into())

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -45,7 +45,7 @@ fn extension() -> Extension {
         .add_op_simple(
             SmolStr::new_inline(AND_NAME),
             "logical 'and'".into(),
-            CustomSignatureFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {
+            CustomSignatureFunc::from_function(vec![H_INT], |arg_values: &[TypeArg]| {
                 let Ok(TypeArg::BoundedNat { n }) = arg_values.iter().exactly_one() else {
                     panic!("should be covered by validation.")
                 };
@@ -62,7 +62,7 @@ fn extension() -> Extension {
         .add_op_simple(
             SmolStr::new_inline(OR_NAME),
             "logical 'or'".into(),
-            CustomSignatureFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {
+            CustomSignatureFunc::from_function(vec![H_INT], |arg_values: &[TypeArg]| {
                 let Ok(TypeArg::BoundedNat { n }) = arg_values.iter().exactly_one() else {
                     panic!("should be covered by validation.")
                 };

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -34,15 +34,15 @@ fn extension() -> Extension {
     let mut extension = Extension::new(EXTENSION_ID);
 
     extension
-        .add_op_type_scheme_simple(
+        .add_op_simple(
             SmolStr::new_inline(NOT_NAME),
             "logical 'not'".into(),
-            FunctionType::new(type_row![BOOL_T], type_row![BOOL_T]).into(),
+            FunctionType::new(type_row![BOOL_T], type_row![BOOL_T]),
         )
         .unwrap();
 
     extension
-        .add_op_custom_sig_simple(
+        .add_op_simple(
             SmolStr::new_inline(AND_NAME),
             "logical 'and'".into(),
             CustomFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {
@@ -59,7 +59,7 @@ fn extension() -> Extension {
         .unwrap();
 
     extension
-        .add_op_custom_sig_simple(
+        .add_op_simple(
             SmolStr::new_inline(OR_NAME),
             "logical 'or'".into(),
             CustomFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -3,7 +3,7 @@
 use smol_str::SmolStr;
 
 use crate::{
-    extension::{prelude::BOOL_T, CustomSignatureFunc, ExtensionId},
+    extension::{prelude::BOOL_T, CustomSignatureFunc, ExtensionId, ExtensionRegistry, OpDef},
     ops, type_row,
     types::{
         type_param::{TypeArg, TypeParam},
@@ -32,12 +32,11 @@ fn logic_op_sig() -> impl CustomSignatureFunc {
 
     const MAX: &[TypeParam; 1] = &[TypeParam::max_nat()];
     impl CustomSignatureFunc for LogicOpCustom {
-        fn compute_signature(
-            &self,
-            _name: &SmolStr,
+        fn compute_signature<'o, 'a: 'o>(
+            &'a self,
             arg_values: &[TypeArg],
-            _misc: &std::collections::HashMap<String, serde_yaml::Value>,
-            _extension_registry: &crate::extension::ExtensionRegistry,
+            _def: &'o OpDef,
+            _extension_registry: &ExtensionRegistry,
         ) -> Result<crate::types::PolyFuncType, crate::extension::SignatureError> {
             let [TypeArg::BoundedNat { n }] = *arg_values else {
                 panic!("Should have been checked already.")

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use smol_str::SmolStr;
 
 use crate::{
-    extension::{prelude::BOOL_T, ExtensionId},
+    extension::{prelude::BOOL_T, CustomFunc, ExtensionId},
     ops, type_row,
     types::{
         type_param::{TypeArg, TypeParam},
@@ -45,8 +45,7 @@ fn extension() -> Extension {
         .add_op_custom_sig_simple(
             SmolStr::new_inline(AND_NAME),
             "logical 'and'".into(),
-            vec![H_INT],
-            |arg_values: &[TypeArg]| {
+            CustomFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {
                 let Ok(TypeArg::BoundedNat { n }) = arg_values.iter().exactly_one() else {
                     panic!("should be covered by validation.")
                 };
@@ -55,7 +54,7 @@ fn extension() -> Extension {
                     vec![BOOL_T; *n as usize],
                     type_row![BOOL_T],
                 ))
-            },
+            }),
         )
         .unwrap();
 
@@ -63,8 +62,7 @@ fn extension() -> Extension {
         .add_op_custom_sig_simple(
             SmolStr::new_inline(OR_NAME),
             "logical 'or'".into(),
-            vec![H_INT],
-            |arg_values: &[TypeArg]| {
+            CustomFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {
                 let Ok(TypeArg::BoundedNat { n }) = arg_values.iter().exactly_one() else {
                     panic!("should be covered by validation.")
                 };
@@ -73,7 +71,7 @@ fn extension() -> Extension {
                     vec![BOOL_T; *n as usize],
                     type_row![BOOL_T],
                 ))
-            },
+            }),
         )
         .unwrap();
 

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -3,7 +3,7 @@
 use smol_str::SmolStr;
 
 use crate::{
-    extension::{prelude::BOOL_T, CustomSignatureFunc, ExtensionId, ExtensionRegistry, OpDef},
+    extension::{prelude::BOOL_T, ExtensionId, SignatureFromArgs},
     ops, type_row,
     types::{
         type_param::{TypeArg, TypeParam},
@@ -27,16 +27,14 @@ pub const OR_NAME: &str = "Or";
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("logic");
 
-fn logic_op_sig() -> impl CustomSignatureFunc {
+fn logic_op_sig() -> impl SignatureFromArgs {
     struct LogicOpCustom;
 
     const MAX: &[TypeParam; 1] = &[TypeParam::max_nat()];
-    impl CustomSignatureFunc for LogicOpCustom {
+    impl SignatureFromArgs for LogicOpCustom {
         fn compute_signature<'o, 'a: 'o>(
             &'a self,
             arg_values: &[TypeArg],
-            _def: &'o OpDef,
-            _extension_registry: &ExtensionRegistry,
         ) -> Result<crate::types::PolyFuncType, crate::extension::SignatureError> {
             let [TypeArg::BoundedNat { n }] = *arg_values else {
                 panic!("Should have been checked already.")

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use smol_str::SmolStr;
 
 use crate::{
-    extension::{prelude::BOOL_T, CustomFunc, ExtensionId},
+    extension::{prelude::BOOL_T, CustomSignatureFunc, ExtensionId},
     ops, type_row,
     types::{
         type_param::{TypeArg, TypeParam},
@@ -45,7 +45,7 @@ fn extension() -> Extension {
         .add_op_simple(
             SmolStr::new_inline(AND_NAME),
             "logical 'and'".into(),
-            CustomFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {
+            CustomSignatureFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {
                 let Ok(TypeArg::BoundedNat { n }) = arg_values.iter().exactly_one() else {
                     panic!("should be covered by validation.")
                 };
@@ -62,7 +62,7 @@ fn extension() -> Extension {
         .add_op_simple(
             SmolStr::new_inline(OR_NAME),
             "logical 'or'".into(),
-            CustomFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {
+            CustomSignatureFunc::from_closure(vec![H_INT], |arg_values: &[TypeArg]| {
                 let Ok(TypeArg::BoundedNat { n }) = arg_values.iter().exactly_one() else {
                     panic!("should be covered by validation.")
                 };

--- a/src/types/poly_func.rs
+++ b/src/types/poly_func.rs
@@ -278,7 +278,7 @@ pub(crate) mod test {
     #[test]
     fn test_mismatched_args() -> Result<(), SignatureError> {
         let ar_def = PRELUDE.get_type("array").unwrap();
-        let typarams = [TypeParam::Type(TypeBound::Any), TypeParam::max_nat()];
+        let typarams = [TypeParam::max_nat(), TypeParam::Type(TypeBound::Any)];
         let [tyvar, szvar] =
             [0, 1].map(|i| TypeArg::new_var_use(i, typarams.get(i).unwrap().clone()));
 
@@ -289,12 +289,12 @@ pub(crate) mod test {
 
         // Sanity check (good args)
         good_ts.instantiate(
-            &[TypeArg::Type { ty: USIZE_T }, TypeArg::BoundedNat { n: 5 }],
+            &[TypeArg::BoundedNat { n: 5 }, TypeArg::Type { ty: USIZE_T }],
             &PRELUDE_REGISTRY,
         )?;
 
         let wrong_args = good_ts.instantiate(
-            &[TypeArg::BoundedNat { n: 5 }, TypeArg::Type { ty: USIZE_T }],
+            &[TypeArg::Type { ty: USIZE_T }, TypeArg::BoundedNat { n: 5 }],
             &PRELUDE_REGISTRY,
         );
         assert_eq!(
@@ -302,7 +302,7 @@ pub(crate) mod test {
             Err(SignatureError::TypeArgMismatch(
                 TypeArgError::TypeMismatch {
                     param: typarams[0].clone(),
-                    arg: TypeArg::BoundedNat { n: 5 }
+                    arg: TypeArg::Type { ty: USIZE_T }
                 }
             ))
         );
@@ -453,12 +453,7 @@ pub(crate) mod test {
 
     // The standard library new_array does not allow passing in a variable for size.
     fn new_array(ty: Type, s: TypeArg) -> Type {
-        let array_def = PRELUDE.get_type("array").unwrap();
-        Type::new_extension(
-            array_def
-                .instantiate(vec![TypeArg::Type { ty }, s])
-                .unwrap(),
-        )
+        crate::extension::prelude::array_type(ty, s)
     }
 
     const USIZE_TA: TypeArg = TypeArg::Type { ty: USIZE_T };

--- a/src/types/poly_func.rs
+++ b/src/types/poly_func.rs
@@ -216,7 +216,7 @@ pub(crate) mod test {
     use lazy_static::lazy_static;
     use smol_str::SmolStr;
 
-    use crate::extension::prelude::{PRELUDE_ID, USIZE_CUSTOM_T, USIZE_T};
+    use crate::extension::prelude::{array_type, PRELUDE_ID, USIZE_CUSTOM_T, USIZE_T};
     use crate::extension::{
         ExtensionId, ExtensionRegistry, SignatureError, TypeDefBound, PRELUDE, PRELUDE_REGISTRY,
     };
@@ -451,11 +451,6 @@ pub(crate) mod test {
         }
     }
 
-    // The standard library new_array does not allow passing in a variable for size.
-    fn new_array(ty: Type, s: TypeArg) -> Type {
-        crate::extension::prelude::array_type(ty, s)
-    }
-
     const USIZE_TA: TypeArg = TypeArg::Type { ty: USIZE_T };
 
     #[test]
@@ -464,9 +459,9 @@ pub(crate) mod test {
         let array_max = PolyFuncType::new_validated(
             vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
             FunctionType::new(
-                vec![new_array(
-                    Type::new_var_use(0, TypeBound::Any),
+                vec![array_type(
                     TypeArg::new_var_use(1, TypeParam::max_nat()),
+                    Type::new_var_use(0, TypeBound::Any),
                 )],
                 vec![Type::new_var_use(0, TypeBound::Any)],
             ),
@@ -474,7 +469,7 @@ pub(crate) mod test {
         )?;
 
         let concrete = FunctionType::new(
-            vec![new_array(USIZE_T, TypeArg::BoundedNat { n: 3 })],
+            vec![array_type(TypeArg::BoundedNat { n: 3 }, USIZE_T)],
             vec![USIZE_T],
         );
         let actual = array_max
@@ -486,9 +481,9 @@ pub(crate) mod test {
         let partial = PolyFuncType::new_validated(
             vec![TypeParam::max_nat()],
             FunctionType::new(
-                vec![new_array(
-                    USIZE_T,
+                vec![array_type(
                     TypeArg::new_var_use(0, TypeParam::max_nat()),
+                    USIZE_T,
                 )],
                 vec![USIZE_T],
             ),
@@ -535,7 +530,7 @@ pub(crate) mod test {
     fn test_instantiate_nested() -> Result<(), SignatureError> {
         let outer = nested_func();
 
-        let arg = new_array(USIZE_T, TypeArg::BoundedNat { n: 5 });
+        let arg = array_type(TypeArg::BoundedNat { n: 5 }, USIZE_T);
         // `arg` -> (forall C. C -> List(Tuple(C, `arg`)))
         let outer_applied = FunctionType::new(
             vec![arg.clone()], // This had index 0, but is replaced
@@ -589,9 +584,9 @@ pub(crate) mod test {
             Type::new_function(new_pf1(
                 TP_EQ,
                 Type::new_var_use(0, TypeBound::Eq),
-                new_array(
-                    Type::new_var_use(0, TypeBound::Eq),
+                array_type(
                     TypeArg::new_var_use(i, TypeParam::max_nat()),
+                    Type::new_var_use(0, TypeBound::Eq),
                 ),
             ))
         };

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -1,4 +1,4 @@
-use super::{PolyFuncType, SumType, Type, TypeBound, TypeEnum, TypeRow};
+use super::{PolyFuncType, SumType, Type, TypeArg, TypeBound, TypeEnum, TypeRow};
 
 use super::custom::CustomType;
 
@@ -48,7 +48,9 @@ impl From<SerSimpleType> for Type {
             SerSimpleType::G(sig) => Type::new_function(*sig),
             SerSimpleType::Tuple { inner } => Type::new_tuple(inner),
             SerSimpleType::Sum(sum) => sum.into(),
-            SerSimpleType::Array { inner, len } => array_type((*inner).into(), len),
+            SerSimpleType::Array { inner, len } => {
+                array_type((*inner).into(), TypeArg::BoundedNat { n: len })
+            }
             SerSimpleType::Opaque(custom) => Type::new_extension(custom),
             SerSimpleType::Alias(a) => Type::new_alias(a),
             SerSimpleType::V { i, b } => Type::new_var_use(i, b),

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -49,7 +49,7 @@ impl From<SerSimpleType> for Type {
             SerSimpleType::Tuple { inner } => Type::new_tuple(inner),
             SerSimpleType::Sum(sum) => sum.into(),
             SerSimpleType::Array { inner, len } => {
-                array_type((*inner).into(), TypeArg::BoundedNat { n: len })
+                array_type(TypeArg::BoundedNat { n: len }, (*inner).into())
             }
             SerSimpleType::Opaque(custom) => Type::new_extension(custom),
             SerSimpleType::Alias(a) => Type::new_alias(a),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,26 +58,25 @@ pub(crate) mod test_quantum_extension {
         let mut extension = Extension::new(EXTENSION_ID);
 
         extension
-            .add_op_type_scheme_simple(SmolStr::new_inline("H"), "Hadamard".into(), one_qb_func())
+            .add_op_simple(SmolStr::new_inline("H"), "Hadamard".into(), one_qb_func())
             .unwrap();
         extension
-            .add_op_type_scheme_simple(
+            .add_op_simple(
                 SmolStr::new_inline("RzF64"),
                 "Rotation specified by float".into(),
-                FunctionType::new(type_row![QB_T, float_types::FLOAT64_TYPE], type_row![QB_T])
-                    .into(),
+                FunctionType::new(type_row![QB_T, float_types::FLOAT64_TYPE], type_row![QB_T]),
             )
             .unwrap();
 
         extension
-            .add_op_type_scheme_simple(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
+            .add_op_simple(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
             .unwrap();
 
         extension
-            .add_op_type_scheme_simple(
+            .add_op_simple(
                 SmolStr::new_inline("Measure"),
                 "Measure a qubit, returning the qubit and the measurement result.".into(),
-                FunctionType::new(type_row![QB_T], type_row![QB_T, BOOL_T]).into(),
+                FunctionType::new(type_row![QB_T], type_row![QB_T, BOOL_T]),
             )
             .unwrap();
 


### PR DESCRIPTION
Closes #675 but not exactly as specified in the issue - SignatureFunc is still an enum, but something close to the desired interface is achieved.

BREAKING_CHANGES: `Extension::add_op...` methods simplified and renamed, there is only `add_op` and `add_op_simple` now.