### PR TITLE
fix!: Normalize input/output value/static/other ports in `OpType`

### DIFF
--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -315,13 +315,11 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
         let src_port = self
             .get_optype(src)
             .other_output_port()
-            .expect("Source operation has no non-dataflow outgoing edges")
-            .as_outgoing()?;
+            .expect("Source operation has no non-dataflow outgoing edges");
         let dst_port = self
             .get_optype(dst)
             .other_input_port()
-            .expect("Destination operation has no non-dataflow incoming edges")
-            .as_incoming()?;
+            .expect("Destination operation has no non-dataflow incoming edges");
         self.connect(src, src_port, dst, dst_port)?;
         Ok((src_port, dst_port))
     }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -139,8 +139,8 @@ impl OpType {
     /// Returns the edge kind for the given port.
     ///
     /// The result may be a value port, a static port, or a non-dataflow port.
-    /// See [`OpType::value_port_kind`], [`OpType::static_port_kind`], and
-    /// [`OpType::dataflow_signature`].
+    /// See [`OpType::dataflow_signature`], [`OpType::static_port_kind`], and
+    /// [`OpType::other_port_kind`].
     pub fn port_kind(&self, port: impl Into<Port>) -> Option<EdgeKind> {
         let signature = self.dataflow_signature().unwrap_or_default();
         let port: Port = port.into();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -243,9 +243,9 @@ impl OpType {
     /// Returns the number of ports for the given direction.
     #[inline]
     pub fn port_count(&self, dir: Direction) -> usize {
-        let static_input = self.static_port_kind(dir).is_some() as usize;
+        let has_static_port = self.static_port_kind(dir).is_some();
         let non_df_count = self.non_df_port_count(dir);
-        self.value_port_count(dir) + static_input + non_df_count
+        self.value_port_count(dir) + has_static_port as usize + non_df_count
     }
 
     /// Returns the number of inputs ports for the operation.

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -122,7 +122,7 @@ impl OpType {
         }
     }
 
-    /// The edge kind for the constant ports of the operation, not described by
+    /// The edge kind for the static ports of the operation, not described by
     /// the dataflow signature.
     ///
     /// If not None, an extra input port of that kind will be present on the
@@ -189,7 +189,7 @@ impl OpType {
             .map(|p| p.as_incoming().unwrap())
     }
 
-    /// The non-dataflow input port for the operation, not described by the signature.
+    /// The non-dataflow output port for the operation, not described by the signature.
     /// See `[OpType::other_port]`.
     #[inline]
     pub fn other_output_port(&self) -> Option<OutgoingPort> {

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -105,7 +105,7 @@ impl OpTrait for Const {
         <Self as StaticTag>::TAG
     }
 
-    fn other_output(&self) -> Option<EdgeKind> {
+    fn static_output(&self) -> Option<EdgeKind> {
         Some(EdgeKind::Static(self.typ.clone()))
     }
 }

--- a/src/ops/dataflow.rs
+++ b/src/ops/dataflow.rs
@@ -45,7 +45,7 @@ pub(crate) trait DataflowOpTrait {
     /// described by the dataflow signature.
     ///
     /// If not None, an extra output port of that kind will be present after the
-    /// dataflow input ports and before any [`DataflowOpTrait::other_output`] ports.
+    /// dataflow output ports and before any [`DataflowOpTrait::other_output`] ports.
     #[inline]
     fn static_output(&self) -> Option<EdgeKind> {
         None

--- a/src/ops/dataflow.rs
+++ b/src/ops/dataflow.rs
@@ -40,16 +40,6 @@ pub(crate) trait DataflowOpTrait {
     fn static_input(&self) -> Option<EdgeKind> {
         None
     }
-
-    /// The edge kind for a single constant output of the operation, not
-    /// described by the dataflow signature.
-    ///
-    /// If not None, an extra output port of that kind will be present after the
-    /// dataflow output ports and before any [`DataflowOpTrait::other_output`] ports.
-    #[inline]
-    fn static_output(&self) -> Option<EdgeKind> {
-        None
-    }
 }
 
 /// Helpers to construct input and output nodes
@@ -150,10 +140,6 @@ impl<T: DataflowOpTrait> OpTrait for T {
 
     fn static_input(&self) -> Option<EdgeKind> {
         DataflowOpTrait::static_input(self)
-    }
-
-    fn static_output(&self) -> Option<EdgeKind> {
-        DataflowOpTrait::static_output(self)
     }
 }
 impl<T: DataflowOpTrait> StaticTag for T {

--- a/src/ops/dataflow.rs
+++ b/src/ops/dataflow.rs
@@ -17,6 +17,7 @@ pub(crate) trait DataflowOpTrait {
     ///
     /// If not None, a single extra output multiport of that kind will be
     /// present.
+    #[inline]
     fn other_input(&self) -> Option<EdgeKind> {
         Some(EdgeKind::StateOrder)
     }
@@ -25,8 +26,29 @@ pub(crate) trait DataflowOpTrait {
     ///
     /// If not None, a single extra output multiport of that kind will be
     /// present.
+    #[inline]
     fn other_output(&self) -> Option<EdgeKind> {
         Some(EdgeKind::StateOrder)
+    }
+
+    /// The edge kind for a single constant input of the operation, not
+    /// described by the dataflow signature.
+    ///
+    /// If not None, an extra input port of that kind will be present after the
+    /// dataflow input ports and before any [`DataflowOpTrait::other_input`] ports.
+    #[inline]
+    fn static_input(&self) -> Option<EdgeKind> {
+        None
+    }
+
+    /// The edge kind for a single constant output of the operation, not
+    /// described by the dataflow signature.
+    ///
+    /// If not None, an extra output port of that kind will be present after the
+    /// dataflow input ports and before any [`DataflowOpTrait::other_output`] ports.
+    #[inline]
+    fn static_output(&self) -> Option<EdgeKind> {
+        None
     }
 }
 
@@ -125,6 +147,14 @@ impl<T: DataflowOpTrait> OpTrait for T {
     fn other_output(&self) -> Option<EdgeKind> {
         DataflowOpTrait::other_output(self)
     }
+
+    fn static_input(&self) -> Option<EdgeKind> {
+        DataflowOpTrait::static_input(self)
+    }
+
+    fn static_output(&self) -> Option<EdgeKind> {
+        DataflowOpTrait::static_output(self)
+    }
 }
 impl<T: DataflowOpTrait> StaticTag for T {
     const TAG: OpTag = T::TAG;
@@ -132,9 +162,9 @@ impl<T: DataflowOpTrait> StaticTag for T {
 
 /// Call a function directly.
 ///
-/// The first ports correspond to the signature of the function being
-/// called. Immediately following those ports, the first input port is
-/// connected to the def/declare block with a `ConstE<Graph>` edge.
+/// The first ports correspond to the signature of the function being called.
+/// The port immediately following those those is connected to the def/declare
+/// block with a [`EdgeKind::Static`] edge.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Call {
     /// Signature of function being called
@@ -152,6 +182,11 @@ impl DataflowOpTrait for Call {
     fn signature(&self) -> FunctionType {
         self.signature.clone()
     }
+
+    fn static_input(&self) -> Option<EdgeKind> {
+        let fn_typ = Type::new_function(self.called_function_type().clone());
+        Some(EdgeKind::Static(fn_typ))
+    }
 }
 impl Call {
     #[inline]
@@ -161,6 +196,19 @@ impl Call {
     }
 
     /// The IncomingPort which links to the function being called.
+    ///
+    /// This matches [`OpType::static_input_port`].
+    ///
+    /// ```
+    /// # use hugr::ops::dataflow::Call;
+    /// # use hugr::ops::OpType;
+    /// # use hugr::types::FunctionType;
+    /// # use hugr::extension::prelude::QB_T;
+    /// let signature = FunctionType::new(vec![QB_T, QB_T], vec![QB_T, QB_T]);
+    /// let call = Call { signature };
+    /// let op = OpType::Call(call.clone());
+    /// assert_eq!(op.static_input_port(), Some(call.called_function_port()));
+    /// ```
     #[inline]
     pub fn called_function_port(&self) -> IncomingPort {
         self.called_function_type().input_count().into()
@@ -208,6 +256,10 @@ impl DataflowOpTrait for LoadConstant {
     fn signature(&self) -> FunctionType {
         FunctionType::new(TypeRow::new(), vec![self.datatype.clone()])
     }
+
+    fn static_input(&self) -> Option<EdgeKind> {
+        Some(EdgeKind::Static(self.constant_type().clone()))
+    }
 }
 impl LoadConstant {
     #[inline]
@@ -217,6 +269,18 @@ impl LoadConstant {
     }
 
     /// The IncomingPort which links to the loaded constant.
+    ///
+    /// This matches [`OpType::static_input_port`].
+    ///
+    /// ```
+    /// # use hugr::ops::dataflow::LoadConstant;
+    /// # use hugr::ops::OpType;
+    /// # use hugr::types::Type;
+    /// let datatype = Type::UNIT;
+    /// let load_constant = LoadConstant { datatype };
+    /// let op = OpType::LoadConstant(load_constant.clone());
+    /// assert_eq!(op.static_input_port(), Some(load_constant.constant_port()));
+    /// ```
     #[inline]
     pub fn constant_port(&self) -> IncomingPort {
         0.into()

--- a/src/ops/dataflow.rs
+++ b/src/ops/dataflow.rs
@@ -209,6 +209,8 @@ impl Call {
     /// let op = OpType::Call(call.clone());
     /// assert_eq!(op.static_input_port(), Some(call.called_function_port()));
     /// ```
+    ///
+    /// [`OpType::static_input_port`]: crate::ops::OpType::static_input_port
     #[inline]
     pub fn called_function_port(&self) -> IncomingPort {
         self.called_function_type().input_count().into()
@@ -281,6 +283,8 @@ impl LoadConstant {
     /// let op = OpType::LoadConstant(load_constant.clone());
     /// assert_eq!(op.static_input_port(), Some(load_constant.constant_port()));
     /// ```
+    ///
+    /// [`OpType::static_input_port`]: crate::ops::OpType::static_input_port
     #[inline]
     pub fn constant_port(&self) -> IncomingPort {
         0.into()

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -52,7 +52,7 @@ impl OpTrait for FuncDefn {
         <Self as StaticTag>::TAG
     }
 
-    fn other_output(&self) -> Option<EdgeKind> {
+    fn static_output(&self) -> Option<EdgeKind> {
         Some(EdgeKind::Static(Type::new_function(self.signature.clone())))
     }
 }
@@ -79,7 +79,7 @@ impl OpTrait for FuncDecl {
         <Self as StaticTag>::TAG
     }
 
-    fn other_output(&self) -> Option<EdgeKind> {
+    fn static_output(&self) -> Option<EdgeKind> {
         Some(EdgeKind::Static(Type::new_function(self.signature.clone())))
     }
 }


### PR DESCRIPTION
Closes #777.

Now `OpTrait` clearly separates `other_port` from `static_port`, and `OpType` has a uniform interface for `value` ports (from the signature), `static` ports (contstants), and `other` ports.

Fixes #779. The bug was caused by the encoder ignoring the constant input port offset, so the decoder reconnected the edge to the `StateOrder` port instead. Now we use the proper OpType methods.

Fixes #778.