### PR TITLE
feat: Arbitrary types in the yaml extension definition

### DIFF
--- a/examples/extension/declarative.yaml
+++ b/examples/extension/declarative.yaml
@@ -7,7 +7,7 @@ extensions:
     types:
       - # Types must have a name.
         # Parameters are not currently supported.
-        name: Copyable type
+        name: CopyableType
         description: A simple type with no parameters
         # Types may have a "Eq", "Copyable", or "Any" bound.
         # This field is optional and defaults to "Any".
@@ -29,3 +29,8 @@ extensions:
               [Q, 1]
             - # Or as a description, followed by the type and a number of repetitions.
               [Control, Q, 2]
+      - name: YetAnotherOperation
+        description: An operation that uses the declared Custom type
+        signature:
+          inputs: [CopyableType]
+          outputs: [CopyableType, CopyableType]

--- a/src/extension/declarative.rs
+++ b/src/extension/declarative.rs
@@ -12,6 +12,16 @@
 #![doc = include_str!("../../examples/extension/declarative.yaml")]
 //! ```
 //!
+//! The definition can be loaded into a registry using the [`load_extensions`] or [`load_extensions_file`] functions.
+//!
+//! ```rust
+//! # const DECLARATIVE_YAML: &str = include_str!("../../examples/extension/declarative.yaml");
+//! # use hugr::extension::declarative::load_extensions;
+//! // Required extensions must already be present in the registry.
+//! let mut reg = hugr::std_extensions::logic::LOGIC_REG.clone();
+//! load_extensions(DECLARATIVE_YAML, &mut reg).unwrap();
+//! ```
+//!
 //! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
 
 mod ops;
@@ -290,8 +300,8 @@ extensions:
   - name: AnotherOperation
     description: An operation from 3 qubits to 3 qubits
     signature:
-        inputs: [Q, Q, Q]
-        outputs: [[Q, 1], [Control, Q, 2]]
+        inputs: [MyType, Q, Q]
+        outputs: [[MyType, 1], [Control, Q, 2]]
 "#;
 
     /// A yaml extension with unsupported features.
@@ -347,7 +357,7 @@ extensions:
 
     #[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
     #[rstest]
-    #[case(EXAMPLE_YAML_FILE, 1, 1, 2, &std_extensions::logic::LOGIC_REG)]
+    #[case(EXAMPLE_YAML_FILE, 1, 1, 3, &std_extensions::logic::LOGIC_REG)]
     fn test_decode_file(
         #[case] yaml_file: &str,
         #[case] num_declarations: usize,

--- a/src/extension/declarative/signature.rs
+++ b/src/extension/declarative/signature.rs
@@ -174,10 +174,7 @@ impl TypeDeclaration {
         ctx: DeclarationContext<'_>,
         _op_params: &[TypeParam],
     ) -> Result<CustomType, ExtensionDeclarationError> {
-        // The prelude is always in scope.
-        debug_assert!(ctx.scope.contains(&PRELUDE_ID));
-
-        let Some(op_def) = self.resolve_type(ext, ctx) else {
+        let Some(type_def) = self.resolve_type(ext, ctx) else {
             return Err(ExtensionDeclarationError::UnknownType {
                 ext: ext.name().clone(),
                 ty: self.0.clone(),
@@ -185,8 +182,8 @@ impl TypeDeclaration {
         };
 
         // The hard-coded types are not parametric.
-        assert!(op_def.params().is_empty());
-        let op = op_def.instantiate(&[]).unwrap();
+        assert!(type_def.params().is_empty());
+        let op = type_def.instantiate(&[]).unwrap();
 
         Ok(op)
     }


### PR DESCRIPTION
The current yaml extension definitions only support hard-coded types in the operation signatures.

This PR leaves the existing `Q` and `USize` hardcoded values, but tries to dereference the type name from the extensions in scopes otherwise.

drive-by: Extend the module doc with an example on how to load the extension.