### PR TITLE
refactor!: unwrap BasicBlock enum

### DIFF
--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -6,7 +6,7 @@ use super::{
 };
 
 use crate::ops::handle::NodeHandle;
-use crate::ops::{self, dataflow::DataflowParent, BasicBlock, OpType};
+use crate::ops::{self, dataflow::DataflowParent, Exit, OpType, DFB};
 use crate::{
     extension::{ExtensionRegistry, ExtensionSet},
     types::FunctionType,
@@ -86,7 +86,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
         output: TypeRow,
     ) -> Result<Self, BuildError> {
         let n_out_wires = output.len();
-        let exit_block_type = OpType::BasicBlock(BasicBlock::Exit {
+        let exit_block_type = OpType::Exit(Exit {
             cfg_outputs: output,
         });
         let exit_node = base
@@ -102,7 +102,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
         })
     }
 
-    /// Return a builder for a non-entry [`BasicBlock::DFB`] child graph with `inputs`
+    /// Return a builder for a non-entry [`DFB`] child graph with `inputs`
     /// and `outputs` and the variants of the branching TupleSum value
     /// specified by `tuple_sum_rows`.
     ///
@@ -134,7 +134,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
         entry: bool,
     ) -> Result<BlockBuilder<&mut Hugr>, BuildError> {
         let tuple_sum_rows: Vec<_> = tuple_sum_rows.into_iter().collect();
-        let op = OpType::BasicBlock(BasicBlock::DFB {
+        let op = OpType::DFB(DFB {
             inputs: inputs.clone(),
             other_outputs: other_outputs.clone(),
             tuple_sum_rows: tuple_sum_rows.clone(),
@@ -153,7 +153,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
         BlockBuilder::create(self.hugr_mut(), block_n)
     }
 
-    /// Return a builder for a non-entry [`BasicBlock::DFB`] child graph with `inputs`
+    /// Return a builder for a non-entry [`DFB`] child graph with `inputs`
     /// and `outputs` and a UnitSum type: a Sum of `n_cases` unit types.
     ///
     /// # Errors
@@ -172,7 +172,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
         )
     }
 
-    /// Return a builder for the entry [`BasicBlock::DFB`] child graph with `inputs`
+    /// Return a builder for the entry [`DFB`] child graph with `inputs`
     /// and `outputs` and the variants of the branching TupleSum value
     /// specified by `tuple_sum_rows`.
     ///
@@ -192,7 +192,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
         self.any_block_builder(inputs, tuple_sum_rows, other_outputs, extension_delta, true)
     }
 
-    /// Return a builder for the entry [`BasicBlock::DFB`] child graph with `inputs`
+    /// Return a builder for the entry [`DFB`] child graph with `inputs`
     /// and `outputs` and a UnitSum type: a Sum of `n_cases` unit types.
     ///
     /// # Errors
@@ -229,7 +229,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
     }
 }
 
-/// Builder for a [`BasicBlock::DFB`] child graph.
+/// Builder for a [`DFB`] child graph.
 pub type BlockBuilder<B> = DFGWrapper<B, BasicBlockID>;
 
 impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
@@ -243,7 +243,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
         Dataflow::set_outputs(self, [branch_wire].into_iter().chain(outputs))
     }
     fn create(base: B, block_n: Node) -> Result<Self, BuildError> {
-        let block_op = base.get_optype(block_n).as_basic_block().unwrap();
+        let block_op = base.get_optype(block_n).as_dfb().unwrap();
         let signature = block_op.inner_signature();
         let inp_ex = base
             .as_ref()
@@ -269,7 +269,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
 }
 
 impl BlockBuilder<Hugr> {
-    /// Initialize a [`BasicBlock::DFB`] rooted HUGR builder
+    /// Initialize a [`DFB`] rooted HUGR builder
     pub fn new(
         inputs: impl Into<TypeRow>,
         input_extensions: impl Into<Option<ExtensionSet>>,
@@ -280,7 +280,7 @@ impl BlockBuilder<Hugr> {
         let inputs = inputs.into();
         let tuple_sum_rows: Vec<_> = tuple_sum_rows.into_iter().collect();
         let other_outputs = other_outputs.into();
-        let op = BasicBlock::DFB {
+        let op = DFB {
             inputs: inputs.clone(),
             other_outputs: other_outputs.clone(),
             tuple_sum_rows: tuple_sum_rows.clone(),

--- a/src/extension/infer/test.rs
+++ b/src/extension/infer/test.rs
@@ -462,7 +462,7 @@ fn make_block(
     let tuple_sum_type = Type::new_tuple_sum(tuple_sum_rows.clone());
     let dfb_sig = FunctionType::new(inputs.clone(), vec![tuple_sum_type])
         .with_extension_delta(&extension_delta.clone());
-    let dfb = ops::BasicBlock::DFB {
+    let dfb = ops::DFB {
         inputs,
         other_outputs: type_row![],
         tuple_sum_rows,
@@ -497,7 +497,7 @@ fn create_entry_exit(
     exit_types: impl Into<TypeRow>,
 ) -> Result<([Node; 3], Node), Box<dyn Error>> {
     let entry_tuple_sum = Type::new_tuple_sum(entry_variants.clone());
-    let dfb = ops::BasicBlock::DFB {
+    let dfb = ops::DFB {
         inputs: inputs.clone(),
         other_outputs: type_row![],
         tuple_sum_rows: entry_variants,
@@ -506,7 +506,7 @@ fn create_entry_exit(
 
     let exit = hugr.add_node_with_parent(
         root,
-        ops::BasicBlock::Exit {
+        ops::Exit {
             cfg_outputs: exit_types.into(),
         },
     )?;

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -267,7 +267,6 @@ mod test {
     use crate::hugr::views::sibling::SiblingMut;
     use crate::hugr::HugrMut;
     use crate::ops::handle::{BasicBlockID, CfgID, NodeHandle};
-    use crate::ops::OpType;
     use crate::types::FunctionType;
     use crate::{type_row, HugrView, Node};
     use cool_asserts::assert_matches;
@@ -408,9 +407,9 @@ mod test {
             .unwrap();
         h.update_validate(&PRELUDE_REGISTRY).unwrap();
         assert_eq!(new_block, h.children(h.root()).next().unwrap());
-        assert_matches!(h.get_optype(new_block), OpType::DFB(_));
+        assert!(h.get_optype(new_block).is_dfb());
         assert_eq!(h.get_parent(new_cfg), Some(new_block));
-        assert_matches!(h.get_optype(new_cfg), OpType::CFG(_));
+        assert!(h.get_optype(new_cfg).is_cfg());
         for n in other_blocks {
             assert_eq!(depth(&h, n), 1);
         }

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -12,9 +12,10 @@ use crate::hugr::rewrite::Rewrite;
 use crate::hugr::views::sibling::SiblingMut;
 use crate::hugr::{HugrMut, HugrView};
 use crate::ops;
+use crate::ops::controlflow::BasicBlock;
 use crate::ops::dataflow::DataflowOpTrait;
 use crate::ops::handle::{BasicBlockID, CfgID, NodeHandle};
-use crate::ops::{BasicBlock, OpType};
+use crate::ops::{OpType, DFB};
 use crate::PortIndex;
 use crate::{type_row, Node};
 
@@ -114,12 +115,13 @@ impl Rewrite for OutlineCfg {
             self.compute_entry_exit_outside_extensions(h)?;
         // 1. Compute signature
         // These panic()s only happen if the Hugr would not have passed validate()
-        let OpType::BasicBlock(BasicBlock::DFB { inputs, .. }) = h.get_optype(entry) else {
+        let OpType::DFB(DFB { inputs, .. }) = h.get_optype(entry) else {
             panic!("Entry node is not a basic block")
         };
         let inputs = inputs.clone();
         let outputs = match h.get_optype(outside) {
-            OpType::BasicBlock(b) => b.dataflow_input().clone(),
+            OpType::DFB(dfb) => dfb.dataflow_input().clone(),
+            OpType::Exit(exit) => exit.dataflow_input().clone(),
             _ => panic!("External successor not a basic block"),
         };
         let outer_cfg = h.get_parent(entry).unwrap();
@@ -265,7 +267,7 @@ mod test {
     use crate::hugr::views::sibling::SiblingMut;
     use crate::hugr::HugrMut;
     use crate::ops::handle::{BasicBlockID, CfgID, NodeHandle};
-    use crate::ops::{BasicBlock, OpType};
+    use crate::ops::OpType;
     use crate::types::FunctionType;
     use crate::{type_row, HugrView, Node};
     use cool_asserts::assert_matches;
@@ -348,12 +350,9 @@ mod test {
             h.output_neighbours(tail).take(2).collect::<HashSet<Node>>(),
             HashSet::from([exit, new_block])
         );
-        assert_matches!(
-            h.get_optype(new_block),
-            OpType::BasicBlock(BasicBlock::DFB { .. })
-        );
+        assert!(h.get_optype(new_block).is_dfb());
         assert_eq!(h.base_hugr().get_parent(new_cfg), Some(new_block));
-        assert_matches!(h.base_hugr().get_optype(new_cfg), OpType::CFG(_));
+        assert!(h.base_hugr().get_optype(new_cfg).is_cfg());
     }
 
     #[test]
@@ -409,10 +408,7 @@ mod test {
             .unwrap();
         h.update_validate(&PRELUDE_REGISTRY).unwrap();
         assert_eq!(new_block, h.children(h.root()).next().unwrap());
-        assert_matches!(
-            h.get_optype(new_block),
-            OpType::BasicBlock(BasicBlock::DFB { .. })
-        );
+        assert_matches!(h.get_optype(new_block), OpType::DFB(_));
         assert_eq!(h.get_parent(new_cfg), Some(new_block));
         assert_matches!(h.get_optype(new_cfg), OpType::CFG(_));
         for n in other_blocks {

--- a/src/hugr/rewrite/replace.rs
+++ b/src/hugr/rewrite/replace.rs
@@ -449,7 +449,7 @@ mod test {
     use crate::ops::custom::{ExternalOp, OpaqueOp};
     use crate::ops::dataflow::DataflowOpTrait;
     use crate::ops::handle::{BasicBlockID, ConstID, NodeHandle};
-    use crate::ops::{self, BasicBlock, Case, LeafOp, OpTag, OpType, DFG};
+    use crate::ops::{self, Case, LeafOp, OpTag, OpType, DFB, DFG};
     use crate::std_extensions::collections;
     use crate::types::{FunctionType, Type, TypeArg, TypeRow};
     use crate::{type_row, Direction, Hugr, HugrView, OutgoingPort};
@@ -504,14 +504,8 @@ mod test {
             let popp = h.get_parent(pop).unwrap();
             let pushp = h.get_parent(push).unwrap();
             assert_ne!(popp, pushp); // Two different BBs
-            assert!(matches!(
-                h.get_optype(popp),
-                OpType::BasicBlock(BasicBlock::DFB { .. })
-            ));
-            assert!(matches!(
-                h.get_optype(pushp),
-                OpType::BasicBlock(BasicBlock::DFB { .. })
-            ));
+            assert!(h.get_optype(popp).is_dfb());
+            assert!(h.get_optype(pushp).is_dfb());
 
             assert_eq!(h.get_parent(popp).unwrap(), h.get_parent(pushp).unwrap());
         }
@@ -523,7 +517,7 @@ mod test {
         }));
         let r_bb = replacement.add_node_with_parent(
             replacement.root(),
-            BasicBlock::DFB {
+            DFB {
                 inputs: vec![listy.clone()].into(),
                 tuple_sum_rows: vec![type_row![]],
                 other_outputs: vec![listy.clone()].into(),
@@ -596,10 +590,7 @@ mod test {
 
             let grandp = h.get_parent(popp).unwrap();
             assert_eq!(grandp, h.get_parent(pushp).unwrap());
-            assert!(matches!(
-                h.get_optype(grandp),
-                OpType::BasicBlock(BasicBlock::DFB { .. })
-            ));
+            assert!(h.get_optype(grandp).is_dfb());
         }
 
         Ok(())

--- a/src/hugr/validate/test.rs
+++ b/src/hugr/validate/test.rs
@@ -289,7 +289,7 @@ fn cfg_children_restrictions() {
     let block = b
         .add_node_with_parent(
             cfg,
-            ops::BasicBlock::DFB {
+            ops::DFB {
                 inputs: type_row![BOOL_T],
                 tuple_sum_rows: vec![type_row![]],
                 other_outputs: type_row![BOOL_T],
@@ -301,7 +301,7 @@ fn cfg_children_restrictions() {
     let exit = b
         .add_node_with_parent(
             cfg,
-            ops::BasicBlock::Exit {
+            ops::Exit {
                 cfg_outputs: type_row![BOOL_T],
             },
         )
@@ -315,7 +315,7 @@ fn cfg_children_restrictions() {
     let exit2 = b
         .add_node_after(
             exit,
-            ops::BasicBlock::Exit {
+            ops::Exit {
                 cfg_outputs: type_row![BOOL_T],
             },
         )
@@ -330,7 +330,7 @@ fn cfg_children_restrictions() {
     // Change the types in the BasicBlock node to work on qubits instead of bits
     b.replace_op(
         block,
-        NodeType::new_pure(ops::BasicBlock::DFB {
+        NodeType::new_pure(ops::DFB {
             inputs: type_row![Q],
             tuple_sum_rows: vec![type_row![]],
             other_outputs: type_row![Q],

--- a/src/hugr/views/root_checked.rs
+++ b/src/hugr/views/root_checked.rs
@@ -74,7 +74,7 @@ mod test {
     use crate::hugr::hugrmut::sealed::HugrMutInternals;
     use crate::hugr::{HugrError, HugrMut, NodeType};
     use crate::ops::handle::{BasicBlockID, CfgID, DataflowParentID, DfgID};
-    use crate::ops::{BasicBlock, LeafOp, OpTag};
+    use crate::ops::{LeafOp, OpTag, DFB};
     use crate::{ops, type_row, types::FunctionType, Hugr, HugrView};
 
     #[test]
@@ -94,7 +94,7 @@ mod test {
         let mut dfg_v = RootChecked::<&mut Hugr, DfgID>::try_new(&mut h).unwrap();
         // That is a HugrMutInternal, so we can try:
         let root = dfg_v.root();
-        let bb = NodeType::new_pure(BasicBlock::DFB {
+        let bb = NodeType::new_pure(DFB {
             inputs: type_row![],
             other_outputs: type_row![],
             tuple_sum_rows: vec![type_row![]],

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -21,7 +21,7 @@ use smol_str::SmolStr;
 use enum_dispatch::enum_dispatch;
 
 pub use constant::Const;
-pub use controlflow::{BasicBlock, Case, Conditional, TailLoop, CFG};
+pub use controlflow::{Case, Conditional, Exit, TailLoop, CFG, DFB};
 pub use dataflow::{Call, CallIndirect, DataflowParent, Input, LoadConstant, Output, DFG};
 pub use leaf::LeafOp;
 pub use module::{AliasDecl, AliasDefn, FuncDecl, FuncDefn, Module};
@@ -48,7 +48,8 @@ pub enum OpType {
     LoadConstant,
     DFG,
     LeafOp,
-    BasicBlock,
+    DFB,
+    Exit,
     TailLoop,
     CFG,
     Conditional,
@@ -93,7 +94,8 @@ impl_op_ref_try_into!(CallIndirect);
 impl_op_ref_try_into!(LoadConstant);
 impl_op_ref_try_into!(DFG, dfg);
 impl_op_ref_try_into!(LeafOp);
-impl_op_ref_try_into!(BasicBlock);
+impl_op_ref_try_into!(DFB, dfb);
+impl_op_ref_try_into!(Exit);
 impl_op_ref_try_into!(TailLoop);
 impl_op_ref_try_into!(CFG, cfg);
 impl_op_ref_try_into!(Conditional);
@@ -344,6 +346,7 @@ impl OpParent for TailLoop {}
 impl OpParent for CFG {}
 impl OpParent for Conditional {}
 impl OpParent for FuncDecl {}
+impl OpParent for Exit {}
 
 #[enum_dispatch]
 /// Methods for Ops to validate themselves and children

--- a/src/ops/controlflow.rs
+++ b/src/ops/controlflow.rs
@@ -224,7 +224,7 @@ impl OpTrait for Exit {
 
 /// Functionality shared by DFB and Exit CFG block types.
 pub trait BasicBlock {
-    /// The input signature of the contained dataflow graph.
+    /// The input dataflow signature of the CFG block.
     fn dataflow_input(&self) -> &TypeRow;
 }
 

--- a/src/ops/controlflow.rs
+++ b/src/ops/controlflow.rs
@@ -115,70 +115,60 @@ impl DataflowOpTrait for CFG {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "block")]
-/// Basic block ops - nodes valid in control flow graphs.
+/// A CFG basic block node. The signature is that of the internal Dataflow graph.
 #[allow(missing_docs)]
-pub enum BasicBlock {
-    /// A CFG basic block node. The signature is that of the internal Dataflow graph.
-    DFB {
-        inputs: TypeRow,
-        other_outputs: TypeRow,
-        tuple_sum_rows: Vec<TypeRow>,
-        extension_delta: ExtensionSet,
-    },
-    /// The single exit node of the CFG, has no children,
-    /// stores the types of the CFG node output.
-    Exit { cfg_outputs: TypeRow },
+pub struct DFB {
+    pub inputs: TypeRow,
+    pub other_outputs: TypeRow,
+    pub tuple_sum_rows: Vec<TypeRow>,
+    pub extension_delta: ExtensionSet,
 }
 
-impl OpName for BasicBlock {
-    /// The name of the operation.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+/// The single exit node of the CFG, has no children,
+/// stores the types of the CFG node output.
+pub struct Exit {
+    /// Output type row of the CFG.
+    pub cfg_outputs: TypeRow,
+}
+
+impl OpName for DFB {
     fn name(&self) -> SmolStr {
-        match self {
-            BasicBlock::DFB { .. } => "DFB".into(),
-            BasicBlock::Exit { .. } => "Exit".into(),
-        }
+        "DFB".into()
     }
 }
 
-impl StaticTag for BasicBlock {
+impl OpName for Exit {
+    fn name(&self) -> SmolStr {
+        "Exit".into()
+    }
+}
+
+impl StaticTag for DFB {
     const TAG: OpTag = OpTag::BasicBlock;
 }
 
-impl DataflowParent for BasicBlock {
+impl StaticTag for Exit {
+    const TAG: OpTag = OpTag::BasicBlockExit;
+}
+
+impl DataflowParent for DFB {
     fn inner_signature(&self) -> FunctionType {
-        match self {
-            BasicBlock::DFB {
-                inputs,
-                other_outputs,
-                tuple_sum_rows,
-                ..
-            } => {
-                // The node outputs a TupleSum before the data outputs of the block node
-                let tuple_sum_type = Type::new_tuple_sum(tuple_sum_rows.clone());
-                let mut node_outputs = vec![tuple_sum_type];
-                node_outputs.extend_from_slice(other_outputs);
-                FunctionType::new(inputs.clone(), TypeRow::from(node_outputs))
-            }
-            BasicBlock::Exit { cfg_outputs } => FunctionType::new(type_row![], cfg_outputs.clone()),
-        }
+        // The node outputs a TupleSum before the data outputs of the block node
+        let tuple_sum_type = Type::new_tuple_sum(self.tuple_sum_rows.clone());
+        let mut node_outputs = vec![tuple_sum_type];
+        node_outputs.extend_from_slice(&self.other_outputs);
+        FunctionType::new(self.inputs.clone(), TypeRow::from(node_outputs))
     }
 }
 
-impl OpTrait for BasicBlock {
-    /// The description of the operation.
+impl OpTrait for DFB {
     fn description(&self) -> &str {
-        match self {
-            BasicBlock::DFB { .. } => "A CFG basic block node",
-            BasicBlock::Exit { .. } => "A CFG exit block node",
-        }
+        "A CFG basic block node"
     }
     /// Tag identifying the operation.
     fn tag(&self) -> OpTag {
-        match self {
-            BasicBlock::DFB { .. } => OpTag::BasicBlock,
-            BasicBlock::Exit { .. } => OpTag::BasicBlockExit,
-        }
+        Self::TAG
     }
 
     fn other_input(&self) -> Option<EdgeKind> {
@@ -190,43 +180,73 @@ impl OpTrait for BasicBlock {
     }
 
     fn dataflow_signature(&self) -> Option<FunctionType> {
-        Some(match self {
-            BasicBlock::DFB {
-                extension_delta, ..
-            } => FunctionType::new(type_row![], type_row![]).with_extension_delta(extension_delta),
-            BasicBlock::Exit { .. } => FunctionType::new(type_row![], type_row![]),
-        })
+        Some(
+            FunctionType::new(type_row![], type_row![]).with_extension_delta(&self.extension_delta),
+        )
     }
 
     fn non_df_port_count(&self, dir: Direction) -> usize {
-        match self {
-            Self::DFB { tuple_sum_rows, .. } if dir == Direction::Outgoing => tuple_sum_rows.len(),
-            Self::Exit { .. } if dir == Direction::Outgoing => 0,
-            _ => 1,
+        match dir {
+            Direction::Incoming => 1,
+            Direction::Outgoing => self.tuple_sum_rows.len(),
         }
     }
 }
 
-impl BasicBlock {
-    /// The input signature of the contained dataflow graph.
-    pub fn dataflow_input(&self) -> &TypeRow {
-        match self {
-            BasicBlock::DFB { inputs, .. } => inputs,
-            BasicBlock::Exit { cfg_outputs } => cfg_outputs,
-        }
+impl OpTrait for Exit {
+    fn description(&self) -> &str {
+        "A CFG exit block node"
+    }
+    /// Tag identifying the operation.
+    fn tag(&self) -> OpTag {
+        Self::TAG
     }
 
+    fn other_input(&self) -> Option<EdgeKind> {
+        Some(EdgeKind::ControlFlow)
+    }
+
+    fn other_output(&self) -> Option<EdgeKind> {
+        Some(EdgeKind::ControlFlow)
+    }
+
+    fn dataflow_signature(&self) -> Option<FunctionType> {
+        Some(FunctionType::new(type_row![], type_row![]))
+    }
+
+    fn non_df_port_count(&self, dir: Direction) -> usize {
+        match dir {
+            Direction::Incoming => 1,
+            Direction::Outgoing => 0,
+        }
+    }
+}
+
+/// Functionality shared by DFB and Exit CFG block types.
+pub trait BasicBlock {
+    /// The input signature of the contained dataflow graph.
+    fn dataflow_input(&self) -> &TypeRow;
+}
+
+impl BasicBlock for DFB {
+    fn dataflow_input(&self) -> &TypeRow {
+        &self.inputs
+    }
+}
+impl DFB {
     /// The correct inputs of any successors. Returns None if successor is not a
     /// valid index.
     pub fn successor_input(&self, successor: usize) -> Option<TypeRow> {
-        match self {
-            BasicBlock::DFB {
-                tuple_sum_rows,
-                other_outputs: outputs,
-                ..
-            } => Some(tuple_sum_first(tuple_sum_rows.get(successor)?, outputs)),
-            BasicBlock::Exit { .. } => panic!("Exit should have no successors"),
-        }
+        Some(tuple_sum_first(
+            self.tuple_sum_rows.get(successor)?,
+            &self.other_outputs,
+        ))
+    }
+}
+
+impl BasicBlock for Exit {
+    fn dataflow_input(&self) -> &TypeRow {
+        &self.cfg_outputs
     }
 }
 

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -103,7 +103,7 @@ impl<const DEF: bool> AliasID<DEF> {
 pub struct ConstID(Node);
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, DerFrom, Debug)]
-/// Handle to a [BasicBlock](crate::ops::BasicBlock) node.
+/// Handle to a [DFB](crate::ops::DFB) or [Exit](crate::ops::Exit) node.
 pub struct BasicBlockID(Node);
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, DerFrom, Debug)]

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -313,20 +313,7 @@ impl ValidateOp for DFB {
     }
 }
 
-impl ValidateOp for Exit {
-    /// Returns the set of allowed parent operation types.
-    fn validity_flags(&self) -> OpValidityFlags {
-        Default::default()
-    }
-
-    /// Validate the ordered list of children.
-    fn validate_op_children<'a>(
-        &self,
-        _children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
-    ) -> Result<(), ChildrenValidationError> {
-        Ok(())
-    }
-}
+impl ValidateOp for Exit {}
 
 impl ValidateOp for super::Case {
     /// Returns the set of allowed parent operation types.

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -6,11 +6,11 @@
 //! It also defines a `validate_op_children` method for more complex tests that
 //! require traversing the children.
 
+use crate::types::TypeRow;
 use itertools::Itertools;
 use portgraph::{NodeIndex, PortOffset};
+use std::any::type_name;
 use thiserror::Error;
-
-use crate::types::TypeRow;
 
 use super::controlflow::BasicBlock;
 use super::dataflow::DataflowParent;
@@ -263,7 +263,7 @@ impl<T: DataflowParent> ValidateOp for T {
         children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
     ) -> Result<(), ChildrenValidationError> {
         let sig = self.inner_signature();
-        validate_io_nodes(&sig.input, &sig.output, "DataflowParent", children)
+        validate_io_nodes(&sig.input, &sig.output, type_name::<T>(), children)
     }
 }
 

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -10,11 +10,11 @@ use itertools::Itertools;
 use portgraph::{NodeIndex, PortOffset};
 use thiserror::Error;
 
-use crate::types::{FunctionType, Type, TypeRow};
+use crate::types::TypeRow;
 
 use super::controlflow::BasicBlock;
 use super::dataflow::DataflowParent;
-use super::{impl_validate_op, Exit, OpTag, OpTrait, OpType, ValidateOp, DFB};
+use super::{impl_validate_op, Exit, OpTag, OpTrait, OpType, ValidateOp};
 
 /// A set of property flags required for an operation.
 #[non_exhaustive]
@@ -60,50 +60,6 @@ impl ValidateOp for super::Module {
             requires_children: false,
             ..Default::default()
         }
-    }
-}
-
-impl ValidateOp for super::FuncDefn {
-    fn validity_flags(&self) -> OpValidityFlags {
-        OpValidityFlags {
-            allowed_children: OpTag::DataflowChild,
-            allowed_first_child: OpTag::Input,
-            allowed_second_child: OpTag::Output,
-            requires_children: true,
-            requires_dag: true,
-            ..Default::default()
-        }
-    }
-
-    fn validate_op_children<'a>(
-        &self,
-        children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
-    ) -> Result<(), ChildrenValidationError> {
-        // We check type-variables are declared in `validate_subtree`, so here
-        // we can just assume all type variables are valid regardless of binders.
-        let FunctionType { input, output, .. } = self.inner_signature();
-        validate_io_nodes(&input, &output, "function definition", children)
-    }
-}
-
-impl ValidateOp for super::DFG {
-    fn validity_flags(&self) -> OpValidityFlags {
-        OpValidityFlags {
-            allowed_children: OpTag::DataflowChild,
-            allowed_first_child: OpTag::Input,
-            allowed_second_child: OpTag::Output,
-            requires_children: true,
-            requires_dag: true,
-            ..Default::default()
-        }
-    }
-
-    fn validate_op_children<'a>(
-        &self,
-        children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
-    ) -> Result<(), ChildrenValidationError> {
-        let sig = self.dataflow_signature().unwrap_or_default();
-        validate_io_nodes(&sig.input, &sig.output, "nested graph", children)
     }
 }
 
@@ -287,35 +243,8 @@ pub struct ChildrenEdgeData {
     /// Target port.
     pub target_port: PortOffset,
 }
-impl ValidateOp for DFB {
-    /// Returns the set of allowed parent operation types.
-    fn validity_flags(&self) -> OpValidityFlags {
-        OpValidityFlags {
-            allowed_children: OpTag::DataflowChild,
-            allowed_first_child: OpTag::Input,
-            allowed_second_child: OpTag::Output,
-            requires_children: true,
-            requires_dag: true,
-            ..Default::default()
-        }
-    }
 
-    /// Validate the ordered list of children.
-    fn validate_op_children<'a>(
-        &self,
-        children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
-    ) -> Result<(), ChildrenValidationError> {
-        let tuple_sum_type = Type::new_tuple_sum(self.tuple_sum_rows.clone());
-        let node_outputs: TypeRow = [&[tuple_sum_type], self.other_outputs.as_ref()]
-            .concat()
-            .into();
-        validate_io_nodes(&self.inputs, &node_outputs, "basic block graph", children)
-    }
-}
-
-impl ValidateOp for Exit {}
-
-impl ValidateOp for super::Case {
+impl<T: DataflowParent> ValidateOp for T {
     /// Returns the set of allowed parent operation types.
     fn validity_flags(&self) -> OpValidityFlags {
         OpValidityFlags {
@@ -334,7 +263,7 @@ impl ValidateOp for super::Case {
         children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
     ) -> Result<(), ChildrenValidationError> {
         let sig = self.inner_signature();
-        validate_io_nodes(&sig.input, &sig.output, "Conditional", children)
+        validate_io_nodes(&sig.input, &sig.output, "DataflowParent", children)
     }
 }
 
@@ -488,3 +417,4 @@ impl_validate_op!(Call);
 impl_validate_op!(LoadConstant);
 impl_validate_op!(CallIndirect);
 impl_validate_op!(LeafOp);
+impl_validate_op!(Exit);

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -12,8 +12,9 @@ use thiserror::Error;
 
 use crate::types::{FunctionType, Type, TypeRow};
 
+use super::controlflow::BasicBlock;
 use super::dataflow::DataflowParent;
-use super::{impl_validate_op, BasicBlock, OpTag, OpTrait, OpType, ValidateOp};
+use super::{impl_validate_op, Exit, OpTag, OpTrait, OpType, ValidateOp, DFB};
 
 /// A set of property flags required for an operation.
 #[non_exhaustive]
@@ -286,21 +287,16 @@ pub struct ChildrenEdgeData {
     /// Target port.
     pub target_port: PortOffset,
 }
-
-impl ValidateOp for BasicBlock {
+impl ValidateOp for DFB {
     /// Returns the set of allowed parent operation types.
     fn validity_flags(&self) -> OpValidityFlags {
-        match self {
-            BasicBlock::DFB { .. } => OpValidityFlags {
-                allowed_children: OpTag::DataflowChild,
-                allowed_first_child: OpTag::Input,
-                allowed_second_child: OpTag::Output,
-                requires_children: true,
-                requires_dag: true,
-                ..Default::default()
-            },
-            // Default flags are valid for non-container operations
-            BasicBlock::Exit { .. } => Default::default(),
+        OpValidityFlags {
+            allowed_children: OpTag::DataflowChild,
+            allowed_first_child: OpTag::Input,
+            allowed_second_child: OpTag::Output,
+            requires_children: true,
+            requires_dag: true,
+            ..Default::default()
         }
     }
 
@@ -309,20 +305,26 @@ impl ValidateOp for BasicBlock {
         &self,
         children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
     ) -> Result<(), ChildrenValidationError> {
-        match self {
-            BasicBlock::DFB {
-                inputs,
-                tuple_sum_rows: tuple_sum_variants,
-                other_outputs: outputs,
-                extension_delta: _,
-            } => {
-                let tuple_sum_type = Type::new_tuple_sum(tuple_sum_variants.clone());
-                let node_outputs: TypeRow = [&[tuple_sum_type], outputs.as_ref()].concat().into();
-                validate_io_nodes(inputs, &node_outputs, "basic block graph", children)
-            }
-            // Exit nodes do not have children
-            BasicBlock::Exit { .. } => Ok(()),
-        }
+        let tuple_sum_type = Type::new_tuple_sum(self.tuple_sum_rows.clone());
+        let node_outputs: TypeRow = [&[tuple_sum_type], self.other_outputs.as_ref()]
+            .concat()
+            .into();
+        validate_io_nodes(&self.inputs, &node_outputs, "basic block graph", children)
+    }
+}
+
+impl ValidateOp for Exit {
+    /// Returns the set of allowed parent operation types.
+    fn validity_flags(&self) -> OpValidityFlags {
+        Default::default()
+    }
+
+    /// Validate the ordered list of children.
+    fn validate_op_children<'a>(
+        &self,
+        _children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
+    ) -> Result<(), ChildrenValidationError> {
+        Ok(())
     }
 }
 
@@ -409,14 +411,18 @@ fn validate_io_nodes<'a>(
 
 /// Validate an edge between two basic blocks in a CFG sibling graph.
 fn validate_cfg_edge(edge: ChildrenEdgeData) -> Result<(), EdgeValidationError> {
-    let [source, target]: [&BasicBlock; 2] = [&edge.source_op, &edge.target_op].map(|op| {
-        let block_op = op
-            .as_basic_block()
-            .expect("CFG sibling graphs can only contain basic block operations.");
-        block_op
-    });
+    let source = &edge
+        .source_op
+        .as_dfb()
+        .expect("CFG sibling graphs can only contain basic block operations.");
 
-    if source.successor_input(edge.source_port.index()).as_ref() != Some(target.dataflow_input()) {
+    let target_input = match &edge.target_op {
+        OpType::DFB(dfb) => dfb.dataflow_input(),
+        OpType::Exit(exit) => exit.dataflow_input(),
+        _ => panic!("CFG sibling graphs can only contain basic block operations."),
+    };
+
+    if source.successor_input(edge.source_port.index()).as_ref() != Some(target_input) {
         return Err(EdgeValidationError::CFGEdgeSignatureMismatch { edge });
     }
 


### PR DESCRIPTION
BREAKING_CHANGES: DFB and Exit are now standalone structs. A level of nesting in serialization is also removed for these operations.