### PR TITLE
chore: Re-enable missing-docs lint

### DIFF
--- a/quantinuum-hugr/Cargo.toml
+++ b/quantinuum-hugr/Cargo.toml
@@ -13,6 +13,9 @@ description = "Quantinuum's Hierarchical Unified Graph Representation"
 keywords = ["Quantum", "Quantinuum"]
 categories = ["compilers"]
 
+[lints]
+workspace = true
+
 [lib]
 name = "hugr"
 bench = false

--- a/quantinuum-hugr/benches/bench_main.rs
+++ b/quantinuum-hugr/benches/bench_main.rs
@@ -1,3 +1,4 @@
+//! Benchmarks
 #[allow(dead_code)]
 mod benchmarks;
 

--- a/quantinuum-hugr/src/builder.rs
+++ b/quantinuum-hugr/src/builder.rs
@@ -124,7 +124,6 @@ pub use circuit::{CircuitBuildError, CircuitBuilder};
 
 #[derive(Debug, Clone, PartialEq, Error)]
 #[non_exhaustive]
-#[allow(missing_docs)]
 /// Error while building the HUGR.
 pub enum BuildError {
     /// The constructed HUGR is invalid.
@@ -144,6 +143,7 @@ pub enum BuildError {
     EntryBuiltError(Node),
     /// Node was expected to have a certain type but was found to not.
     #[error("Node with index {node:?} does not have type {op_desc:?} as expected.")]
+    #[allow(missing_docs)]
     UnexpectedType {
         /// Index of node where error occurred.
         node: Node,
@@ -164,6 +164,7 @@ pub enum BuildError {
 
     /// Invalid wires when setting outputs
     #[error("Found an error while setting the outputs of a {} container, {container_node}. {error}", .container_op.name())]
+    #[allow(missing_docs)]
     OutputWiring {
         container_op: OpType,
         container_node: Node,
@@ -175,6 +176,7 @@ pub enum BuildError {
     ///
     /// The internal error message already contains the node index.
     #[error("Got an input wire while adding a {} to the circuit. {error}", .op.name())]
+    #[allow(missing_docs)]
     OperationWiring {
         op: OpType,
         #[source]
@@ -184,11 +186,11 @@ pub enum BuildError {
 
 #[derive(Debug, Clone, PartialEq, Error)]
 #[non_exhaustive]
-#[allow(missing_docs)]
 /// Error raised when wiring up a node during the build process.
 pub enum BuilderWiringError {
     /// Tried to copy a linear type.
     #[error("Cannot copy linear type {typ} from output {src_offset} of node {src}")]
+    #[allow(missing_docs)]
     NoCopyLinear {
         typ: Type,
         src: Node,
@@ -196,6 +198,7 @@ pub enum BuilderWiringError {
     },
     /// The ancestors of an inter-graph edge are not related.
     #[error("Cannot connect an inter-graph edge between unrelated nodes. Tried connecting {src} ({src_offset}) with {dst} ({dst_offset}).")]
+    #[allow(missing_docs)]
     NoRelationIntergraph {
         src: Node,
         src_offset: Port,
@@ -204,6 +207,7 @@ pub enum BuilderWiringError {
     },
     /// Inter-Graph edges can only carry copyable data.
     #[error("Inter-graph edges cannot carry non-copyable data {typ}. Tried connecting {src} ({src_offset}) with {dst} ({dst_offset}).")]
+    #[allow(missing_docs)]
     NonCopyableIntergraph {
         src: Node,
         src_offset: Port,

--- a/quantinuum-hugr/src/builder.rs
+++ b/quantinuum-hugr/src/builder.rs
@@ -124,6 +124,7 @@ pub use circuit::{CircuitBuildError, CircuitBuilder};
 
 #[derive(Debug, Clone, PartialEq, Error)]
 #[non_exhaustive]
+#[allow(missing_docs)]
 /// Error while building the HUGR.
 pub enum BuildError {
     /// The constructed HUGR is invalid.
@@ -183,6 +184,7 @@ pub enum BuildError {
 
 #[derive(Debug, Clone, PartialEq, Error)]
 #[non_exhaustive]
+#[allow(missing_docs)]
 /// Error raised when wiring up a node during the build process.
 pub enum BuilderWiringError {
     /// Tried to copy a linear type.


### PR DESCRIPTION
#868 didn't actually enable the lints in `quantinuum-hugr` when the config was moved to the workspace.