### PR TITLE
chore: Compile the test skipped due to extension_inference

### DIFF
--- a/quantinuum-hugr/src/algorithm/const_fold.rs
+++ b/quantinuum-hugr/src/algorithm/const_fold.rs
@@ -330,8 +330,11 @@ mod test {
         Ok(())
     }
 
-    #[cfg(not(feature = "extension_inference"))] // inference fails for test graph, shouldn't
     #[test]
+    #[cfg_attr(
+        feature = "extension_inference",
+        ignore = "inference fails for test graph, it shouldn't"
+    )]
     fn test_list_ops() -> Result<(), Box<dyn std::error::Error>> {
         use crate::std_extensions::collections::{self, ListOp, ListValue};
 


### PR DESCRIPTION
This tests fails at runtime if extension inference is enabled.

We should however compile it, so compiler errors are more easily catched.