### PR TITLE
fix: Ignore unsupported test in miri

### DIFF
--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -483,6 +483,9 @@ pub mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "Extension ops cannot be used with miri.")]
+    // Miri doesn't run the extension registration required by `typetag` for registering `CustomConst`s.
+    // https://github.com/rust-lang/miri/issues/450
     fn constants_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
         let mut builder = DFGBuilder::new(FunctionType::new(vec![], vec![FLOAT64_TYPE])).unwrap();
         let w = builder.add_load_const(ConstF64::new(0.5))?;


### PR DESCRIPTION
The miri test in CI currently [fails](https://github.com/CQCL/hugr/actions/runs/7447240566/job/20259152793) with an error `"unknown variant 'ConstF64', there are no variants"`.

This is due to `CustomConst` serialization depending on `typetag`, which registers each constant variant at the start of the program using `ctor` (i.e. running code before `main`).

Miri does not currenly [support running this](https://www.github.com/rust-lang/miri/issues/450), so the deserialization finds the CustomConst registry empty (hence the "there are no variants").

The solution until support is added to miri is just to ignore test with constants.