### PR TITLE
refactor: remove Signature struct

### DIFF
--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -437,9 +437,8 @@ pub(crate) mod test {
             FunctionType::new(type_row![BIT], type_row![BIT]).with_extension_delta(&abc_extensions);
         let mut parent = DFGBuilder::new(parent_sig)?;
 
-        let add_c_sig = FunctionType::new(type_row![BIT], type_row![BIT])
-            .with_extension_delta(&c_extensions)
-            .with_input_extensions(ab_extensions.clone());
+        let add_c_sig =
+            FunctionType::new(type_row![BIT], type_row![BIT]).with_extension_delta(&c_extensions);
 
         let [w] = parent.input_wires_arr();
 
@@ -476,8 +475,7 @@ pub(crate) mod test {
 
         // Add another node (a sibling to add_ab) which adds extension C
         // via a child lift node
-        let mut add_c =
-            parent.dfg_builder(add_c_sig.signature, Some(add_c_sig.input_extensions), [w])?;
+        let mut add_c = parent.dfg_builder(add_c_sig, Some(ab_extensions.clone()), [w])?;
         let [w] = add_c.input_wires_arr();
         let lift_c = add_c.add_dataflow_node(
             NodeType::new(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,7 +47,7 @@ pub(crate) use impl_box_clone;
 /// const U: Type = Type::UNIT;
 /// let static_row: TypeRow = type_row![U, U];
 /// let dynamic_row: TypeRow = vec![U, U, U].into();
-/// let sig = FunctionType::new(static_row, dynamic_row).pure();
+/// let sig = FunctionType::new(static_row, dynamic_row);
 ///
 /// let repeated_row: TypeRow = type_row![U; 3];
 /// assert_eq!(repeated_row, *sig.output());

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ pub mod type_row;
 pub use check::{ConstTypeError, CustomCheckFailure};
 pub use custom::CustomType;
 pub use poly_func::PolyFuncType;
-pub use signature::{FunctionType, Signature};
+pub use signature::FunctionType;
 pub use type_param::TypeArg;
 pub use type_row::TypeRow;
 


### PR DESCRIPTION
Main uses were removed in #700 and #692. A few tests remained using Signature as a simple struct (no methods), but it's simpler not to glue the two things together only to separate them moments later...