### PR TITLE
feat: Minimal implementation for YAML extensions

### DIFF
--- a/examples/extension/declarative.yaml
+++ b/examples/extension/declarative.yaml
@@ -1,0 +1,31 @@
+# Optionally import other extensions. The `prelude` is always imported.
+imports: [logic]
+
+extensions:
+  - # Each extension must have a name
+    name: SimpleExt
+    types:
+      - # Types must have a name.
+        # Parameters are not currently supported.
+        name: Copyable type
+        description: A simple type with no parameters
+        # Types may have a "Eq", "Copyable", or "Any" bound.
+        # This field is optional and defaults to "Any".
+        bound: Copyable
+    operations:
+      - # Operations must have a name and a signature.
+        name: MyOperation
+        description: A simple operation with no inputs nor outputs
+        signature:
+          inputs: []
+          outputs: []
+      - name: AnotherOperation
+        description: An operation from 3 qubits to 3 qubits
+        signature:
+          # The input and outputs can be written directly as the types
+          inputs: [Q, Q, Q]
+          outputs:
+            - # Or as the type followed by a number of repetitions.
+              [Q, 1]
+            - # Or as a description, followed by the type and a number of repetitions.
+              [Control, Q, 2]

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1134,7 +1134,7 @@ extensions:
     signature:
       inputs: [[null, Function[r](USize -> USize)], ["arg", USize]]
       outputs: [[null, USize]]
-      extensions: r # Indicates that running this operation also invokes extensions r
+      extensions: [r] # Indicates that running this operation also invokes extensions r
     lowering:
       file: "graph_op_hugr.bin"
       extensions: ["arithmetic.int", r] # r is the ExtensionSet in "params"

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1094,16 +1094,16 @@ extensions:
   - name: SU2
     description: "One qubit unitary matrix"
     params: # per-node values passed to the type-scheme interpreter, but not used in signature
-      - matrix: Opaque(complex_matrix,2,2)
+      matrix: Opaque(complex_matrix,2,2)
     signature:
       inputs: [[null, Q]]
       outputs: [[null, Q]]
   - name: MatMul
     description: "Multiply matrices of statically-known size"
     params:  # per-node values passed to type-scheme-interpreter and used in signature
-      - i: USize
-      - j: USize
-      - k: USize
+      i: USize
+      j: USize
+      k: USize
     signature:
       inputs: [["a", Array<i>(Array<j>(F64))], ["b", Array<j>(Array<k>(F64))]]
       outputs: [[null, Array<i>(Array<k>(F64))]]
@@ -1112,7 +1112,7 @@ extensions:
   - name: max_float
     description: "Variable number of inputs"
     params:
-      - n: USize
+      n: USize
     signature:
       # Where an element of a signature has three subelements, the third is the number of repeats
       inputs: [[null, F64, n]] # (defaulting to 1 if omitted)
@@ -1120,9 +1120,9 @@ extensions:
   - name: ArrayConcat
     description: "Concatenate two arrays. Extension provides a compute_signature implementation."
     params:
-      - t: Type  # Classic or Quantum
-      - i: USize
-      - j: USize
+      t: Type  # Classic or Quantum
+      i: USize
+      j: USize
     # inputs could be: Array<i>(t), Array<j>(t)
     # outputs would be, in principle: Array<i+j>(t)
     # - but default type scheme interpreter does not support such addition

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1072,6 +1072,7 @@ extensions:
   # Declare custom types
   types:
   - name: QubitVector
+    description: "A vector of qubits"
     # Opaque types can take type arguments, with specified names
     params: [["size", USize]]
   operations:

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -399,24 +399,6 @@ pub enum ExtensionBuildError {
     /// Existing [`TypeDef`]
     #[error("Extension already has an type called {0}.")]
     TypeDefExists(SmolStr),
-    /// Referenced an unknown type.
-    #[error("Extension {ext} referenced an unknown type {ty}.")]
-    MissingType {
-        /// The extension that referenced the unknown type.
-        ext: ExtensionId,
-        /// The unknown type.
-        ty: TypeName,
-    },
-    /// Parametric types are not currently supported as type parameters.
-    ///
-    /// TODO: Support this.
-    #[error("Found an unsupported higher-order type parameter {ty} in extension {ext}")]
-    ParametricTypeParameter {
-        /// The extension that referenced the unsupported type parameter.
-        ext: ExtensionId,
-        /// The unsupported type parameter.
-        ty: TypeName,
-    },
 }
 
 /// A set of extensions identified by their unique [`ExtensionId`].

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -40,7 +40,7 @@ pub mod validate;
 pub use const_fold::{ConstFold, ConstFoldResult};
 pub use prelude::{PRELUDE, PRELUDE_REGISTRY};
 
-mod declarative;
+pub mod declarative;
 
 /// Extension Registries store extensions to be looked up e.g. during validation.
 #[derive(Clone, Debug)]
@@ -73,6 +73,21 @@ impl ExtensionRegistry {
             ext.validate(&res).map_err(|e| (ext.name().clone(), e))?;
         }
         Ok(res)
+    }
+
+    /// Returns the number of extensions in the registry.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the registry contains no extensions.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator over the extensions in the registry.
+    pub fn iter(&self) -> impl Iterator<Item = (&ExtensionId, &Extension)> {
+        self.0.iter()
     }
 }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -37,6 +37,7 @@ pub mod simple_op;
 pub mod validate;
 pub use const_fold::{ConstFold, ConstFoldResult};
 pub use prelude::{PRELUDE, PRELUDE_REGISTRY};
+mod declarative;
 
 /// Extension Registries store extensions to be looked up e.g. during validation.
 #[derive(Clone, Debug)]

--- a/src/extension/declarative.rs
+++ b/src/extension/declarative.rs
@@ -9,18 +9,37 @@
 mod ops;
 mod types;
 
-use super::ExtensionId;
+use std::fs::File;
+
+use crate::Extension;
+
+use super::{ExtensionBuildError, ExtensionId, ExtensionRegistry, ExtensionSet, SignatureError};
 use ops::OperationDeclaration;
 use types::TypeDeclaration;
 
 use serde::{Deserialize, Serialize};
+
+/// Load a set of extensions from a YAML string.
+pub fn load_extensions(yaml: &str) -> Result<ExtensionRegistry, ExtensionDeclarationError> {
+    let ext: ExtensionSetDeclaration = serde_yaml::from_str(yaml)?;
+    ext.make_registry()
+}
+
+/// Load a set of extensions from a file.
+pub fn load_extensions_file(
+    path: &std::path::Path,
+) -> Result<ExtensionRegistry, ExtensionDeclarationError> {
+    let file = File::open(path)?;
+    let ext: ExtensionSetDeclaration = serde_yaml::from_reader(file)?;
+    ext.make_registry()
+}
 
 /// A set of declarative extension definitions with some metadata.
 ///
 /// These are normally contained in a single YAML file.
 //
 // TODO: More metadata, "namespace"?
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct ExtensionSetDeclaration {
     /// A set of extension definitions.
     //
@@ -30,11 +49,11 @@ struct ExtensionSetDeclaration {
     /// Optional.
     #[serde(default)]
     #[serde(skip_serializing_if = "crate::utils::is_default")]
-    imports: Vec<ExtensionId>,
+    imports: ExtensionSet,
 }
 
 /// A declarative extension definition.
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct ExtensionDeclaration {
     /// The name of the extension.
     name: ExtensionId,
@@ -46,4 +65,115 @@ struct ExtensionDeclaration {
     #[serde(default)]
     #[serde(skip_serializing_if = "crate::utils::is_default")]
     operations: Vec<OperationDeclaration>,
+    // TODO: Values?
+}
+
+impl ExtensionSetDeclaration {
+    /// Register this set of extensions with the given registry.
+    pub fn make_registry(&self) -> Result<ExtensionRegistry, ExtensionDeclarationError> {
+        let exts = self
+            .extensions
+            .iter()
+            .map(|ext| ext.make_extension(&self.imports))
+            .collect::<Result<Vec<Extension>, _>>()?;
+        Ok(ExtensionRegistry::try_new(exts)?)
+    }
+}
+
+impl ExtensionDeclaration {
+    /// Create an [`Extension`] from this declaration.
+    pub fn make_extension(
+        &self,
+        imports: &ExtensionSet,
+    ) -> Result<Extension, ExtensionDeclarationError> {
+        let mut ext = Extension::new_with_reqs(self.name.clone(), imports.clone());
+
+        for t in &self.types {
+            t.register(&mut ext)?;
+        }
+
+        for o in &self.operations {
+            o.register(&mut ext)?;
+        }
+
+        Ok(ext)
+    }
+}
+
+/// Errors that can occur while loading an extension set.
+#[derive(Debug, thiserror::Error)]
+pub enum ExtensionDeclarationError {
+    /// An error occurred while deserializing the extension set.
+    #[error("Error while parsing the extension set yaml: {0}")]
+    Deserialize(#[from] serde_yaml::Error),
+    /// An error in the validation of the loaded extensions.
+    #[error("Error validating extension {ext}: {err}")]
+    ExtensionValidationError {
+        /// The extension that failed validation.
+        ext: ExtensionId,
+        /// The error that occurred.
+        err: SignatureError,
+    },
+    /// An error occurred while adding operations or types to the extension.
+    #[error("Error while adding operations or types to the extension: {0}")]
+    ExtensionBuildError(#[from] ExtensionBuildError),
+    /// Invalid yaml file.
+    #[error("Invalid yaml declaration file {0}")]
+    InvalidFile(#[from] std::io::Error),
+}
+
+impl From<(ExtensionId, SignatureError)> for ExtensionDeclarationError {
+    fn from((ext, err): (ExtensionId, SignatureError)) -> Self {
+        ExtensionDeclarationError::ExtensionValidationError { ext, err }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+
+    use super::*;
+
+    /// A yaml extension defining an empty extension.
+    const EMPTY_YAML: &str = r#"
+extensions:
+- name: EmptyExt
+"#;
+
+    /// A yaml extension defining an extension with one type and two operations.
+    const BASIC_YAML: &str = r#"
+extensions:
+- name: SimpleExt
+  types:
+  - name: MyType
+    description: A simple type with no parameters
+  operations:
+  - name: MyOperation
+    description: A simple operation with no inputs nor outputs
+    signature:
+      inputs: []
+      outputs: []
+  - name: UnusableOperation
+    description: An operation without a defined signature
+"#;
+
+    #[rstest]
+    #[case(EMPTY_YAML, 1, 0, 0)]
+    #[case(BASIC_YAML, 1, 1, 2)]
+    fn test_decode(
+        #[case] yaml: &str,
+        #[case] num_declarations: usize,
+        #[case] num_types: usize,
+        #[case] num_operations: usize,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let ext: ExtensionRegistry = load_extensions(yaml)?;
+
+        assert_eq!(ext.len(), num_declarations);
+        assert_eq!(ext.iter().flat_map(|(_, e)| e.types()).count(), num_types);
+        assert_eq!(
+            ext.iter().flat_map(|(_, e)| e.operations()).count(),
+            num_operations
+        );
+        Ok(())
+    }
 }

--- a/src/extension/declarative.rs
+++ b/src/extension/declarative.rs
@@ -228,6 +228,16 @@ pub enum ExtensionDeclarationError {
         /// The repetition expression
         parametric_repetition: SmolStr,
     },
+    /// Lowering definitions for an operation are not currently supported.
+    ///
+    /// TODO: Support this.
+    #[error("Unsupported lowering definition for op {op} in extension {ext}")]
+    LoweringNotSupported {
+        /// The extension.
+        ext: crate::hugr::IdentList,
+        /// The operation with the lowering definition.
+        op: SmolStr,
+    },
 }
 
 #[cfg(test)]

--- a/src/extension/declarative.rs
+++ b/src/extension/declarative.rs
@@ -1,8 +1,16 @@
 //! Declarative extension definitions.
 //!
-//! This module defines a YAML schema for defining extensions in a declarative way.
+//! This module includes functions to dynamically load HUGR extensions defined in a YAML file.
+//!
+//! An extension file may define multiple extensions, each with a set of types and operations.
 //!
 //! See the [specification] for more details.
+//!
+//! ### Example
+//!
+//! ```yaml
+#![doc = include_str!("../../examples/extension/declarative.yaml")]
+//! ```
 //!
 //! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
 
@@ -276,10 +284,10 @@ extensions:
       inputs: []
       outputs: []
   - name: AnotherOperation
-    description: An operation from 2 qubits to 2 qubits
+    description: An operation from 3 qubits to 3 qubits
     signature:
-        inputs: [["Target", Q], ["Control", Q, 1]]
-        outputs: [[null, Q, 2]]
+        inputs: [Q, Q, Q]
+        outputs: [[Q, 1], [Control, Q, 2]]
 "#;
 
     #[rstest]

--- a/src/extension/declarative.rs
+++ b/src/extension/declarative.rs
@@ -1,0 +1,49 @@
+//! Declarative extension definitions.
+//!
+//! This module defines a YAML schema for defining extensions in a declarative way.
+//!
+//! See the [specification] for more details.
+//!
+//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
+
+mod ops;
+mod types;
+
+use super::ExtensionId;
+use ops::OperationDeclaration;
+use types::TypeDeclaration;
+
+use serde::{Deserialize, Serialize};
+
+/// A set of declarative extension definitions with some metadata.
+///
+/// These are normally contained in a single YAML file.
+//
+// TODO: More metadata, "namespace"?
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+struct ExtensionSetDeclaration {
+    /// A set of extension definitions.
+    //
+    // TODO: allow qualified, and maybe locally-scoped?
+    extensions: Vec<ExtensionDeclaration>,
+    /// A list of extension IDs that this extension depends on.
+    /// Optional.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    imports: Vec<ExtensionId>,
+}
+
+/// A declarative extension definition.
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+struct ExtensionDeclaration {
+    /// The name of the extension.
+    name: String,
+    /// A list of types that this extension provides.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    types: Vec<TypeDeclaration>,
+    /// A list of operations that this extension provides.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    operations: Vec<OperationDeclaration>,
+}

--- a/src/extension/declarative.rs
+++ b/src/extension/declarative.rs
@@ -37,7 +37,7 @@ struct ExtensionSetDeclaration {
 #[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
 struct ExtensionDeclaration {
     /// The name of the extension.
-    name: String,
+    name: ExtensionId,
     /// A list of types that this extension provides.
     #[serde(default)]
     #[serde(skip_serializing_if = "crate::utils::is_default")]

--- a/src/extension/declarative.rs
+++ b/src/extension/declarative.rs
@@ -345,6 +345,7 @@ extensions:
         Ok(())
     }
 
+    #[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
     #[rstest]
     #[case(EXAMPLE_YAML_FILE, 1, 1, 2, &std_extensions::logic::LOGIC_REG)]
     fn test_decode_file(

--- a/src/extension/declarative/ops.rs
+++ b/src/extension/declarative/ops.rs
@@ -7,8 +7,176 @@
 //! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
 //! [`ExtensionSetDeclaration`]: super::ExtensionSetDeclaration
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+
+use crate::extension::ExtensionId;
+use crate::types::TypeName;
+use crate::utils::is_default;
 
 /// A declarative operation definition.
 #[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
-pub(super) struct OperationDeclaration {}
+pub(super) struct OperationDeclaration {
+    /// The identifier the operation.
+    name: SmolStr,
+    /// A description for the operation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    description: String,
+}
+
+/// A declarative operation signature definition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct SignatureDeclaration {
+    /// The inputs to the operation.
+    inputs: Vec<SignaturePortDeclaration>,
+    /// The outputs of the operation.
+    outputs: Vec<SignaturePortDeclaration>,
+    /// A set of extensions invoked while running this operation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    extensions: Vec<ExtensionId>,
+    /// A set of per-node parameters required to instantiate this operation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    params: HashMap<SmolStr, ParamDeclaration>,
+    /// An extra set of data associated to the operation.
+    ///
+    /// This data is kept in the Hugr, and may be accessed by the relevant runtime.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    misc: HashMap<SmolStr, serde_yaml::Value>,
+    /// A pre-compiled lowering routine.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    lowering: Option<LoweringDeclaration>,
+}
+
+/// A declarative definition for a number of ports in a signature's input or output.
+///
+/// Serialized as a 2 or 3-element list, where:
+/// - The first element is an optional human-readable name of the port.
+/// - The second element is the port type id.
+/// - The optional third element is either:
+///     - A number, indicating a repetition of the port that amount of times.
+///     - A parameter identifier, to use as the repetition number.
+///     - Nothing, in which case we default to a single repetition.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct SignaturePortDeclaration {
+    /// The description of the ports. May be `null`.
+    description: Option<String>,
+    /// The type identifier for the port.
+    ///
+    /// TODO: The spec definition is more complex than just a type identifier,
+    /// we should be able to support expressions like:
+    ///
+    /// - `Q`
+    /// - `Array<i>(Array<j>(F64))`
+    /// - `Function[r](USize -> USize)`
+    /// - `Opaque(complex_matrix,i,j)`
+    type_name: TypeName,
+    /// The number of repetitions for this port definition.
+    repeat: PortRepetitionDeclaration,
+}
+
+impl Serialize for SignaturePortDeclaration {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let len = if is_default(&self.repeat) { 2 } else { 3 };
+        let mut seq = serializer.serialize_seq(Some(len))?;
+        seq.serialize_element(&self.description)?;
+        seq.serialize_element(&self.type_name)?;
+        if !is_default(&self.repeat) {
+            seq.serialize_element(&self.repeat)?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for SignaturePortDeclaration {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct TypeParamVisitor;
+        const EXPECTED_MSG: &str = "a 2-element list containing a type parameter name and id";
+
+        impl<'de> serde::de::Visitor<'de> for TypeParamVisitor {
+            type Value = SignaturePortDeclaration;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(EXPECTED_MSG)
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let description = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &EXPECTED_MSG))?;
+                let type_name = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &EXPECTED_MSG))?;
+                let repeat = seq.next_element()?.unwrap_or_default();
+                Ok(SignaturePortDeclaration {
+                    description,
+                    type_name,
+                    repeat,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(TypeParamVisitor)
+    }
+}
+
+/// A number of repetitions for a signature's port definition.
+///
+/// This value may be either:
+/// - A number, indicating a repetition of the port that amount of times.
+/// - A parameter identifier, to use as the repetition number.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum PortRepetitionDeclaration {
+    /// A constant number of repetitions for the port definition.
+    Count(usize),
+    /// An (integer) operation parameter identifier to use as the number of repetitions.
+    Parameter(SmolStr),
+}
+
+impl Default for PortRepetitionDeclaration {
+    fn default() -> Self {
+        PortRepetitionDeclaration::Count(1)
+    }
+}
+
+/// The type of a per-node operation parameter required to instantiate an operation.
+///
+/// TODO: The value should be decoded as a [`TypeParam`].
+/// Valid options include:
+///
+/// - `USize`
+/// - `Type`
+///
+/// [`TypeParam`]: crate::types::type_param::TypeParam
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+struct ParamDeclaration(
+    /// TODO: Store a [`TypeParam`], and implement custom parsers.
+    ///
+    /// [`TypeParam`]: crate::types::type_param::TypeParam
+    String,
+);
+
+/// Reference to a binary lowering function.
+///
+/// TODO: How this works is not defined in the spec. This is currently a stub.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+struct LoweringDeclaration {
+    /// Path to the lowering executable.
+    file: PathBuf,
+    /// A set of extensions invoked while running this operation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    extensions: Vec<ExtensionId>,
+}

--- a/src/extension/declarative/ops.rs
+++ b/src/extension/declarative/ops.rs
@@ -87,12 +87,12 @@ impl OperationDeclaration {
 
         let signature_func: SignatureFunc = signature.make_signature(ext, ctx, &params)?;
 
-        let op_def = ext.add_op_with_misc(
-            self.name.clone(),
-            self.description.clone(),
-            signature_func,
-            self.misc.clone(),
-        )?;
+        let op_def = ext.add_op(self.name.clone(), self.description.clone(), signature_func)?;
+
+        for (k, v) in &self.misc {
+            op_def.add_misc(k, v.clone());
+        }
+
         Ok(op_def)
     }
 }

--- a/src/extension/declarative/ops.rs
+++ b/src/extension/declarative/ops.rs
@@ -14,9 +14,12 @@ use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
-use crate::extension::{ExtensionBuildError, ExtensionSet, OpDef, SignatureFunc};
+use crate::extension::{
+    ExtensionBuildError, ExtensionRegistry, ExtensionSet, OpDef, SignatureFunc,
+};
 use crate::types::TypeName;
 use crate::utils::is_default;
+use crate::Extension;
 
 /// A declarative operation definition.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -46,11 +49,15 @@ pub(super) struct OperationDeclaration {
     #[serde(skip_serializing_if = "crate::utils::is_default")]
     lowering: Option<LoweringDeclaration>,
 }
+
 impl OperationDeclaration {
     /// Register this operation in the given extension.
+    #[allow(unused, unreachable_code, clippy::diverging_sub_expression)]
     pub fn register<'ext>(
         &self,
-        ext: &'ext mut crate::Extension,
+        ext: &'ext mut Extension,
+        scope: &ExtensionSet,
+        registry: &ExtensionRegistry,
     ) -> Result<&'ext mut OpDef, ExtensionBuildError> {
         let signature_func: SignatureFunc = unimplemented!("signature_func");
         ext.add_op(self.name.clone(), self.description.clone(), signature_func)

--- a/src/extension/declarative/ops.rs
+++ b/src/extension/declarative/ops.rs
@@ -1,0 +1,14 @@
+//! Declarative operation definitions.
+//!
+//! This module defines a YAML schema for defining operations in a declarative way.
+//!
+//! See the [specification] and [`ExtensionSetDeclaration`] for more details.
+//!
+//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
+//! [`ExtensionSetDeclaration`]: super::ExtensionSetDeclaration
+
+use serde::{Deserialize, Serialize};
+
+/// A declarative operation definition.
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+pub(super) struct OperationDeclaration {}

--- a/src/extension/declarative/ops.rs
+++ b/src/extension/declarative/ops.rs
@@ -12,12 +12,12 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
-use crate::extension::{ExtensionRegistry, ExtensionSet, OpDef, SignatureFunc};
+use crate::extension::{OpDef, SignatureFunc};
 use crate::types::type_param::TypeParam;
 use crate::Extension;
 
 use super::signature::SignatureDeclaration;
-use super::ExtensionDeclarationError;
+use super::{DeclarationContext, ExtensionDeclarationError};
 
 /// A declarative operation definition.
 ///
@@ -57,8 +57,7 @@ impl OperationDeclaration {
     pub fn register<'ext>(
         &self,
         ext: &'ext mut Extension,
-        scope: &ExtensionSet,
-        registry: &ExtensionRegistry,
+        ctx: DeclarationContext<'_>,
     ) -> Result<&'ext mut OpDef, ExtensionDeclarationError> {
         // We currently only support explicit signatures.
         //
@@ -86,8 +85,7 @@ impl OperationDeclaration {
             });
         }
 
-        let signature_func: SignatureFunc =
-            signature.make_signature(ext, scope, registry, &params)?;
+        let signature_func: SignatureFunc = signature.make_signature(ext, ctx, &params)?;
 
         let op_def = ext.add_op_with_misc(
             self.name.clone(),

--- a/src/extension/declarative/signature.rs
+++ b/src/extension/declarative/signature.rs
@@ -94,10 +94,6 @@ struct SignaturePortDeclaration {
 
 impl SignaturePortDeclaration {
     /// Return an iterator with the types for this port declaration.
-    ///
-    /// Only a fixed number of repetitions is supported for now.
-    ///
-    /// TODO: We may need to use custom signature functions if `repeat` depends on a variable.
     fn make_types(
         &self,
         ext: &Extension,
@@ -172,9 +168,9 @@ impl<'de> Deserialize<'de> for SignaturePortDeclaration {
 
 /// A number of repetitions for a signature's port definition.
 ///
-/// This value may be either:
-/// - A number, indicating a repetition of the port that amount of times.
-/// - A parameter identifier, to use as the repetition number.
+/// This value must be a number, indicating a repetition of the port that amount of times.
+///
+/// Generic expressions are not yet supported.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 enum PortRepetitionDeclaration {

--- a/src/extension/declarative/signature.rs
+++ b/src/extension/declarative/signature.rs
@@ -1,0 +1,257 @@
+//! Declarative signature definitions.
+//!
+//! This module defines a YAML schema for defining the signature of an operation in a declarative way.
+//!
+//! See the [specification] and [`ExtensionSetDeclaration`] for more details.
+//!
+//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
+//! [`ExtensionSetDeclaration`]: super::ExtensionSetDeclaration
+
+use itertools::Itertools;
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+
+use crate::extension::prelude::PRELUDE_ID;
+use crate::extension::{
+    CustomValidator, ExtensionRegistry, ExtensionSet, SignatureFunc, TypeDef, TypeParametrised,
+};
+use crate::types::type_param::TypeParam;
+use crate::types::{CustomType, FunctionType, PolyFuncType, Type, TypeRow};
+use crate::utils::is_default;
+use crate::Extension;
+
+use super::ExtensionDeclarationError;
+
+/// A declarative operation signature definition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct SignatureDeclaration {
+    /// The inputs to the operation.
+    inputs: Vec<SignaturePortDeclaration>,
+    /// The outputs of the operation.
+    outputs: Vec<SignaturePortDeclaration>,
+    /// A set of extensions invoked while running this operation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    extensions: ExtensionSet,
+}
+
+impl SignatureDeclaration {
+    pub fn make_signature(
+        &self,
+        ext: &Extension,
+        scope: &ExtensionSet,
+        registry: &ExtensionRegistry,
+        op_params: &[TypeParam],
+    ) -> Result<SignatureFunc, ExtensionDeclarationError> {
+        let body = FunctionType {
+            input: self.make_type_row(&self.inputs, ext, scope, registry, op_params)?,
+            output: self.make_type_row(&self.outputs, ext, scope, registry, op_params)?,
+            extension_reqs: self.extensions.clone(),
+        };
+
+        let poly_func = PolyFuncType::new(op_params, body);
+        Ok(SignatureFunc::TypeScheme(CustomValidator::from_polyfunc(
+            poly_func,
+        )))
+    }
+
+    /// Create a type row from a list of port declarations.
+    fn make_type_row(
+        &self,
+        v: &[SignaturePortDeclaration],
+        ext: &Extension,
+        scope: &ExtensionSet,
+        registry: &ExtensionRegistry,
+        op_params: &[TypeParam],
+    ) -> Result<TypeRow, ExtensionDeclarationError> {
+        let types = v
+            .iter()
+            .map(|port_decl| port_decl.make_types(ext, scope, registry, op_params))
+            .flatten_ok()
+            .collect::<Result<Vec<Type>, _>>()?;
+        Ok(types.into())
+    }
+}
+
+/// A declarative definition for a number of ports in a signature's input or output.
+///
+/// Serialized as a 2 or 3-element list, where:
+/// - The first element is an optional human-readable name of the port.
+/// - The second element is the port type id.
+/// - The optional third element is either:
+///     - A number, indicating a repetition of the port that amount of times.
+///     - A parameter identifier, to use as the repetition number.
+///     - Nothing, in which case we default to a single repetition.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct SignaturePortDeclaration {
+    /// The description of the ports. May be `null`.
+    description: Option<String>,
+    /// The type for the port.
+    type_decl: TypeDeclaration,
+    /// The number of repetitions for this port definition.
+    repeat: PortRepetitionDeclaration,
+}
+
+impl SignaturePortDeclaration {
+    /// Return an iterator with the types for this port declaration.
+    ///
+    /// Only a fixed number of repetitions is supported for now.
+    ///
+    /// TODO: We may need to use custom signature functions if `repeat` depends on a variable.
+    fn make_types(
+        &self,
+        ext: &Extension,
+        scope: &ExtensionSet,
+        registry: &ExtensionRegistry,
+        op_params: &[TypeParam],
+    ) -> Result<impl Iterator<Item = Type>, ExtensionDeclarationError> {
+        let n: usize = match &self.repeat {
+            PortRepetitionDeclaration::Count(n) => *n,
+            PortRepetitionDeclaration::Parameter(parametric_repetition) => {
+                return Err(ExtensionDeclarationError::UnsupportedPortRepetition {
+                    ext: ext.name().clone(),
+                    parametric_repetition: parametric_repetition.clone(),
+                })
+            }
+        };
+
+        let ty = self.type_decl.make_type(ext, scope, registry, op_params)?;
+        let ty = Type::new_extension(ty);
+
+        Ok(itertools::repeat_n(ty, n))
+    }
+}
+
+impl Serialize for SignaturePortDeclaration {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let len = if is_default(&self.repeat) { 2 } else { 3 };
+        let mut seq = serializer.serialize_seq(Some(len))?;
+        seq.serialize_element(&self.description)?;
+        seq.serialize_element(&self.type_decl)?;
+        if !is_default(&self.repeat) {
+            seq.serialize_element(&self.repeat)?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for SignaturePortDeclaration {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct TypeParamVisitor;
+        const EXPECTED_MSG: &str = "a 2-element list containing a type parameter name and id";
+
+        impl<'de> serde::de::Visitor<'de> for TypeParamVisitor {
+            type Value = SignaturePortDeclaration;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(EXPECTED_MSG)
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let description = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &EXPECTED_MSG))?;
+                let type_decl = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &EXPECTED_MSG))?;
+                let repeat = seq.next_element()?.unwrap_or_default();
+                Ok(SignaturePortDeclaration {
+                    description,
+                    type_decl,
+                    repeat,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(TypeParamVisitor)
+    }
+}
+
+/// A number of repetitions for a signature's port definition.
+///
+/// This value may be either:
+/// - A number, indicating a repetition of the port that amount of times.
+/// - A parameter identifier, to use as the repetition number.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum PortRepetitionDeclaration {
+    /// A constant number of repetitions for the port definition.
+    Count(usize),
+    /// An (integer) operation parameter identifier to use as the number of repetitions.
+    Parameter(SmolStr),
+}
+
+impl Default for PortRepetitionDeclaration {
+    fn default() -> Self {
+        PortRepetitionDeclaration::Count(1)
+    }
+}
+
+/// A type declaration used in signatures.
+///
+/// TODO: The spec definition is more complex than just a type identifier,
+/// we should be able to support expressions like:
+///
+/// - `Q`
+/// - `Array<i>(Array<j>(F64))`
+/// - `Function[r](USize -> USize)`
+/// - `Opaque(complex_matrix,i,j)`
+///
+/// Note that `Q` is not the name used for a qubit in the prelude.
+///
+/// For now, we just hard-code some basic types.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+struct TypeDeclaration(
+    /// The encoded type description.
+    String,
+);
+
+impl TypeDeclaration {
+    /// Parse the type represented by this declaration.
+    ///
+    /// Currently hard-codes some basic types.
+    ///
+    /// TODO: Support arbitrary types.
+    /// TODO: Support parametric types.
+    pub fn make_type(
+        &self,
+        ext: &Extension,
+        scope: &ExtensionSet,
+        registry: &ExtensionRegistry,
+        _op_params: &[TypeParam],
+    ) -> Result<CustomType, ExtensionDeclarationError> {
+        if !scope.contains(&PRELUDE_ID) {
+            return Err(ExtensionDeclarationError::NoPreludeInScope {
+                ext: ext.name().clone(),
+            });
+        }
+
+        // Only hard-coded prelude types are supported for now.
+        let prelude = registry.get(&PRELUDE_ID).unwrap();
+        let op_def: &TypeDef = match self.0.as_str() {
+            "USize" => prelude.get_type("usize"),
+            "Q" => prelude.get_type("qubit"),
+            _ => {
+                return Err(ExtensionDeclarationError::UnknownType {
+                    ext: ext.name().clone(),
+                    ty: self.0.clone(),
+                })
+            }
+        }
+        .ok_or(ExtensionDeclarationError::UnknownType {
+            ext: ext.name().clone(),
+            ty: self.0.clone(),
+        })?;
+
+        // The hard-coded types are not parametric.
+        assert!(op_def.params().is_empty());
+        let op = op_def.instantiate(&[]).unwrap();
+
+        Ok(op)
+    }
+}

--- a/src/extension/declarative/signature.rs
+++ b/src/extension/declarative/signature.rs
@@ -225,11 +225,8 @@ impl TypeDeclaration {
         registry: &ExtensionRegistry,
         _op_params: &[TypeParam],
     ) -> Result<CustomType, ExtensionDeclarationError> {
-        if !scope.contains(&PRELUDE_ID) {
-            return Err(ExtensionDeclarationError::NoPreludeInScope {
-                ext: ext.name().clone(),
-            });
-        }
+        // The prelude is always in scope.
+        debug_assert!(scope.contains(&PRELUDE_ID));
 
         // Only hard-coded prelude types are supported for now.
         let prelude = registry.get(&PRELUDE_ID).unwrap();

--- a/src/extension/declarative/types.rs
+++ b/src/extension/declarative/types.rs
@@ -102,6 +102,7 @@ impl From<TypeDefBoundDeclaration> for TypeDefBound {
 ///
 /// Either a type, or a 2-element list containing a human-readable name and a type id.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 enum TypeParamDeclaration {
     /// Just the type id.
     Type(TypeName),

--- a/src/extension/declarative/types.rs
+++ b/src/extension/declarative/types.rs
@@ -1,0 +1,123 @@
+//! Declarative type definitions.
+//!
+//! This module defines a YAML schema for defining types in a declarative way.
+//!
+//! See the [specification] and [`ExtensionSetDeclaration`] for more details.
+//!
+//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
+//! [`ExtensionSetDeclaration`]: super::ExtensionSetDeclaration
+
+use crate::types::TypeBound;
+
+use super::ExtensionId;
+
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Serialize};
+
+/// A declarative type definition.
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+pub(super) struct TypeDeclaration {
+    /// The name of the type.
+    name: String,
+    /// The [`TypeBound`] describing what can be done to instances of this type.
+    /// Options are `Eq`, `Copyable`, or `Any`.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    bound: TypeBoundDeclaration,
+    /// A list of type parameters for this type.
+    ///
+    /// Each element in the list is a 2-element list, where the first element is
+    /// the human-readable name of the type parameter, and the second element is
+    /// the type id.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::utils::is_default")]
+    params: Vec<TypeParamDeclaration>,
+}
+
+/// A declarative TypeBound definition.
+///
+/// Equivalent to [`TypeBound`]. Provides human-friendly serialized names for the
+/// type bounds, using their full names.
+#[derive(
+    Debug, Copy, Clone, Serialize, Deserialize, Hash, PartialEq, Eq, Default, derive_more::Display,
+)]
+enum TypeBoundDeclaration {
+    /// The equality operation is valid on this type.
+    Eq,
+    /// The type can be copied in the program.
+    Copyable,
+    /// No bound on the type.
+    #[default]
+    Any,
+}
+
+impl From<TypeBoundDeclaration> for TypeBound {
+    fn from(bound: TypeBoundDeclaration) -> Self {
+        match bound {
+            TypeBoundDeclaration::Eq => Self::Eq,
+            TypeBoundDeclaration::Copyable => Self::Copyable,
+            TypeBoundDeclaration::Any => Self::Any,
+        }
+    }
+}
+
+impl From<TypeBound> for TypeBoundDeclaration {
+    fn from(bound: TypeBound) -> Self {
+        match bound {
+            TypeBound::Eq => Self::Eq,
+            TypeBound::Copyable => Self::Copyable,
+            TypeBound::Any => Self::Any,
+        }
+    }
+}
+
+/// A declarative type parameter definition.
+///
+/// Serialized as a 2-element list, where the first element is the human-readable name of the type parameter,
+/// and the second element is the type id.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct TypeParamDeclaration {
+    /// The name of the parameter.
+    name: String,
+    /// The parameter type.
+    id: ExtensionId,
+}
+
+impl Serialize for TypeParamDeclaration {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(2))?;
+        seq.serialize_element(&self.name)?;
+        seq.serialize_element(&self.id)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for TypeParamDeclaration {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct TypeParamVisitor;
+        const EXPECTED_MSG: &str = "a 2-element list containing a type parameter name and id";
+
+        impl<'de> serde::de::Visitor<'de> for TypeParamVisitor {
+            type Value = TypeParamDeclaration;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(EXPECTED_MSG)
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let name = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &EXPECTED_MSG))?;
+                let id = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &EXPECTED_MSG))?;
+                Ok(TypeParamDeclaration { name, id })
+            }
+        }
+
+        deserializer.deserialize_seq(TypeParamVisitor)
+    }
+}

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -446,28 +446,12 @@ impl Extension {
         description: String,
         signature_func: impl Into<SignatureFunc>,
     ) -> Result<&mut OpDef, ExtensionBuildError> {
-        self.add_op_with_misc(name, description, signature_func, Default::default())
-    }
-
-    /// Add an operation definition to the extension. Must be a type scheme
-    /// (defined by a [`PolyFuncType`]), a type scheme along with binary
-    /// validation for type arguments ([`CustomValidator`]), or a custom binary
-    /// function for computing the signature given type arguments (`impl [CustomSignatureFunc]`).
-    ///
-    /// Includes a `misc` field for additional data that can be associated with the operation.
-    pub fn add_op_with_misc(
-        &mut self,
-        name: SmolStr,
-        description: String,
-        signature_func: impl Into<SignatureFunc>,
-        misc: HashMap<String, serde_yaml::Value>,
-    ) -> Result<&mut OpDef, ExtensionBuildError> {
         let op = OpDef {
             extension: self.name.clone(),
             name,
             description,
             signature_func: signature_func.into(),
-            misc,
+            misc: Default::default(),
             lower_funcs: Default::default(),
             constant_folder: Default::default(),
         };

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -446,12 +446,28 @@ impl Extension {
         description: String,
         signature_func: impl Into<SignatureFunc>,
     ) -> Result<&mut OpDef, ExtensionBuildError> {
+        self.add_op_with_misc(name, description, signature_func, Default::default())
+    }
+
+    /// Add an operation definition to the extension. Must be a type scheme
+    /// (defined by a [`PolyFuncType`]), a type scheme along with binary
+    /// validation for type arguments ([`CustomValidator`]), or a custom binary
+    /// function for computing the signature given type arguments (`impl [CustomSignatureFunc]`).
+    ///
+    /// Includes a `misc` field for additional data that can be associated with the operation.
+    pub fn add_op_with_misc(
+        &mut self,
+        name: SmolStr,
+        description: String,
+        signature_func: impl Into<SignatureFunc>,
+        misc: HashMap<String, serde_yaml::Value>,
+    ) -> Result<&mut OpDef, ExtensionBuildError> {
         let op = OpDef {
             extension: self.name.clone(),
             name,
             description,
             signature_func: signature_func.into(),
-            misc: Default::default(),
+            misc,
             lower_funcs: Default::default(),
             constant_folder: Default::default(),
         };

--- a/src/extension/type_def.rs
+++ b/src/extension/type_def.rs
@@ -3,13 +3,11 @@ use std::collections::hash_map::Entry;
 use super::{CustomConcrete, ExtensionBuildError};
 use super::{Extension, ExtensionId, SignatureError, TypeParametrised};
 
-use crate::types::{least_upper_bound, CustomType};
+use crate::types::{least_upper_bound, CustomType, TypeName};
 
 use crate::types::type_param::TypeArg;
 
 use crate::types::type_param::TypeParam;
-
-use smol_str::SmolStr;
 
 use crate::types::TypeBound;
 
@@ -36,7 +34,7 @@ pub struct TypeDef {
     /// The unique Extension owning this TypeDef (of which this TypeDef is a member)
     extension: ExtensionId,
     /// The unique name of the type
-    name: SmolStr,
+    name: TypeName,
     /// Declaration of type parameters. The TypeDef must be instantiated
     /// with the same number of [`TypeArg`]'s to make an actual type.
     ///
@@ -133,7 +131,7 @@ impl TypeParametrised for TypeDef {
         &self.params
     }
 
-    fn name(&self) -> &SmolStr {
+    fn name(&self) -> &TypeName {
         &self.name
     }
 
@@ -146,7 +144,7 @@ impl Extension {
     /// Add an exported type to the extension.
     pub fn add_type(
         &mut self,
-        name: SmolStr,
+        name: TypeName,
         params: Vec<TypeParam>,
         description: String,
         bound: TypeDefBound,

--- a/src/extension/type_def.rs
+++ b/src/extension/type_def.rs
@@ -181,7 +181,7 @@ mod test {
                 b: TypeBound::Copyable,
             }],
             extension: "MyRsrc".try_into().unwrap(),
-            description: "Some parameterised type".into(),
+            description: "Some parametrised type".into(),
             bound: TypeDefBound::FromParams(vec![0]),
         };
         let typ = Type::new_extension(

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,6 +12,7 @@ pub use check::{ConstTypeError, CustomCheckFailure};
 pub use custom::CustomType;
 pub use poly_func::PolyFuncType;
 pub use signature::FunctionType;
+use smol_str::SmolStr;
 pub use type_param::TypeArg;
 pub use type_row::TypeRow;
 
@@ -25,6 +26,9 @@ use crate::type_row;
 use std::fmt::Debug;
 
 use self::type_param::TypeParam;
+
+/// A unique identifier for a type.
+pub type TypeName = SmolStr;
 
 /// The kinds of edges in a HUGR, excluding Hierarchy.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -1,11 +1,11 @@
 //! Opaque types, used to represent a user-defined [`Type`].
 //!
 //! [`Type`]: super::Type
-use smol_str::SmolStr;
 use std::fmt::{self, Display};
 
 use crate::extension::{ExtensionId, ExtensionRegistry, SignatureError, TypeDef};
 
+use super::TypeName;
 use super::{
     type_param::{TypeArg, TypeParam},
     Substitution, TypeBound,
@@ -19,7 +19,7 @@ pub struct CustomType {
     /// Same as the corresponding [`TypeDef`]
     ///
     /// [`TypeDef`]: crate::extension::TypeDef
-    id: SmolStr,
+    id: TypeName,
     /// Arguments that fit the [`TypeParam`]s declared by the typedef
     ///
     /// [`TypeParam`]: super::type_param::TypeParam
@@ -31,7 +31,7 @@ pub struct CustomType {
 impl CustomType {
     /// Creates a new opaque type.
     pub fn new(
-        id: impl Into<SmolStr>,
+        id: impl Into<TypeName>,
         args: impl Into<Vec<TypeArg>>,
         extension: ExtensionId,
         bound: TypeBound,
@@ -45,7 +45,7 @@ impl CustomType {
     }
 
     /// Creates a new opaque type (constant version, no type arguments)
-    pub const fn new_simple(id: SmolStr, extension: ExtensionId, bound: TypeBound) -> Self {
+    pub const fn new_simple(id: TypeName, extension: ExtensionId, bound: TypeBound) -> Self {
         Self {
             id,
             args: vec![],
@@ -107,7 +107,7 @@ impl CustomType {
     }
 
     /// unique name of the type.
-    pub fn name(&self) -> &SmolStr {
+    pub fn name(&self) -> &TypeName {
         &self.id
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,6 +27,23 @@ pub fn collect_array<const N: usize, T: Debug>(arr: &[T]) -> [&T; N] {
     arr.iter().collect_vec().try_into().unwrap()
 }
 
+/// Helper method to skip serialization of default values in serde.
+///
+/// ```ignore
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct MyStruct {
+///     #[serde(skip_serializing_if = "crate::utils::is_default")]
+///     field: i32,
+/// }
+/// ```
+///
+/// From https://github.com/serde-rs/serde/issues/818.
+pub(crate) fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    *t == Default::default()
+}
+
 #[cfg(test)]
 pub(crate) mod test_quantum_extension {
     use smol_str::SmolStr;


### PR DESCRIPTION
This PR add a method `hugr::extensions::declarative::load_extensions` that dynamically loads a set of extensions defined as YAML onto a registry.

The code is mostly comprised of struct definitions to match the human-readable serialisation format described in the spec, and some methods to translate them into the internal hugr definitions.

There's a myriad of TODOs that should be addressed in future PRs, including:
- Most parametric things (operations, type bounds, number of ports in a signature, ...).
- Lowering functions, operations with non explicit signatures.
- Resolving the signature types.
  - The syntax for describing these is not defined in the spec, so currently there's just a couple of basic hard-coded types used for testing: "Q" and "USize".
  
Here's an example of a supported definition:
```yaml
imports: [prelude]

extensions:
- name: SimpleExt
  types:
  - name: MyType
    description: A simple type with no parameters
  operations:
  - name: MyOperation
    description: A simple operation with no inputs nor outputs
    signature:
      inputs: []
      outputs: []
  - name: AnotherOperation
    description: An operation from 2 qubits to 2 qubits
    signature:
        inputs: [["Target", Q], ["Control", Q, 1]]
        outputs: [[null, Q, 2]]
```