### PR TITLE
feat!: Make some `Container` methods infallible

### DIFF
--- a/quantinuum-hugr/src/algorithm/const_fold.rs
+++ b/quantinuum-hugr/src/algorithm/const_fold.rs
@@ -348,7 +348,7 @@ mod test {
         ))
         .unwrap();
 
-        let list_wire = build.add_load_const(list.clone())?;
+        let list_wire = build.add_load_const(list.clone());
 
         let pop = build.add_dataflow_op(
             ListOp::Pop.with_type(BOOL_T).to_extension_op(&reg).unwrap(),

--- a/quantinuum-hugr/src/algorithm/const_fold.rs
+++ b/quantinuum-hugr/src/algorithm/const_fold.rs
@@ -86,7 +86,7 @@ fn const_graph(consts: Vec<Const>, reg: &ExtensionRegistry) -> Hugr {
 
     let outputs = consts
         .into_iter()
-        .map(|c| b.add_load_const(c).unwrap())
+        .map(|c| b.add_load_const(c))
         .collect_vec();
 
     b.finish_hugr_with_outputs(outputs, reg).unwrap()
@@ -265,9 +265,7 @@ mod test {
         let mut build =
             DFGBuilder::new(FunctionType::new(type_row![], vec![sum_type.clone()])).unwrap();
 
-        let tup = build
-            .add_load_const(Const::new_tuple([f2c(5.6), f2c(3.2)]))
-            .unwrap();
+        let tup = build.add_load_const(Const::new_tuple([f2c(5.6), f2c(3.2)]));
 
         let unpack = build
             .add_dataflow_op(
@@ -320,7 +318,7 @@ mod test {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut build = DFGBuilder::new(FunctionType::new(type_row![], vec![BOOL_T])).unwrap();
 
-        let ins = ins.map(|b| build.add_load_const(Const::from_bool(b)).unwrap());
+        let ins = ins.map(|b| build.add_load_const(Const::from_bool(b)));
         let logic_op = build.add_dataflow_op(op.with_n_inputs(ins.len() as u64), ins)?;
 
         let reg =

--- a/quantinuum-hugr/src/algorithm/nest_cfgs.rs
+++ b/quantinuum-hugr/src/algorithm/nest_cfgs.rs
@@ -605,8 +605,8 @@ pub(crate) mod test {
         //               \-> right -/             \-<--<-/
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
 
-        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2))?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(Const::unary_unit_sum())?;
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2)); // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::unary_unit_sum());
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,
@@ -813,7 +813,7 @@ pub(crate) mod test {
         pred_const: &ConstID,
     ) -> Result<T::ContainerHandle, BuildError> {
         let w = dataflow_builder.input_wires();
-        let u = dataflow_builder.load_const(pred_const)?;
+        let u = dataflow_builder.load_const(pred_const);
         dataflow_builder.finish_with_outputs([u].into_iter().chain(w))
     }
 
@@ -887,8 +887,8 @@ pub(crate) mod test {
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
-        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2))?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(Const::unary_unit_sum())?;
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2)); // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::unary_unit_sum());
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 2, ExtensionSet::new())?,
@@ -929,8 +929,8 @@ pub(crate) mod test {
         cfg_builder: &mut CFGBuilder<T>,
         separate_headers: bool,
     ) -> Result<(BasicBlockID, BasicBlockID), BuildError> {
-        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2))?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(Const::unary_unit_sum())?;
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2)); // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::unary_unit_sum());
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,

--- a/quantinuum-hugr/src/algorithm/nest_cfgs.rs
+++ b/quantinuum-hugr/src/algorithm/nest_cfgs.rs
@@ -605,7 +605,7 @@ pub(crate) mod test {
         //               \-> right -/             \-<--<-/
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
 
-        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2)); // Nothing here cares which
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2));
         let const_unit = cfg_builder.add_constant(Const::unary_unit_sum());
 
         let entry = n_identity(
@@ -887,7 +887,7 @@ pub(crate) mod test {
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
-        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2)); // Nothing here cares which
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2));
         let const_unit = cfg_builder.add_constant(Const::unary_unit_sum());
 
         let entry = n_identity(
@@ -929,7 +929,7 @@ pub(crate) mod test {
         cfg_builder: &mut CFGBuilder<T>,
         separate_headers: bool,
     ) -> Result<(BasicBlockID, BasicBlockID), BuildError> {
-        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2)); // Nothing here cares which
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2));
         let const_unit = cfg_builder.add_constant(Const::unary_unit_sum());
 
         let entry = n_identity(

--- a/quantinuum-hugr/src/builder/cfg.rs
+++ b/quantinuum-hugr/src/builder/cfg.rs
@@ -77,7 +77,7 @@ use crate::{
 ///             ops::Const::tuple_sum(0,
 ///                                   Value::tuple([prelude::ConstUsize::new(42).into()]),
 ///                                   sum_variants.clone())?;
-///         let sum = entry_b.add_load_const(left_42)?;
+///         let sum = entry_b.add_load_const(left_42);
 ///
 ///         entry_b.finish_with_outputs(sum, [inw])?
 ///     };
@@ -92,7 +92,7 @@ use crate::{
 ///         )?;
 ///     let successor_a = {
 ///         // This block has one successor. The choice is denoted by a unary sum.
-///         let sum_unary = successor_builder.add_load_const(ops::Const::unary_unit_sum())?;
+///         let sum_unary = successor_builder.add_load_const(ops::Const::unary_unit_sum());
 ///
 ///         // The input wires of a node start with the data embedded in the variant
 ///         // which selected this block.
@@ -104,7 +104,7 @@ use crate::{
 ///    let mut successor_builder =
 ///        cfg_builder.simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?;
 ///    let successor_b = {
-///        let sum_unary = successor_builder.add_load_const(ops::Const::unary_unit_sum())?;
+///        let sum_unary = successor_builder.add_load_const(ops::Const::unary_unit_sum());
 ///        let [in_wire] = successor_builder.input_wires_arr();
 ///        successor_builder.finish_with_outputs(sum_unary, [in_wire])?
 ///    };
@@ -469,7 +469,7 @@ pub(crate) mod test {
         let mut middle_b = cfg_builder
             .simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?;
         let middle = {
-            let c = middle_b.add_load_const(ops::Const::unary_unit_sum())?;
+            let c = middle_b.add_load_const(ops::Const::unary_unit_sum());
             let [inw] = middle_b.input_wires_arr();
             middle_b.finish_with_outputs(c, [inw])?
         };
@@ -482,21 +482,21 @@ pub(crate) mod test {
     #[test]
     fn test_dom_edge() -> Result<(), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
-        let sum_tuple_const = cfg_builder.add_constant(ops::Const::unary_unit_sum())?;
+        let sum_tuple_const = cfg_builder.add_constant(ops::Const::unary_unit_sum());
         let sum_variants = vec![type_row![]];
 
         let mut entry_b =
             cfg_builder.entry_builder(sum_variants.clone(), type_row![], ExtensionSet::new())?;
         let [inw] = entry_b.input_wires_arr();
         let entry = {
-            let sum = entry_b.load_const(&sum_tuple_const)?;
+            let sum = entry_b.load_const(&sum_tuple_const);
 
             entry_b.finish_with_outputs(sum, [])?
         };
         let mut middle_b =
             cfg_builder.simple_block_builder(FunctionType::new(type_row![], type_row![NAT]), 1)?;
         let middle = {
-            let c = middle_b.load_const(&sum_tuple_const)?;
+            let c = middle_b.load_const(&sum_tuple_const);
             middle_b.finish_with_outputs(c, [inw])?
         };
         let exit = cfg_builder.exit_block();
@@ -510,20 +510,20 @@ pub(crate) mod test {
     #[test]
     fn test_non_dom_edge() -> Result<(), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
-        let sum_tuple_const = cfg_builder.add_constant(ops::Const::unary_unit_sum())?;
+        let sum_tuple_const = cfg_builder.add_constant(ops::Const::unary_unit_sum());
         let sum_variants = vec![type_row![]];
         let mut middle_b = cfg_builder
             .simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?;
         let [inw] = middle_b.input_wires_arr();
         let middle = {
-            let c = middle_b.load_const(&sum_tuple_const)?;
+            let c = middle_b.load_const(&sum_tuple_const);
             middle_b.finish_with_outputs(c, [inw])?
         };
 
         let mut entry_b =
             cfg_builder.entry_builder(sum_variants.clone(), type_row![NAT], ExtensionSet::new())?;
         let entry = {
-            let sum = entry_b.load_const(&sum_tuple_const)?;
+            let sum = entry_b.load_const(&sum_tuple_const);
             // entry block uses wire from middle block even though middle block
             // does not dominate entry
             entry_b.finish_with_outputs(sum, [inw])?

--- a/quantinuum-hugr/src/builder/conditional.rs
+++ b/quantinuum-hugr/src/builder/conditional.rs
@@ -129,7 +129,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
             if let Some(&sibling_node) = self.case_nodes[case + 1..].iter().flatten().next() {
                 self.hugr_mut().add_node_before(sibling_node, case_op)
             } else {
-                self.add_child_op(case_op)?
+                self.add_child_op(case_op)
             };
 
         self.case_nodes[case] = Some(case_node);
@@ -242,9 +242,9 @@ mod test {
                 "main",
                 FunctionType::new(type_row![NAT], type_row![NAT]).into(),
             )?;
-            let tru_const = fbuild.add_constant(Const::true_val())?;
+            let tru_const = fbuild.add_constant(Const::true_val());
             let _fdef = {
-                let const_wire = fbuild.load_const(&tru_const)?;
+                let const_wire = fbuild.load_const(&tru_const);
                 let [int] = fbuild.input_wires_arr();
                 let conditional_id = {
                     let other_inputs = vec![(NAT, int)];

--- a/quantinuum-hugr/src/builder/dataflow.rs
+++ b/quantinuum-hugr/src/builder/dataflow.rs
@@ -410,7 +410,7 @@ pub(crate) mod test {
             let [i1] = f_build.input_wires_arr();
             let dfg = f_build.add_hugr_with_wires(dfg_hugr, [i1])?;
             let f = f_build.finish_with_outputs([dfg.out_wire(0)])?;
-            module_builder.set_child_metadata(f.node(), "x", "hi")?;
+            module_builder.set_child_metadata(f.node(), "x", "hi");
             (dfg.node(), f.node())
         };
 

--- a/quantinuum-hugr/src/builder/module.rs
+++ b/quantinuum-hugr/src/builder/module.rs
@@ -111,7 +111,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         let declare_n = self.add_child_node(NodeType::new_pure(ops::FuncDecl {
             signature,
             name: name.into(),
-        }))?;
+        }));
 
         Ok(declare_n.into())
     }
@@ -136,7 +136,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         let node = self.add_child_op(ops::AliasDefn {
             name: name.clone(),
             definition: typ,
-        })?;
+        });
 
         Ok(AliasID::new(node, name, bound))
     }
@@ -154,7 +154,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         let node = self.add_child_op(ops::AliasDecl {
             name: name.clone(),
             bound,
-        })?;
+        });
 
         Ok(AliasID::new(node, name, bound))
     }

--- a/quantinuum-hugr/src/builder/tail_loop.rs
+++ b/quantinuum-hugr/src/builder/tail_loop.rs
@@ -109,7 +109,7 @@ mod test {
         let build_result: Result<Hugr, ValidationError> = {
             let mut loop_b = TailLoopBuilder::new(vec![], vec![BIT], vec![USIZE_T])?;
             let [i1] = loop_b.input_wires_arr();
-            let const_wire = loop_b.add_load_const(ConstUsize::new(1))?;
+            let const_wire = loop_b.add_load_const(ConstUsize::new(1));
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
@@ -145,7 +145,7 @@ mod test {
                         fbuild.tail_loop_builder(vec![(BIT, b1)], vec![], type_row![NAT])?;
                     let signature = loop_b.loop_signature()?.clone();
                     let const_val = Const::true_val();
-                    let const_wire = loop_b.add_load_const(Const::true_val())?;
+                    let const_wire = loop_b.add_load_const(Const::true_val());
                     let lift_node = loop_b.add_dataflow_op(
                         ops::LeafOp::Lift {
                             type_row: vec![const_val.const_type().clone()].into(),
@@ -173,7 +173,7 @@ mod test {
                         let mut branch_1 = conditional_b.case_builder(1)?;
                         let [_b1] = branch_1.input_wires_arr();
 
-                        let wire = branch_1.add_load_const(ConstUsize::new(2))?;
+                        let wire = branch_1.add_load_const(ConstUsize::new(2));
                         let break_wire = branch_1.make_break(signature, [wire])?;
                         branch_1.finish_with_outputs([break_wire])?;
 

--- a/quantinuum-hugr/src/extension/prelude.rs
+++ b/quantinuum-hugr/src/extension/prelude.rs
@@ -287,7 +287,7 @@ mod test {
 
         let mut b = DFGBuilder::new(FunctionType::new_endo(type_row![])).unwrap();
 
-        let err = b.add_load_const(error_val).unwrap();
+        let err = b.add_load_const(error_val);
 
         let op = PRELUDE
             .instantiate_extension_op(PANIC_OP_ID, [], &PRELUDE_REGISTRY)

--- a/quantinuum-hugr/src/hugr/rewrite/consts.rs
+++ b/quantinuum-hugr/src/hugr/rewrite/consts.rs
@@ -130,12 +130,12 @@ mod test {
     #[test]
     fn test_const_remove() -> Result<(), Box<dyn std::error::Error>> {
         let mut build = ModuleBuilder::new();
-        let con_node = build.add_constant(ConstUsize::new(2))?;
+        let con_node = build.add_constant(ConstUsize::new(2));
 
         let mut dfg_build =
             build.define_function("main", FunctionType::new_endo(type_row![]).into())?;
-        let load_1 = dfg_build.load_const(&con_node)?;
-        let load_2 = dfg_build.load_const(&con_node)?;
+        let load_1 = dfg_build.load_const(&con_node);
+        let load_2 = dfg_build.load_const(&con_node);
         let tup = dfg_build.add_dataflow_op(
             LeafOp::MakeTuple {
                 tys: type_row![USIZE_T, USIZE_T],

--- a/quantinuum-hugr/src/hugr/rewrite/inline_dfg.rs
+++ b/quantinuum-hugr/src/hugr/rewrite/inline_dfg.rs
@@ -192,7 +192,7 @@ mod test {
                 },
                 int_ty.clone(),
             )?;
-            let c1 = d.add_load_const(cst)?;
+            let c1 = d.add_load_const(cst);
             let [lifted] = d
                 .add_dataflow_op(
                     LeafOp::Lift {
@@ -374,8 +374,8 @@ mod test {
             h_b.outputs(),
         )?;
         let [i] = inner.input_wires_arr();
-        let f = inner.add_load_const(float_types::ConstF64::new(1.0))?;
-        inner.add_other_wire(inner.input().node(), f.node())?;
+        let f = inner.add_load_const(float_types::ConstF64::new(1.0));
+        inner.add_other_wire(inner.input().node(), f.node());
         let r = inner.add_dataflow_op(test_quantum_extension::rz_f64(), [i, f])?;
         let [m, b] = inner
             .add_dataflow_op(test_quantum_extension::measure(), r.outputs())?
@@ -390,11 +390,11 @@ mod test {
         if_n.case_builder(0)?.finish_with_outputs([])?;
         if_n.case_builder(1)?.finish_with_outputs([])?;
         let if_n = if_n.finish_sub_container()?;
-        inner.add_other_wire(if_n.node(), inner.output().node())?;
+        inner.add_other_wire(if_n.node(), inner.output().node());
         let inner = inner.finish_with_outputs([m])?;
-        outer.add_other_wire(h_a.node(), inner.node())?;
+        outer.add_other_wire(h_a.node(), inner.node());
         let h_a2 = outer.add_dataflow_op(test_quantum_extension::h_gate(), h_a.outputs())?;
-        outer.add_other_wire(inner.node(), h_a2.node())?;
+        outer.add_other_wire(inner.node(), h_a2.node());
         let cx = outer.add_dataflow_op(
             test_quantum_extension::cx_gate(),
             h_a2.outputs().chain(inner.outputs()),

--- a/quantinuum-hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/quantinuum-hugr/src/hugr/rewrite/outline_cfg.rs
@@ -143,10 +143,8 @@ impl Rewrite for OutlineCfg {
                 .cfg_builder(wires_in, input_extensions, outputs, extension_delta)
                 .unwrap();
             let cfg = cfg.finish_sub_container().unwrap();
-            let unit_sum = new_block_bldr
-                .add_constant(ops::Const::unary_unit_sum())
-                .unwrap();
-            let pred_wire = new_block_bldr.load_const(&unit_sum).unwrap();
+            let unit_sum = new_block_bldr.add_constant(ops::Const::unary_unit_sum());
+            let pred_wire = new_block_bldr.load_const(&unit_sum);
             new_block_bldr
                 .set_outputs(pred_wire, cfg.outputs())
                 .unwrap();

--- a/quantinuum-hugr/src/hugr/rewrite/replace.rs
+++ b/quantinuum-hugr/src/hugr/rewrite/replace.rs
@@ -498,7 +498,7 @@ mod test {
             FunctionType::new_endo(just_list.clone()),
         )?;
 
-        let pred_const = cfg.add_constant(ops::Const::unary_unit_sum())?;
+        let pred_const = cfg.add_constant(ops::Const::unary_unit_sum());
 
         let entry = single_node_block(&mut cfg, pop, &pred_const, true)?;
         let bb2 = single_node_block(&mut cfg, push, &pred_const, false)?;
@@ -640,7 +640,7 @@ mod test {
         };
         let op: OpType = op.into();
         let op = bb.add_dataflow_op(op, bb.input_wires())?;
-        let load_pred = bb.load_const(pred_const)?;
+        let load_pred = bb.load_const(pred_const);
         bb.finish_with_outputs(load_pred, op.outputs())
     }
 

--- a/quantinuum-hugr/src/hugr/serialize.rs
+++ b/quantinuum-hugr/src/hugr/serialize.rs
@@ -523,7 +523,7 @@ pub mod test {
     // https://github.com/rust-lang/miri/issues/450
     fn constants_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
         let mut builder = DFGBuilder::new(FunctionType::new(vec![], vec![FLOAT64_TYPE])).unwrap();
-        let w = builder.add_load_const(ConstF64::new(0.5))?;
+        let w = builder.add_load_const(ConstF64::new(0.5));
         let hugr = builder.finish_hugr_with_outputs([w], &FLOAT_OPS_REGISTRY)?;
 
         let ser = serde_json::to_string(&hugr)?;

--- a/quantinuum-hugr/src/hugr/validate/test.rs
+++ b/quantinuum-hugr/src/hugr/validate/test.rs
@@ -527,7 +527,7 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
             Type::new_var_use(0, TypeBound::Copyable),
         )),),
     };
-    let cst = def.add_load_const(Const::new(empty_list, list_of_var)?)?;
+    let cst = def.add_load_const(Const::new(empty_list, list_of_var)?);
     let res = def.finish_hugr_with_outputs([cst], &reg);
     assert_matches!(
         res.unwrap_err(),

--- a/quantinuum-hugr/src/hugr/views/tests.rs
+++ b/quantinuum-hugr/src/hugr/views/tests.rs
@@ -24,7 +24,7 @@ fn sample_hugr() -> (Hugr, BuildHandle<DataflowOpID>, BuildHandle<DataflowOpID>)
     let n1 = dfg.add_dataflow_op(cx_gate(), [q1, q2]).unwrap();
     let [q1, q2] = n1.outputs_arr();
     let n2 = dfg.add_dataflow_op(cx_gate(), [q2, q1]).unwrap();
-    dfg.add_other_wire(n1.node(), n2.node()).unwrap();
+    dfg.add_other_wire(n1.node(), n2.node());
 
     (
         dfg.finish_prelude_hugr_with_outputs(n2.outputs()).unwrap(),
@@ -131,7 +131,7 @@ fn value_types() {
     let [q, b] = dfg.input_wires_arr();
     let n1 = dfg.add_dataflow_op(h_gate(), [q]).unwrap();
     let n2 = dfg.add_dataflow_op(NotOp, [b]).unwrap();
-    dfg.add_other_wire(n1.node(), n2.node()).unwrap();
+    dfg.add_other_wire(n1.node(), n2.node());
     let h = dfg
         .finish_prelude_hugr_with_outputs([n2.out_wire(0), n1.out_wire(0)])
         .unwrap();
@@ -154,9 +154,9 @@ fn static_targets() {
     )
     .unwrap();
 
-    let c = dfg.add_constant(ConstUsize::new(1)).unwrap();
+    let c = dfg.add_constant(ConstUsize::new(1));
 
-    let load = dfg.load_const(&c).unwrap();
+    let load = dfg.load_const(&c);
 
     let h = dfg.finish_prelude_hugr_with_outputs([load]).unwrap();
 
@@ -198,7 +198,7 @@ fn test_dataflow_ports_only() {
             &PRELUDE_REGISTRY,
         )
         .unwrap();
-    dfg.add_other_wire(not.node(), call.node()).unwrap();
+    dfg.add_other_wire(not.node(), call.node());
     let h = dfg
         .finish_hugr_with_outputs(not.outputs(), &PRELUDE_REGISTRY)
         .unwrap();

--- a/quantinuum-hugr/src/ops/constant.rs
+++ b/quantinuum-hugr/src/ops/constant.rs
@@ -179,13 +179,13 @@ mod test {
                 serialized_float(5.1),
             ]),
             pred_rows.clone(),
-        )?)?;
-        let w = b.load_const(&c)?;
+        )?);
+        let w = b.load_const(&c);
         b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
 
         let mut b = DFGBuilder::new(FunctionType::new(type_row![], TypeRow::from(vec![pred_ty])))?;
-        let c = b.add_constant(Const::tuple_sum(1, Value::unit(), pred_rows)?)?;
-        let w = b.load_const(&c)?;
+        let c = b.add_constant(Const::tuple_sum(1, Value::unit(), pred_rows)?);
+        let w = b.load_const(&c);
         b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
 
         Ok(())


### PR DESCRIPTION
Updated methods that could only return `Err` on internal bugs.
This is a followup to #869, doing some more cleaning on the `build_traits::Container` interface.

Changes outside `build_traits.rs` are just fixing the call sites.

BREAKING CHANGE: Multiple methods in `Container` no longer return a `Result`