### PR TITLE
refactor!: use enum op traits for floats + conversions

### DIFF
--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -148,7 +148,7 @@ mod test {
     use super::*;
 
     fn test_registry() -> ExtensionRegistry {
-        ExtensionRegistry::try_new([PRELUDE.to_owned(), float_types::extension()]).unwrap()
+        ExtensionRegistry::try_new([PRELUDE.to_owned(), float_types::EXTENSION.to_owned()]).unwrap()
     }
 
     #[test]

--- a/src/std_extensions/arithmetic/conversions.rs
+++ b/src/std_extensions/arithmetic/conversions.rs
@@ -1,63 +1,131 @@
 //! Conversions between integer and floating-point values.
 
+use smol_str::SmolStr;
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
+
 use crate::{
-    extension::{prelude::sum_with_error, ExtensionId, ExtensionSet},
+    extension::{
+        prelude::sum_with_error,
+        simple_op::{MakeExtensionOp, MakeOpDef, MakeRegisteredOp, OpLoadError},
+        ExtensionId, ExtensionRegistry, ExtensionSet, OpDef, SignatureError, SignatureFunc,
+    },
+    ops::{custom::ExtensionOp, OpName},
     type_row,
-    types::{FunctionType, PolyFuncType},
+    types::{FunctionType, PolyFuncType, TypeArg},
     Extension,
 };
 
 use super::int_types::int_tv;
 use super::{float_types::FLOAT64_TYPE, int_types::LOG_WIDTH_TYPE_PARAM};
+use lazy_static::lazy_static;
 
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.conversions");
 
-/// Extension for basic arithmetic operations.
-pub fn extension() -> Extension {
-    let ftoi_sig = PolyFuncType::new(
-        vec![LOG_WIDTH_TYPE_PARAM],
-        FunctionType::new(type_row![FLOAT64_TYPE], vec![sum_with_error(int_tv(0))]),
-    );
+/// Extensiop for conversions between floats and integers.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
+#[allow(missing_docs, non_camel_case_types)]
+pub enum ConvertOpDef {
+    trunc_u,
+    trunc_s,
+    convert_u,
+    convert_s,
+}
 
-    let itof_sig = PolyFuncType::new(
-        vec![LOG_WIDTH_TYPE_PARAM],
-        FunctionType::new(vec![int_tv(0)], type_row![FLOAT64_TYPE]),
-    );
+impl MakeOpDef for ConvertOpDef {
+    fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
+        crate::extension::simple_op::try_from_name(op_def.name())
+    }
 
-    let mut extension = Extension::new_with_reqs(
-        EXTENSION_ID,
-        ExtensionSet::from_iter(vec![
-            super::int_types::EXTENSION_ID,
-            super::float_types::EXTENSION_ID,
-        ]),
-    );
-    extension
-        .add_op(
-            "trunc_u".into(),
-            "float to unsigned int".to_owned(),
-            ftoi_sig.clone(),
-        )
-        .unwrap();
-    extension
-        .add_op("trunc_s".into(), "float to signed int".to_owned(), ftoi_sig)
-        .unwrap();
-    extension
-        .add_op(
-            "convert_u".into(),
-            "unsigned int to float".to_owned(),
-            itof_sig.clone(),
-        )
-        .unwrap();
-    extension
-        .add_op(
-            "convert_s".into(),
-            "signed int to float".to_owned(),
-            itof_sig,
-        )
-        .unwrap();
+    fn signature(&self) -> SignatureFunc {
+        use ConvertOpDef::*;
+        match self {
+            trunc_s | trunc_u => PolyFuncType::new(
+                vec![LOG_WIDTH_TYPE_PARAM],
+                FunctionType::new(type_row![FLOAT64_TYPE], vec![sum_with_error(int_tv(0))]),
+            ),
 
-    extension
+            convert_s | convert_u => PolyFuncType::new(
+                vec![LOG_WIDTH_TYPE_PARAM],
+                FunctionType::new(vec![int_tv(0)], type_row![FLOAT64_TYPE]),
+            ),
+        }
+        .into()
+    }
+
+    fn description(&self) -> String {
+        use ConvertOpDef::*;
+        match self {
+            trunc_u => "float to unsigned int",
+            trunc_s => "float to signed int",
+            convert_u => "unsigned int to float",
+            convert_s => "signed int to float",
+        }
+        .to_string()
+    }
+}
+
+/// Concrete convert operation with integer width set.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConvertOpType {
+    def: ConvertOpDef,
+    width: u64,
+}
+
+impl OpName for ConvertOpType {
+    fn name(&self) -> SmolStr {
+        self.def.name()
+    }
+}
+
+impl MakeExtensionOp for ConvertOpType {
+    fn from_extension_op(ext_op: &ExtensionOp) -> Result<Self, OpLoadError> {
+        let def = ConvertOpDef::from_def(ext_op.def())?;
+        let width = match *ext_op.args() {
+            [TypeArg::BoundedNat { n }] => n,
+            _ => return Err(SignatureError::InvalidTypeArgs.into()),
+        };
+        Ok(Self { def, width })
+    }
+
+    fn type_args(&self) -> Vec<crate::types::TypeArg> {
+        vec![TypeArg::BoundedNat { n: self.width }]
+    }
+}
+
+lazy_static! {
+    /// Extension for conversions between integers and floats.
+    pub static ref EXTENSION: Extension = {
+        let mut extension = Extension::new_with_reqs(
+            EXTENSION_ID,
+            ExtensionSet::from_iter(vec![
+                super::int_types::EXTENSION_ID,
+                super::float_types::EXTENSION_ID,
+            ]),
+        );
+
+        ConvertOpDef::load_all_ops(&mut extension).unwrap();
+
+        extension
+    };
+
+    /// Registry of extensions required to validate integer operations.
+    pub static ref CONVERT_OPS_REGISTRY: ExtensionRegistry  = ExtensionRegistry::try_new([
+        super::int_types::EXTENSION.to_owned(),
+        super::float_types::EXTENSION.to_owned(),
+        EXTENSION.to_owned(),
+    ])
+    .unwrap();
+}
+
+impl MakeRegisteredOp for ConvertOpType {
+    fn extension_id(&self) -> ExtensionId {
+        EXTENSION_ID.to_owned()
+    }
+
+    fn registry<'s, 'r: 's>(&'s self) -> &'r ExtensionRegistry {
+        &CONVERT_OPS_REGISTRY
+    }
 }
 
 #[cfg(test)]
@@ -66,7 +134,7 @@ mod test {
 
     #[test]
     fn test_conversions_extension() {
-        let r = extension();
+        let r = &EXTENSION;
         assert_eq!(r.name() as &str, "arithmetic.conversions");
         assert_eq!(r.types().count(), 0);
         for (name, _) in r.operations() {

--- a/src/std_extensions/arithmetic/float_types.rs
+++ b/src/std_extensions/arithmetic/float_types.rs
@@ -8,6 +8,7 @@ use crate::{
     values::{CustomConst, KnownTypeConst},
     Extension,
 };
+use lazy_static::lazy_static;
 
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.float.types");
@@ -72,29 +73,30 @@ impl CustomConst for ConstF64 {
     }
 }
 
-/// Extension for basic floating-point types.
-pub fn extension() -> Extension {
-    let mut extension = Extension::new(EXTENSION_ID);
+lazy_static! {
+    /// Extension defining the float type.
+    pub static ref EXTENSION: Extension = {
+        let mut extension = Extension::new(EXTENSION_ID);
 
-    extension
-        .add_type(
-            FLOAT_TYPE_ID,
-            vec![],
-            "64-bit IEEE 754-2019 floating-point value".to_owned(),
-            TypeBound::Copyable.into(),
-        )
-        .unwrap();
+        extension
+            .add_type(
+                FLOAT_TYPE_ID,
+                vec![],
+                "64-bit IEEE 754-2019 floating-point value".to_owned(),
+                TypeBound::Copyable.into(),
+            )
+            .unwrap();
 
-    extension
+        extension
+    };
 }
-
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
     fn test_float_types_extension() {
-        let r = extension();
+        let r = &EXTENSION;
         assert_eq!(r.name() as &str, "arithmetic.float.types");
         assert_eq!(r.types().count(), 1);
         assert_eq!(r.operations().count(), 0);

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -41,7 +41,7 @@ impl ValidateJustArgs for IOValidator {
         Ok(())
     }
 }
-/// Logic extension operation definitions.
+/// Integer extension operation definitions.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
 #[allow(missing_docs, non_camel_case_types)]
 pub enum IntOpDef {

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -177,7 +177,7 @@ mod test {
         let reg = ExtensionRegistry::try_new([
             EXTENSION.to_owned(),
             PRELUDE.to_owned(),
-            float_types::extension(),
+            float_types::EXTENSION.to_owned(),
         ])
         .unwrap();
         let pop_sig = get_op(&POP_NAME)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,7 +86,7 @@ pub(crate) mod test_quantum_extension {
     lazy_static! {
         /// Quantum extension definition.
         pub static ref EXTENSION: Extension = extension();
-        static ref REG: ExtensionRegistry = ExtensionRegistry::try_new([EXTENSION.to_owned(), PRELUDE.to_owned(), float_types::extension()]).unwrap();
+        static ref REG: ExtensionRegistry = ExtensionRegistry::try_new([EXTENSION.to_owned(), PRELUDE.to_owned(), float_types::EXTENSION.to_owned()]).unwrap();
 
     }
     fn get_gate(gate_name: &str) -> LeafOp {


### PR DESCRIPTION
BREAKING CHANGES: extension() function replaced with EXTENSION static ref for float_ops and conversions