### PR TITLE
docs: Update spec wrt. polymorphism

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -851,7 +851,10 @@ extension ops. See [Extension System](#extension-system).
 
 ### Extension Tracking
 
-The type of `Function` includes a set of extensions (that is, [Extensions](#extension-implementation)) which are required to execute the graph. Every node in the HUGR is annotated with the set of extensions required to produce its inputs, and the set of extensions required to execute the node; the union of these two must match the set of extensions on each successor node.
+The type of `Function` includes a set of [extensions](#extension-system) which are required to execute the graph.
+Every node in the HUGR is annotated with the set of extensions required to produce its inputs,
+and each operation provides (a way to compute) the set of extensions required to execute the node;
+the union of these two must match the set of extensions on each successor node.
 
 Keeping track of the extension requirements like this allows extension designers
 and third-party tooling to control how/where a module is run.

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1145,8 +1145,6 @@ extensions:
       extensions: ["arithmetic.int", r] # r is the ExtensionSet in "params"
 ```
 
-<!-- To use an OpDef as an Op, or a TypeDef as a type, the user must provide a type argument for each type param in the def: a type in the appropriate class, a bounded usize, a set of extensions, a list or tuple of arguments. -->
-
 **Implementation note** Reading this format into Rust is made easy by `serde` and
 [serde\_yaml](https://github.com/dtolnay/serde-yaml) (see the
 Serialization section). It is also trivial to serialize these

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -995,9 +995,9 @@ at runtime. In many cases this is desirable.
 
 ### Extension Implementation
 
-To strike a balance then, every extension provides YAML (or equivalent Rust structs)
-that declares named opaque **TypeDef**s and **OpDef**s. These are (potentially-polymorphic)
-definitions of types and operations, respectively---polymorphism arises because both may
+To strike a balance then, every extension provides declarative structs containing
+named **TypeDef**s and **OpDef**s---see [Declarative Format](#declarative-format).
+These are (potentially polymorphic) definitions of types and operations, respectively---polymorphism arises because both may
 declare any number TypeParams (as per [Type System](#type-system)). To use a TypeDef as a type,
 it must be instantiated with TypeArgs appropriate for its TypeParams, and similarly
 to use an OpDef as a node operation: each node stores a static-constant list of TypeArgs.
@@ -1057,7 +1057,8 @@ needed by the compiler to correctly treat the operation (the minimum
 case is opaque operations that should be left untouched). However, we
 wish to also leave it expressive enough to specify arbitrary extra data
 that may be used by compiler extensions. This suggests a flexible
-standard format such as YAML would be suitable. Here we provide an
+standard format such as YAML would be suitable. (The internal Rust structs
+may also be used directly.) Here we provide an
 illustrative example:
 
 See [Type System](#type-system) for more on Extensions.

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -797,7 +797,8 @@ Extensions ::= (Extension)* -- a set, not a list
 Type ::= Tuple(#) -- fixed-arity, heterogeneous components 
        | Sum(#)   -- disjoint union of other types, ??tagged by unsigned int??
        | Opaque(Name, [TypeArg]) -- a (instantiation of a) custom type defined by an extension
-       | Function(TypeParams, #, #, Extensions) -- polymorphic with type parameters, function arguments + results
+       | Function(TypeParams, #, #, Extensions) -- polymorphic with type parameters,
+                                                -- function arguments + results, and delta (see below)
        | Variable -- refers to a TypeParam bound by the nearest enclosing FuncDefn node, or an enclosing Function Type
 ```
 The majority of types will be Opaque ones defined by extensions including the [standard library](#standard-library). However a number of types can be constructed using only the core type constructors: for example the empty tuple type, aka `unit`, with exactly one instance (so 0 bits of data); the empty sum, with no instances; the empty Function type (taking no arguments and producing no results - `void -> void`); and compositions thereof.
@@ -853,7 +854,7 @@ extension ops. See [Extension System](#extension-system).
 
 The type of `Function` includes a set of [extensions](#extension-system) which are required to execute the graph.
 Every node in the HUGR is annotated with the set of extensions required to produce its inputs,
-and each operation provides (a way to compute) the set of extensions required to execute the node;
+and each operation provides (a way to compute) the set of extensions required to execute the node, known as the "delta";
 the union of these two must match the set of extensions on each successor node.
 
 Keeping track of the extension requirements like this allows extension designers

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -272,7 +272,7 @@ the following basic dataflow operations are available (in addition to the
     `Static<Function>` edge to specify the graph being called. The
     signature of the node (defined by its incoming and outgoing `Value` edges) matches the function being called.
   - `LoadConstant<T>`: has an incoming `Static<T>` edge, where `T` is a `CopyableType`, and a
-    `Value<Local,T>` output, used to load a static constant into the local
+    `Value<T>` output, used to load a static constant into the local
     dataflow graph.
   - `identity<T>`: pass-through, no operation is performed.
   - `DFG`: A nested dataflow graph.
@@ -765,7 +765,7 @@ indices after the list of node indices?
 
 ## Type System
 
-There are three classes of type: ``AnyType`` $\supset$ ``CopyableType`` $\supset$ ``EqType``. Types in these classes  are distinguished by the operations possible on (runtime) values of those types:
+There are three classes of type: ``AnyType`` $\supset$ ``CopyableType`` $\supset$ ``EqType``. Types in these classes are distinguished by the operations possible on (runtime) values of those types:
   - For the broadest class (``AnyType``), the only operation supported is the identity operation (aka no-op, or `lift` - see [Extension Tracking](#extension-tracking) below). Specifically, we do not require it to be possible to copy or discard all values, hence the requirement that outports of linear type must have exactly one edge. (That is, a type not known to be in the copyable subset). All incoming ports must have exactly one edge.
 
     In fully qubit-counted contexts programs take in a number of qubits as input and return the same number, with no discarding. See [quantum extension](#quantum-extension) for more.
@@ -1083,9 +1083,9 @@ the value of each member of `params` is given by the following production:
 ```
 TypeParam ::= "Type"("Any"|"Copyable"|"Eq") | "BoundedUSize(u64)" | "Extensions" | "List"(TypeParam) | "Tuple"([TypeParam]) | Opaque
 
-Opaque ::= string<[TypeArgs]>
+Opaque ::= string<[TypeArg]>
 
-TypeArgs ::= Type(Type) | BoundedUSize(u64) | Extensions | List([TypeArg]) | Tuple([TypeArg])
+TypeArg ::= Type(Type) | BoundedUSize(u64) | Extensions | List([TypeArg]) | Tuple([TypeArg])
 
 Type ::= Name<[TypeArg]>
 ```

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -286,6 +286,7 @@ the following basic dataflow operations are available (in addition to the
     The signature of the operation comprises the output signature of the child
     Input node (as input) and the input signature of the child Output node (as
     output). 
+  - `OpaqueOp`: an operation defined by an [Extension](#extension-system).
 
 The example below shows two DFGs, one nested within the other. Each has an Input
 and an Output node, whose outputs and inputs respectively match the inputs and
@@ -1000,7 +1001,7 @@ named **TypeDef**s and **OpDef**s---see [Declarative Format](#declarative-format
 These are (potentially polymorphic) definitions of types and operations, respectively---polymorphism arises because both may
 declare any number TypeParams (as per [Type System](#type-system)). To use a TypeDef as a type,
 it must be instantiated with TypeArgs appropriate for its TypeParams, and similarly
-to use an OpDef as a node operation: each node stores a static-constant list of TypeArgs.
+to use an OpDef as a node operation: each `OpaqueOp` node stores a static-constant list of TypeArgs.
 
 For TypeDef's, any set of TypeArgs conforming to its TypeParams, produces a valid type.
 However, for OpDef's, greater flexibility is allowed: each OpDef *either*

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1006,8 +1006,8 @@ However, for OpDef's, greater flexibility is allowed: each OpDef *either*
 2. The extension may self-register binary code (e.g. a Rust trait) providing a function
    `compute_signature` that fallibly computes a `Function` type given some type arguments.
    The operation declares the arguments required by the `compute_signature` function as a list
-   of TypeParams (notably including `TypeParam::List`, `Tuple` and `Opaque`);
-   the returned `Function` type may then declare additional TypeParams.
+   of TypeParams; if this successfully returns a `Function` type, then that may then require
+   additional TypeParams.
 
 For example, the TypeDef for `array` in the prelude declares two TypeParams: a `BoundedUSize`
 (the array length) and a `Type`. Any valid instantiation (e.g. `array<5, usize>`) is a type.
@@ -1016,8 +1016,11 @@ Much the same applies for OpDef's that provide a `Function` type.
 However, for OpDefs providing binary `compute_signature`,
 * each node will provide TypeArgs for *both* the binary function *and* the `Function` type that returns
 * the operation is only valid if `compute_signature` succeeds, and returns a `Function` type
-  into whose TypeParams the *remaining* TypeArgs (in the node) fit
-* the args to `compute_signature` may *not* refer to any type variables declared by
+  into whose TypeParams the *remaining* TypeArgs (in the node) fit. Note that this means
+  the binary function may use the values of its TypeArgs---specifically including `List`, `Tuple` and
+  `Opaque`---to determine the structure of the returned `Function` type such that the latter's own TypeParams
+  depend upon the values of the TypeArgs passed into the binary.
+* the TypeArgs passed to `compute_signature` may *not* refer to any type variables declared by
   ancestor nodes in the Hugr (specifically, may *not* use variables declared by the
   enclosing FuncDefn) i.e. these must be static constants unaffected by substitution.
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -274,7 +274,7 @@ the following basic dataflow operations are available (in addition to the
     matches the (type-instantiated) function being called.
   - `TypeApply`: has a `Value<Function>` input, whose type is polymorphic (i.e. declares some type parameters);
     the node specifies some type arguments (matching those parameters) in the node weight;
-    and there is  a `Value<Function>` output (corresponding to the type instantiation of the input)
+    and there is  a `Value<Function>` output (corresponding to the type instantiation of the input).
   - `LoadConstant<T>`: has an incoming `Static<T>` edge, where `T` is a `CopyableType`, and a
     `Value<T>` output, used to load a static constant into the local
     dataflow graph.

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -801,6 +801,8 @@ Type ::= Tuple(#) -- fixed-arity, heterogeneous components
                                                 -- function arguments + results, and delta (see below)
        | Variable -- refers to a TypeParam bound by the nearest enclosing FuncDefn node, or an enclosing Function Type
 ```
+(We write `[Foo]` to indicate a list of Foo's.)
+
 The majority of types will be Opaque ones defined by extensions including the [standard library](#standard-library). However a number of types can be constructed using only the core type constructors: for example the empty tuple type, aka `unit`, with exactly one instance (so 0 bits of data); the empty sum, with no instances; the empty Function type (taking no arguments and producing no results - `void -> void`); and compositions thereof.
 
 Types representing functions are generally ``CopyableType``, but not ``EqType``. (It is undecidable whether two functions produce the same result for all possible inputs, or similarly whether one computation graph can be rewritten into another by semantic-preserving rewrites).
@@ -819,7 +821,6 @@ TypeParam ::= Type(Any|Copyable|Eq)
             | Tuple([TypeParam]) -- heterogenous, fixed size
             | Opaque(Name, [TypeArg]) -- e.g. Opaque("Array", [5, Opaque("usize", [])])
 ```
-(We write `[Foo]` to indicate a list of Foo's.)
 
 For each such TypeParam, the body of the FunctionType (input, output, and extensions - see [Extension Tracking](#extension-tracking))
 may contain "type variables" referring to that TypeParam, i.e. the binder. (The type variable is typically a type, but


### PR DESCRIPTION
* Move "Operation Extensionsibility" to after Type System (and up one level), rename to "Extension System"
* Add Polymorphism section inside Type System: any `Function` type may be polymorphic
* Clarify working of operations, including adding Appendix 3 with full details binary `compute_signature`
* Add `OpaqueOp` as a dataflow node operation
 
fixes #790 
