### PR TITLE
fix!: Add serde tag to TypeParam enum

### DIFF
--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -457,7 +457,7 @@ mod test {
     fn op_def_with_type_scheme() -> Result<(), Box<dyn std::error::Error>> {
         let list_def = EXTENSION.get_type(&LIST_TYPENAME).unwrap();
         let mut e = Extension::new(EXT_ID);
-        const TP: TypeParam = TypeParam::Type(TypeBound::Any);
+        const TP: TypeParam = TypeParam::Type { b: TypeBound::Any };
         let list_of_var =
             Type::new_extension(list_def.instantiate(vec![TypeArg::new_var_use(0, TP)])?);
         const OP_NAME: SmolStr = SmolStr::new_inline("Reverse");
@@ -501,7 +501,7 @@ mod test {
                 &self,
                 arg_values: &[TypeArg],
             ) -> Result<PolyFuncType, SignatureError> {
-                const TP: TypeParam = TypeParam::Type(TypeBound::Any);
+                const TP: TypeParam = TypeParam::Type { b: TypeBound::Any };
                 let [TypeArg::BoundedNat { n }] = arg_values else {
                     return Err(SignatureError::InvalidTypeArgs);
                 };
@@ -546,12 +546,20 @@ mod test {
                 vec![Type::new_tuple(tyvars)]
             ))
         );
-        def.validate_args(&args, &PRELUDE_REGISTRY, &[TypeParam::Type(TypeBound::Eq)])
-            .unwrap();
+        def.validate_args(
+            &args,
+            &PRELUDE_REGISTRY,
+            &[TypeParam::Type { b: TypeBound::Eq }],
+        )
+        .unwrap();
 
         // quick sanity check that we are validating the args - note changed bound:
         assert_eq!(
-            def.validate_args(&args, &PRELUDE_REGISTRY, &[TypeParam::Type(TypeBound::Any)]),
+            def.validate_args(
+                &args,
+                &PRELUDE_REGISTRY,
+                &[TypeParam::Type { b: TypeBound::Any }]
+            ),
             Err(SignatureError::TypeVarDoesNotMatchDeclaration {
                 actual: TypeBound::Any.into(),
                 cached: TypeBound::Eq.into()
@@ -587,7 +595,7 @@ mod test {
             "SimpleOp".into(),
             "".into(),
             PolyFuncType::new(
-                vec![TypeParam::Type(TypeBound::Any)],
+                vec![TypeParam::Type { b: TypeBound::Any }],
                 FunctionType::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
             ),
         )?;

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -546,20 +546,12 @@ mod test {
                 vec![Type::new_tuple(tyvars)]
             ))
         );
-        def.validate_args(
-            &args,
-            &PRELUDE_REGISTRY,
-            &[TypeParam::Type { b: TypeBound::Eq }],
-        )
-        .unwrap();
+        def.validate_args(&args, &PRELUDE_REGISTRY, &[TypeBound::Eq.into()])
+            .unwrap();
 
         // quick sanity check that we are validating the args - note changed bound:
         assert_eq!(
-            def.validate_args(
-                &args,
-                &PRELUDE_REGISTRY,
-                &[TypeParam::Type { b: TypeBound::Any }]
-            ),
+            def.validate_args(&args, &PRELUDE_REGISTRY, &[TypeBound::Any.into()]),
             Err(SignatureError::TypeVarDoesNotMatchDeclaration {
                 actual: TypeBound::Any.into(),
                 cached: TypeBound::Eq.into()
@@ -595,7 +587,7 @@ mod test {
             "SimpleOp".into(),
             "".into(),
             PolyFuncType::new(
-                vec![TypeParam::Type { b: TypeBound::Any }],
+                vec![TypeBound::Any.into()],
                 FunctionType::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
             ),
         )?;

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -29,7 +29,7 @@ impl SignatureFromArgs for ArrayOpCustom {
         let other_row = vec![array_type(TypeArg::BoundedNat { n }, elem_ty_var.clone())];
 
         Ok(PolyFuncType::new(
-            vec![TypeParam::Type(TypeBound::Any)],
+            vec![TypeParam::Type { b: TypeBound::Any }],
             FunctionType::new(var_arg_row, other_row),
         ))
     }
@@ -57,7 +57,7 @@ lazy_static! {
         prelude
             .add_type(
                 SmolStr::new_inline("array"),
-                vec![ TypeParam::max_nat(),TypeParam::Type(TypeBound::Any)],
+                vec![ TypeParam::max_nat(),TypeParam::Type { b: TypeBound::Any }],
                 "array".into(),
                 TypeDefBound::FromParams(vec![1]),
             )

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -29,7 +29,7 @@ impl SignatureFromArgs for ArrayOpCustom {
         let other_row = vec![array_type(TypeArg::BoundedNat { n }, elem_ty_var.clone())];
 
         Ok(PolyFuncType::new(
-            vec![TypeParam::Type { b: TypeBound::Any }],
+            vec![TypeBound::Any.into()],
             FunctionType::new(var_arg_row, other_row),
         ))
     }
@@ -57,7 +57,7 @@ lazy_static! {
         prelude
             .add_type(
                 SmolStr::new_inline("array"),
-                vec![ TypeParam::max_nat(),TypeParam::Type { b: TypeBound::Any }],
+                vec![ TypeParam::max_nat(), TypeBound::Any.into()],
                 "array".into(),
                 TypeDefBound::FromParams(vec![1]),
             )

--- a/src/extension/type_def.rs
+++ b/src/extension/type_def.rs
@@ -179,7 +179,9 @@ mod test {
     fn test_instantiate_typedef() {
         let def = TypeDef {
             name: "MyType".into(),
-            params: vec![TypeParam::Type(TypeBound::Copyable)],
+            params: vec![TypeParam::Type {
+                b: TypeBound::Copyable,
+            }],
             extension: "MyRsrc".try_into().unwrap(),
             description: "Some parameterised type".into(),
             bound: TypeDefBound::FromParams(vec![0]),
@@ -200,7 +202,9 @@ mod test {
             Err(SignatureError::TypeArgMismatch(
                 TypeArgError::TypeMismatch {
                     arg: TypeArg::Type { ty: QB_T },
-                    param: TypeParam::Type(TypeBound::Copyable)
+                    param: TypeParam::Type {
+                        b: TypeBound::Copyable
+                    }
                 }
             ))
         );

--- a/src/extension/type_def.rs
+++ b/src/extension/type_def.rs
@@ -202,9 +202,7 @@ mod test {
             Err(SignatureError::TypeArgMismatch(
                 TypeArgError::TypeMismatch {
                     arg: TypeArg::Type { ty: QB_T },
-                    param: TypeParam::Type {
-                        b: TypeBound::Copyable
-                    }
+                    param: TypeBound::Copyable.into()
                 }
             ))
         );

--- a/src/hugr/validate/test.rs
+++ b/src/hugr/validate/test.rs
@@ -671,7 +671,9 @@ fn invalid_types() {
     let mut e = Extension::new(name.clone());
     e.add_type(
         "MyContainer".into(),
-        vec![TypeParam::Type(TypeBound::Copyable)],
+        vec![TypeParam::Type {
+            b: TypeBound::Copyable,
+        }],
         "".into(),
         TypeDefBound::Explicit(TypeBound::Any),
     )
@@ -709,7 +711,9 @@ fn invalid_types() {
     assert_eq!(
         validate_to_sig_error(element_outside_bound),
         SignatureError::TypeArgMismatch(TypeArgError::TypeMismatch {
-            param: TypeParam::Type(TypeBound::Copyable),
+            param: TypeParam::Type {
+                b: TypeBound::Copyable
+            },
             arg: TypeArg::Type { ty: valid }
         })
     );
@@ -813,7 +817,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
     let f = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
-            [TypeParam::Type(TypeBound::Any)],
+            [TypeParam::Type { b: TypeBound::Any }],
             FunctionType::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
         ),
     )?;
@@ -823,7 +827,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
     let f = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
-            [TypeParam::Type(TypeBound::Any)],
+            [TypeParam::Type { b: TypeBound::Any }],
             FunctionType::new_endo(vec![Type::new_var_use(1, TypeBound::Any)]),
         ),
     )?;
@@ -833,7 +837,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
     let f = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
-            [TypeParam::Type(TypeBound::Any)],
+            [TypeParam::Type { b: TypeBound::Any }],
             FunctionType::new_endo(vec![Type::new_var_use(1, TypeBound::Copyable)]),
         ),
     )?;
@@ -884,7 +888,9 @@ fn nested_typevars() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
     use crate::std_extensions::collections;
-    const BOUND: TypeParam = TypeParam::Type(TypeBound::Copyable);
+    const BOUND: TypeParam = TypeParam::Type {
+        b: TypeBound::Copyable,
+    };
     let list_of_var = Type::new_extension(
         collections::EXTENSION
             .get_type(&collections::LIST_TYPENAME)

--- a/src/hugr/validate/test.rs
+++ b/src/hugr/validate/test.rs
@@ -671,9 +671,7 @@ fn invalid_types() {
     let mut e = Extension::new(name.clone());
     e.add_type(
         "MyContainer".into(),
-        vec![TypeParam::Type {
-            b: TypeBound::Copyable,
-        }],
+        vec![TypeBound::Copyable.into()],
         "".into(),
         TypeDefBound::Explicit(TypeBound::Any),
     )
@@ -711,9 +709,7 @@ fn invalid_types() {
     assert_eq!(
         validate_to_sig_error(element_outside_bound),
         SignatureError::TypeArgMismatch(TypeArgError::TypeMismatch {
-            param: TypeParam::Type {
-                b: TypeBound::Copyable
-            },
+            param: TypeBound::Copyable.into(),
             arg: TypeArg::Type { ty: valid }
         })
     );
@@ -817,7 +813,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
     let f = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
-            [TypeParam::Type { b: TypeBound::Any }],
+            [TypeBound::Any.into()],
             FunctionType::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
         ),
     )?;
@@ -827,7 +823,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
     let f = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
-            [TypeParam::Type { b: TypeBound::Any }],
+            [TypeBound::Any.into()],
             FunctionType::new_endo(vec![Type::new_var_use(1, TypeBound::Any)]),
         ),
     )?;
@@ -837,7 +833,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
     let f = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
-            [TypeParam::Type { b: TypeBound::Any }],
+            [TypeBound::Any.into()],
             FunctionType::new_endo(vec![Type::new_var_use(1, TypeBound::Copyable)]),
         ),
     )?;

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -67,7 +67,7 @@ impl CustomConst for ListValue {
         crate::values::downcast_equal_consts(self, other)
     }
 }
-const TP: TypeParam = TypeParam::Type(TypeBound::Any);
+const TP: TypeParam = TypeParam::Type { b: TypeBound::Any };
 
 fn extension() -> Extension {
     let mut extension = Extension::new(EXTENSION_NAME);

--- a/src/types.rs
+++ b/src/types.rs
@@ -313,7 +313,7 @@ impl Type {
             TypeEnum::Extension(custy) => custy.validate(extension_registry, var_decls),
             TypeEnum::Function(ft) => ft.validate(extension_registry, var_decls),
             TypeEnum::Variable(idx, bound) => {
-                check_typevar_decl(var_decls, *idx, &TypeParam::Type(*bound))
+                check_typevar_decl(var_decls, *idx, &TypeParam::Type { b: *bound })
             }
         }
     }
@@ -337,7 +337,7 @@ impl Type {
 pub(crate) trait Substitution {
     /// Apply to a variable of kind [TypeParam::Type]
     fn apply_typevar(&self, idx: usize, bound: TypeBound) -> Type {
-        let TypeArg::Type { ty } = self.apply_var(idx, &TypeParam::Type(bound)) else {
+        let TypeArg::Type { ty } = self.apply_var(idx, &TypeParam::Type { b: bound }) else {
             panic!("Variable was not a type - try validate() first")
         };
         ty

--- a/src/types.rs
+++ b/src/types.rs
@@ -312,9 +312,7 @@ impl Type {
             TypeEnum::Alias(_) => Ok(()),
             TypeEnum::Extension(custy) => custy.validate(extension_registry, var_decls),
             TypeEnum::Function(ft) => ft.validate(extension_registry, var_decls),
-            TypeEnum::Variable(idx, bound) => {
-                check_typevar_decl(var_decls, *idx, &TypeParam::Type { b: *bound })
-            }
+            TypeEnum::Variable(idx, bound) => check_typevar_decl(var_decls, *idx, &(*bound).into()),
         }
     }
 
@@ -337,7 +335,7 @@ impl Type {
 pub(crate) trait Substitution {
     /// Apply to a variable of kind [TypeParam::Type]
     fn apply_typevar(&self, idx: usize, bound: TypeBound) -> Type {
-        let TypeArg::Type { ty } = self.apply_var(idx, &TypeParam::Type { b: bound }) else {
+        let TypeArg::Type { ty } = self.apply_var(idx, &bound.into()) else {
             panic!("Variable was not a type - try validate() first")
         };
         ty

--- a/src/types/poly_func.rs
+++ b/src/types/poly_func.rs
@@ -338,7 +338,9 @@ pub(crate) mod test {
         let body_type = id_fn(Type::new_extension(list_def.instantiate([tv])?));
         for decl in [
             TypeParam::Extensions,
-            TypeParam::List(Box::new(TypeParam::max_nat())),
+            TypeParam::List {
+                param: Box::new(TypeParam::max_nat()),
+            },
             TypeParam::Opaque(USIZE_CUSTOM_T),
             TypeParam::Tuple(vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()]),
         ] {
@@ -424,7 +426,9 @@ pub(crate) mod test {
             &[TypeParam::Type(TypeBound::Any)],
         )?;
 
-        let list_of_tys = |b| TypeParam::List(Box::new(TypeParam::Type(b)));
+        let list_of_tys = |b| TypeParam::List {
+            param: Box::new(TypeParam::Type(b)),
+        };
         decl_accepts_rejects_var(
             list_of_tys(TypeBound::Copyable),
             &[list_of_tys(TypeBound::Copyable), list_of_tys(TypeBound::Eq)],

--- a/src/types/poly_func.rs
+++ b/src/types/poly_func.rs
@@ -247,10 +247,10 @@ pub(crate) mod test {
     #[test]
     fn test_opaque() -> Result<(), SignatureError> {
         let list_def = EXTENSION.get_type(&LIST_TYPENAME).unwrap();
-        let tyvar = TypeArg::new_var_use(0, TypeParam::Type(TypeBound::Any));
+        let tyvar = TypeArg::new_var_use(0, TypeParam::Type { b: TypeBound::Any });
         let list_of_var = Type::new_extension(list_def.instantiate([tyvar.clone()])?);
         let list_len = PolyFuncType::new_validated(
-            [TypeParam::Type(TypeBound::Any)],
+            [TypeParam::Type { b: TypeBound::Any }],
             FunctionType::new(vec![list_of_var], vec![USIZE_T]),
             &REGISTRY,
         )?;
@@ -278,7 +278,7 @@ pub(crate) mod test {
     #[test]
     fn test_mismatched_args() -> Result<(), SignatureError> {
         let ar_def = PRELUDE.get_type("array").unwrap();
-        let typarams = [TypeParam::max_nat(), TypeParam::Type(TypeBound::Any)];
+        let typarams = [TypeParam::max_nat(), TypeParam::Type { b: TypeBound::Any }];
         let [tyvar, szvar] =
             [0, 1].map(|i| TypeArg::new_var_use(i, typarams.get(i).unwrap().clone()));
 
@@ -333,7 +333,12 @@ pub(crate) mod test {
     #[test]
     fn test_misused_variables() -> Result<(), SignatureError> {
         // Variables in args have different bounds from variable declaration
-        let tv = TypeArg::new_var_use(0, TypeParam::Type(TypeBound::Copyable));
+        let tv = TypeArg::new_var_use(
+            0,
+            TypeParam::Type {
+                b: TypeBound::Copyable,
+            },
+        );
         let list_def = EXTENSION.get_type(&LIST_TYPENAME).unwrap();
         let body_type = id_fn(Type::new_extension(list_def.instantiate([tv])?));
         for decl in [
@@ -341,15 +346,19 @@ pub(crate) mod test {
             TypeParam::List {
                 param: Box::new(TypeParam::max_nat()),
             },
-            TypeParam::Opaque(USIZE_CUSTOM_T),
-            TypeParam::Tuple(vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()]),
+            TypeParam::Opaque { ty: USIZE_CUSTOM_T },
+            TypeParam::Tuple {
+                params: vec![TypeParam::Type { b: TypeBound::Any }, TypeParam::max_nat()],
+            },
         ] {
             let invalid_ts =
                 PolyFuncType::new_validated([decl.clone()], body_type.clone(), &REGISTRY);
             assert_eq!(
                 invalid_ts.err(),
                 Some(SignatureError::TypeVarDoesNotMatchDeclaration {
-                    cached: TypeParam::Type(TypeBound::Copyable),
+                    cached: TypeParam::Type {
+                        b: TypeBound::Copyable
+                    },
                     actual: decl
                 })
             );
@@ -418,16 +427,20 @@ pub(crate) mod test {
     #[test]
     fn test_bound_covariance() -> Result<(), SignatureError> {
         decl_accepts_rejects_var(
-            TypeParam::Type(TypeBound::Copyable),
+            TypeParam::Type {
+                b: TypeBound::Copyable,
+            },
             &[
-                TypeParam::Type(TypeBound::Copyable),
-                TypeParam::Type(TypeBound::Eq),
+                TypeParam::Type {
+                    b: TypeBound::Copyable,
+                },
+                TypeParam::Type { b: TypeBound::Eq },
             ],
-            &[TypeParam::Type(TypeBound::Any)],
+            &[TypeParam::Type { b: TypeBound::Any }],
         )?;
 
         let list_of_tys = |b| TypeParam::List {
-            param: Box::new(TypeParam::Type(b)),
+            param: Box::new(TypeParam::Type { b }),
         };
         decl_accepts_rejects_var(
             list_of_tys(TypeBound::Copyable),
@@ -461,7 +474,7 @@ pub(crate) mod test {
     fn partial_instantiate() -> Result<(), SignatureError> {
         // forall A,N.(Array<A,N> -> A)
         let array_max = PolyFuncType::new_validated(
-            vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
+            vec![TypeParam::Type { b: TypeBound::Any }, TypeParam::max_nat()],
             FunctionType::new(
                 vec![array_type(
                     TypeArg::new_var_use(1, TypeParam::max_nat()),
@@ -513,11 +526,13 @@ pub(crate) mod test {
     // forall A. A -> (forall C. C -> List(Tuple(C, A))
     pub(crate) fn nested_func() -> PolyFuncType {
         PolyFuncType::new_validated(
-            vec![TypeParam::Type(TypeBound::Any)],
+            vec![TypeParam::Type { b: TypeBound::Any }],
             FunctionType::new(
                 vec![Type::new_var_use(0, TypeBound::Any)],
                 vec![Type::new_function(new_pf1(
-                    TypeParam::Type(TypeBound::Copyable),
+                    TypeParam::Type {
+                        b: TypeBound::Copyable,
+                    },
                     Type::new_var_use(0, TypeBound::Copyable),
                     list_of_tup(
                         Type::new_var_use(0, TypeBound::Copyable),
@@ -539,7 +554,9 @@ pub(crate) mod test {
         let outer_applied = FunctionType::new(
             vec![arg.clone()], // This had index 0, but is replaced
             vec![Type::new_function(new_pf1(
-                TypeParam::Type(TypeBound::Copyable),
+                TypeParam::Type {
+                    b: TypeBound::Copyable,
+                },
                 // We are checking that the substitution has been applied to the right var
                 // - NOT to the inner_var which has index 0 here
                 Type::new_var_use(0, TypeBound::Copyable),
@@ -561,7 +578,7 @@ pub(crate) mod test {
 
         // Now substitute in a free var from further outside
         const FREE: usize = 3;
-        const TP_EQ: TypeParam = TypeParam::Type(TypeBound::Eq);
+        const TP_EQ: TypeParam = TypeParam::Type { b: TypeBound::Eq };
         let res = outer
             .instantiate(&[TypeArg::new_var_use(FREE, TP_EQ)], &REGISTRY)
             .unwrap();
@@ -571,7 +588,9 @@ pub(crate) mod test {
             FunctionType::new(
                 vec![Type::new_var_use(FREE, TypeBound::Eq)],
                 vec![Type::new_function(new_pf1(
-                    TypeParam::Type(TypeBound::Copyable),
+                    TypeParam::Type {
+                        b: TypeBound::Copyable
+                    },
                     Type::new_var_use(0, TypeBound::Copyable), // unchanged
                     list_of_tup(
                         Type::new_var_use(0, TypeBound::Copyable),
@@ -604,7 +623,9 @@ pub(crate) mod test {
                 vec![rhs(FREE)], // Input: forall TEQ. (TEQ -> Array(TEQ, FREE))
                 // Output: forall C. C -> List(Tuple(C, Input))
                 vec![Type::new_function(new_pf1(
-                    TypeParam::Type(TypeBound::Copyable),
+                    TypeParam::Type {
+                        b: TypeBound::Copyable
+                    },
                     Type::new_var_use(0, TypeBound::Copyable),
                     list_of_tup(
                         Type::new_var_use(0, TypeBound::Copyable), // not renumbered...

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -47,6 +47,7 @@ impl UpperBound {
     Clone, Debug, PartialEq, Eq, derive_more::Display, serde::Deserialize, serde::Serialize,
 )]
 #[non_exhaustive]
+#[serde(tag = "typ")]
 pub enum TypeParam {
     /// Argument is a [TypeArg::Type].
     Type(TypeBound),

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -50,19 +50,31 @@ impl UpperBound {
 #[serde(tag = "tp")]
 pub enum TypeParam {
     /// Argument is a [TypeArg::Type].
-    Type(TypeBound),
+    Type {
+        /// Bound for the type parameter.
+        b: TypeBound,
+    },
     /// Argument is a [TypeArg::BoundedNat] that is less than the upper bound.
-    BoundedNat(UpperBound),
+    BoundedNat {
+        /// Upper bound for the Nat parameter.
+        bound: UpperBound,
+    },
     /// Argument is a [TypeArg::Opaque], defined by a [CustomType].
-    Opaque(CustomType),
+    Opaque {
+        /// The [CustomType] defining the parameter.
+        ty: CustomType,
+    },
     /// Argument is a [TypeArg::Sequence]. A list of indeterminate size containing parameters.
     List {
-        #[allow(missing_docs)]
+        /// The [TypeParam] contained in the list.
         param: Box<TypeParam>,
     },
     /// Argument is a [TypeArg::Sequence]. A tuple of parameters.
-    #[display(fmt = "Tuple({})", "_0.iter().map(|t|t.to_string()).join(\", \")")]
-    Tuple(Vec<TypeParam>),
+    #[display(fmt = "Tuple({})", "params.iter().map(|t|t.to_string()).join(\", \")")]
+    Tuple {
+        /// The [TypeParam]s contained in the tuple.
+        params: Vec<TypeParam>,
+    },
     /// Argument is a [TypeArg::Extensions]. A set of [ExtensionId]s.
     ///
     /// [ExtensionId]: crate::extension::ExtensionId
@@ -72,21 +84,27 @@ pub enum TypeParam {
 impl TypeParam {
     /// [`TypeParam::BoundedNat`] with the maximum bound (`u64::MAX` + 1)
     pub const fn max_nat() -> Self {
-        Self::BoundedNat(UpperBound(None))
+        Self::BoundedNat {
+            bound: UpperBound(None),
+        }
     }
 
     /// [`TypeParam::BoundedNat`] with the stated upper bound (non-exclusive)
     pub const fn bounded_nat(upper_bound: NonZeroU64) -> Self {
-        Self::BoundedNat(UpperBound(Some(upper_bound)))
+        Self::BoundedNat {
+            bound: UpperBound(Some(upper_bound)),
+        }
     }
 
     fn contains(&self, other: &TypeParam) -> bool {
         match (self, other) {
-            (TypeParam::Type(b1), TypeParam::Type(b2)) => b1.contains(*b2),
-            (TypeParam::BoundedNat(b1), TypeParam::BoundedNat(b2)) => b1.contains(b2),
-            (TypeParam::Opaque(c1), TypeParam::Opaque(c2)) => c1 == c2,
+            (TypeParam::Type { b: b1 }, TypeParam::Type { b: b2 }) => b1.contains(*b2),
+            (TypeParam::BoundedNat { bound: b1 }, TypeParam::BoundedNat { bound: b2 }) => {
+                b1.contains(b2)
+            }
+            (TypeParam::Opaque { ty: c1 }, TypeParam::Opaque { ty: c2 }) => c1 == c2,
             (TypeParam::List { param: e1 }, TypeParam::List { param: e2 }) => e1.contains(e2),
-            (TypeParam::Tuple(es1), TypeParam::Tuple(es2)) => {
+            (TypeParam::Tuple { params: es1 }, TypeParam::Tuple { params: es2 }) => {
                 es1.len() == es2.len() && es1.iter().zip(es2).all(|(e1, e2)| e1.contains(e2))
             }
             (TypeParam::Extensions, TypeParam::Extensions) => true,
@@ -97,7 +115,7 @@ impl TypeParam {
 
 impl From<TypeBound> for TypeParam {
     fn from(bound: TypeBound) -> Self {
-        Self::Type(bound)
+        Self::Type { b: bound }
     }
 }
 
@@ -159,7 +177,7 @@ impl TypeArg {
     /// `bound` must match that with which the variable was declared.
     pub fn new_var_use(idx: usize, decl: TypeParam) -> Self {
         match decl {
-            TypeParam::Type(b) => TypeArg::Type {
+            TypeParam::Type { b } => TypeArg::Type {
                 ty: Type::new_var_use(idx, b),
             },
             TypeParam::Extensions => TypeArg::Extensions {
@@ -260,7 +278,7 @@ pub fn check_type_arg(arg: &TypeArg, param: &TypeParam) -> Result<(), TypeArgErr
             },
             _,
         ) if param.contains(cached_decl) => Ok(()),
-        (TypeArg::Type { ty }, TypeParam::Type(bound))
+        (TypeArg::Type { ty }, TypeParam::Type { b: bound })
             if bound.contains(ty.least_upper_bound()) =>
         {
             Ok(())
@@ -268,7 +286,7 @@ pub fn check_type_arg(arg: &TypeArg, param: &TypeParam) -> Result<(), TypeArgErr
         (TypeArg::Sequence { elems }, TypeParam::List { param }) => {
             elems.iter().try_for_each(|arg| check_type_arg(arg, param))
         }
-        (TypeArg::Sequence { elems: items }, TypeParam::Tuple(types)) => {
+        (TypeArg::Sequence { elems: items }, TypeParam::Tuple { params: types }) => {
             if items.len() != types.len() {
                 Err(TypeArgError::WrongNumberTuple(items.len(), types.len()))
             } else {
@@ -278,13 +296,13 @@ pub fn check_type_arg(arg: &TypeArg, param: &TypeParam) -> Result<(), TypeArgErr
                     .try_for_each(|(arg, param)| check_type_arg(arg, param))
             }
         }
-        (TypeArg::BoundedNat { n: val }, TypeParam::BoundedNat(bound))
+        (TypeArg::BoundedNat { n: val }, TypeParam::BoundedNat { bound })
             if bound.valid_value(*val) =>
         {
             Ok(())
         }
 
-        (TypeArg::Opaque { arg }, TypeParam::Opaque(param))
+        (TypeArg::Opaque { arg }, TypeParam::Opaque { ty: param })
             if param.bound() == TypeBound::Eq && &arg.typ == param =>
         {
             Ok(())


### PR DESCRIPTION
Needed for Pydantic serialisation.

BREAKING_CHANGES: Turn the `TypeParam` enum variants into struct variants