### PR TITLE
feat: Ancilla support in CircuitBuilder

### DIFF
--- a/quantinuum-hugr/src/builder.rs
+++ b/quantinuum-hugr/src/builder.rs
@@ -119,7 +119,7 @@ mod conditional;
 pub use conditional::{CaseBuilder, ConditionalBuilder};
 
 mod circuit;
-pub use circuit::CircuitBuilder;
+pub use circuit::{CircuitBuildError, CircuitBuilder};
 
 #[derive(Debug, Clone, PartialEq, Error)]
 /// Error while building the HUGR.

--- a/quantinuum-hugr/src/builder/circuit.rs
+++ b/quantinuum-hugr/src/builder/circuit.rs
@@ -338,7 +338,7 @@ mod test {
     #[test]
     fn circuit_builder_errors() {
         let _build_res = build_main(
-            FunctionType::new(type_row![QB, QB], type_row![QB, QB]).into(),
+            FunctionType::new_endo(type_row![QB, QB]).into(),
             |mut f_build| {
                 let mut circ = f_build.as_circuit(f_build.input_wires());
                 let [q0, q1] = circ.tracked_units_arr();

--- a/quantinuum-hugr/src/builder/circuit.rs
+++ b/quantinuum-hugr/src/builder/circuit.rs
@@ -23,6 +23,7 @@ pub struct CircuitBuilder<'a, T: ?Sized> {
 
 #[derive(Debug, Clone, PartialEq, Error)]
 /// Error in [`CircuitBuilder`]
+#[non_exhaustive]
 pub enum CircuitBuildError {
     /// Invalid index for stored wires.
     #[error("Invalid wire index {invalid_index} while attempting to add operation {}.", .op.as_ref().map(|o| o.name()).unwrap_or_default())]

--- a/quantinuum-hugr/src/builder/handle.rs
+++ b/quantinuum-hugr/src/builder/handle.rs
@@ -7,7 +7,7 @@ use crate::{Node, OutgoingPort, Wire};
 use itertools::Itertools;
 use std::iter::FusedIterator;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Handle to a dataflow node which has a known number of value outputs
 pub struct BuildHandle<T> {
     node_handle: T,

--- a/quantinuum-hugr/src/utils.rs
+++ b/quantinuum-hugr/src/utils.rs
@@ -86,10 +86,6 @@ pub(crate) mod test_quantum_extension {
             .unwrap();
 
         extension
-            .add_op(SmolStr::new_inline("CZ"), "CZ".into(), two_qb_func())
-            .unwrap();
-
-        extension
             .add_op(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
             .unwrap();
 
@@ -138,10 +134,6 @@ pub(crate) mod test_quantum_extension {
 
     pub(crate) fn cx_gate() -> LeafOp {
         get_gate("CX")
-    }
-
-    pub(crate) fn cz_gate() -> LeafOp {
-        get_gate("CZ")
     }
 
     pub(crate) fn measure() -> LeafOp {

--- a/quantinuum-hugr/src/utils.rs
+++ b/quantinuum-hugr/src/utils.rs
@@ -86,6 +86,10 @@ pub(crate) mod test_quantum_extension {
             .unwrap();
 
         extension
+            .add_op(SmolStr::new_inline("CZ"), "CZ".into(), two_qb_func())
+            .unwrap();
+
+        extension
             .add_op(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
             .unwrap();
 
@@ -94,6 +98,22 @@ pub(crate) mod test_quantum_extension {
                 SmolStr::new_inline("Measure"),
                 "Measure a qubit, returning the qubit and the measurement result.".into(),
                 FunctionType::new(type_row![QB_T], type_row![QB_T, BOOL_T]),
+            )
+            .unwrap();
+
+        extension
+            .add_op(
+                SmolStr::new_inline("QAlloc"),
+                "Allocate a new qubit.".into(),
+                FunctionType::new(type_row![], type_row![QB_T]),
+            )
+            .unwrap();
+
+        extension
+            .add_op(
+                SmolStr::new_inline("QDiscard"),
+                "Discard a qubit.".into(),
+                FunctionType::new(type_row![QB_T], type_row![]),
             )
             .unwrap();
 
@@ -120,12 +140,24 @@ pub(crate) mod test_quantum_extension {
         get_gate("CX")
     }
 
+    pub(crate) fn cz_gate() -> LeafOp {
+        get_gate("CZ")
+    }
+
     pub(crate) fn measure() -> LeafOp {
         get_gate("Measure")
     }
 
     pub(crate) fn rz_f64() -> LeafOp {
         get_gate("RzF64")
+    }
+
+    pub(crate) fn q_alloc() -> LeafOp {
+        get_gate("QAlloc")
+    }
+
+    pub(crate) fn q_discard() -> LeafOp {
+        get_gate("QDiscard")
     }
 }
 


### PR DESCRIPTION
Adds `add_ancilla` and `discard_ancilla` methods to the circuit builder, to modify the list of tracked wires.
Also adds extra info in the error messages.

Closes #854.