### PR TITLE
fix: case node should not have an external signature

### DIFF
--- a/src/extension/infer/test.rs
+++ b/src/extension/infer/test.rs
@@ -11,7 +11,7 @@ use crate::extension::{prelude::PRELUDE_REGISTRY, ExtensionSet};
 use crate::hugr::{validate::ValidationError, Hugr, HugrMut, HugrView, NodeType};
 use crate::macros::const_extension_ids;
 use crate::ops::custom::{ExternalOp, OpaqueOp};
-use crate::ops::{self, dataflow::IOTrait, handle::NodeHandle, OpTrait};
+use crate::ops::{self, dataflow::IOTrait, handle::NodeHandle};
 use crate::ops::{LeafOp, OpType};
 
 use crate::type_row;
@@ -314,12 +314,8 @@ fn test_conditional_inference() -> Result<(), Box<dyn Error>> {
         first_ext: ExtensionId,
         second_ext: ExtensionId,
     ) -> Result<Node, Box<dyn Error>> {
-        let [case, case_in, case_out] = create_with_io(
-            hugr,
-            conditional_node,
-            op.clone(),
-            Into::<OpType>::into(op).dataflow_signature().unwrap(),
-        )?;
+        let [case, case_in, case_out] =
+            create_with_io(hugr, conditional_node, op.clone(), op.inner_signature())?;
 
         let lift1 = hugr.add_node_with_parent(
             case,

--- a/src/hugr/rewrite/replace.rs
+++ b/src/hugr/rewrite/replace.rs
@@ -820,7 +820,7 @@ mod test {
                 mu_out: vec![new_out_edge.clone()],
                 ..r.clone()
             }),
-            Err(ReplaceError::NoRemovedEdge(new_out_edge))
+            Err(ReplaceError::BadEdgeKind(Direction::Outgoing, new_out_edge))
         );
         Ok(())
     }

--- a/src/hugr/rewrite/replace.rs
+++ b/src/hugr/rewrite/replace.rs
@@ -233,20 +233,20 @@ impl Rewrite for Replacement {
                     e.clone(),
                 ));
             }
-            e.check_src(h, &e)?;
+            e.check_src(h, e)?;
         }
         self.mu_out.iter().try_for_each(|e| {
             self.replacement.valid_non_root(e.src).map_err(|_| {
                 ReplaceError::BadEdgeSpec(Direction::Outgoing, WhichHugr::Replacement, e.clone())
             })?;
-            e.check_src(&self.replacement, &e)
+            e.check_src(&self.replacement, e)
         })?;
         // Edge targets...
         self.mu_inp.iter().try_for_each(|e| {
             self.replacement.valid_non_root(e.tgt).map_err(|_| {
                 ReplaceError::BadEdgeSpec(Direction::Incoming, WhichHugr::Replacement, e.clone())
             })?;
-            e.check_tgt(&self.replacement, &e)
+            e.check_tgt(&self.replacement, e)
         })?;
         for e in self.mu_out.iter().chain(self.mu_new.iter()) {
             if !h.contains_node(e.tgt) || removed.contains(&e.tgt) {
@@ -256,7 +256,7 @@ impl Rewrite for Replacement {
                     e.clone(),
                 ));
             }
-            e.check_tgt(h, &e)?;
+            e.check_tgt(h, e)?;
             // The descendant check is to allow the case where the old edge is nonlocal
             // from a part of the Hugr being moved (which may require changing source,
             // depending on where the transplanted portion ends up). While this subsumes
@@ -353,8 +353,8 @@ fn transfer_edges<'a>(
         h.valid_node(e.tgt).map_err(|_| {
             ReplaceError::BadEdgeSpec(Direction::Incoming, WhichHugr::Retained, oe.clone())
         })?;
-        e.check_src(h, &oe)?;
-        e.check_tgt(h, &oe)?;
+        e.check_src(h, oe)?;
+        e.check_tgt(h, oe)?;
         match e.kind {
             NewEdgeKind::Order => {
                 h.add_other_edge(e.src, e.tgt).unwrap();

--- a/src/hugr/rewrite/replace.rs
+++ b/src/hugr/rewrite/replace.rs
@@ -353,8 +353,15 @@ fn transfer_edges<'a>(
         h.valid_node(e.tgt).map_err(|_| {
             ReplaceError::BadEdgeSpec(Direction::Incoming, WhichHugr::Retained, oe.clone())
         })?;
-        e.check_src(h)?;
-        e.check_tgt(h)?;
+        let fix_edge_nums = |err| match err {
+            ReplaceError::BadEdgeKind(d, e2) => {
+                assert_eq!(e, e2);
+                ReplaceError::BadEdgeKind(d, oe.clone())
+            }
+            _ => panic!("{err} not a BadEdgeKind"),
+        };
+        e.check_src(h).map_err(fix_edge_nums)?;
+        e.check_tgt(h).map_err(fix_edge_nums)?;
         match e.kind {
             NewEdgeKind::Order => {
                 h.add_other_edge(e.src, e.tgt).unwrap();

--- a/src/ops/controlflow.rs
+++ b/src/ops/controlflow.rs
@@ -235,10 +235,6 @@ impl OpTrait for Case {
     fn tag(&self) -> OpTag {
         <Self as StaticTag>::TAG
     }
-
-    fn dataflow_signature(&self) -> Option<FunctionType> {
-        Some(self.signature.clone())
-    }
 }
 
 impl Case {
@@ -250,6 +246,11 @@ impl Case {
     /// The output signature of the contained dataflow graph.
     pub fn dataflow_output(&self) -> &TypeRow {
         &self.signature.output
+    }
+
+    /// The signature of the dataflow sibling graph contained in the [`Case`]
+    pub fn inner_signature(&self) -> FunctionType {
+        self.signature.clone()
     }
 }
 


### PR DESCRIPTION
Previously it was incorrectly reporting the internal signature as the node signature.

Fixes #750 

Required further fixes to `replace.rs`:
* test was looking for an error that should have been hidden behind another (that was not previously reported because of #750). Look for the latter, not the former.
* Fix node indices not being correctly reported from `apply`
