### PR TITLE
feat: `CircuitBuilder::append_with_output_arr`

### DIFF
--- a/quantinuum-hugr/src/builder.rs
+++ b/quantinuum-hugr/src/builder.rs
@@ -119,7 +119,7 @@ mod conditional;
 pub use conditional::{CaseBuilder, ConditionalBuilder};
 
 mod circuit;
-pub use circuit::CircuitBuilder;
+pub use circuit::{CircuitBuildError, CircuitBuilder};
 
 #[derive(Debug, Clone, PartialEq, Error)]
 /// Error while building the HUGR.

--- a/quantinuum-hugr/src/builder/build_traits.rs
+++ b/quantinuum-hugr/src/builder/build_traits.rs
@@ -3,6 +3,7 @@ use crate::hugr::validate::InterGraphEdgeError;
 use crate::hugr::views::HugrView;
 use crate::hugr::{NodeMetadata, ValidationError};
 use crate::ops::{self, LeafOp, OpTag, OpTrait, OpType};
+use crate::utils::collect_array;
 use crate::{IncomingPort, Node, OutgoingPort};
 
 use std::iter;
@@ -275,10 +276,7 @@ pub trait Dataflow: Container {
     ///
     /// Panics if the number of input Wires does not match the size of the array.
     fn input_wires_arr<const N: usize>(&self) -> [Wire; N] {
-        self.input_wires()
-            .collect_vec()
-            .try_into()
-            .expect(&format!("Incorrect number of wires: {N}")[..])
+        collect_array(self.input_wires())
     }
 
     /// Return a builder for a [`crate::ops::DFG`] node, i.e. a nested dataflow subgraph.

--- a/quantinuum-hugr/src/builder/circuit.rs
+++ b/quantinuum-hugr/src/builder/circuit.rs
@@ -23,6 +23,7 @@ pub struct CircuitBuilder<'a, T: ?Sized> {
 
 #[derive(Debug, Clone, PartialEq, Error)]
 /// Error in [`CircuitBuilder`]
+#[non_exhaustive]
 pub enum CircuitBuildError {
     /// Invalid index for stored wires.
     #[error("Invalid wire index {invalid_index} while attempting to add operation {}.", .op.as_ref().map(|o| o.name()).unwrap_or_default())]

--- a/quantinuum-hugr/src/builder/circuit.rs
+++ b/quantinuum-hugr/src/builder/circuit.rs
@@ -190,7 +190,7 @@ impl<'a, T: Dataflow + ?Sized> CircuitBuilder<'a, T> {
     /// # Panics
     ///
     /// If the number of outputs does not match `N`.
-    pub fn append_with_output_arr<A: Into<CircuitUnit>, const N: usize>(
+    pub fn append_with_output_arr<const N: usize, A: Into<CircuitUnit>>(
         &mut self,
         op: impl Into<OpType>,
         inputs: impl IntoIterator<Item = A>,
@@ -320,10 +320,7 @@ mod test {
                 assert_eq!(circ.n_wires(), 1);
 
                 let [q0] = circ.tracked_units_arr();
-                let [ancilla] = circ
-                    .append_with_outputs::<CircuitUnit>(q_alloc(), [])?
-                    .try_into()
-                    .expect("Expected a single ancilla wire");
+                let [ancilla] = circ.append_with_output_arr(q_alloc(), [] as [CircuitUnit; 0])?;
                 let ancilla = circ.track_wire(ancilla);
 
                 assert_ne!(ancilla, 0);
@@ -331,10 +328,7 @@ mod test {
                 assert_eq!(circ.tracked_units_arr(), [q0, ancilla]);
 
                 circ.append(cx_gate(), [q0, ancilla])?;
-                let [_bit] = circ
-                    .append_with_outputs(measure(), [q0])?
-                    .try_into()
-                    .unwrap();
+                let [_bit] = circ.append_with_output_arr(measure(), [q0])?;
 
                 let q0 = circ.untrack_wire(q0)?;
 

--- a/quantinuum-hugr/src/builder/circuit.rs
+++ b/quantinuum-hugr/src/builder/circuit.rs
@@ -190,7 +190,7 @@ impl<'a, T: Dataflow + ?Sized> CircuitBuilder<'a, T> {
     /// # Panics
     ///
     /// If the number of outputs does not match `N`.
-    pub fn append_with_output_arr<const N: usize, A: Into<CircuitUnit>>(
+    pub fn append_with_outputs_arr<const N: usize, A: Into<CircuitUnit>>(
         &mut self,
         op: impl Into<OpType>,
         inputs: impl IntoIterator<Item = A>,
@@ -320,7 +320,7 @@ mod test {
                 assert_eq!(circ.n_wires(), 1);
 
                 let [q0] = circ.tracked_units_arr();
-                let [ancilla] = circ.append_with_output_arr(q_alloc(), [] as [CircuitUnit; 0])?;
+                let [ancilla] = circ.append_with_outputs_arr(q_alloc(), [] as [CircuitUnit; 0])?;
                 let ancilla = circ.track_wire(ancilla);
 
                 assert_ne!(ancilla, 0);
@@ -328,7 +328,7 @@ mod test {
                 assert_eq!(circ.tracked_units_arr(), [q0, ancilla]);
 
                 circ.append(cx_gate(), [q0, ancilla])?;
-                let [_bit] = circ.append_with_output_arr(measure(), [q0])?;
+                let [_bit] = circ.append_with_outputs_arr(measure(), [q0])?;
 
                 let q0 = circ.untrack_wire(q0)?;
 

--- a/quantinuum-hugr/src/builder/handle.rs
+++ b/quantinuum-hugr/src/builder/handle.rs
@@ -49,7 +49,7 @@ impl<T: NodeHandle> BuildHandle<T> {
 
     /// Attempt to cast outputs in to array of Wires.
     pub fn outputs_arr<const N: usize>(&self) -> [Wire; N] {
-        collect_array(self.outputs())
+        self.outputs().to_array()
     }
 
     #[inline]
@@ -108,6 +108,18 @@ impl From<BuildHandle<DfgID>> for BuildHandle<TailLoopID> {
 pub struct Outputs {
     node: Node,
     range: std::ops::Range<usize>,
+}
+
+impl Outputs {
+    #[inline]
+    /// Returns the output wires as an array.
+    ///
+    /// # Panics
+    ///
+    /// If the length of the slice is not equal to `N`.
+    pub fn to_array<const N: usize>(self) -> [Wire; N] {
+        collect_array(self)
+    }
 }
 
 impl Iterator for Outputs {

--- a/quantinuum-hugr/src/builder/handle.rs
+++ b/quantinuum-hugr/src/builder/handle.rs
@@ -2,9 +2,9 @@
 //!
 use crate::ops::handle::{BasicBlockID, CaseID, DfgID, FuncID, NodeHandle, TailLoopID};
 use crate::ops::OpTag;
+use crate::utils::collect_array;
 use crate::{Node, OutgoingPort, Wire};
 
-use itertools::Itertools;
 use std::iter::FusedIterator;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -49,10 +49,7 @@ impl<T: NodeHandle> BuildHandle<T> {
 
     /// Attempt to cast outputs in to array of Wires.
     pub fn outputs_arr<const N: usize>(&self) -> [Wire; N] {
-        self.outputs()
-            .collect_vec()
-            .try_into()
-            .expect(&format!("Incorrect number of wires: {}", N)[..])
+        collect_array(self.outputs())
     }
 
     #[inline]

--- a/quantinuum-hugr/src/builder/handle.rs
+++ b/quantinuum-hugr/src/builder/handle.rs
@@ -7,7 +7,7 @@ use crate::{Node, OutgoingPort, Wire};
 use itertools::Itertools;
 use std::iter::FusedIterator;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Handle to a dataflow node which has a known number of value outputs
 pub struct BuildHandle<T> {
     node_handle: T,

--- a/quantinuum-hugr/src/utils.rs
+++ b/quantinuum-hugr/src/utils.rs
@@ -86,10 +86,6 @@ pub(crate) mod test_quantum_extension {
             .unwrap();
 
         extension
-            .add_op(SmolStr::new_inline("CZ"), "CZ".into(), two_qb_func())
-            .unwrap();
-
-        extension
             .add_op(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
             .unwrap();
 
@@ -138,10 +134,6 @@ pub(crate) mod test_quantum_extension {
 
     pub(crate) fn cx_gate() -> LeafOp {
         get_gate("CX")
-    }
-
-    pub(crate) fn cz_gate() -> LeafOp {
-        get_gate("CZ")
     }
 
     pub(crate) fn measure() -> LeafOp {

--- a/quantinuum-hugr/src/utils.rs
+++ b/quantinuum-hugr/src/utils.rs
@@ -23,8 +23,46 @@ where
 }
 
 /// Collect a vector into an array.
-pub fn collect_array<const N: usize, T: Debug>(arr: &[T]) -> [&T; N] {
-    arr.iter().collect_vec().try_into().unwrap()
+///
+/// This is useful for deconstructing a vectors content.
+///
+/// # Example
+///
+/// ```ignore
+/// let iter = 0..3;
+/// let [a, b, c] = crate::utils::collect_array(iter);
+/// assert_eq!(b, 1);
+/// ```
+///
+/// # Panics
+///
+/// If the length of the slice is not equal to `N`.
+///
+/// See also [`try_collect_array`] for a non-panicking version.
+#[inline]
+pub fn collect_array<const N: usize, T: Debug>(arr: impl IntoIterator<Item = T>) -> [T; N] {
+    try_collect_array(arr).unwrap_or_else(|v| panic!("Expected {} elements, got {:?}", N, v))
+}
+
+/// Collect a vector into an array.
+///
+/// This is useful for deconstructing a vectors content.
+///
+/// # Example
+///
+/// ```ignore
+/// let iter = 0..3;
+/// let [a, b, c] = crate::utils::try_collect_array(iter)
+///     .unwrap_or_else(|v| panic!("Expected 3 elements, got {:?}", v));
+/// assert_eq!(b, 1);
+/// ```
+///
+/// See also [`collect_array`].
+#[inline]
+pub fn try_collect_array<const N: usize, T>(
+    arr: impl IntoIterator<Item = T>,
+) -> Result<[T; N], Vec<T>> {
+    arr.into_iter().collect_vec().try_into()
 }
 
 /// Helper method to skip serialization of default values in serde.

--- a/quantinuum-hugr/src/utils.rs
+++ b/quantinuum-hugr/src/utils.rs
@@ -86,6 +86,10 @@ pub(crate) mod test_quantum_extension {
             .unwrap();
 
         extension
+            .add_op(SmolStr::new_inline("CZ"), "CZ".into(), two_qb_func())
+            .unwrap();
+
+        extension
             .add_op(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
             .unwrap();
 
@@ -94,6 +98,22 @@ pub(crate) mod test_quantum_extension {
                 SmolStr::new_inline("Measure"),
                 "Measure a qubit, returning the qubit and the measurement result.".into(),
                 FunctionType::new(type_row![QB_T], type_row![QB_T, BOOL_T]),
+            )
+            .unwrap();
+
+        extension
+            .add_op(
+                SmolStr::new_inline("QAlloc"),
+                "Allocate a new qubit.".into(),
+                FunctionType::new(type_row![], type_row![QB_T]),
+            )
+            .unwrap();
+
+        extension
+            .add_op(
+                SmolStr::new_inline("QDiscard"),
+                "Discard a qubit.".into(),
+                FunctionType::new(type_row![QB_T], type_row![]),
             )
             .unwrap();
 
@@ -120,12 +140,24 @@ pub(crate) mod test_quantum_extension {
         get_gate("CX")
     }
 
+    pub(crate) fn cz_gate() -> LeafOp {
+        get_gate("CZ")
+    }
+
     pub(crate) fn measure() -> LeafOp {
         get_gate("Measure")
     }
 
     pub(crate) fn rz_f64() -> LeafOp {
         get_gate("RzF64")
+    }
+
+    pub(crate) fn q_alloc() -> LeafOp {
+        get_gate("QAlloc")
+    }
+
+    pub(crate) fn q_discard() -> LeafOp {
+        get_gate("QDiscard")
     }
 }
 


### PR DESCRIPTION
- Fleshes out `utils::collect_array`, and uses it in all the methods that return a fixed size array.
- Adds `CircuitBuilder::append_with_output_arr`.

Follow up to  https://github.com/CQCL/hugr/pull/867#discussion_r1517711129