### PR TITLE
feat!: impls of CustomConst must be able to report their type

### DIFF
--- a/src/algorithm/const_fold.rs
+++ b/src/algorithm/const_fold.rs
@@ -335,7 +335,7 @@ mod test {
     #[cfg(not(feature = "extension_inference"))] // inference fails for test graph, shouldn't
     #[test]
     fn test_list_ops() -> Result<(), Box<dyn std::error::Error>> {
-        use crate::std_extensions::collections::{self, make_list_const, ListOp, ListValue};
+        use crate::std_extensions::collections::{self, ListOp, ListValue};
 
         let reg = ExtensionRegistry::try_new([
             PRELUDE.to_owned(),
@@ -343,7 +343,7 @@ mod test {
             collections::EXTENSION.to_owned(),
         ])
         .unwrap();
-        let list = make_list_const(ListValue::new(BOOL_T, vec![Value::unit_sum(1)]));
+        let list: Const = ListValue::new(BOOL_T, vec![Value::unit_sum(1)]).into();
         let mut build = DFGBuilder::new(FunctionType::new(
             type_row![],
             vec![list.const_type().clone()],

--- a/src/algorithm/const_fold.rs
+++ b/src/algorithm/const_fold.rs
@@ -336,7 +336,6 @@ mod test {
     #[test]
     fn test_list_ops() -> Result<(), Box<dyn std::error::Error>> {
         use crate::std_extensions::collections::{self, make_list_const, ListOp, ListValue};
-        use crate::types::TypeArg;
 
         let reg = ExtensionRegistry::try_new([
             PRELUDE.to_owned(),
@@ -344,10 +343,7 @@ mod test {
             collections::EXTENSION.to_owned(),
         ])
         .unwrap();
-        let list = make_list_const(
-            ListValue::new(vec![Value::unit_sum(1)]),
-            &[TypeArg::Type { ty: BOOL_T }],
-        );
+        let list = make_list_const(ListValue::new(BOOL_T, vec![Value::unit_sum(1)]));
         let mut build = DFGBuilder::new(FunctionType::new(
             type_row![],
             vec![list.const_type().clone()],

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -191,7 +191,7 @@ impl CustomConst for ConstUsize {
         ExtensionSet::singleton(&PRELUDE_ID)
     }
 
-    fn typ(&self) -> CustomType {
+    fn custom_type(&self) -> CustomType {
         USIZE_CUSTOM_T
     }
 }
@@ -228,7 +228,7 @@ impl CustomConst for ConstError {
     fn extension_reqs(&self) -> ExtensionSet {
         ExtensionSet::singleton(&PRELUDE_ID)
     }
-    fn typ(&self) -> CustomType {
+    fn custom_type(&self) -> CustomType {
         ERROR_CUSTOM_TYPE
     }
 }

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -9,9 +9,9 @@ use crate::{
     type_row,
     types::{
         type_param::{TypeArg, TypeParam},
-        CustomCheckFailure, CustomType, FunctionType, PolyFuncType, Type, TypeBound,
+        CustomType, FunctionType, PolyFuncType, Type, TypeBound,
     },
-    values::{CustomConst, KnownTypeConst},
+    values::CustomConst,
     Extension,
 };
 
@@ -183,10 +183,6 @@ impl CustomConst for ConstUsize {
         format!("ConstUsize({:?})", self.0).into()
     }
 
-    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        self.check_known_type(typ)
-    }
-
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
         crate::values::downcast_equal_consts(self, other)
     }
@@ -198,10 +194,6 @@ impl CustomConst for ConstUsize {
     fn typ(&self) -> CustomType {
         USIZE_CUSTOM_T
     }
-}
-
-impl KnownTypeConst for ConstUsize {
-    const TYPE: CustomType = USIZE_CUSTOM_T;
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -229,10 +221,6 @@ impl CustomConst for ConstError {
         format!("ConstError({:?}, {:?})", self.signal, self.message).into()
     }
 
-    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        self.check_known_type(typ)
-    }
-
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
         crate::values::downcast_equal_consts(self, other)
     }
@@ -243,10 +231,6 @@ impl CustomConst for ConstError {
     fn typ(&self) -> CustomType {
         ERROR_CUSTOM_TYPE
     }
-}
-
-impl KnownTypeConst for ConstError {
-    const TYPE: CustomType = ERROR_CUSTOM_TYPE;
 }
 
 #[cfg(test)]

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -194,6 +194,10 @@ impl CustomConst for ConstUsize {
     fn extension_reqs(&self) -> ExtensionSet {
         ExtensionSet::singleton(&PRELUDE_ID)
     }
+
+    fn typ(&self) -> CustomType {
+        USIZE_CUSTOM_T
+    }
 }
 
 impl KnownTypeConst for ConstUsize {
@@ -235,6 +239,9 @@ impl CustomConst for ConstError {
 
     fn extension_reqs(&self) -> ExtensionSet {
         ExtensionSet::singleton(&PRELUDE_ID)
+    }
+    fn typ(&self) -> CustomType {
+        ERROR_CUSTOM_TYPE
     }
 }
 

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -276,7 +276,7 @@ mod test {
 
         assert_eq!(error_val.name(), "ConstError(2, \"my message\")");
 
-        assert!(error_val.check_custom_type(&ERROR_CUSTOM_TYPE).is_ok());
+        assert!(error_val.validate().is_ok());
 
         assert_eq!(
             error_val.extension_reqs(),

--- a/src/hugr/validate/test.rs
+++ b/src/hugr/validate/test.rs
@@ -542,7 +542,10 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
         ),
     )?;
     let empty_list = Value::Extension {
-        c: (Box::new(collections::ListValue::new(vec![])),),
+        c: (Box::new(collections::ListValue::new(
+            Type::new_var_use(0, TypeBound::Copyable),
+            vec![],
+        )),),
     };
     let cst = def.add_load_const(Const::new(empty_list, list_of_var)?)?;
     let res = def.finish_hugr_with_outputs([cst], &reg);

--- a/src/hugr/validate/test.rs
+++ b/src/hugr/validate/test.rs
@@ -542,9 +542,8 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
         ),
     )?;
     let empty_list = Value::Extension {
-        c: (Box::new(collections::ListValue::new(
+        c: (Box::new(collections::ListValue::new_empty(
             Type::new_var_use(0, TypeBound::Copyable),
-            vec![],
         )),),
     };
     let cst = def.add_load_const(Const::new(empty_list, list_of_var)?)?;

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -140,7 +140,7 @@ mod test {
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
         extension::{
-            prelude::{ConstUsize, USIZE_T},
+            prelude::{ConstUsize, USIZE_CUSTOM_T, USIZE_T},
             ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE,
         },
         std_extensions::arithmetic::float_types::{self, ConstF64, FLOAT64_TYPE},
@@ -174,7 +174,7 @@ mod test {
         let c = b.add_constant(Const::tuple_sum(
             0,
             Value::tuple([
-                CustomTestValue(TypeBound::Eq, ExtensionSet::new()).into(),
+                CustomTestValue(USIZE_CUSTOM_T).into(),
                 serialized_float(5.1),
             ]),
             pred_rows.clone(),

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -127,7 +127,7 @@ where
     T: CustomConst,
 {
     fn from(value: T) -> Self {
-        let typ = Type::new_extension(value.typ());
+        let typ = Type::new_extension(value.custom_type());
         Const {
             value: Value::custom(value),
             typ,

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -3,7 +3,7 @@
 use crate::{
     extension::ExtensionSet,
     types::{ConstTypeError, EdgeKind, Type, TypeRow},
-    values::{CustomConst, KnownTypeConst, Value},
+    values::{CustomConst, Value},
 };
 
 use smol_str::SmolStr;
@@ -124,12 +124,13 @@ impl OpTrait for Const {
 // without initial type check.
 impl<T> From<T> for Const
 where
-    T: KnownTypeConst + CustomConst,
+    T: CustomConst,
 {
     fn from(value: T) -> Self {
+        let typ = Type::new_extension(value.typ());
         Const {
             value: Value::custom(value),
-            typ: Type::new_extension(T::TYPE),
+            typ,
         }
     }
 }

--- a/src/std_extensions/arithmetic/float_types.rs
+++ b/src/std_extensions/arithmetic/float_types.rs
@@ -4,8 +4,8 @@ use smol_str::SmolStr;
 
 use crate::{
     extension::{ExtensionId, ExtensionSet},
-    types::{CustomCheckFailure, CustomType, Type, TypeBound},
-    values::{CustomConst, KnownTypeConst},
+    types::{CustomType, Type, TypeBound},
+    values::CustomConst,
     Extension,
 };
 use lazy_static::lazy_static;
@@ -50,22 +50,14 @@ impl ConstF64 {
     }
 }
 
-impl KnownTypeConst for ConstF64 {
-    const TYPE: CustomType = FLOAT64_CUSTOM_TYPE;
-}
-
 #[typetag::serde]
 impl CustomConst for ConstF64 {
     fn name(&self) -> SmolStr {
         format!("f64({})", self.value).into()
     }
 
-    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        self.check_known_type(typ)
-    }
-
     fn typ(&self) -> CustomType {
-        Self::TYPE
+        FLOAT64_CUSTOM_TYPE
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {

--- a/src/std_extensions/arithmetic/float_types.rs
+++ b/src/std_extensions/arithmetic/float_types.rs
@@ -56,7 +56,7 @@ impl CustomConst for ConstF64 {
         format!("f64({})", self.value).into()
     }
 
-    fn typ(&self) -> CustomType {
+    fn custom_type(&self) -> CustomType {
         FLOAT64_CUSTOM_TYPE
     }
 

--- a/src/std_extensions/arithmetic/float_types.rs
+++ b/src/std_extensions/arithmetic/float_types.rs
@@ -64,6 +64,10 @@ impl CustomConst for ConstF64 {
         self.check_known_type(typ)
     }
 
+    fn typ(&self) -> CustomType {
+        Self::TYPE
+    }
+
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
         crate::values::downcast_equal_consts(self, other)
     }

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -8,7 +8,7 @@ use crate::{
     extension::{ExtensionId, ExtensionSet},
     types::{
         type_param::{TypeArg, TypeArgError, TypeParam},
-        ConstTypeError, CustomCheckFailure, CustomType, Type, TypeBound,
+        ConstTypeError, CustomType, Type, TypeBound,
     },
     values::CustomConst,
     Extension,
@@ -149,15 +149,6 @@ impl CustomConst for ConstIntU {
     fn name(&self) -> SmolStr {
         format!("u{}({})", self.log_width, self.value).into()
     }
-    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        if typ == &self.custom_type() {
-            Ok(())
-        } else {
-            Err(CustomCheckFailure::Message(
-                "Unsigned integer constant type mismatch.".into(),
-            ))
-        }
-    }
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
         crate::values::downcast_equal_consts(self, other)
     }
@@ -175,15 +166,6 @@ impl CustomConst for ConstIntU {
 impl CustomConst for ConstIntS {
     fn name(&self) -> SmolStr {
         format!("i{}({})", self.log_width, self.value).into()
-    }
-    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        if typ == &self.custom_type() {
-            Ok(())
-        } else {
-            Err(CustomCheckFailure::Message(
-                "Signed integer constant type mismatch.".into(),
-            ))
-        }
     }
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
         crate::values::downcast_equal_consts(self, other)
@@ -282,31 +264,15 @@ mod test {
         assert!(const_u32_7.equal_consts(&ConstIntU::new(5, 7).unwrap()));
         assert_eq!(const_u32_7.log_width(), 5);
         assert_eq!(const_u32_7.value(), 7);
-        assert!(const_u32_7
-            .check_custom_type(&int_custom_type(TypeArg::BoundedNat { n: 5 }))
-            .is_ok());
-        assert!(const_u32_7
-            .check_custom_type(&int_custom_type(TypeArg::BoundedNat { n: 6 }))
-            .is_err());
+        assert!(const_u32_7.validate().is_ok());
 
         assert_eq!(const_u32_7.name(), "u5(7)");
-        assert!(const_u32_7
-            .check_custom_type(&int_custom_type(TypeArg::BoundedNat { n: 19 }))
-            .is_err());
 
         let const_i32_2 = ConstIntS::new(5, -2).unwrap();
         assert!(const_i32_2.equal_consts(&ConstIntS::new(5, -2).unwrap()));
         assert_eq!(const_i32_2.log_width(), 5);
         assert_eq!(const_i32_2.value(), -2);
-        assert!(const_i32_2
-            .check_custom_type(&int_custom_type(TypeArg::BoundedNat { n: 5 }))
-            .is_ok());
-        assert!(const_i32_2
-            .check_custom_type(&int_custom_type(TypeArg::BoundedNat { n: 6 }))
-            .is_err());
-        assert!(const_i32_2
-            .check_custom_type(&int_custom_type(TypeArg::BoundedNat { n: 19 }))
-            .is_err());
+        assert!(const_i32_2.validate().is_ok());
         assert_eq!(const_i32_2.name(), "i5(-2)");
 
         ConstIntS::new(50, -2).unwrap_err();

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -165,6 +165,12 @@ impl CustomConst for ConstIntU {
     fn extension_reqs(&self) -> ExtensionSet {
         ExtensionSet::singleton(&EXTENSION_ID)
     }
+
+    fn typ(&self) -> CustomType {
+        int_custom_type(TypeArg::BoundedNat {
+            n: self.log_width as u64,
+        })
+    }
 }
 
 #[typetag::serde]
@@ -187,6 +193,12 @@ impl CustomConst for ConstIntS {
 
     fn extension_reqs(&self) -> ExtensionSet {
         ExtensionSet::singleton(&EXTENSION_ID)
+    }
+
+    fn typ(&self) -> CustomType {
+        int_custom_type(TypeArg::BoundedNat {
+            n: self.log_width as u64,
+        })
     }
 }
 

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -150,7 +150,7 @@ impl CustomConst for ConstIntU {
         format!("u{}({})", self.log_width, self.value).into()
     }
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        if typ == &self.typ() {
+        if typ == &self.custom_type() {
             Ok(())
         } else {
             Err(CustomCheckFailure::Message(
@@ -166,7 +166,7 @@ impl CustomConst for ConstIntU {
         ExtensionSet::singleton(&EXTENSION_ID)
     }
 
-    fn typ(&self) -> CustomType {
+    fn custom_type(&self) -> CustomType {
         int_custom_type(type_arg(self.log_width))
     }
 }
@@ -177,7 +177,7 @@ impl CustomConst for ConstIntS {
         format!("i{}({})", self.log_width, self.value).into()
     }
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        if typ == &self.typ() {
+        if typ == &self.custom_type() {
             Ok(())
         } else {
             Err(CustomCheckFailure::Message(
@@ -193,7 +193,7 @@ impl CustomConst for ConstIntS {
         ExtensionSet::singleton(&EXTENSION_ID)
     }
 
-    fn typ(&self) -> CustomType {
+    fn custom_type(&self) -> CustomType {
         int_custom_type(type_arg(self.log_width))
     }
 }

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -66,7 +66,7 @@ pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TypeArgError> {
     }
 }
 
-pub(super) const fn type_arg(log_width: u8) -> TypeArg {
+const fn type_arg(log_width: u8) -> TypeArg {
     TypeArg::BoundedNat {
         n: log_width as u64,
     }
@@ -150,7 +150,7 @@ impl CustomConst for ConstIntU {
         format!("u{}({})", self.log_width, self.value).into()
     }
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        if typ == &int_custom_type(type_arg(self.log_width)) {
+        if typ == &self.typ() {
             Ok(())
         } else {
             Err(CustomCheckFailure::Message(
@@ -167,9 +167,7 @@ impl CustomConst for ConstIntU {
     }
 
     fn typ(&self) -> CustomType {
-        int_custom_type(TypeArg::BoundedNat {
-            n: self.log_width as u64,
-        })
+        int_custom_type(type_arg(self.log_width))
     }
 }
 
@@ -179,7 +177,7 @@ impl CustomConst for ConstIntS {
         format!("i{}({})", self.log_width, self.value).into()
     }
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        if typ == &int_custom_type(type_arg(self.log_width)) {
+        if typ == &self.typ() {
             Ok(())
         } else {
             Err(CustomCheckFailure::Message(
@@ -196,9 +194,7 @@ impl CustomConst for ConstIntS {
     }
 
     fn typ(&self) -> CustomType {
-        int_custom_type(TypeArg::BoundedNat {
-            n: self.log_width as u64,
-        })
+        int_custom_type(type_arg(self.log_width))
     }
 }
 

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -150,7 +150,7 @@ impl CustomConst for ConstIntU {
         format!("u{}({})", self.log_width, self.value).into()
     }
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        if typ.clone() == int_custom_type(type_arg(self.log_width)) {
+        if typ == &int_custom_type(type_arg(self.log_width)) {
             Ok(())
         } else {
             Err(CustomCheckFailure::Message(
@@ -179,7 +179,7 @@ impl CustomConst for ConstIntS {
         format!("i{}({})", self.log_width, self.value).into()
     }
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        if typ.clone() == int_custom_type(type_arg(self.log_width)) {
+        if typ == &int_custom_type(type_arg(self.log_width)) {
             Ok(())
         } else {
             Err(CustomCheckFailure::Message(

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -1,5 +1,6 @@
 //! List type and operations.
 
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
@@ -36,8 +37,8 @@ pub struct ListValue(Vec<Value>, Type);
 impl ListValue {
     /// Create a new [CustomConst] for a list of values of type `typ`.
     /// That all values ore of type `typ` is not checked here.
-    pub fn new(typ: Type, contents: Vec<Value>) -> Self {
-        Self(contents, typ)
+    pub fn new(typ: Type, contents: impl IntoIterator<Item = Value>) -> Self {
+        Self(contents.into_iter().collect_vec(), typ)
     }
 
     /// Create a new [CustomConst] for an empty list of values of type `typ`.
@@ -52,7 +53,7 @@ impl CustomConst for ListValue {
         SmolStr::new_inline("list")
     }
 
-    fn typ(&self) -> CustomType {
+    fn custom_type(&self) -> CustomType {
         let list_type_def = EXTENSION.get_type(&LIST_TYPENAME).unwrap();
         list_type_def
             .instantiate(vec![Into::<TypeArg>::into(self.1.clone())])

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -60,7 +60,8 @@ impl CustomConst for ListValue {
             .unwrap()
     }
 
-    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
+    fn validate(&self) -> Result<(), CustomCheckFailure> {
+        let typ = self.custom_type();
         let error = || {
             // TODO more bespoke errors
             CustomCheckFailure::Message("List type check fail.".to_string())
@@ -69,7 +70,7 @@ impl CustomConst for ListValue {
         EXTENSION
             .get_type(&LIST_TYPENAME)
             .unwrap()
-            .check_custom(typ)
+            .check_custom(&typ)
             .map_err(|_| error())?;
 
         // constant can only hold classic type.
@@ -320,10 +321,10 @@ mod test {
         list_def.check_custom(&list_type).unwrap();
         let list_value = ListValue(vec![ConstUsize::new(3).into()], USIZE_T);
 
-        list_value.check_custom_type(&list_type).unwrap();
+        list_value.validate().unwrap();
 
         let wrong_list_value = ListValue(vec![ConstF64::new(1.2).into()], USIZE_T);
-        assert!(wrong_list_value.check_custom_type(&list_type).is_err());
+        assert!(wrong_list_value.validate().is_err());
     }
 
     #[test]

--- a/src/values.rs
+++ b/src/values.rs
@@ -154,16 +154,8 @@ pub trait CustomConst:
     fn extension_reqs(&self) -> ExtensionSet;
 
     /// Check the value is a valid instance of the provided type.
-    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        let expected = self.custom_type();
-        if typ == &expected {
-            Ok(())
-        } else {
-            Err(CustomCheckFailure::TypeMismatch {
-                expected,
-                found: typ.clone(),
-            })
-        }
+    fn validate(&self) -> Result<(), CustomCheckFailure> {
+        Ok(())
     }
 
     /// Compare two constants for equality, using downcasting and comparing the definitions.
@@ -253,16 +245,6 @@ pub(crate) mod test {
     impl CustomConst for CustomTestValue {
         fn name(&self) -> SmolStr {
             format!("CustomTestValue({:?})", self.0).into()
-        }
-
-        fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-            if self.0 == *typ {
-                Ok(())
-            } else {
-                Err(CustomCheckFailure::Message(
-                    "CustomTestValue check fail.".into(),
-                ))
-            }
         }
 
         fn extension_reqs(&self) -> ExtensionSet {

--- a/src/values.rs
+++ b/src/values.rs
@@ -155,7 +155,7 @@ pub trait CustomConst:
 
     /// Check the value is a valid instance of the provided type.
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        let expected = self.typ();
+        let expected = self.custom_type();
         if typ == &expected {
             Ok(())
         } else {
@@ -174,7 +174,7 @@ pub trait CustomConst:
     }
 
     /// report the type
-    fn typ(&self) -> CustomType;
+    fn custom_type(&self) -> CustomType;
 }
 
 /// Const equality for types that have PartialEq
@@ -224,7 +224,7 @@ impl CustomConst for CustomSerialized {
     fn extension_reqs(&self) -> ExtensionSet {
         self.extensions.clone()
     }
-    fn typ(&self) -> CustomType {
+    fn custom_type(&self) -> CustomType {
         self.typ.clone()
     }
 }
@@ -269,7 +269,7 @@ pub(crate) mod test {
             ExtensionSet::singleton(self.0.extension())
         }
 
-        fn typ(&self) -> CustomType {
+        fn custom_type(&self) -> CustomType {
             self.0.clone()
         }
     }


### PR DESCRIPTION
We remove `trait KnownTypeConst` as it is now redundant. We move the body of `check_known_type` into a new default implementation of `CustomConst::check_custom_type`.