### PR TITLE
docs: Add builder module docs + example

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,8 +21,9 @@
 //!
 //! # Example
 //!
-//! The following example shows how to build a simple HUGR module with a generic
-//! dataflow graph, a control flow graph, and a circuit.
+//! The following example shows how to build a simple HUGR module with two
+//! dataflow functions, one built using the `DFGBuilder` and the other using the
+//! `CircuitBuilder`.
 //!
 //! ```rust
 //! # use hugr::Hugr;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -7,15 +7,15 @@
 //!
 //! - [ModuleBuilder]: For building a module with function declarations and
 //!       definitions.
-//! - [DFGBuilder]: For building a Dataflow Graph.
+//! - [DFGBuilder]: For building a dataflow graph.
 //! - [FunctionBuilder]: A `DFGBuilder` specialised in defining functions with a
-//!       Dataflow Graph.
-//! - [CFGBuilder]: For building a Control Flow Graph.
-//! - [ConditionalBuilder]: For building a Conditional node.
-//! - [TailLoopBuilder]: For building a TailLoop node.
+//!       dataflow graph.
+//! - [CFGBuilder]: For building a control flow graph.
+//! - [ConditionalBuilder]: For building a conditional node.
+//! - [TailLoopBuilder]: For building a tail-loop node.
 //!
 //! Additionally, the [CircuitBuilder] provides an alternative to the
-//! [DFGBuilder] when working with circuits, some inputs of operations directly
+//! [DFGBuilder] when working with circuits, where some inputs of operations directly
 //! correspond to some outputs and operations can be directly appended using
 //! unit indices.
 //!
@@ -66,12 +66,12 @@
 //!         // Add multiple operations, indicating only the wire index.
 //!         circuit.append(NotOp, [0])?.append(NotOp, [1])?;
 //!
-//!         // Finish the circuit, and return the dfg after connecting its outputs.
+//!         // Finish the circuit, and return the dataflow graph after connecting its outputs.
 //!         let outputs = circuit.finish();
 //!         dfg.finish_with_outputs(outputs)
 //!     }?;
 //!
-//!     // Finish building the hugr, consuming the builder.
+//!     // Finish building the HUGR, consuming the builder.
 //!     //
 //!     // Requires a registry with all the extensions used in the module.
 //!     module_builder.finish_hugr(&LOGIC_REG)
@@ -79,7 +79,7 @@
 //!
 //! // The built HUGR is always valid.
 //! hugr.validate(&LOGIC_REG).unwrap_or_else(|e| {
-//!     panic!("Hugr validation failed: {e}");
+//!     panic!("HUGR validation failed: {e}");
 //! });
 //! # Ok(())
 //! # }

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -613,7 +613,7 @@ pub trait Dataflow: Container {
 
     /// For the vector of `wires`, produce a `CircuitBuilder` where ops can be
     /// added using indices in to the vector.
-    fn as_circuit(&mut self, wires: Vec<Wire>) -> CircuitBuilder<Self> {
+    fn as_circuit(&mut self, wires: impl IntoIterator<Item = Wire>) -> CircuitBuilder<Self> {
         CircuitBuilder::new(wires, self)
     }
 }

--- a/src/builder/circuit.rs
+++ b/src/builder/circuit.rs
@@ -27,8 +27,11 @@ pub enum CircuitBuildError {
 impl<'a, T: Dataflow + ?Sized> CircuitBuilder<'a, T> {
     /// Construct a new [`CircuitBuilder`] from a vector of incoming wires and the
     /// builder for the graph
-    pub fn new(wires: Vec<Wire>, builder: &'a mut T) -> Self {
-        Self { wires, builder }
+    pub fn new(wires: impl IntoIterator<Item = Wire>, builder: &'a mut T) -> Self {
+        Self {
+            wires: wires.into_iter().collect(),
+            builder,
+        }
     }
 
     /// Number of wires tracked, upper bound of valid wire indices
@@ -188,7 +191,7 @@ mod test {
             |mut f_build| {
                 let [q0, q1, angle]: [Wire; 3] = f_build.input_wires_arr();
 
-                let mut linear = f_build.as_circuit(vec![q0, q1]);
+                let mut linear = f_build.as_circuit([q0, q1]);
 
                 let measure_out = linear
                     .append(cx_gate(), [0, 1])?

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -484,7 +484,7 @@ pub(in crate::hugr::rewrite) mod test {
     fn test_replace_cx_cross() {
         let q_row: Vec<Type> = vec![QB, QB];
         let mut builder = DFGBuilder::new(FunctionType::new(q_row.clone(), q_row)).unwrap();
-        let mut circ = builder.as_circuit(builder.input_wires().collect());
+        let mut circ = builder.as_circuit(builder.input_wires());
         circ.append(cx_gate(), [0, 1]).unwrap();
         circ.append(cx_gate(), [1, 0]).unwrap();
         let wires = circ.finish();


### PR DESCRIPTION
drive-by: Make the `CircuitBuilder` constructor a bit more generic.