### PR TITLE
chore: Fix crates.io category capitalization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/hugr/"
 repository = "https://github.com/CQCL/hugr"
 description = "Quantinuum's Hierarchical Unified Graph Representation"
 keywords = ["Quantum", "Quantinuum"]
-categories = ["Compilers"]
+categories = ["compilers"]
 
 [lib]
 # Using different names for the lib and for the package is supported, but may be confusing.


### PR DESCRIPTION
From the `cargo-release` log:
```
warning: the following are not valid category slugs and were ignored: Compilers.
Please see https://crates.io/category_slugs for the list of all category slugs. 
```

The category should be in [lower-case](https://crates.io/category_slugs).