### PR TITLE
Infer extension constraints on FuncDefn; remove many ExtensionSets from builder

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -97,8 +97,7 @@ pub trait Container {
             ExtensionSet::new(),
         ))?;
 
-        let db =
-            DFGBuilder::create_with_io(self.hugr_mut(), f_node, body, Some(ExtensionSet::new()))?;
+        let db = DFGBuilder::create_with_io(self.hugr_mut(), f_node, body)?;
         Ok(FunctionBuilder::from_dfg_builder(db))
     }
 
@@ -303,10 +302,10 @@ pub trait Dataflow: Container {
         let op = ops::DFG {
             signature: signature.clone(),
         };
-        let nodetype = NodeType::new(op, input_extensions.clone());
+        let nodetype = NodeType::new(op, input_extensions);
         let (dfg_n, _) = add_node_with_wires(self, nodetype, input_wires.into_iter().collect())?;
 
-        DFGBuilder::create_with_io(self.hugr_mut(), dfg_n, signature, input_extensions)
+        DFGBuilder::create_with_io(self.hugr_mut(), dfg_n, signature)
     }
 
     /// Return a builder for a [`crate::ops::CFG`] node,

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -296,13 +296,12 @@ pub trait Dataflow: Container {
     fn dfg_builder(
         &mut self,
         signature: FunctionType,
-        input_extensions: Option<ExtensionSet>,
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<DFGBuilder<&mut Hugr>, BuildError> {
         let op = ops::DFG {
             signature: signature.clone(),
         };
-        let nodetype = NodeType::new(op, input_extensions);
+        let nodetype = NodeType::new_auto(op);
         let (dfg_n, _) = add_node_with_wires(self, nodetype, input_wires.into_iter().collect())?;
 
         DFGBuilder::create_with_io(self.hugr_mut(), dfg_n, signature)

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -260,12 +260,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
         let mut node_outputs = vec![tuple_sum_type];
         node_outputs.extend_from_slice(&other_outputs);
         let signature = FunctionType::new(inputs, TypeRow::from(node_outputs));
-        let inp_ex = base
-            .as_ref()
-            .get_nodetype(block_n)
-            .input_extensions()
-            .cloned();
-        let db = DFGBuilder::create_with_io(base, block_n, signature, inp_ex)?;
+        let db = DFGBuilder::create_with_io(base, block_n, signature)?;
         Ok(BlockBuilder::from_dfg_builder(db))
     }
 

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -138,7 +138,6 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
             self.hugr_mut(),
             case_node,
             FunctionType::new(inputs, outputs).with_extension_delta(&extension_delta),
-            None,
         )?;
 
         Ok(CaseBuilder::from_dfg_builder(dfg_builder))
@@ -197,7 +196,7 @@ impl CaseBuilder<Hugr> {
         };
         let base = Hugr::new(NodeType::new_open(op));
         let root = base.root();
-        let dfg_builder = DFGBuilder::create_with_io(base, root, signature, None)?;
+        let dfg_builder = DFGBuilder::create_with_io(base, root, signature)?;
 
         Ok(CaseBuilder::from_dfg_builder(dfg_builder))
     }

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -246,11 +246,8 @@ pub(crate) mod test {
                         [int],
                     )?
                     .outputs_arr();
-                let inner_builder = func_builder.dfg_builder(
-                    FunctionType::new(type_row![NAT], type_row![NAT]),
-                    None,
-                    [int],
-                )?;
+                let inner_builder = func_builder
+                    .dfg_builder(FunctionType::new(type_row![NAT], type_row![NAT]), [int])?;
                 let inner_id = n_identity(inner_builder)?;
 
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?
@@ -372,7 +369,7 @@ pub(crate) mod test {
             let i1 = noop.out_wire(0);
 
             let mut nested =
-                f_build.dfg_builder(FunctionType::new(type_row![], type_row![BIT]), None, [])?;
+                f_build.dfg_builder(FunctionType::new(type_row![], type_row![BIT]), [])?;
 
             let id = nested.add_dataflow_op(LeafOp::Noop { ty: BIT }, [i1])?;
 
@@ -395,8 +392,7 @@ pub(crate) mod test {
         let noop = f_build.add_dataflow_op(LeafOp::Noop { ty: QB }, [i1])?;
         let i1 = noop.out_wire(0);
 
-        let mut nested =
-            f_build.dfg_builder(FunctionType::new(type_row![], type_row![QB]), None, [])?;
+        let mut nested = f_build.dfg_builder(FunctionType::new(type_row![], type_row![QB]), [])?;
 
         let id_res = nested.add_dataflow_op(LeafOp::Noop { ty: QB }, [i1]);
 
@@ -474,7 +470,7 @@ pub(crate) mod test {
             FunctionType::new(type_row![BIT], type_row![BIT]).with_extension_delta(&ab_extensions);
 
         // A box which adds extensions A and B, via child Lift nodes
-        let mut add_ab = parent.dfg_builder(add_ab_sig, Some(ExtensionSet::new()), [w])?;
+        let mut add_ab = parent.dfg_builder(add_ab_sig, [w])?;
         let [w] = add_ab.input_wires_arr();
 
         let lift_a = add_ab.add_dataflow_op(
@@ -503,7 +499,7 @@ pub(crate) mod test {
 
         // Add another node (a sibling to add_ab) which adds extension C
         // via a child lift node
-        let mut add_c = parent.dfg_builder(add_c_sig, Some(ab_extensions.clone()), [w])?;
+        let mut add_c = parent.dfg_builder(add_c_sig, [w])?;
         let [w] = add_c.input_wires_arr();
         let lift_c = add_c.add_dataflow_node(
             NodeType::new(
@@ -528,10 +524,10 @@ pub(crate) mod test {
     fn non_cfg_ancestor() -> Result<(), BuildError> {
         let unit_sig = FunctionType::new(type_row![Type::UNIT], type_row![Type::UNIT]);
         let mut b = DFGBuilder::new(unit_sig.clone())?;
-        let b_child = b.dfg_builder(unit_sig.clone(), None, [b.input().out_wire(0)])?;
+        let b_child = b.dfg_builder(unit_sig.clone(), [b.input().out_wire(0)])?;
         let b_child_in_wire = b_child.input().out_wire(0);
         b_child.finish_with_outputs([])?;
-        let b_child_2 = b.dfg_builder(unit_sig.clone(), None, [])?;
+        let b_child_2 = b.dfg_builder(unit_sig.clone(), [])?;
 
         // DFG block has edge coming a sibling block, which is only valid for
         // CFGs
@@ -552,17 +548,16 @@ pub(crate) mod test {
     fn no_relation_edge() -> Result<(), BuildError> {
         let unit_sig = FunctionType::new(type_row![Type::UNIT], type_row![Type::UNIT]);
         let mut b = DFGBuilder::new(unit_sig.clone())?;
-        let mut b_child = b.dfg_builder(unit_sig.clone(), None, [b.input().out_wire(0)])?;
-        let b_child_child =
-            b_child.dfg_builder(unit_sig.clone(), None, [b_child.input().out_wire(0)])?;
+        let mut b_child = b.dfg_builder(unit_sig.clone(), [b.input().out_wire(0)])?;
+        let b_child_child = b_child.dfg_builder(unit_sig.clone(), [b_child.input().out_wire(0)])?;
         let b_child_child_in_wire = b_child_child.input().out_wire(0);
 
         b_child_child.finish_with_outputs([])?;
         b_child.finish_with_outputs([])?;
 
-        let mut b_child_2 = b.dfg_builder(unit_sig.clone(), None, [])?;
+        let mut b_child_2 = b.dfg_builder(unit_sig.clone(), [])?;
         let b_child_2_child =
-            b_child_2.dfg_builder(unit_sig.clone(), None, [b_child_2.input().out_wire(0)])?;
+            b_child_2.dfg_builder(unit_sig.clone(), [b_child_2.input().out_wire(0)])?;
 
         let res = b_child_2_child.finish_with_outputs([b_child_child_in_wire]);
 

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -90,7 +90,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
             NodeType::new_pure(ops::FuncDefn { name, signature }),
         )?;
 
-        let db = DFGBuilder::create_with_io(self.hugr_mut(), f_node, body, None)?;
+        let db = DFGBuilder::create_with_io(self.hugr_mut(), f_node, body)?;
         Ok(FunctionBuilder::from_dfg_builder(db))
     }
 

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -21,7 +21,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
         tail_loop: &ops::TailLoop,
     ) -> Result<Self, BuildError> {
         let signature = FunctionType::new(tail_loop.body_input_row(), tail_loop.body_output_row());
-        let dfg_build = DFGBuilder::create_with_io(base, loop_node, signature, None)?;
+        let dfg_build = DFGBuilder::create_with_io(base, loop_node, signature)?;
 
         Ok(TailLoopBuilder::from_dfg_builder(dfg_build))
     }

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -323,19 +323,13 @@ impl UnificationContext {
                 self.add_constraint(m_output, Constraint::Equal(m_exit));
             }
 
-            match node_type.io_extensions() {
-                // Input extensions are open
-                None => {
-                    let delta = node_type.op().extension_delta();
-                    self.add_constraint(m_output, make_constraint(delta, m_input));
-                }
-                // We have a solution for everything!
-                Some((input_exts, output_exts)) => {
-                    self.add_solution(m_input, input_exts.clone());
-                    self.add_solution(m_output, output_exts);
-                }
+            let delta = node_type.op().extension_delta();
+            self.add_constraint(m_output, make_constraint(delta, m_input));
+            if let Some(input_exts) = node_type.input_extensions() {
+                self.add_solution(m_input, input_exts.clone());
             }
         }
+
         // Separate loop so that we can assume that a metavariable has been
         // added for every (Node, Direction) in the graph already.
         for tgt_node in hugr.nodes() {

--- a/src/extension/infer/test.rs
+++ b/src/extension/infer/test.rs
@@ -986,6 +986,7 @@ fn funcdefn_signature_mismatch() -> Result<(), Box<dyn Error>> {
         result,
         Err(ValidationError::CantInfer(
             InferExtensionError::MismatchedConcreteWithLocations { .. }
+                | InferExtensionError::EdgeMismatch(ExtensionError::SrcExceedsTgtExtensions { .. })
         ))
     );
     Ok(())

--- a/src/hugr/rewrite/replace.rs
+++ b/src/hugr/rewrite/replace.rs
@@ -689,7 +689,7 @@ mod test {
         let case1 = case1.finish_with_outputs(foo.outputs())?.node();
         let mut case2 = cond.case_builder(1)?;
         let bar = case2.add_dataflow_op(mk_op("bar"), case2.input_wires())?;
-        let mut baz_dfg = case2.dfg_builder(utou.clone(), None, bar.outputs())?;
+        let mut baz_dfg = case2.dfg_builder(utou.clone(), bar.outputs())?;
         let baz = baz_dfg.add_dataflow_op(mk_op("baz"), baz_dfg.input_wires())?;
         let baz_dfg = baz_dfg.finish_with_outputs(baz.outputs())?;
         let case2 = case2.finish_with_outputs(baz_dfg.outputs())?.node();

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -263,7 +263,6 @@ pub(in crate::hugr::rewrite) mod test {
 
             let mut inner_builder = func_builder.dfg_builder(
                 FunctionType::new_endo(type_row![QB, QB]).with_extension_delta(&delta),
-                None,
                 [qb0, qb1],
             )?;
             let inner_graph = {

--- a/src/hugr/views/descendants.rs
+++ b/src/hugr/views/descendants.rs
@@ -242,11 +242,8 @@ pub(super) mod test {
                 .outputs_arr();
 
             let inner_id = {
-                let inner_builder = func_builder.dfg_builder(
-                    FunctionType::new_endo(type_row![NAT]),
-                    None,
-                    [int],
-                )?;
+                let inner_builder =
+                    func_builder.dfg_builder(FunctionType::new_endo(type_row![NAT]), [int])?;
                 let w = inner_builder.input_wires();
                 inner_builder.finish_with_outputs(w)
             }?;

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -402,7 +402,7 @@ mod test {
         let mut module_builder = ModuleBuilder::new();
         let fty = FunctionType::new(type_row![NAT], type_row![NAT]);
         let mut fbuild = module_builder.define_function("main", fty.clone().into())?;
-        let dfg = fbuild.dfg_builder(fty, None, fbuild.input_wires())?;
+        let dfg = fbuild.dfg_builder(fty, fbuild.input_wires())?;
         let ins = dfg.input_wires();
         let sub_dfg = dfg.finish_with_outputs(ins)?;
         let fun = fbuild.finish_with_outputs(sub_dfg.outputs())?;

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -996,10 +996,10 @@ mod tests {
         let func_graph: SiblingGraph<'_, FuncID<true>> =
             SiblingGraph::try_new(&hugr, func_root).unwrap();
         let subgraph = SiblingSubgraph::try_new_dataflow_subgraph(&func_graph).unwrap();
-        let extracted =
+        let mut extracted =
             subgraph.extract_subgraph(&hugr, "region", &ExtensionSet::singleton(&EXTENSION_ID))?;
 
-        extracted.validate(&PRELUDE_REGISTRY).unwrap();
+        extracted.update_validate(&PRELUDE_REGISTRY).unwrap();
 
         Ok(())
     }

--- a/src/hugr/views/tests.rs
+++ b/src/hugr/views/tests.rs
@@ -203,13 +203,10 @@ fn test_dataflow_ports_only() {
         assert_eq!(nt.input_extensions, Some(ExtensionSet::new()));
         nt.input_extensions = Some(ExtensionSet::singleton(&EXTENSION_ID));
     }
-    // Note that presently the builder sets too many input-exts that could be
-    // left to the inference (https://github.com/CQCL/hugr/issues/702) hence we
-    // must manually change these too, although we can let inference deal with them
+    // Just (sanity-)check that no input-extensions have been set by the builder
     for node in dfg.hugr().get_io(local_and.node()).unwrap() {
-        let nt = dfg.hugr_mut().op_types.get_mut(node.pg_index());
-        assert_eq!(nt.input_extensions, Some(ExtensionSet::new()));
-        nt.input_extensions = None;
+        let nt = dfg.hugr().op_types.get(node.pg_index());
+        assert_eq!(nt.input_extensions, None);
     }
 
     let h = dfg


### PR DESCRIPTION
Follows #734. Big step towards #702 but maybe not the last word?
* Builder methods `create_with_io` and `dfg_builder` no longer take an ExtensionSet, nor set extensions of the Input/Output node
* Instead, extension inference now correctly understands the constraint between Input and Output for FuncDefn (the missing case before)
* Many test changes...e.g. tests looking for *validation* (rather than inference) failures must construct Hugrs that do not need inference (i.e. have all annotations already set), which often now means *not using the builder*