### PR TITLE
docs: HUGR spec copyediting

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1896,7 +1896,7 @@ Conversions between integers and floats:
         true.
   - We *could* parse a CFG into a DSG with only Conditional-nodes and
     TailLoop-nodes by introducing extra variables, as per [Google
-    paper](https://dl.acm.org/doi/pdf/10.1145/2693261), and then expect
+    paper](https://doi.org/10.1145/2693261), and then expect
     LLVM to remove those extra variables later. However that's a
     significant amount of analysis and transformation, which is
     undesirable for using the HUGR as a common interchange format (e.g.
@@ -1918,13 +1918,13 @@ e.g. for authors of "rewrite rules" and other optimisations.
 
 #### **Alternative representations considered but rejected**
 
-  - A [Google paper](https://dl.acm.org/doi/pdf/10.1145/2693261) allows
+  - A [Google paper](https://doi.org/10.1145/2693261) allows
     for the introduction of extra variables into the DSG that can be
     eliminated at compile-time (ensuring no runtime cost), but only if
     stringent well-formedness conditions are maintained on the DSG, and
     there are issues with variable liveness.
   - [Lawrence's
-    thesis](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-705.pdf)
+    thesis](https://doi.org/10.48456/tr-705)
     handles some cases (e.g. shortcircuit evaluation) but cannot handle
     arbitrary (even reducible) control flow and the multi-stage approach
     makes it hard to see what amount of code duplication will be

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1597,7 +1597,7 @@ crate. A base PortGraph is composed with hierarchy (as an alternate
 implementation of `Hierarchy` relationships) and weight components. The
 implementation of this design document is available on GitHub.
 
-<https://github.com/CQCL-DEV/hugr>
+<https://github.com/CQCL/hugr>
 
 ## Standard Library
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1,6 +1,6 @@
 # HUGR design document
 
-The Hierarchical Unified Graph Representation (HUGR, pronounced *hugger* 
+The Hierarchical Unified Graph Representation (HUGR, pronounced *hugger*
 🫂) is a proposed new
 common internal representation used across TKET2, Tierkreis, and the L3
 compiler. The HUGR project aims to give a faithful representation of
@@ -182,7 +182,7 @@ them.
 
 A `Value` edge represents dataflow that happens at runtime - i.e. the
 source of the edge will, at runtime, produce a value that is consumed by
-the edge’s target. Value edges are from an outgoing port of the
+the edge's target. Value edges are from an outgoing port of the
 source node, to an incoming port of the target node.
 
 #### `Static` edges
@@ -255,7 +255,7 @@ no `FuncDecl/AliasDecl` nodes.
 
 An **executable HUGR** or **executable module** is a loadable HUGR where the
 root Module node has a `FuncDefn` child with function name
-“main”, that is the designated entry point. Modules that act as libraries need
+"main", that is the designated entry point. Modules that act as libraries need
 not be executable.
 
 #### Dataflow
@@ -285,7 +285,7 @@ the following basic dataflow operations are available (in addition to the
     These nodes are parents in the hierarchy.
     The signature of the operation comprises the output signature of the child
     Input node (as input) and the input signature of the child Output node (as
-    output). 
+    output).
   - `OpaqueOp`: an operation defined by an [Extension](#extension-system).
 
 The example below shows two DFGs, one nested within the other. Each has an Input
@@ -336,7 +336,7 @@ outputs of the Conditional; that child is evaluated, but the others are
 not. That is, Conditional-nodes act as "if-then-else" followed by a
 control-flow merge.
 
-A **TupleSum(T0, T1…TN)** type is an algebraic “sum of products” type,
+A **TupleSum(T0, T1…TN)** type is an algebraic "sum of products" type,
 defined as `Sum(Tuple(#T0), Tuple(#T1), ...Tuple(#Tn))` (see [type
 system](#type-system)), where `#Ti` is the *i*th row (sequence of types) defining it.
 
@@ -486,7 +486,7 @@ flowchart
 #### Hierarchical Relationships and Constraints
 
 To clarify the possible hierarchical relationships, using the operation
-definitions above and also defining “*O”* to be all non-nested dataflow
+definitions above and also defining "*O"* to be all non-nested dataflow
 operations, we can define the relationships in the following table.
 **D** and **C** are useful (and intersecting) groupings of operations:
 dataflow nodes and the nodes which contain them. The "Parent" column in the
@@ -608,7 +608,7 @@ allocation, as that representation makes storage explicit. For example,
 when a true/false subgraph of a Conditional-node wants a value from the
 outside, we add an outgoing port to the Input node of each subgraph, a
 corresponding incoming port to the Conditional-node, and discard nodes to each
-subgraph that doesn’t use the value. It is straightforward to turn an
+subgraph that doesn't use the value. It is straightforward to turn an
 edge between graphs into a combination of intra-graph edges and extra
 input/output ports+nodes in such a way, but this is akin to
 decompression.
@@ -743,7 +743,7 @@ structures.
 
 For each node, the metadata is a dictionary keyed by strings. Keys are
 used to identify applications or users so these do not (accidentally)
-interfere with each other’s metadata; for example a reverse-DNS system
+interfere with each other's metadata; for example a reverse-DNS system
 (`com.quantinuum.username....` or `com.quantinuum.tket....`). The values
 are tuples of (1) any serializable struct, and (2) a list of node
 indices. References from the serialized struct to other nodes should
@@ -793,7 +793,7 @@ The Hugr defines a number of type constructors, that can be instantiated into ty
 
 Extensions ::= (Extension)* -- a set, not a list
 
-Type ::= Tuple(#) -- fixed-arity, heterogeneous components 
+Type ::= Tuple(#) -- fixed-arity, heterogeneous components
        | Sum(#)   -- disjoint union of other types, ??tagged by unsigned int??
        | Opaque(Name, [TypeArg]) -- a (instantiation of a) custom type defined by an extension
        | Function(TypeParams, #, #, Extensions) -- polymorphic with type parameters,
@@ -864,7 +864,7 @@ Concretely, if a plugin writer adds an extension
 *X*, then some function from
 a plugin needs to provide a mechanism to convert the
 *X* to some other extension
-requirement before it can interface with other plugins which don’t know
+requirement before it can interface with other plugins which don't know
 about *X*.
 
 A runtime could have access to means of
@@ -900,7 +900,7 @@ function from below.
 
 Note that here, any letter with vector notation refers to a variable
 which stands in for a row. Hence, when checking the inputs and outputs
-align, we’re introducing a *row equality constraint*, rather than the
+align, we're introducing a *row equality constraint*, rather than the
 equality constraint of `typeof(b) ~ Bool`.
 
 ### Rewriting Extension Requirements
@@ -955,19 +955,19 @@ docs](https://mlir.llvm.org/docs/DefiningDialects/Operations/#motivation)
 
 > MLIR allows pluggable dialects, and dialects contain, among others, a
 > list of operations. This open and extensible ecosystem leads to the
-> “stringly” type IR problem, e.g., repetitive string comparisons
+> "stringly" type IR problem, e.g., repetitive string comparisons
 > during optimization and analysis passes, unintuitive accessor methods
-> (e.g., generic/error prone `getOperand(3)` vs
-> self-documenting `getStride()`) with more generic return types,
+> (e.g., generic/error prone `getOperand(3)` vs
+> self-documenting `getStride()`) with more generic return types,
 > verbose and generic constructors without default arguments, verbose
 > textual IR dumps, and so on. Furthermore, operation verification is:
-> 
+>
 > 1\. best case: a central string-to-verification-function map
-> 
+>
 > 2\. middle case: duplication of verification across the code base, or
-> 
+>
 > 3\. worst case: no verification functions.
-> 
+>
 > The fix is to support defining ops in a table-driven manner. Then for
 > each dialect, we can have a central place that contains everything you
 > need to know about each op, including its constraints, custom assembly
@@ -1174,7 +1174,7 @@ graph under n is *convex* (DFG-convex or CFG-convex respectively) if
 every node on every path in the sibling graph that starts and ends in S
 is itself in S.
 
-The meaning of “convex” is: if A and B are nodes in the convex set S,
+The meaning of "convex" is: if A and B are nodes in the convex set S,
 then any sibling node on a path from A to B is also in S.
 
 #### API methods
@@ -1212,9 +1212,9 @@ The method takes as input:
       * $\textrm{out}_H(T \setminus \\{\texttt{Output}\\})$ is just the input ports to the $\texttt{Output}$ node (their source must all be in $H$)
       * in order to produce a valid hugr, all keys $\textrm{out}_{\Gamma}(S)$ must be present
       * ...and each possible value must be either Copyable and/or present exactly once. Any that is absent could just be omitted from $H$....
-  
+
 The new hugr is then derived as follows:
-  
+
   1. Make a copy in $\Gamma$ of all children of $R$, excluding Input and Output,
      and all edges between them. Make all the newly added nodes children of $P$.
      Notation: for each port $p$ of a node in $R$ of which a copy is made, write
@@ -1422,8 +1422,8 @@ containers. This simplifies the API, and is not a serious restriction
 since we can use the outlining and inlining methods to target a group of
 nodes.
 
-The most basic case – replacing a convex set of Op nodes in a DSG with
-another graph of Op nodes having the same signature – is implemented by
+The most basic case -- replacing a convex set of Op nodes in a DSG with
+another graph of Op nodes having the same signature -- is implemented by
 `SimpleReplace`.
 
 If one of the nodes in the region is a complex container node that we
@@ -1431,17 +1431,17 @@ wish to preserve in the replacement without doing a deep copy, we can
 use an empty node in the replacement and have B map this node to the old
 one.
 
-We can, for example, implement “turning a Conditional-node with known
-TupleSum into a DFG-node” by a `Replace` where the Conditional (and its
+We can, for example, implement "turning a Conditional-node with known
+TupleSum into a DFG-node" by a `Replace` where the Conditional (and its
 preceding TupleSum) is replaced by an empty DFG and the map B specifies
-the “good” child of the Conditional as the surrogate parent of the new
-DFG’s children. (If the good child was just an Op, we could either
-remove it and include it in the replacement, or – to avoid this overhead
-– outline it in a DFG first.)
+the "good" child of the Conditional as the surrogate parent of the new
+DFG's children. (If the good child was just an Op, we could either
+remove it and include it in the replacement, or -- to avoid this overhead
+-- outline it in a DFG first.)
 
 Similarly, replacement of a CFG node having a single BasicBlock child
 with a DFG node can be achieved using `Replace` (specifying the
-BasicBlock node as the surrogate parent for the new DFG’s children).
+BasicBlock node as the surrogate parent for the new DFG's children).
 
 Arbitrary node insertion on dataflow edges can be achieved using
 `InsertIdentity` followed by `Replace`. Removal of a node in a DSG
@@ -1547,7 +1547,7 @@ pseudocode, though we advocate MessagePack format in practice (see
 [Serialization implementation](schema/serialization.md)).
 Note in particular that hierarchical relationships
 have a special encoding outside `edges`, as a field `parent`
-in a node definition. 
+in a node definition.
 The unique root node of the HUGR reports itself as the parent.
 
 The other required field in a node is `op` which identifies an operation by
@@ -1822,7 +1822,7 @@ Conversions between integers and floats:
     function exists but without giving a definition. May be the source
     of Static-edges to Call nodes and others.
   - **FuncDefn node**: child of a module node, defines a function (by being
-    parent to the function’s body). May be the source of Static-edges to
+    parent to the function's body). May be the source of Static-edges to
     Call nodes and others.
   - **DFG node**: A node representing a data-flow graph. Its children
     are all data-dependency nodes.
@@ -1897,12 +1897,12 @@ Conversions between integers and floats:
   - We *could* parse a CFG into a DSG with only Conditional-nodes and
     TailLoop-nodes by introducing extra variables, as per [Google
     paper](https://dl.acm.org/doi/pdf/10.1145/2693261), and then expect
-    LLVM to remove those extra variables later. However that’s a
+    LLVM to remove those extra variables later. However that's a
     significant amount of analysis and transformation, which is
     undesirable for using the HUGR as a common interchange format (e.g.
     QIR → HUGR → LLVM) when little optimization is being done (perhaps
     no cross-basic-block optimization).
-  - It’s possible that maintaining support for CFGs-nodes may become a
+  - It's possible that maintaining support for CFGs-nodes may become a
     burden, i.e. if we find we are not using CFGs much. However, I
     believe that this burden can be kept acceptably low if we are
     willing to drop support for rewriting across basic block boundaries,
@@ -1944,8 +1944,8 @@ e.g. for authors of "rewrite rules" and other optimisations.
 
 ##### Comparison with MLIR
 
-There are a lot of broad similarities here, with MLIR’s regions
-providing hierarchy, and “graph” regions being like DSGs. Significant
+There are a lot of broad similarities here, with MLIR's regions
+providing hierarchy, and "graph" regions being like DSGs. Significant
 differences include:
 
   - MLIR uses names everywhere, which internally are mapped to some kind
@@ -1954,12 +1954,12 @@ differences include:
         SSA/SSI name.
       - MLIR does not do linearity or SSI.
   - Our CFGs are Single Entry Single Exit (results defined by the output
-    node of the exit block), rather than MLIR’s Single Entry Multiple
+    node of the exit block), rather than MLIR's Single Entry Multiple
     Exit (with `return` instruction)
   - MLIR allows multiple regions inside a single operation, whereas we
     introduce extra levels of hierarchy to allow this.
   - I note re. closures that MLIR expects the enclosing scope to make
-    sure any referenced values are kept ‘live’ for long enough. Not what
+    sure any referenced values are kept 'live' for long enough. Not what
     we do in Tierkreis (the closure-maker copies them)\!
 
 ### Appendix 2: Node types and their edges
@@ -1974,7 +1974,7 @@ The "Root" row of the table applies to whichever node is the HUGR root,
 including `Module`.
 
 | Node type      | `Value` | `Order` | `Static` | `ControlFlow` | `Hierarchy` | Children |
-| -------------- | ------- | ------- |--------- | ------------- | ----------- | -------- | 
+| -------------- | ------- | ------- |--------- | ------------- | ----------- | -------- |
 | Root           | 0, 0    | 0, 0    | 0, 0     | 0, 0          | 0, ✱        |          |
 | `FuncDefn`          | 0, 0    | 0, 0    | 0, ✱     | 0, 0          | 1, +        | DSG      |
 | `FuncDecl`      | 0, 0    | 0, 0    | 0, ✱     | 0, 0          | 1, 0        |          |
@@ -1990,7 +1990,7 @@ including `Module`.
 | `CFG`          | ✱, ✱    | ✱, ✱    | 0, 0     | 0, 0          | 1, +        | CSG      |
 | `DFB`          | 0, 0    | 0, 0    | 0, 0     | ✱, ✱          | 1, +        | DSG      |
 | `Exit`         | 0, 0    | 0, 0    | 0, 0     | +, 0          | 1, 0        |          |
-| `TailLoop`     | ✱, ✱    | ✱, ✱    | 0, 0     | 0, 0          | 1, +        | DSG      | 
+| `TailLoop`     | ✱, ✱    | ✱, ✱    | 0, 0     | 0, 0          | 1, +        | DSG      |
 | `Conditional`  | ✱, ✱    | ✱, ✱    | 0, 0     | 0, 0          | 1, +        | `Case`   |
 | `Case`         | 0, 0    | 0, 0    | 0, 0     | 0, 0          | 1, +        | DSG      |
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -75,8 +75,8 @@ represent (typed) data or control dependencies.
 
 ## Functional description
 
-A HUGR is a directed graph. There are several different types of nodes, and
-several different types of edges, with different semantics, described below.
+A HUGR is a directed graph. There are several different types of node, and
+several different types of edge, with different semantics, described below.
 
 A node usually has additional data associated with it, which we will
 refer to as its *node weight*.
@@ -213,8 +213,7 @@ always local, i.e. source and target have the same parent.
 ### Node Operations
 
 Here we define some core types of operation required to represent
-full programs, including dataflow operations (in
-[functions](#dataflow)).
+full programs, including [dataflow operations](#dataflow).
 
 #### Module
 
@@ -771,23 +770,23 @@ indices after the list of node indices?
 
 ## Type System
 
-There are three classes of type: ``AnyType`` $\supset$ ``CopyableType`` $\supset$ ``EqType``. Types in these classes are distinguished by the operations possible on (runtime) values of those types:
+There are three classes of type: `AnyType` $\supset$ `CopyableType` $\supset$ `EqType`. Types in these classes are distinguished by the operations possible on (runtime) values of those types:
 
-- For the broadest class (``AnyType``), the only operation supported is the identity operation (aka no-op, or `lift` - see [Extension Tracking](#extension-tracking) below). Specifically, we do not require it to be possible to copy or discard all values, hence the requirement that outports of linear type must have exactly one edge. (That is, a type not known to be in the copyable subset). All incoming ports must have exactly one edge.
+- For the broadest class (`AnyType`), the only operation supported is the identity operation (aka no-op, or `lift` - see [Extension Tracking](#extension-tracking) below). Specifically, we do not require it to be possible to copy or discard all values, hence the requirement that outports of linear type must have exactly one edge. (That is, a type not known to be in the copyable subset). All incoming ports must have exactly one edge.
 
     In fully qubit-counted contexts programs take in a number of qubits as input and return the same number, with no discarding.
 
-- The next class is ``CopyableType``, i.e. types holding ordinary classical
+- The next class is `CopyableType`, i.e. types holding ordinary classical
   data, where values can be copied (and discarded, the 0-ary copy). This
   allows multiple (or 0) outgoing edges from an outport; also these types can
   be sent down `Static` edges. Note: dataflow inputs (`Value` and `Static`) always
   require a single connection.
 
-- The final class is ``EqType``: these are copyable types with a well-defined
+- The final class is `EqType`: these are copyable types with a well-defined
   notion of equality between values. (While *some* notion of equality is defined on
   any type with a binary representation, that if the bits are equal then the value is, the converse is not necessarily true - values that are indistinguishable can have different bit representations.)
 
-For example, a `float` type (defined in an extension) would be a ``CopyableType``, but not an ``EqType``.
+For example, a `float` type (defined in an extension) would be a `CopyableType`, but not an `EqType`.
 
 **Rows** The `#` is a *row* which is a sequence of zero or more types. Types in the row can optionally be given names in metadata i.e. this does not affect behaviour of the HUGR.
 
@@ -809,9 +808,9 @@ Type ::= Tuple(#) -- fixed-arity, heterogeneous components
 
 The majority of types will be Opaque ones defined by extensions including the [standard library](#standard-library). However a number of types can be constructed using only the core type constructors: for example the empty tuple type, aka `unit`, with exactly one instance (so 0 bits of data); the empty sum, with no instances; the empty Function type (taking no arguments and producing no results - `void -> void`); and compositions thereof.
 
-Types representing functions are generally ``CopyableType``, but not ``EqType``. (It is undecidable whether two functions produce the same result for all possible inputs, or similarly whether one computation graph can be rewritten into another by semantic-preserving rewrites).
+Types representing functions are generally `CopyableType`, but not `EqType`. (It is undecidable whether two functions produce the same result for all possible inputs, or similarly whether one computation graph can be rewritten into another by semantic-preserving rewrites).
 
-Tuples and Sums are ``CopyableType`` (respectively, ``EqType``) if all their components are; they are also fixed-size if their components are.
+Tuples and Sums are `CopyableType` (respectively, `EqType`) if all their components are; they are also fixed-size if their components are.
 
 ### Polymorphism
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -38,7 +38,7 @@ represent (typed) data or control dependencies.
 
 - Translations to other representations. While the HUGR should be able
   to encode programs in languages such as QIR, the translation should
-  be implemented by separately.
+  be implemented separately.
 - Execution, or any kind of interpretation of the program. The HUGR
   describes the graph representation and control flow, without fixing
   the semantics of any extension operations defined outside the core
@@ -53,8 +53,9 @@ represent (typed) data or control dependencies.
   unconnected.
 - Control-flow support with ability to capture both LLVM SSACFG style
   programs and programs from future front-ends designed to target
-  HUGR. These including the upcoming Python eDSL for quantum-classical
-  programming, and BRAT (which already uses an internal graph-like
+  HUGR. These include the [guppylang](https://github.com/CQCL/guppylang)
+  Python eDSL for quantum-classical programming,
+  and BRAT (which already uses an internal graph-like
   representation for classical functional programs and quantum
   kernels). We expect that these front-ends will provide
   programmer-facing control flow constructs that map to the preferred
@@ -74,11 +75,11 @@ represent (typed) data or control dependencies.
 
 ## Functional description
 
-A HUGR is a directed graph. There are several different types of node, and
-several different types of edge, with different semantics, described below.
+A HUGR is a directed graph. There are several different types of nodes, and
+several different types of edges, with different semantics, described below.
 
 A node usually has additional data associated with it, which we will
-refer to as it's node weight.
+refer to as its *node weight*.
 
 The nodes represent
 processes that produce values - either statically, i.e. at compile time,
@@ -140,7 +141,7 @@ As well as the type, dataflow edges are also parametrized by a
 `Locality`, which declares whether the edge crosses levels in the hierarchy. See
 [Edge Locality](#edge-locality) for details.
 
-```ebnf
+```haskell
 AnyType ⊃ CopyableType
 
 EdgeKind ::= Hierarchy | Value(Locality, AnyType) | Static(Local | Ext, CopyableType) | Order | ControlFlow
@@ -718,8 +719,8 @@ flowchart
 ### Extensible metadata
 
 Each node in the HUGR may have arbitrary metadata attached to it. This
-is preserved during graph modifications, and, [when possible](##Metadata updates on replacement), copied when
-rewriting.
+is preserved during graph modifications, and,
+[when possible](#metadata-updates-on-replacement), copied when rewriting.
 Additionally the metadata may record references to other nodes; these
 references are updated along with node indices.
 
@@ -751,15 +752,15 @@ are tuples of (1) any serializable struct, and (2) a list of node
 indices. References from the serialized struct to other nodes should
 indirect through the list of node indices stored with the struct.
 
-TODO: Specify format, constraints, and serialization. Is YAML syntax
+**TODO**: Specify format, constraints, and serialization. Is YAML syntax
 appropriate?
 
 There is an API to add metadata, or extend existing metadata, or read
 existing metadata, given the node ID.
 
-TODO Examples illustrating this API.
+**TODO** Examples illustrating this API.
 
-TODO Do we want to reserve any top-level metadata keys, e.g. `Name`,
+**TODO** Do we want to reserve any top-level metadata keys, e.g. `Name`,
 `Ports` (for port metadata) or `History` (for use by the rewrite
 engine)?
 
@@ -779,7 +780,7 @@ There are three classes of type: ``AnyType`` $\supset$ ``CopyableType`` $\supset
 - The next class is ``CopyableType``, i.e. types holding ordinary classical
   data, where values can be copied (and discarded, the 0-ary copy). This
   allows multiple (or 0) outgoing edges from an outport; also these types can
-  be sent down Static edges. Note: dataflow inputs (Value and Static) always
+  be sent down `Static` edges. Note: dataflow inputs (`Value` and `Static`) always
   require a single connection.
 
 - The final class is ``EqType``: these are copyable types with a well-defined
@@ -999,7 +1000,7 @@ at runtime. In many cases this is desirable.
 To strike a balance then, every extension provides declarative structs containing
 named **TypeDef**s and **OpDef**s---see [Declarative Format](#declarative-format).
 These are (potentially polymorphic) definitions of types and operations, respectively---polymorphism arises because both may
-declare any number TypeParams (as per [Type System](#type-system)). To use a TypeDef as a type,
+declare any number of TypeParams (as per [Type System](#type-system)). To use a TypeDef as a type,
 it must be instantiated with TypeArgs appropriate for its TypeParams, and similarly
 to use an OpDef as a node operation: each `OpaqueOp` node stores a static-constant list of TypeArgs.
 
@@ -1395,7 +1396,7 @@ siblings in a DSG such that there is no path in the DSG from `n1` to
 
 Given nodes `n0` and `n1`, if there is an Order edge from `n0` to `n1`,
 remove it. (If there is an non-local edge from `n0` to a descendent of
-`n1`, this invalidates the hugr. TODO should this be an error?)
+`n1`, this invalidates the hugr. **TODO** should this be an error?)
 
 ##### Insertion and removal of const loads
 
@@ -1530,7 +1531,7 @@ of the child-rewiring lists.
 - Fast serialization/deserialization in Rust.
 - Ability to generate and consume from Python.
 - Reasonably small sized files/payloads.
-- Ability to send over wire. Myqos will need to do things like:
+- Ability to send over wire. Nexus will need to do things like:
   - Store the program in a database
   - Search the program(?) (Increasingly
     unlikely with larger more complicated programs)
@@ -1587,7 +1588,7 @@ struct Edge = ((Int, Optional<Int>), (Int, Optional<Int>))
 
 Node indices, used within the
 definitions of nodes and edges, directly correspond to indices of the
-node list. An edge is defined by the source and target nodes, and
+`nodes` list. An edge is defined by the source and target nodes, and
 optionally the offset of the output/input ports within those nodes, if the edge
 kind is one that connects to a port. This scheme
 enforces that nodes are contiguous - a node index must always point to a
@@ -1598,15 +1599,13 @@ while keeping all other indices pointing to the same node.
 ## Architecture
 
 The HUGR is implemented as a Rust crate named `quantinuum-hugr`. This
-crate is intended to be a common dependency for all projects, and is to
-be published on the <http://crates.io> registry.
+crate is intended to be a common dependency for all projects, and is published
+at the [crates.io registry](https://crates.io/crates/quantinuum-hugr).
 
 The HUGR is represented internally using structures from the `portgraph`
 crate. A base PortGraph is composed with hierarchy (as an alternate
 implementation of `Hierarchy` relationships) and weight components. The
-implementation of this design document is available on GitHub.
-
-<https://github.com/CQCL/hugr>
+implementation of this design document is [available on GitHub](https://github.com/CQCL/hugr).
 
 ## Standard Library
 
@@ -1945,7 +1944,7 @@ e.g. for authors of "rewrite rules" and other optimisations.
   the return address is the extra boolean variable, likely to be very
   cheap). However, I think this means pattern-matching will want to
   span across function-call boundaries; and it rules out using
-  non-local edges for called functions. TODO are those objections
+  non-local edges for called functions. **TODO** are those objections
   sufficient to rule this out?
 
 ##### Comparison with MLIR

--- a/specification/schema/serialization.md
+++ b/specification/schema/serialization.md
@@ -30,7 +30,7 @@ schema-related problems mentioned above.
 The highest performing target is
 [bincode](https://github.com/bincode-org/bincode), but it does not seem
 to be widely used and has poor python support. Another notable mention
-is [CBOR](https://cbor.io/), it is however not very well performing on the benchmarks.
+is [CBOR](https://cbor.io/); it is however not very well performing on the benchmarks.
 
 If we take a good balance between performance and language compatibility
 MessagePack (or [msgpack](https://msgpack.org/) ) appears to be a very
@@ -66,7 +66,6 @@ relatively simply with [Pydantic](https://docs.pydantic.dev/). This also
 brings with it Python-side schema generation and validation. As an
 example, the below fully implements serialization/deserialization of the
 spec described in the [main document](hugr.md).
-
 
 ```python
 from typing import Any

--- a/specification/schema/serialization.md
+++ b/specification/schema/serialization.md
@@ -40,7 +40,7 @@ MessagePack (or [msgpack](https://msgpack.org/) ) appears to be a very
 solid option. It has good serde support (as well as very wide language
 support in general, including a fast python package implemented in C),
 is one of the top performers on benchmarks (see also [this
-thesis](https://uh-ir.tdl.org/bitstream/handle/10657/13140/CASEY-THESIS-2022.pdf?sequence=1)),
+thesis](https://hdl.handle.net/10657/13140)),
 and has small data size. Another nice benefit is that, like CBOR, it is
 very similar to JSON when decoded, which, given that serde can easily
 let us go between JSON and msgpack, gives us human-friendly text

--- a/specification/schema/serialization.md
+++ b/specification/schema/serialization.md
@@ -1,6 +1,5 @@
- 
 
-# Options
+# Serialization Options
 
 Given most of our tooling is in Rust it is useful to narrow our search
 to options that have good [serde](https://serde.rs/) compatibility. For
@@ -31,9 +30,7 @@ schema-related problems mentioned above.
 The highest performing target is
 [bincode](https://github.com/bincode-org/bincode), but it does not seem
 to be widely used and has poor python support. Another notable mention
-is [CBOR](https://cbor.io/), ~~which is used for sending execution
-outputs over the wire by the hardware team~~ (they went with Protobuf
-instead). It is however not very well performing on the benchmarks.
+is [CBOR](https://cbor.io/), it is however not very well performing on the benchmarks.
 
 If we take a good balance between performance and language compatibility
 MessagePack (or [msgpack](https://msgpack.org/) ) appears to be a very

--- a/specification/schema/serialization.md
+++ b/specification/schema/serialization.md
@@ -58,7 +58,7 @@ Python dictionaries.
   standalone module - this could well be [a set of MLIR
   dialects](https://github.com/PennyLaneAI/catalyst/tree/main/mlir) .
 
-**Note**
+## Note
 
 One important downside of this approach, particularly in comparison with
 code-generating options like Protobuf, is that non-Rust languages (in

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -8,7 +8,7 @@
 //!  (this last condition is necessary because loop backedges do not affect (post)dominance).
 //!
 //! # Algorithm
-//! See paper: <https://dl.acm.org/doi/10.1145/773473.178258>, approximately:
+//! See paper: <https://doi.org/10.1145/178243.178258>, approximately:
 //! 1. those three conditions are equivalent to:
 //! *a and b are cycle-equivalent in the CFG with an extra edge from the exit node to the entry*
 //! where cycle-equivalent means every cycle has either both a and b, or neither

--- a/src/extension/infer/test.rs
+++ b/src/extension/infer/test.rs
@@ -869,7 +869,7 @@ fn plus_on_self() -> Result<(), Box<dyn std::error::Error>> {
     let ft = FunctionType::new_endo(type_row![QB_T, QB_T]).with_extension_delta(&delta);
     let mut dfg = DFGBuilder::new(ft.clone())?;
 
-    // While https://github.com/CQCL-DEV/hugr/issues/388 is unsolved,
+    // While https://github.com/CQCL/hugr/issues/388 is unsolved,
     // most operations have empty extension_reqs (not including their own extension).
     // Define some that do.
     let binop: LeafOp = ExternalOp::Opaque(OpaqueOp::new(

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -260,7 +260,7 @@ impl SiblingSubgraph {
                     return false;
                 }
                 // TODO: what if there are multiple outgoing edges?
-                // See https://github.com/CQCL-DEV/hugr/issues/518
+                // See https://github.com/CQCL/hugr/issues/518
                 let (in_n, _) = hugr.linked_ports(n, p).next().unwrap();
                 !nodes_set.contains(&in_n)
             })
@@ -350,7 +350,7 @@ impl SiblingSubgraph {
         }
 
         // TODO: handle state order edges. For now panic if any are present.
-        // See https://github.com/CQCL-DEV/hugr/discussions/432
+        // See https://github.com/CQCL/hugr/discussions/432
         let rep_inputs = replacement.node_outputs(rep_input).map(|p| (rep_input, p));
         let rep_outputs = replacement.node_inputs(rep_output).map(|p| (rep_output, p));
         let (rep_inputs, in_order_ports): (Vec<_>, Vec<_>) = rep_inputs.partition(|&(n, p)| {
@@ -981,7 +981,7 @@ mod tests {
 
     #[test]
     fn edge_both_output_and_copy() {
-        // https://github.com/CQCL-DEV/hugr/issues/518
+        // https://github.com/CQCL/hugr/issues/518
         let one_bit = type_row![BOOL_T];
         let two_bit = type_row![BOOL_T, BOOL_T];
 


### PR DESCRIPTION
- docs: fix hugr URLs
- docs(spec): normalize gremlins
- fix: prefer DOI/handle links over others for papers
- style: markdownlint it
- fix(spec): several edits
