### PR TITLE
ci: Skip invalid miri test, avoid concurrent undsoundness checks

### DIFF
--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -6,6 +6,10 @@ on:
       - main 
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/quantinuum-hugr/src/hugr/views/tests.rs
+++ b/quantinuum-hugr/src/hugr/views/tests.rs
@@ -65,11 +65,11 @@ fn node_connections(
 ///
 /// The first parameter `test_name` is required due to insta and rstest limitations.
 /// See https://github.com/la10736/rstest/issues/183
-#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
 #[rstest]
 #[case::dfg("dot_dfg", sample_hugr().0)]
 #[case::cfg("dot_cfg", crate::builder::test::simple_cfg_hugr())]
 #[case::empty_dfg("dot_empty_dfg", crate::builder::test::simple_dfg_hugr())]
+#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
 fn dot_string(#[case] test_name: &str, #[case] h: Hugr) {
     insta::assert_yaml_snapshot!(test_name, h.dot_string());
 }
@@ -78,11 +78,11 @@ fn dot_string(#[case] test_name: &str, #[case] h: Hugr) {
 ///
 /// The first parameter `test_name` is required due to insta and rstest limitations.
 /// See https://github.com/la10736/rstest/issues/183
-#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
 #[rstest]
 #[case::dfg("mmd_dfg", sample_hugr().0)]
 #[case::cfg("mmd_cfg", crate::builder::test::simple_cfg_hugr())]
 #[case::empty_dfg("mmd_empty_dfg", crate::builder::test::simple_dfg_hugr())]
+#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
 fn mermaid_string(#[case] test_name: &str, #[case] h: Hugr) {
     insta::assert_snapshot!(test_name, h.mermaid_string());
 }


### PR DESCRIPTION
- Fixes the failing unsoundness check in `main`
  https://github.com/CQCL/hugr/actions/runs/8158956607/job/22302072598
  
  The test change in #852 moved the miri ignore flag, and it seems it has to be placed after `rstest`'s cases.
  
- Adds a concurrency group for the unsoundness check.
  The check currently takes around 15mins (and it will only grow as we add more tests).
  This makes it so old jobs get cancelled when pushing new changes to main, and a new check is started.