### PR TITLE
feat!: `OpEnum` trait for common opdef functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ serde_json = "1.0.97"
 delegate = "0.10.0"
 rustversion = "1.0.14"
 paste = "1.0"
+strum = "0.25.0"
+strum_macros = "0.25.3"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -23,14 +23,14 @@ pub use infer::{infer_extensions, ExtensionSolution, InferExtensionError};
 
 mod op_def;
 pub use op_def::{
-    CustomSignatureFunc, CustomValidator, OpDef, SignatureFromArgs, ValidateJustArgs,
-    ValidateTypeArgs,
+    CustomSignatureFunc, CustomValidator, OpDef, SignatureFromArgs, SignatureFunc,
+    ValidateJustArgs, ValidateTypeArgs,
 };
 mod type_def;
 pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;
+pub mod simple_op;
 pub mod validate;
-
 pub use prelude::{PRELUDE, PRELUDE_REGISTRY};
 
 /// Extension Registries store extensions to be looked up e.g. during validation.

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -441,7 +441,7 @@ impl Extension {
         &mut self,
         op: &(impl super::simple_op::OpEnum + OpName),
     ) -> Result<&mut OpDef, ExtensionBuildError> {
-        let def = self.add_op(op.name(), op.description().to_string(), op.def_signature())?;
+        let def = self.add_op(op.name(), op.description(), op.def_signature())?;
 
         op.post_opdef(def);
 

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -438,7 +438,7 @@ impl Extension {
 
     pub fn add_op_enum(
         &mut self,
-        op: &impl super::simple_op::OpEnum,
+        op: &(impl super::simple_op::OpEnum + super::simple_op::OpEnumName),
     ) -> Result<&mut OpDef, ExtensionBuildError> {
         let def = self.add_op(
             op.name().into(),

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -6,12 +6,10 @@ use std::sync::Arc;
 
 use smol_str::SmolStr;
 
-use super::simple_op::OpEnum;
 use super::{
     Extension, ExtensionBuildError, ExtensionId, ExtensionRegistry, ExtensionSet, SignatureError,
 };
 
-use crate::ops::OpName;
 use crate::types::type_param::{check_type_args, TypeArg, TypeParam};
 use crate::types::{FunctionType, PolyFuncType};
 use crate::Hugr;
@@ -448,19 +446,6 @@ impl Extension {
             // Just made the arc so should only be one reference to it, can get_mut,
             Entry::Vacant(ve) => Ok(Arc::get_mut(ve.insert(Arc::new(op))).unwrap()),
         }
-    }
-
-    /// Add an operation implemented as an [OpEnum], which can provide the data
-    /// required to define an [OpDef].
-    pub fn add_op_enum(
-        &mut self,
-        op: &(impl OpEnum + OpName),
-    ) -> Result<&mut OpDef, ExtensionBuildError> {
-        let def = self.add_op(op.name(), op.description(), op.def_signature())?;
-
-        op.post_opdef(def);
-
-        Ok(def)
     }
 }
 

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -247,8 +247,8 @@ impl SignatureFunc {
 
         let res = pf.instantiate(args, exts)?;
         // TODO bring this assert back once resource inference is done?
-        // https://github.com/CQCL-DEV/hugr/issues/425
-        // assert!(res.contains(self.extension()));
+        // https://github.com/CQCL/hugr/issues/388
+        // debug_assert!(res.extension_reqs.contains(def.extension()));
         Ok(res)
     }
 }

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use smol_str::SmolStr;
 
+use super::simple_op::OpEnum;
 use super::{
     Extension, ExtensionBuildError, ExtensionId, ExtensionRegistry, ExtensionSet, SignatureError,
 };
@@ -212,6 +213,18 @@ impl SignatureFunc {
             SignatureFunc::CustomFunc(func) => func.static_params(),
         }
     }
+
+    /// Compute the concrete signature ([FunctionType]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if is [SignatureFunc::CustomFunc] and there are not enough type
+    /// arguments provided to match the number of static parameters.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the type arguments are invalid or
+    /// there is some error in type computation.
     pub fn compute_signature(
         &self,
         def: &OpDef,
@@ -437,9 +450,11 @@ impl Extension {
         }
     }
 
+    /// Add an operation implemented as an [OpEnum], which can provide the data
+    /// required to define an [OpDef].
     pub fn add_op_enum(
         &mut self,
-        op: &(impl super::simple_op::OpEnum + OpName),
+        op: &(impl OpEnum + OpName),
     ) -> Result<&mut OpDef, ExtensionBuildError> {
         let def = self.add_op(op.name(), op.description(), op.def_signature())?;
 

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -148,18 +148,18 @@ impl CustomValidator {
 }
 
 /// The two ways in which an OpDef may compute the Signature of each operation node.
-/// Either as a TypeScheme (polymorphic function type), with optional custom
-/// validation for provided type arguments,
-/// or a custom binary which computes a polymorphic function type given values
-/// for its static type parameters.
 #[derive(serde::Deserialize, serde::Serialize)]
 pub enum SignatureFunc {
     // Note: except for serialization, we could have type schemes just implement the same
     // CustomSignatureFunc trait too, and replace this enum with Box<dyn CustomSignatureFunc>.
     // However instead we treat all CustomFunc's as non-serializable.
+    /// A TypeScheme (polymorphic function type), with optional custom
+    /// validation for provided type arguments,
     #[serde(rename = "signature")]
     TypeScheme(CustomValidator),
     #[serde(skip)]
+    /// A custom binary which computes a polymorphic function type given values
+    /// for its static type parameters.
     CustomFunc(Box<dyn CustomSignatureFunc>),
 }
 struct NoValidate;

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -10,6 +10,7 @@ use super::{
     Extension, ExtensionBuildError, ExtensionId, ExtensionRegistry, ExtensionSet, SignatureError,
 };
 
+use crate::ops::OpName;
 use crate::types::type_param::{check_type_args, TypeArg, TypeParam};
 use crate::types::{FunctionType, PolyFuncType};
 use crate::Hugr;
@@ -438,13 +439,9 @@ impl Extension {
 
     pub fn add_op_enum(
         &mut self,
-        op: &(impl super::simple_op::OpEnum + super::simple_op::OpEnumName),
+        op: &(impl super::simple_op::OpEnum + OpName),
     ) -> Result<&mut OpDef, ExtensionBuildError> {
-        let def = self.add_op(
-            op.name().into(),
-            op.description().to_string(),
-            op.def_signature(),
-        )?;
+        let def = self.add_op(op.name(), op.description().to_string(), op.def_signature())?;
 
         op.post_opdef(def);
 

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -216,7 +216,7 @@ impl SignatureFunc {
     ///
     /// # Panics
     ///
-    /// Panics if is [SignatureFunc::CustomFunc] and there are not enough type
+    /// Panics if `self` is a [SignatureFunc::CustomFunc] and there are not enough type
     /// arguments provided to match the number of static parameters.
     ///
     /// # Errors

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -435,6 +435,21 @@ impl Extension {
             Entry::Vacant(ve) => Ok(Arc::get_mut(ve.insert(Arc::new(op))).unwrap()),
         }
     }
+
+    pub fn add_op_enum(
+        &mut self,
+        op: &impl super::simple_op::OpEnum,
+    ) -> Result<&mut OpDef, ExtensionBuildError> {
+        let def = self.add_op(
+            op.name().into(),
+            op.description().to_string(),
+            op.def_signature(),
+        )?;
+
+        op.post_opdef(def);
+
+        Ok(def)
+    }
 }
 
 #[cfg(test)]

--- a/src/extension/simple_op.rs
+++ b/src/extension/simple_op.rs
@@ -1,0 +1,160 @@
+//! A trait that enum for op definitions that gathers up some shared functionality.
+use std::str::FromStr;
+
+use strum::IntoEnumIterator;
+
+use crate::Extension;
+
+use super::{op_def::SignatureFunc, ExtensionBuildError, ExtensionId, OpDef};
+use thiserror::Error;
+
+/// Error when definition extension does not match that of the [OpEnum]
+#[derive(Debug, Error, PartialEq)]
+#[error("Expected extension ID {expected} but found {provided}.")]
+pub struct WrongExtension {
+    expected: ExtensionId,
+    provided: ExtensionId,
+}
+
+/// Error loading [OpEnum]
+#[derive(Debug, Error, PartialEq)]
+#[error("{0}")]
+#[allow(missing_docs)]
+pub enum OpLoadError<T> {
+    WrongExtension(#[from] WrongExtension),
+    LoadError(T),
+}
+
+/// A trait that operation sets defined by simple (C-style) enums can implement
+/// to simplify interactions with the extension.
+/// Relies on `strum_macros::{EnumIter, EnumString, IntoStaticStr}`
+pub trait OpEnum: Into<&'static str> + FromStr + Copy + IntoEnumIterator {
+    /// The name of the extension these ops belong to.
+    const EXTENSION_ID: ExtensionId;
+
+    // TODO can be removed after rust 1.75
+    /// Error thrown when loading from string fails.
+    type LoadError: std::error::Error;
+    /// Description type.
+    type Description: ToString;
+
+    /// Return the signature (polymorphic function type) of the operation.
+    fn signature(&self) -> SignatureFunc;
+
+    /// Description of the operation.
+    fn description(&self) -> Self::Description;
+
+    /// Edit the opdef before finalising.
+    fn post_opdef(&self, _def: &mut OpDef) {}
+
+    /// Name of the operation - derived from strum serialization.
+    fn name(&self) -> &str {
+        (*self).into()
+    }
+
+    /// Load an operation from the name of the operation.
+    fn from_extension_name(op_name: &str) -> Result<Self, Self::LoadError>;
+
+    /// Try to load one of the operations of this set from an [OpDef].
+    fn try_from_op_def(op_def: &OpDef) -> Result<Self, OpLoadError<Self::LoadError>> {
+        if op_def.extension() != &Self::EXTENSION_ID {
+            return Err(WrongExtension {
+                expected: Self::EXTENSION_ID.clone(),
+                provided: op_def.extension().clone(),
+            }
+            .into());
+        }
+        Self::from_extension_name(op_def.name()).map_err(OpLoadError::LoadError)
+    }
+
+    /// Add an operation to an extension.
+    fn add_to_extension<'e>(
+        &self,
+        ext: &'e mut Extension,
+    ) -> Result<&'e OpDef, ExtensionBuildError> {
+        let def = ext.add_op(
+            self.name().into(),
+            self.description().to_string(),
+            self.signature(),
+        )?;
+
+        self.post_opdef(def);
+
+        Ok(def)
+    }
+
+    /// Iterator over all operations in the set.
+    fn all_variants() -> <Self as IntoEnumIterator>::Iterator {
+        <Self as IntoEnumIterator>::iter()
+    }
+
+    /// load all variants of a `SimpleOpEnum` in to an extension as op defs.
+    fn load_all_ops(extension: &mut Extension) -> Result<(), ExtensionBuildError> {
+        for op in Self::all_variants() {
+            op.add_to_extension(extension)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{type_row, types::FunctionType};
+
+    use super::*;
+    use strum_macros::{EnumIter, EnumString, IntoStaticStr};
+    #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
+    enum DummyEnum {
+        Dumb,
+    }
+    #[derive(Debug, thiserror::Error, PartialEq)]
+    #[error("Dummy")]
+    struct DummyError;
+    impl OpEnum for DummyEnum {
+        const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("dummy");
+
+        type LoadError = DummyError;
+
+        type Description = &'static str;
+
+        fn signature(&self) -> SignatureFunc {
+            FunctionType::new_endo(type_row![]).into()
+        }
+
+        fn description(&self) -> Self::Description {
+            "dummy"
+        }
+
+        fn from_extension_name(_op_name: &str) -> Result<Self, Self::LoadError> {
+            Ok(Self::Dumb)
+        }
+    }
+
+    #[test]
+    fn test_dummy_enum() {
+        let o = DummyEnum::Dumb;
+
+        let good_name = ExtensionId::new("dummy").unwrap();
+        let mut e = Extension::new(good_name.clone());
+
+        o.add_to_extension(&mut e).unwrap();
+
+        assert_eq!(
+            DummyEnum::try_from_op_def(e.get_op(o.name()).unwrap()).unwrap(),
+            o
+        );
+
+        let bad_name = ExtensionId::new("not_dummy").unwrap();
+        let mut e = Extension::new(bad_name.clone());
+
+        o.add_to_extension(&mut e).unwrap();
+
+        assert_eq!(
+            DummyEnum::try_from_op_def(e.get_op(o.name()).unwrap()),
+            Err(OpLoadError::WrongExtension(WrongExtension {
+                expected: good_name,
+                provided: bad_name
+            }))
+        );
+    }
+}

--- a/src/extension/simple_op.rs
+++ b/src/extension/simple_op.rs
@@ -38,7 +38,9 @@ where
 }
 
 /// Traits implemented by types which can add themselves to [`Extension`]s as
-/// [`OpDef`]s or load themselves from an [`OpDef`]
+/// [`OpDef`]s or load themselves from an [`OpDef`].
+/// Particularly useful with C-style enums that implement [strum::IntoEnumIterator],
+/// as then all definitions can be added to an extension at once.
 pub trait MakeOpDef: OpName {
     /// Try to load one of the operations of this set from an [OpDef].
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError>

--- a/src/extension/simple_op.rs
+++ b/src/extension/simple_op.rs
@@ -71,6 +71,8 @@ pub trait OpEnum: OpName {
         Self::from_op_def(ext.def(), ext.args()).ok()
     }
 
+    /// Given the ID of the extension this operation is defined in, and a
+    /// registry containing that extension, return a [RegisteredEnum].
     fn to_registered(
         self,
         extension_id: ExtensionId,

--- a/src/extension/simple_op.rs
+++ b/src/extension/simple_op.rs
@@ -66,7 +66,8 @@ pub trait MakeOpDef: OpName {
         Ok(())
     }
 
-    /// load all variants of a [OpEnum] in to an extension as op defs.
+    /// Load all variants of an enum of op definitions in to an extension as op defs.
+    /// See [strum::IntoEnumIterator].
     fn load_all_ops(extension: &mut Extension) -> Result<(), ExtensionBuildError>
     where
         Self: IntoEnumIterator,
@@ -99,7 +100,7 @@ pub trait MakeExtensionOp: OpName {
     fn type_args(&self) -> Vec<TypeArg>;
 
     /// Given the ID of the extension this operation is defined in, and a
-    /// registry containing that extension, return a [RegisteredEnum].
+    /// registry containing that extension, return a [RegisteredOp].
     fn to_registered(
         self,
         extension_id: ExtensionId,
@@ -132,8 +133,7 @@ impl<T: MakeOpDef> MakeExtensionOp for T {
     }
 }
 
-/// Load an [OpEnum] from its name. Works best for C-style enums where each
-/// variant corresponds to an [OpDef] and an [OpType], i,e, there are no type parameters.
+/// Load an [MakeOpDef] from its name.
 /// See [strum_macros::EnumString].
 pub fn try_from_name<T>(name: &str) -> Result<T, OpLoadError>
 where
@@ -142,14 +142,15 @@ where
     T::from_str(name).map_err(|_| OpLoadError::NotMember(name.to_string()))
 }
 
-/// Wrap an [OpEnum] with an extension registry to allow type computation.
-/// Generate from [OpEnum::to_registered]
+/// Wrap an [MakeExtensionOp] with an extension registry to allow type computation.
+/// Generate from [MakeExtensionOp::to_registered]
+#[derive(Clone, Debug)]
 pub struct RegisteredOp<'r, T> {
     /// The name of the extension these ops belong to.
     extension_id: ExtensionId,
     /// A registry of all extensions, used for type computation.
     registry: &'r ExtensionRegistry,
-    /// The inner [OpEnum]
+    /// The inner [MakeExtensionOp]
     op: T,
 }
 

--- a/src/extension/simple_op.rs
+++ b/src/extension/simple_op.rs
@@ -110,10 +110,14 @@ pub trait OpEnum: FromStr + IntoEnumIterator + IntoStaticSt {
     }
 }
 
+/// Wrap an [OpEnum] with an extension registry to allow type computation.
+/// Generate from [OpEnum::to_registered]
 pub struct RegisteredEnum<'r, T> {
     /// The name of the extension these ops belong to.
     extension_id: ExtensionId,
+    /// A registry of all extensions, used for type computation.
     registry: &'r ExtensionRegistry,
+    /// The inner [OpEnum]
     op_enum: T,
 }
 
@@ -134,6 +138,7 @@ impl<'a, T: OpEnum> RegisteredEnum<'a, T> {
         Some(leaf.into())
     }
 
+    /// Compute the [FunctionType] for this operation, instantiating with type arguments.
     pub fn function_type(&self) -> Result<FunctionType, SignatureError> {
         self.op_enum.def_signature().compute_signature(
             self.registry
@@ -147,8 +152,11 @@ impl<'a, T: OpEnum> RegisteredEnum<'a, T> {
     }
     delegate! {
         to self.op_enum {
+            /// Name of the operation - derived from strum serialization.
             pub fn name(&self) -> &str;
+            /// Any type args which define this operation. Default is no type arguments.
             pub fn type_args(&self) -> Vec<TypeArg>;
+            /// Description of the operation.
             pub fn description(&self) -> T::Description;
         }
     }

--- a/src/ops/custom.rs
+++ b/src/ops/custom.rs
@@ -157,6 +157,13 @@ impl From<ExtensionOp> for LeafOp {
     }
 }
 
+impl From<ExtensionOp> for OpType {
+    fn from(value: ExtensionOp) -> Self {
+        let leaf: LeafOp = value.into();
+        leaf.into()
+    }
+}
+
 impl PartialEq for ExtensionOp {
     fn eq(&self, other: &Self) -> bool {
         Arc::<OpDef>::ptr_eq(&self.def, &other.def) && self.args == other.args

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -2,7 +2,7 @@
 
 use smol_str::SmolStr;
 
-use super::custom::ExternalOp;
+use super::custom::{ExtensionOp, ExternalOp};
 use super::dataflow::DataflowOpTrait;
 use super::{OpName, OpTag};
 
@@ -60,6 +60,20 @@ pub enum LeafOp {
         /// The type and args, plus a cache of the resulting type
         ta: TypeApplication,
     },
+}
+
+impl LeafOp {
+    /// If instance of [ExtensionOp] return a reference to it.
+    pub fn as_extension_op(&self) -> Option<&ExtensionOp> {
+        let LeafOp::CustomOp(ext) = self else {
+            return None;
+        };
+
+        match ext.as_ref() {
+            ExternalOp::Extension(e) => Some(e),
+            ExternalOp::Opaque(_) => None,
+        }
+    }
 }
 
 /// Records details of an application of a [PolyFuncType] to some [TypeArg]s

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -129,7 +129,11 @@ lazy_static! {
 pub(crate) mod test {
     use super::{extension, LogicOp, EXTENSION, EXTENSION_ID, FALSE_NAME, TRUE_NAME};
     use crate::{
-        extension::{prelude::BOOL_T, simple_op::OpEnum, ExtensionRegistry},
+        extension::{
+            prelude::BOOL_T,
+            simple_op::{OpEnum, OpEnumName},
+            ExtensionRegistry,
+        },
         ops::OpType,
         types::TypeArg,
         Extension,

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -31,8 +31,6 @@ pub enum LogicOp {
 }
 
 impl OpEnum for LogicOp {
-    type Description = &'static str;
-
     fn from_op_def(op_def: &OpDef, args: &[TypeArg]) -> Result<Self, OpLoadError> {
         let mut out: LogicOp = try_from_name(op_def.name())?;
         match &mut out {
@@ -55,12 +53,13 @@ impl OpEnum for LogicOp {
         }
     }
 
-    fn description(&self) -> &'static str {
+    fn description(&self) -> String {
         match self {
             LogicOp::And(_) => "logical 'and'",
             LogicOp::Or(_) => "logical 'or'",
             LogicOp::Not => "logical 'not'",
         }
+        .to_string()
     }
     fn type_args(&self) -> Vec<TypeArg> {
         match self {

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -109,7 +109,7 @@ lazy_static! {
 pub(crate) mod test {
     use crate::{
         extension::{prelude::BOOL_T, simple_op::OpEnum, EMPTY_REG},
-        ops::LeafOp,
+        ops::OpType,
         types::type_param::TypeArg,
         Extension,
     };
@@ -143,34 +143,21 @@ pub(crate) mod test {
     }
 
     /// Generate a logic extension and "and" operation over [`crate::prelude::BOOL_T`]
-    pub(crate) fn and_op() -> LeafOp {
-        EXTENSION
-            .instantiate_extension_op(
-                LogicOp::And.name(),
-                [TypeArg::BoundedNat { n: 2 }],
-                &EMPTY_REG,
-            )
+    pub(crate) fn and_op() -> OpType {
+        LogicOp::And
+            .to_optype(&EXTENSION, &[TypeArg::BoundedNat { n: 2 }], &EMPTY_REG)
             .unwrap()
-            .into()
     }
 
     /// Generate a logic extension and "or" operation over [`crate::prelude::BOOL_T`]
-    pub(crate) fn or_op() -> LeafOp {
-        EXTENSION
-            .instantiate_extension_op(
-                LogicOp::Or.name(),
-                [TypeArg::BoundedNat { n: 2 }],
-                &EMPTY_REG,
-            )
+    pub(crate) fn or_op() -> OpType {
+        LogicOp::Or
+            .to_optype(&EXTENSION, &[TypeArg::BoundedNat { n: 2 }], &EMPTY_REG)
             .unwrap()
-            .into()
     }
 
     /// Generate a logic extension and "not" operation over [`crate::prelude::BOOL_T`]
-    pub(crate) fn not_op() -> LeafOp {
-        EXTENSION
-            .instantiate_extension_op(LogicOp::Not.name(), [], &EMPTY_REG)
-            .unwrap()
-            .into()
+    pub(crate) fn not_op() -> OpType {
+        LogicOp::Not.to_optype(&EXTENSION, &[], &EMPTY_REG).unwrap()
     }
 }

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -118,12 +118,8 @@ lazy_static! {
 pub(crate) mod test {
     use super::{extension, LogicOp, EXTENSION, EXTENSION_ID, FALSE_NAME, TRUE_NAME};
     use crate::{
-        extension::{
-            prelude::BOOL_T,
-            simple_op::{OpEnum, OpEnumName},
-            ExtensionRegistry,
-        },
-        ops::OpType,
+        extension::{prelude::BOOL_T, simple_op::OpEnum, ExtensionRegistry},
+        ops::{OpName, OpType},
         types::TypeArg,
         Extension,
     };
@@ -141,7 +137,7 @@ pub(crate) mod test {
         for op in LogicOp::all_variants() {
             assert_eq!(
                 LogicOp::from_op_def(
-                    r.get_op(op.name()).unwrap(),
+                    r.get_op(&op.name()).unwrap(),
                     // `all_variants` will set default type arg values.
                     &[TypeArg::BoundedNat { n: 0 }]
                 )


### PR DESCRIPTION
BREAKING_CHANGES: const logic op names removd

Closes #656 

Have demonstrated with logic operations, pending comments on general approach can port other larger extension op sets:
TODO:

- [x] Port logic.rs
- [ ] Port collections.rs
- [ ] Port int_ops.rs
- [ ] Port other arithmetic ops?