### PR TITLE
feat: Always require a signature in `OpaqueOp`

### DIFF
--- a/src/builder/circuit.rs
+++ b/src/builder/circuit.rs
@@ -179,7 +179,7 @@ mod test {
                 "MyOp",
                 "unknown op".to_string(),
                 vec![],
-                Some(FunctionType::new(vec![QB, NAT], vec![QB])),
+                FunctionType::new(vec![QB, NAT], vec![QB]),
             ))
             .into(),
         );

--- a/src/extension/infer/test.rs
+++ b/src/extension/infer/test.rs
@@ -450,8 +450,7 @@ fn extension_adding_sequence() -> Result<(), Box<dyn Error>> {
 }
 
 fn make_opaque(extension: impl Into<ExtensionId>, signature: FunctionType) -> ops::LeafOp {
-    let opaque =
-        ops::custom::OpaqueOp::new(extension.into(), "", "".into(), vec![], Some(signature));
+    let opaque = ops::custom::OpaqueOp::new(extension.into(), "", "".into(), vec![], signature);
     ops::custom::ExternalOp::from(opaque).into()
 }
 
@@ -874,7 +873,7 @@ fn plus_on_self() -> Result<(), Box<dyn std::error::Error>> {
         "2qb_op",
         String::new(),
         vec![],
-        Some(ft),
+        ft,
     ))
     .into();
     let unary_sig = FunctionType::new_endo(type_row![QB_T])
@@ -884,7 +883,7 @@ fn plus_on_self() -> Result<(), Box<dyn std::error::Error>> {
         "1qb_op",
         String::new(),
         vec![],
-        Some(unary_sig),
+        unary_sig,
     ))
     .into();
     // Constrain q1,q2 as PLUS(ext1, inputs):

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -349,13 +349,6 @@ impl OpDef {
         self.signature_func.compute_signature(self, args, exts)
     }
 
-    pub(crate) fn should_serialize_signature(&self) -> bool {
-        match self.signature_func {
-            SignatureFunc::TypeScheme { .. } => false,
-            SignatureFunc::CustomFunc { .. } => true,
-        }
-    }
-
     /// Fallibly returns a Hugr that may replace an instance of this OpDef
     /// given a set of available extensions that may be used in the Hugr.
     pub fn try_lower(&self, args: &[TypeArg], available_extensions: &ExtensionSet) -> Option<Hugr> {

--- a/src/hugr/rewrite/replace.rs
+++ b/src/hugr/rewrite/replace.rs
@@ -652,7 +652,7 @@ mod test {
                 s,
                 String::new(),
                 vec![],
-                Some(utou.clone()),
+                utou.clone(),
             )))
         };
         let mut h = DFGBuilder::new(FunctionType::new(

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -423,7 +423,7 @@ pub mod test {
     }
 
     #[test]
-    fn canonicalisation() {
+    fn hierarchy_order() {
         let mut hugr = closed_dfg_root_hugr(FunctionType::new(vec![QB], vec![QB]));
         let [old_in, out] = hugr.get_io(hugr.root()).unwrap();
         hugr.connect(old_in, 0, out, 0).unwrap();

--- a/src/ops/custom.rs
+++ b/src/ops/custom.rs
@@ -36,6 +36,40 @@ impl ExternalOp {
             Self::Extension(op) => op.args(),
         }
     }
+
+    /// Name of the ExternalOp
+    pub fn name(&self) -> SmolStr {
+        let (res_id, op_name) = match self {
+            Self::Opaque(op) => (&op.extension, &op.op_name),
+            Self::Extension(ExtensionOp { def, .. }) => (def.extension(), def.name()),
+        };
+        qualify_name(res_id, op_name)
+    }
+
+    /// A description of the external op.
+    pub fn description(&self) -> &str {
+        match self {
+            Self::Opaque(op) => op.description.as_str(),
+            Self::Extension(ext_op) => DataflowOpTrait::description(ext_op),
+        }
+    }
+
+    /// Note the case of an OpaqueOp without a signature should already
+    /// have been detected in [resolve_extension_ops]
+    pub fn dataflow_signature(&self) -> FunctionType {
+        match self {
+            Self::Opaque(op) => op.signature.clone(),
+            Self::Extension(ext_op) => ext_op.signature(),
+        }
+    }
+
+    /// Downgrades this ExternalOp into an OpaqueOp
+    pub fn as_opaque(self) -> OpaqueOp {
+        match self {
+            Self::Opaque(op) => op,
+            Self::Extension(op) => op.into(),
+        }
+    }
 }
 
 impl From<ExternalOp> for OpaqueOp {
@@ -63,39 +97,6 @@ impl From<ExternalOp> for OpType {
     fn from(value: ExternalOp) -> Self {
         let leaf: LeafOp = value.into();
         leaf.into()
-    }
-}
-
-impl ExternalOp {
-    /// Name of the ExternalOp
-    pub fn name(&self) -> SmolStr {
-        let (res_id, op_name) = match self {
-            Self::Opaque(op) => (&op.extension, &op.op_name),
-            Self::Extension(ExtensionOp { def, .. }) => (def.extension(), def.name()),
-        };
-        qualify_name(res_id, op_name)
-    }
-}
-
-impl ExternalOp {
-    /// A description of the external op.
-    pub fn description(&self) -> &str {
-        match self {
-            Self::Opaque(op) => op.description.as_str(),
-            Self::Extension(ext_op) => DataflowOpTrait::description(ext_op),
-        }
-    }
-
-    /// Note the case of an OpaqueOp without a signature should already
-    /// have been detected in [resolve_extension_ops]
-    pub fn dataflow_signature(&self) -> FunctionType {
-        match self {
-            Self::Opaque(op) => op
-                .signature
-                .clone()
-                .expect("Op should have been serialized with signature."),
-            Self::Extension(ext_op) => ext_op.signature(),
-        }
     }
 }
 
@@ -144,17 +145,12 @@ impl From<ExtensionOp> for OpaqueOp {
             args,
             signature,
         } = op;
-        let opt_sig = if def.should_serialize_signature() {
-            Some(signature)
-        } else {
-            None
-        };
         OpaqueOp {
             extension: def.extension().clone(),
             op_name: def.name().clone(),
             description: def.description().into(),
             args,
-            signature: opt_sig,
+            signature,
         }
     }
 }
@@ -199,7 +195,7 @@ pub struct OpaqueOp {
     op_name: SmolStr,
     description: String, // cache in advance so description() can return &str
     args: Vec<TypeArg>,
-    signature: Option<FunctionType>,
+    signature: FunctionType,
 }
 
 fn qualify_name(res_id: &ExtensionId, op_name: &SmolStr) -> SmolStr {
@@ -213,7 +209,7 @@ impl OpaqueOp {
         op_name: impl Into<SmolStr>,
         description: String,
         args: impl Into<Vec<TypeArg>>,
-        signature: Option<FunctionType>,
+        signature: FunctionType,
     ) -> Self {
         Self {
             extension,
@@ -291,7 +287,7 @@ pub fn resolve_extension_ops(
 /// # Errors
 /// If the serialized opaque resolves to a definition that conflicts with what was serialized
 pub fn resolve_opaque_op(
-    n: Node,
+    _n: Node,
     opaque: &OpaqueOp,
     extension_registry: &ExtensionRegistry,
 ) -> Result<Option<ExtensionOp>, CustomOpError> {
@@ -305,22 +301,15 @@ pub fn resolve_opaque_op(
         };
         let ext_op =
             ExtensionOp::new(def.clone(), opaque.args.clone(), extension_registry).unwrap();
-        if let Some(stored_sig) = &opaque.signature {
-            if stored_sig != &ext_op.signature {
-                return Err(CustomOpError::SignatureMismatch {
-                    extension: opaque.extension.clone(),
-                    op: def.name().clone(),
-                    computed: ext_op.signature.clone(),
-                    stored: stored_sig.clone(),
-                });
-            };
-        }
+        if opaque.signature != ext_op.signature {
+            return Err(CustomOpError::SignatureMismatch {
+                extension: opaque.extension.clone(),
+                op: def.name().clone(),
+                computed: ext_op.signature.clone(),
+                stored: opaque.signature.clone(),
+            });
+        };
         Ok(Some(ext_op))
-    } else if opaque.signature.is_none() {
-        Err(CustomOpError::NoStoredSignature(
-            ExternalOp::Opaque(opaque.clone()).name(),
-            n,
-        ))
     } else {
         Ok(None)
     }
@@ -330,9 +319,6 @@ pub fn resolve_opaque_op(
 /// when trying to resolve the serialized names against a registry of known Extensions.
 #[derive(Clone, Debug, Error, PartialEq)]
 pub enum CustomOpError {
-    /// Extension not found, and no signature
-    #[error("Unable to resolve operation {0} for node {1:?} with no saved signature")]
-    NoStoredSignature(SmolStr, Node),
     /// The Extension was found but did not contain the expected OpDef
     #[error("Operation {0} not found in Extension {1}")]
     OpNotFoundInExtension(SmolStr, ExtensionId),
@@ -350,22 +336,24 @@ pub enum CustomOpError {
 #[cfg(test)]
 mod test {
 
-    use crate::extension::prelude::USIZE_T;
+    use crate::extension::prelude::{QB_T, USIZE_T};
 
     use super::*;
 
     #[test]
     fn new_opaque_op() {
+        let sig = FunctionType::new_endo(vec![QB_T]);
         let op = OpaqueOp::new(
             "res".try_into().unwrap(),
             "op",
             "desc".into(),
             vec![TypeArg::Type { ty: USIZE_T }],
-            None,
+            sig.clone(),
         );
         let op: ExternalOp = op.into();
         assert_eq!(op.name(), "res.op");
         assert_eq!(op.description(), "desc");
         assert_eq!(op.args(), &[TypeArg::Type { ty: USIZE_T }]);
+        assert_eq!(op.dataflow_signature(), sig);
     }
 }

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -170,7 +170,7 @@ impl DataflowOpTrait for LeafOp {
 
         match self {
             LeafOp::Noop { ty: typ } => FunctionType::new(vec![typ.clone()], vec![typ.clone()]),
-            LeafOp::CustomOp(ext) => ext.dataflow_signature(),
+            LeafOp::CustomOp(ext) => ext.signature(),
             LeafOp::MakeTuple { tys: types } => {
                 FunctionType::new(types.clone(), vec![Type::new_tuple(types.clone())])
             }


### PR DESCRIPTION
Closes #689 

Adds a previously-failing test for the serialiser, where the signature of an opaque op was discarded and couldn't be recovered. Depends on #730.