### PR TITLE
feat!: Drop the `pyo3` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,6 @@ path = "src/lib.rs"
 [dependencies]
 thiserror = "1.0.28"
 portgraph = { version = "0.10.0", features = ["serde", "petgraph"] }
-pyo3 = { version = "0.20.0", optional = true, features = [
-    "multiple-pymethods",
-] }
 regex = "1.9.5"
 cgmath = { version = "0.18.0", features = ["serde"] }
 num-rational = { version = "0.4.1", features = ["serde"] }
@@ -52,9 +49,6 @@ serde_json = "1.0.97"
 delegate = "0.10.0"
 rustversion = "1.0.14"
 paste = "1.0"
-
-[features]
-pyo3 = ["dep:pyo3"]
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ compilation and encodes runnable programs.
 
 The HUGR specification is [here](specification/hugr.md).
 
-## Features
-
--   `pyo3`: Enable Python bindings via pyo3.
-
 ## Usage
 
 Add this to your `Cargo.toml`:

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,9 +2,6 @@
 //!
 use thiserror::Error;
 
-#[cfg(feature = "pyo3")]
-use pyo3::{create_exception, exceptions::PyException, PyErr};
-
 use crate::extension::SignatureError;
 use crate::hugr::{HugrError, ValidationError};
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
@@ -82,21 +79,6 @@ pub enum BuildError {
     /// Error in CircuitBuilder
     #[error("Error in CircuitBuilder: {0}.")]
     CircuitError(#[from] circuit::CircuitBuildError),
-}
-
-#[cfg(feature = "pyo3")]
-create_exception!(
-    pyrs,
-    PyBuildError,
-    PyException,
-    "Errors that can occur while building a Hugr"
-);
-
-#[cfg(feature = "pyo3")]
-impl From<BuildError> for PyErr {
-    fn from(err: BuildError) -> Self {
-        PyBuildError::new_err(err.to_string())
-    }
 }
 
 #[cfg(test)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -7,9 +7,6 @@ pub use itertools::Either;
 use derive_more::From;
 use itertools::Either::{Left, Right};
 
-#[cfg(feature = "pyo3")]
-use pyo3::pyclass;
-
 use crate::hugr::HugrError;
 
 /// A handle to a node in the HUGR.
@@ -17,7 +14,6 @@ use crate::hugr::HugrError;
     Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, serde::Serialize, serde::Deserialize,
 )]
 #[serde(transparent)]
-#[cfg_attr(feature = "pyo3", pyclass)]
 pub struct Node {
     index: portgraph::NodeIndex,
 }
@@ -37,7 +33,6 @@ pub struct Node {
     serde::Deserialize,
 )]
 #[serde(transparent)]
-#[cfg_attr(feature = "pyo3", pyclass)]
 pub struct Port {
     offset: portgraph::PortOffset,
 }

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -21,9 +21,6 @@ use portgraph::multiportgraph::MultiPortGraph;
 use portgraph::{Hierarchy, PortMut, UnmanagedDenseMap};
 use thiserror::Error;
 
-#[cfg(feature = "pyo3")]
-use pyo3::{create_exception, exceptions::PyException, pyclass, PyErr};
-
 pub use self::views::{HugrView, RootTagged};
 use crate::core::NodeIndex;
 use crate::extension::{
@@ -38,7 +35,6 @@ use delegate::delegate;
 
 /// The Hugr data structure.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "pyo3", pyclass)]
 pub struct Hugr {
     /// The graph encoding the adjacency structure of the HUGR.
     graph: MultiPortGraph,
@@ -351,21 +347,6 @@ pub enum HugrError {
     /// An invalid port was specified.
     #[error("Invalid port direction {0:?}.")]
     InvalidPortDirection(Direction),
-}
-
-#[cfg(feature = "pyo3")]
-create_exception!(
-    pyrs,
-    PyHugrError,
-    PyException,
-    "Errors that can occur while manipulating a Hugr"
-);
-
-#[cfg(feature = "pyo3")]
-impl From<HugrError> for PyErr {
-    fn from(err: HugrError) -> Self {
-        PyHugrError::new_err(err.to_string())
-    }
 }
 
 #[cfg(test)]

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -4,9 +4,6 @@
 use std::collections::HashMap;
 use thiserror::Error;
 
-#[cfg(feature = "pyo3")]
-use pyo3::{create_exception, exceptions::PyException, PyErr};
-
 use crate::core::NodeIndex;
 use crate::extension::ExtensionSet;
 use crate::hugr::{Hugr, NodeType};
@@ -89,21 +86,6 @@ pub enum HUGRSerializationError {
     /// First node in node list must be the HUGR root.
     #[error("The first node in the node list has parent {0:?}, should be itself (index 0)")]
     FirstNodeNotRoot(Node),
-}
-
-#[cfg(feature = "pyo3")]
-create_exception!(
-    pyrs,
-    PyHUGRSerializationError,
-    PyException,
-    "Errors that can occur while serializing a Hugr"
-);
-
-#[cfg(feature = "pyo3")]
-impl From<HUGRSerializationError> for PyErr {
-    fn from(err: HUGRSerializationError) -> Self {
-        PyHUGRSerializationError::new_err(err.to_string())
-    }
 }
 
 impl Serialize for Hugr {

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -9,9 +9,6 @@ use petgraph::visit::{Topo, Walker};
 use portgraph::{LinkView, PortView};
 use thiserror::Error;
 
-#[cfg(feature = "pyo3")]
-use pyo3::{create_exception, exceptions::PyException, PyErr};
-
 use crate::extension::SignatureError;
 use crate::extension::{
     validate::{ExtensionError, ExtensionValidator},
@@ -714,21 +711,6 @@ pub enum ValidationError {
     /// [Opaque]: crate::ops::custom::ExternalOp::Opaque
     #[error(transparent)]
     CustomOpError(#[from] CustomOpError),
-}
-
-#[cfg(feature = "pyo3")]
-create_exception!(
-    pyrs,
-    PyValidationError,
-    PyException,
-    "Errors that can occur while validating a Hugr"
-);
-
-#[cfg(feature = "pyo3")]
-impl From<ValidationError> for PyErr {
-    fn from(err: ValidationError) -> Self {
-        PyValidationError::new_err(err.to_string())
-    }
 }
 
 /// Errors related to the inter-graph edge validations.

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -24,9 +24,6 @@ use crate::ops::{OpTag, OpTrait};
 use crate::types::{FunctionType, Type};
 use crate::{Hugr, IncomingPort, Node, OutgoingPort, Port, SimpleReplacement};
 
-#[cfg(feature = "pyo3")]
-use pyo3::{create_exception, exceptions::PyException, PyErr};
-
 /// A non-empty convex subgraph of a HUGR sibling graph.
 ///
 /// A HUGR region in which all nodes share the same parent. Unlike
@@ -633,21 +630,6 @@ pub enum InvalidReplacement {
     /// SiblingSubgraph is not convex.
     #[error("SiblingSubgraph is not convex.")]
     NonConvexSubgraph,
-}
-
-#[cfg(feature = "pyo3")]
-create_exception!(
-    pyrs,
-    PyInvalidReplacementError,
-    PyException,
-    "Errors that can occur while constructing a SimpleReplacement"
-);
-
-#[cfg(feature = "pyo3")]
-impl From<InvalidReplacement> for PyErr {
-    fn from(err: InvalidReplacement) -> Self {
-        PyInvalidReplacementError::new_err(err.to_string())
-    }
 }
 
 /// Errors that can occur while constructing a [`SiblingSubgraph`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,10 +132,6 @@
 //! println!("{}", serialized);
 //! ```
 //!
-//! # Optional feature flags
-//!
-//! - `pyo3`: Enable Python bindings via [pyo3](https://docs.rs/pyo3).
-//!
 
 #![warn(missing_docs)]
 // Unstable check, may cause false positives.

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,6 @@ pub use signature::{FunctionType, Signature};
 pub use type_param::TypeArg;
 pub use type_row::TypeRow;
 
-use derive_more::{From, Into};
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -26,9 +25,6 @@ use crate::type_row;
 use std::fmt::Debug;
 
 use self::type_param::TypeParam;
-
-#[cfg(feature = "pyo3")]
-use pyo3::pyclass;
 
 /// The kinds of edges in a HUGR, excluding Hierarchy.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
@@ -50,12 +46,6 @@ impl EdgeKind {
         matches!(self, EdgeKind::Value(t) if !t.copyable())
     }
 }
-
-/// Python representation for [`EdgeKind`], the kinds of edges in a HUGR.
-#[cfg_attr(feature = "pyo3", pyclass)]
-#[repr(transparent)]
-#[derive(Clone, PartialEq, Eq, Debug, From, Into)]
-pub struct PyEdgeKind(EdgeKind);
 
 #[derive(
     Copy, Default, Clone, PartialEq, Eq, Hash, Debug, derive_more::Display, Serialize, Deserialize,
@@ -196,7 +186,6 @@ impl TypeEnum {
 )]
 #[display(fmt = "{}", "_0")]
 #[serde(into = "serialize::SerSimpleType", from = "serialize::SerSimpleType")]
-#[cfg_attr(feature = "pyo3", pyclass)]
 /// A HUGR type - the valid types of [EdgeKind::Value] and [EdgeKind::Static] edges.
 /// Such an edge is valid if the ports on either end agree on the [Type].
 /// Types have an optional [TypeBound] which places limits on the valid

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -1,8 +1,6 @@
 //! Abstract and concrete Signature types.
 
 use itertools::Either;
-#[cfg(feature = "pyo3")]
-use pyo3::{pyclass, pymethods};
 
 use delegate::delegate;
 use std::fmt::{self, Display, Write};
@@ -13,7 +11,6 @@ use super::{subst_row, Substitution, Type, TypeRow};
 use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
 use crate::{Direction, IncomingPort, OutgoingPort, Port};
 
-#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 /// Describes the edges required to/from a node. This includes both the concept of "signature" in the spec,
 /// and also the target (value) of a call (static).
@@ -91,7 +88,6 @@ impl Signature {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pymethods)]
 impl FunctionType {
     /// The number of wires in the signature.
     #[inline(always)]

--- a/src/types/type_row.rs
+++ b/src/types/type_row.rs
@@ -12,12 +12,8 @@ use crate::utils::display_list;
 use crate::PortIndex;
 use delegate::delegate;
 
-#[cfg(feature = "pyo3")]
-use pyo3::pyclass;
-
 /// List of types, used for function signatures.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "pyo3", pyclass)]
 #[non_exhaustive]
 #[serde(transparent)]
 pub struct TypeRow {
@@ -33,8 +29,6 @@ impl Display for TypeRow {
     }
 }
 
-// TODO some of these, but not all, will probably want exposing via
-// pyo3 wrappers eventually.
 impl TypeRow {
     /// Create a new empty row.
     pub const fn new() -> Self {


### PR DESCRIPTION
Drop the remaining python binding definitions from the crate.

We currently re-wrap all objects in `tket2-py`, and only required this for the `Into<PyErr>` implementations. As of https://github.com/CQCL/tket2/pull/258, this is no longer needed.

The main benefit of removing this dependency is avoiding linking problems when mismatching versions of `pyo3` are used by different dependencies. The error is unavoidable due to it dynamically linking to a single `python` lib, and cargo doesn't provide an easy way to deal with it.