### PR TITLE
feat!: Merge `Value` into `Const`

### DIFF
--- a/quantinuum-hugr/src/algorithm/nest_cfgs.rs
+++ b/quantinuum-hugr/src/algorithm/nest_cfgs.rs
@@ -605,7 +605,7 @@ pub(crate) mod test {
         //               \-> right -/             \-<--<-/
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
 
-        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2));
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2).expect("0 < 2"));
         let const_unit = cfg_builder.add_constant(Const::unary_unit_sum());
 
         let entry = n_identity(
@@ -887,7 +887,7 @@ pub(crate) mod test {
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
-        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2));
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2).expect("0 < 2"));
         let const_unit = cfg_builder.add_constant(Const::unary_unit_sum());
 
         let entry = n_identity(
@@ -929,7 +929,7 @@ pub(crate) mod test {
         cfg_builder: &mut CFGBuilder<T>,
         separate_headers: bool,
     ) -> Result<(BasicBlockID, BasicBlockID), BuildError> {
-        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2));
+        let pred_const = cfg_builder.add_constant(Const::unit_sum(0, 2).expect("0 < 2"));
         let const_unit = cfg_builder.add_constant(Const::unary_unit_sum());
 
         let entry = n_identity(

--- a/quantinuum-hugr/src/builder/cfg.rs
+++ b/quantinuum-hugr/src/builder/cfg.rs
@@ -52,7 +52,6 @@ use crate::{
 ///   types::{FunctionType, Type, SumType},
 ///   ops,
 ///   type_row,
-///   values::Value,
 /// };
 ///
 /// const NAT: Type = prelude::USIZE_T;
@@ -73,10 +72,11 @@ use crate::{
 ///     let [inw] = entry_b.input_wires_arr();
 ///     let entry = {
 ///         // Pack the const "42" into the appropriate sum type.
-///         let left_42 =
-///             ops::Const::new_sum(0,
-///                                   [prelude::ConstUsize::new(42).into()],
-///                                   SumType::new(sum_variants.clone()))?;
+///         let left_42 = ops::Const::sum(
+///             0,
+///             [prelude::ConstUsize::new(42).into()],
+///             SumType::new(sum_variants.clone())
+///         )?;
 ///         let sum = entry_b.add_load_const(left_42);
 ///
 ///         entry_b.finish_with_outputs(sum, [inw])?

--- a/quantinuum-hugr/src/extension/prelude.rs
+++ b/quantinuum-hugr/src/extension/prelude.rs
@@ -6,13 +6,13 @@ use smol_str::SmolStr;
 use crate::types::SumType;
 use crate::{
     extension::{ExtensionId, TypeDefBound},
+    ops::constant::CustomConst,
     ops::LeafOp,
     type_row,
     types::{
         type_param::{TypeArg, TypeParam},
         CustomType, FunctionType, PolyFuncType, Type, TypeBound,
     },
-    values::CustomConst,
     Extension,
 };
 
@@ -185,7 +185,7 @@ impl CustomConst for ConstUsize {
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
-        crate::values::downcast_equal_consts(self, other)
+        crate::ops::constant::downcast_equal_consts(self, other)
     }
 
     fn extension_reqs(&self) -> ExtensionSet {
@@ -223,7 +223,7 @@ impl CustomConst for ConstError {
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
-        crate::values::downcast_equal_consts(self, other)
+        crate::ops::constant::downcast_equal_consts(self, other)
     }
 
     fn extension_reqs(&self) -> ExtensionSet {

--- a/quantinuum-hugr/src/extension/prelude.rs
+++ b/quantinuum-hugr/src/extension/prelude.rs
@@ -3,6 +3,7 @@
 use lazy_static::lazy_static;
 use smol_str::SmolStr;
 
+use crate::types::SumType;
 use crate::{
     extension::{ExtensionId, TypeDefBound},
     ops::LeafOp,
@@ -157,8 +158,8 @@ pub const ERROR_TYPE: Type = Type::new_extension(ERROR_CUSTOM_TYPE);
 pub const ERROR_TYPE_NAME: SmolStr = SmolStr::new_inline("error");
 
 /// Return a Sum type with the first variant as the given type and the second an Error.
-pub fn sum_with_error(ty: Type) -> Type {
-    Type::new_sum([vec![ty].into(), vec![ERROR_TYPE].into()])
+pub fn sum_with_error(ty: Type) -> SumType {
+    SumType::new([vec![ty], vec![ERROR_TYPE]])
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/quantinuum-hugr/src/hugr/rewrite/inline_dfg.rs
+++ b/quantinuum-hugr/src/hugr/rewrite/inline_dfg.rs
@@ -147,7 +147,6 @@ mod test {
     use crate::std_extensions::arithmetic::int_types::{self, ConstIntU};
     use crate::types::FunctionType;
     use crate::utils::test_quantum_extension;
-    use crate::values::Value;
     use crate::{type_row, Direction, HugrView, Node, Port};
     use crate::{Hugr, Wire};
 
@@ -186,12 +185,7 @@ mod test {
             d: &mut DFGBuilder<T>,
         ) -> Result<Wire, Box<dyn std::error::Error>> {
             let int_ty = &int_types::INT_TYPES[6];
-            let cst = Const::new(
-                Value::Extension {
-                    c: (Box::new(ConstIntU::new(6, 15)?),),
-                },
-                int_ty.clone(),
-            )?;
+            let cst = Const::extension(ConstIntU::new(6, 15)?);
             let c1 = d.add_load_const(cst);
             let [lifted] = d
                 .add_dataflow_op(

--- a/quantinuum-hugr/src/lib.rs
+++ b/quantinuum-hugr/src/lib.rs
@@ -149,7 +149,6 @@ pub mod ops;
 pub mod std_extensions;
 pub mod types;
 mod utils;
-pub mod values;
 
 pub use crate::core::{
     CircuitUnit, Direction, IncomingPort, Node, NodeIndex, OutgoingPort, Port, PortIndex, Wire,

--- a/quantinuum-hugr/src/ops.rs
+++ b/quantinuum-hugr/src/ops.rs
@@ -409,17 +409,6 @@ impl OpParent for Conditional {}
 impl OpParent for FuncDecl {}
 impl OpParent for ExitBlock {}
 
-/// Properties of operations that represent a function, either as a declaration
-/// or by defining a dataflow graph.kkk
-pub trait FunctionOp {
-    /// The type of .
-    ///
-    /// Non-container ops like `FuncDecl` return `None` even though they represent a function.
-    fn inner_function_type(&self) -> Option<FunctionType> {
-        None
-    }
-}
-
 #[enum_dispatch]
 /// Methods for Ops to validate themselves and children
 pub trait ValidateOp {

--- a/quantinuum-hugr/src/ops.rs
+++ b/quantinuum-hugr/src/ops.rs
@@ -380,6 +380,8 @@ pub trait OpTrait {
 pub trait OpParent {
     /// The inner function type of the operation, if it has a child dataflow
     /// sibling graph.
+    ///
+    /// Non-container ops like `FuncDecl` return `None` even though they represent a function.
     fn inner_function_type(&self) -> Option<FunctionType> {
         None
     }
@@ -406,6 +408,17 @@ impl OpParent for CFG {}
 impl OpParent for Conditional {}
 impl OpParent for FuncDecl {}
 impl OpParent for ExitBlock {}
+
+/// Properties of operations that represent a function, either as a declaration
+/// or by defining a dataflow graph.kkk
+pub trait FunctionOp {
+    /// The type of .
+    ///
+    /// Non-container ops like `FuncDecl` return `None` even though they represent a function.
+    fn inner_function_type(&self) -> Option<FunctionType> {
+        None
+    }
+}
 
 #[enum_dispatch]
 /// Methods for Ops to validate themselves and children

--- a/quantinuum-hugr/src/ops/constant.rs
+++ b/quantinuum-hugr/src/ops/constant.rs
@@ -1,69 +1,178 @@
 //! Constant value definitions.
 
-use crate::{
-    extension::ExtensionSet,
-    types::{ConstTypeError, EdgeKind, SumType, Type},
-    values::{CustomConst, Value},
-};
-
-use smol_str::SmolStr;
-
-use super::OpTag;
 use super::{OpName, OpTrait, StaticTag};
+use super::{OpTag, OpType};
+use crate::extension::ExtensionSet;
+use crate::types::{CustomType, EdgeKind, SumType, SumTypeError, Type};
+use crate::values::CustomConst;
+use crate::{Hugr, HugrView};
 
-/// A constant value definition.
+use itertools::Itertools;
+use smol_str::SmolStr;
+use thiserror::Error;
+
+/// An operation returning a constant value.
+///
+/// Represents core types and extension types.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct Const {
-    value: Value,
-    typ: Type,
+#[serde(tag = "v")]
+pub enum Const {
+    /// An extension constant value, that can check it is of a given [CustomType].
+    ///
+    // Note: the extra level of tupling is to avoid https://github.com/rust-lang/rust/issues/78808
+    Extension {
+        #[allow(missing_docs)]
+        c: (Box<dyn CustomConst>,),
+    },
+    /// A higher-order function value.
+    // TODO use a root parametrised hugr, e.g. Hugr<DFG>.
+    Function {
+        #[allow(missing_docs)]
+        hugr: Box<Hugr>,
+    },
+    /// A tuple
+    Tuple {
+        #[allow(missing_docs)]
+        vs: Vec<Const>,
+    },
+    /// A Sum variant, with a tag indicating the index of the variant and its
+    /// value.
+    Sum {
+        /// The tag index of the variant.
+        tag: usize,
+        /// The value of the variant.
+        ///
+        /// Sum variants are always a row of values, hence the Vec.
+        values: Vec<Const>,
+        /// The full type of the Sum, including the other variants.
+        #[serde(rename = "typ")]
+        sum_type: SumType,
+    },
+}
+
+/// Struct for custom type check fails.
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum CustomCheckFailure {
+    /// The value had a specific type that was not what was expected
+    #[error("Expected type: {expected} but value was of type: {found}")]
+    TypeMismatch {
+        /// The expected custom type.
+        expected: CustomType,
+        /// The custom type found when checking.
+        found: Type,
+    },
+    /// Any other message
+    #[error("{0}")]
+    Message(String),
+}
+
+/// Errors that arise from typechecking constants
+#[derive(Clone, Debug, PartialEq, Error)]
+pub enum ConstTypeError {
+    /// Invalid sum type definition.
+    #[error("{0}")]
+    SumType(#[from] SumTypeError),
+    /// Function constant missing a function type.
+    #[error(
+        "A function constant cannot be defined using a Hugr with root of type {}.",
+        .hugr_root_type.name()
+    )]
+    FunctionTypeMissing {
+        /// The root node type of the Hugr defining the function constant.
+        hugr_root_type: OpType,
+    },
+    /// A mismatch between the type expected and the value.
+    #[error("Value {1:?} does not match expected type {0}")]
+    ConstCheckFail(Type, Const),
+    /// Error when checking a custom value.
+    #[error("Error when checking custom type: {0:?}")]
+    CustomCheckFail(#[from] CustomCheckFailure),
 }
 
 impl Const {
-    /// Creates a new Const, type-checking the value.
-    pub fn new(value: Value, typ: Type) -> Result<Self, ConstTypeError> {
-        typ.check_type(&value)?;
-        Ok(Self { value, typ })
-    }
-
-    /// Returns a reference to the value of this [`Const`].
-    pub fn value(&self) -> &Value {
-        &self.value
-    }
-
     /// Returns a reference to the type of this [`Const`].
-    pub fn const_type(&self) -> &Type {
-        &self.typ
+    pub fn const_type(&self) -> Type {
+        match self {
+            Self::Extension { c: (e,) } => e.get_type(),
+            Self::Tuple { vs } => Type::new_tuple(vs.iter().map(Self::const_type).collect_vec()),
+            Self::Sum { sum_type, .. } => sum_type.clone().into(),
+            Self::Function { hugr } => {
+                let func_type = hugr.get_function_type().unwrap_or_else(|| {
+                    panic!(
+                        "{}",
+                        ConstTypeError::FunctionTypeMissing {
+                            hugr_root_type: hugr.get_optype(hugr.root()).clone()
+                        }
+                    )
+                });
+                Type::new_function(func_type)
+            }
+        }
     }
 
     /// Creates a new Const Sum.  The value is determined by `items` and is
     /// type-checked `typ`
-    pub fn new_sum(
+    pub fn sum(
         tag: usize,
         items: impl IntoIterator<Item = Const>,
         typ: SumType,
     ) -> Result<Self, ConstTypeError> {
-        Self::new(
-            Value::sum(tag, items.into_iter().map(|x| x.value().to_owned())),
-            typ.into(),
-        )
+        let values: Vec<Const> = items.into_iter().collect();
+        typ.check_type(tag, &values)?;
+        Ok(Self::Sum {
+            tag,
+            values,
+            sum_type: typ,
+        })
+    }
+
+    /// Returns a tuple constant of constant values.
+    pub fn tuple(items: impl IntoIterator<Item = Const>) -> Self {
+        Self::Tuple {
+            vs: items.into_iter().collect(),
+        }
+    }
+
+    /// Returns a constant function defined by a Hugr.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Hugr root node does not define a function.
+    pub fn function(hugr: impl Into<Hugr>) -> Result<Self, ConstTypeError> {
+        let hugr = hugr.into();
+        if hugr.get_function_type().is_none() {
+            Err(ConstTypeError::FunctionTypeMissing {
+                hugr_root_type: hugr.get_optype(hugr.root()).clone(),
+            })?;
+        }
+        Ok(Self::Function {
+            hugr: Box::new(hugr),
+        })
+    }
+
+    /// Constant unit type (empty Tuple).
+    pub const fn unit() -> Self {
+        Self::Tuple { vs: vec![] }
     }
 
     /// Constant Sum over units, used as branching values.
-    pub fn unit_sum(tag: usize, size: u8) -> Self {
-        Self {
-            value: Value::unit_sum(tag),
-            typ: Type::new_unit_sum(size),
-        }
+    pub fn unit_sum(tag: usize, size: u8) -> Result<Self, ConstTypeError> {
+        Self::sum(tag, [], SumType::Unit { size })
     }
 
     /// Constant Sum over units, with only one variant.
     pub fn unary_unit_sum() -> Self {
-        Self::unit_sum(0, 1)
+        Self::unit_sum(0, 1).expect("0 < 1")
     }
 
-    /// Constant "true" value, i.e. the second variant of Sum((), ()).
+    /// Returns a constant "true" value, i.e. the second variant of Sum((), ()).
     pub fn true_val() -> Self {
-        Self::unit_sum(1, 2)
+        Self::unit_sum(1, 2).expect("1 < 2")
+    }
+
+    /// Returns a constant "false" value, i.e. the first variant of Sum((), ()).
+    pub fn false_val() -> Self {
+        Self::unit_sum(0, 2).expect("0 < 2")
     }
 
     /// Generate a constant equivalent of a boolean,
@@ -76,29 +185,42 @@ impl Const {
         }
     }
 
-    /// Constant "false" value, i.e. the first variant of Sum((), ()).
-    pub fn false_val() -> Self {
-        Self::unit_sum(0, 2)
-    }
-
-    /// Tuple of values
-    pub fn new_tuple(items: impl IntoIterator<Item = Const>) -> Self {
-        let (values, types): (Vec<Value>, Vec<Type>) = items
-            .into_iter()
-            .map(|Const { value, typ }| (value, typ))
-            .unzip();
-        Self::new(Value::tuple(values), Type::new_tuple(types)).unwrap()
+    /// Returns a tuple constant of constant values.
+    pub fn extension(custom_const: impl CustomConst) -> Self {
+        Self::Extension {
+            c: (Box::new(custom_const),),
+        }
     }
 
     /// For a Const holding a CustomConst, extract the CustomConst by downcasting.
     pub fn get_custom_value<T: CustomConst>(&self) -> Option<&T> {
-        self.value().get_custom_value()
+        if let Self::Extension { c: (custom,) } = self {
+            custom.downcast_ref()
+        } else {
+            None
+        }
     }
 }
 
 impl OpName for Const {
     fn name(&self) -> SmolStr {
-        self.value.name().into()
+        match self {
+            Self::Extension { c: e } => format!("const:custom:{}", e.0.name()),
+            Self::Function { hugr: h } => {
+                let Some(t) = h.get_function_type() else {
+                    panic!("HUGR root node isn't a valid function parent.");
+                };
+                format!("const:function:[{}]", t)
+            }
+            Self::Tuple { vs: vals } => {
+                let names: Vec<_> = vals.iter().map(Self::name).collect();
+                format!("const:seq:{{{}}}", names.join(", "))
+            }
+            Self::Sum { tag, values, .. } => {
+                format!("const:sum:{{tag:{tag}, vals:{values:?}}}")
+            }
+        }
+        .into()
     }
 }
 impl StaticTag for Const {
@@ -106,11 +228,18 @@ impl StaticTag for Const {
 }
 impl OpTrait for Const {
     fn description(&self) -> &str {
-        self.value.description()
+        "Constant value"
     }
 
     fn extension_delta(&self) -> ExtensionSet {
-        self.value.extension_reqs()
+        match self {
+            Self::Extension { c } => c.0.extension_reqs().clone(),
+            Self::Function { .. } => ExtensionSet::new(), // no extensions required to load Hugr (only to run)
+            Self::Tuple { vs } => ExtensionSet::union_over(vs.iter().map(Const::extension_delta)),
+            Self::Sum { values, .. } => {
+                ExtensionSet::union_over(values.iter().map(|x| x.extension_delta()))
+            }
+        }
     }
 
     fn tag(&self) -> OpTag {
@@ -118,7 +247,7 @@ impl OpTrait for Const {
     }
 
     fn static_output(&self) -> Option<EdgeKind> {
-        Some(EdgeKind::Static(self.typ.clone()))
+        Some(EdgeKind::Static(self.const_type()))
     }
 }
 
@@ -129,17 +258,14 @@ where
     T: CustomConst,
 {
     fn from(value: T) -> Self {
-        let typ = value.get_type();
-        Const {
-            value: Value::custom(value),
-            typ,
-        }
+        Self::extension(value)
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::Const;
+    use crate::builder::test::simple_dfg_hugr;
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
         extension::{
@@ -149,13 +275,14 @@ mod test {
         std_extensions::arithmetic::float_types::{self, ConstF64, FLOAT64_TYPE},
         type_row,
         types::type_param::TypeArg,
-        types::{CustomCheckFailure, CustomType, FunctionType, Type, TypeBound, TypeRow},
+        types::{CustomType, FunctionType, Type, TypeBound, TypeRow},
         values::{
             test::{serialized_float, CustomTestValue},
-            CustomSerialized, Value,
+            CustomSerialized,
         },
     };
     use cool_asserts::assert_matches;
+    use rstest::{fixture, rstest};
     use serde_yaml::Value as YamlValue;
 
     use super::*;
@@ -164,6 +291,7 @@ mod test {
         ExtensionRegistry::try_new([PRELUDE.to_owned(), float_types::EXTENSION.to_owned()]).unwrap()
     }
 
+    /// Constructs a DFG hugr defining a sum constant, and returning the loaded value.
     #[test]
     fn test_sum() -> Result<(), BuildError> {
         use crate::builder::Container;
@@ -174,7 +302,7 @@ mod test {
             type_row![],
             TypeRow::from(vec![pred_ty.clone().into()]),
         ))?;
-        let c = b.add_constant(Const::new_sum(
+        let c = b.add_constant(Const::sum(
             0,
             [
                 Into::<Const>::into(CustomTestValue(USIZE_CUSTOM_T)),
@@ -189,7 +317,7 @@ mod test {
             type_row![],
             TypeRow::from(vec![pred_ty.clone().into()]),
         ))?;
-        let c = b.add_constant(Const::new_sum(1, [], pred_ty.clone())?);
+        let c = b.add_constant(Const::sum(1, [], pred_ty.clone())?);
         let w = b.load_const(&c);
         b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
 
@@ -200,73 +328,97 @@ mod test {
     fn test_bad_sum() {
         let pred_ty = SumType::new([type_row![USIZE_T, FLOAT64_TYPE], type_row![]]);
 
-        let res = Const::new_sum(0, [Const::new_tuple(std::iter::empty())], pred_ty);
-        assert_matches!(res, Err(ConstTypeError::SumWrongLength));
+        let res = Const::sum(0, [], pred_ty.clone());
+        assert_matches!(
+            res,
+            Err(ConstTypeError::SumType(SumTypeError::WrongVariantLength {
+                tag: 0,
+                expected: 2,
+                found: 0
+            }))
+        );
+
+        let res = Const::sum(4, [], pred_ty.clone());
+        assert_matches!(
+            res,
+            Err(ConstTypeError::SumType(SumTypeError::InvalidTag {
+                tag: 4,
+                num_variants: 2
+            }))
+        );
+
+        let res = Const::sum(0, [const_usize(), const_usize()], pred_ty);
+        assert_matches!(
+            res,
+            Err(ConstTypeError::SumType(SumTypeError::InvalidValueType {
+                tag: 0,
+                index: 1,
+                expected,
+                found,
+            })) if expected == FLOAT64_TYPE && found == const_usize()
+        );
     }
 
-    #[test]
-    fn test_constant_values() {
-        let int_value: Value = ConstUsize::new(257).into();
-        USIZE_T.check_type(&int_value).unwrap();
-        FLOAT64_TYPE
-            .check_type(serialized_float(17.4).value())
-            .unwrap();
-        assert_matches!(
-            FLOAT64_TYPE.check_type(&int_value),
-            Err(ConstTypeError::CustomCheckFail(
-                CustomCheckFailure::TypeMismatch { .. }
-            ))
-        );
-        let tuple_ty = Type::new_tuple(vec![USIZE_T, FLOAT64_TYPE]);
-        let tuple_val = Value::tuple([int_value.clone(), serialized_float(5.1).value().to_owned()]);
-        tuple_ty.check_type(&tuple_val).unwrap();
-        let tuple_val2 = Value::tuple(vec![
-            serialized_float(6.1).value().to_owned(),
-            int_value.clone(),
-        ]);
-        assert_matches!(
-            tuple_ty.check_type(&tuple_val2),
-            Err(ConstTypeError::ValueCheckFail(ty, tv2)) => ty == tuple_ty && tv2 == tuple_val2
-        );
-        let tuple_val3 = Value::tuple([
-            int_value.clone(),
-            serialized_float(3.3).value().clone(),
-            serialized_float(2.0).value().clone(),
-        ]);
+    #[rstest]
+    fn function_value(simple_dfg_hugr: Hugr) {
+        let v = Const::Function {
+            hugr: Box::new(simple_dfg_hugr),
+        };
+
+        let correct_type = Type::new_function(FunctionType::new_endo(type_row![
+            crate::extension::prelude::BOOL_T
+        ]));
+
+        assert_eq!(v.const_type(), correct_type);
+    }
+
+    #[fixture]
+    fn const_usize() -> Const {
+        ConstUsize::new(257).into()
+    }
+
+    #[fixture]
+    fn const_tuple() -> Const {
+        Const::tuple([ConstUsize::new(257).into(), serialized_float(5.1)])
+    }
+
+    #[rstest]
+    #[case(const_usize(), USIZE_T)]
+    #[case(serialized_float(17.4), FLOAT64_TYPE)]
+    #[case(const_tuple(), Type::new_tuple(type_row![USIZE_T, FLOAT64_TYPE]))]
+    fn const_type(#[case] const_value: Const, #[case] expected_type: Type) {
+        assert_eq!(const_value.const_type(), expected_type);
+    }
+
+    #[rstest]
+    fn const_custom_value(const_usize: Const, const_tuple: Const) {
         assert_eq!(
-            tuple_ty.check_type(&tuple_val3),
-            Err(ConstTypeError::TupleWrongLength)
+            const_usize.get_custom_value::<ConstUsize>(),
+            Some(&ConstUsize::new(257))
         );
-
-        let op = Const::new(int_value, USIZE_T).unwrap();
-
-        assert_eq!(op.get_custom_value(), Some(&ConstUsize::new(257)));
-        let try_float: Option<&ConstF64> = op.get_custom_value();
-        assert!(try_float.is_none());
-        let try_usize: Option<&ConstUsize> = tuple_val.get_custom_value();
-        assert!(try_usize.is_none());
+        assert_eq!(const_usize.get_custom_value::<ConstF64>(), None);
+        assert_eq!(const_tuple.get_custom_value::<ConstUsize>(), None);
+        assert_eq!(const_tuple.get_custom_value::<ConstF64>(), None);
     }
 
     #[test]
     fn test_yaml_const() {
-        let ex_id: ExtensionId = "myrsrc".try_into().unwrap();
+        let ex_id: ExtensionId = "my_extension".try_into().unwrap();
         let typ_int = CustomType::new(
-            "mytype",
+            "my_type",
             vec![TypeArg::BoundedNat { n: 8 }],
             ex_id.clone(),
             TypeBound::Eq,
         );
-        let val: Value =
+        let yaml_const: Const =
             CustomSerialized::new(typ_int.clone(), YamlValue::Number(6.into()), ex_id.clone())
                 .into();
         let classic_t = Type::new_extension(typ_int.clone());
         assert_matches!(classic_t.least_upper_bound(), TypeBound::Eq);
-        classic_t.check_type(&val).unwrap();
+        assert_eq!(yaml_const.const_type(), classic_t);
 
-        let typ_qb: Type = CustomType::new("mytype", vec![], ex_id, TypeBound::Eq).into();
-        assert_matches!(typ_qb.check_type(&val),
-            Err(ConstTypeError::CustomCheckFail(CustomCheckFailure::TypeMismatch{expected, found})) => expected == typ_int && found == typ_qb);
-
-        assert_eq!(val, val);
+        let typ_qb = CustomType::new("my_type", vec![], ex_id, TypeBound::Eq);
+        let t = Type::new_extension(typ_qb.clone());
+        assert_ne!(yaml_const.const_type(), t);
     }
 }

--- a/quantinuum-hugr/src/ops/constant.rs
+++ b/quantinuum-hugr/src/ops/constant.rs
@@ -21,8 +21,6 @@ pub use custom::{downcast_equal_consts, CustomConst, CustomSerialized};
 #[serde(tag = "c")]
 pub enum Const {
     /// An extension constant value, that can check it is of a given [CustomType].
-    ///
-    // Note: the extra level of tupling is to avoid https://github.com/rust-lang/rust/issues/78808
     Extension {
         /// The custom constant value.
         e: ExtensionConst,

--- a/quantinuum-hugr/src/ops/constant.rs
+++ b/quantinuum-hugr/src/ops/constant.rs
@@ -55,11 +55,11 @@ pub enum Const {
 
 /// Boxed [`CustomConst`] trait object.
 ///
-/// This is used to avoid https://github.com/rust-lang/rust/issues/78808 in
+/// Use [`Const::extension`] to create a new variant of this type.
+///
+/// This is required to avoid <https://github.com/rust-lang/rust/issues/78808> in
 /// [`Const::Extension`], while implementing a transparent encoding into a
 /// `CustomConst`.
-///
-/// Use [`Const::extension`] to create a new variant of this type.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct ExtensionConst(pub(super) Box<dyn CustomConst>);

--- a/quantinuum-hugr/src/ops/constant.rs
+++ b/quantinuum-hugr/src/ops/constant.rs
@@ -413,15 +413,14 @@ mod test {
 
     #[rstest]
     fn function_value(simple_dfg_hugr: Hugr) {
-        let v = Const::Function {
-            hugr: Box::new(simple_dfg_hugr),
-        };
+        let v = Const::function(simple_dfg_hugr).unwrap();
 
         let correct_type = Type::new_function(FunctionType::new_endo(type_row![
             crate::extension::prelude::BOOL_T
         ]));
 
         assert_eq!(v.const_type(), correct_type);
+        assert!(v.name().starts_with("const:function:"))
     }
 
     #[fixture]
@@ -435,11 +434,21 @@ mod test {
     }
 
     #[rstest]
-    #[case(const_usize(), USIZE_T)]
-    #[case(serialized_float(17.4), FLOAT64_TYPE)]
-    #[case(const_tuple(), Type::new_tuple(type_row![USIZE_T, FLOAT64_TYPE]))]
-    fn const_type(#[case] const_value: Const, #[case] expected_type: Type) {
+    #[case(Const::unit(), Type::UNIT, "const:seq:{}")]
+    #[case(const_usize(), USIZE_T, "const:custom:ConstUsize(")]
+    #[case(serialized_float(17.4), FLOAT64_TYPE, "const:custom:yaml:Number(17.4)")]
+    #[case(const_tuple(), Type::new_tuple(type_row![USIZE_T, FLOAT64_TYPE]), "const:seq:{")]
+    fn const_type(
+        #[case] const_value: Const,
+        #[case] expected_type: Type,
+        #[case] name_prefix: &str,
+    ) {
         assert_eq!(const_value.const_type(), expected_type);
+        let name = const_value.name();
+        assert!(
+            name.starts_with(name_prefix),
+            "{name} does not start with {name_prefix}"
+        );
     }
 
     #[rstest]

--- a/quantinuum-hugr/src/ops/constant/custom.rs
+++ b/quantinuum-hugr/src/ops/constant/custom.rs
@@ -19,7 +19,7 @@ use crate::types::{CustomCheckFailure, Type};
 /// When implementing this trait, include the `#[typetag::serde]` attribute to
 /// enable serialization.
 ///
-/// [CustomType]: crate::types::CustomType
+/// [`CustomType`]: crate::types::CustomType
 #[typetag::serde(tag = "c")]
 pub trait CustomConst:
     Send + Sync + std::fmt::Debug + CustomConstBoxClone + Any + Downcast

--- a/quantinuum-hugr/src/std_extensions/arithmetic/conversions.rs
+++ b/quantinuum-hugr/src/std_extensions/arithmetic/conversions.rs
@@ -23,7 +23,7 @@ mod const_fold;
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.conversions");
 
-/// Extensiop for conversions between floats and integers.
+/// Extension for conversions between floats and integers.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
 #[allow(missing_docs, non_camel_case_types)]
 pub enum ConvertOpDef {
@@ -43,7 +43,10 @@ impl MakeOpDef for ConvertOpDef {
         match self {
             trunc_s | trunc_u => PolyFuncType::new(
                 vec![LOG_WIDTH_TYPE_PARAM],
-                FunctionType::new(type_row![FLOAT64_TYPE], vec![sum_with_error(int_tv(0))]),
+                FunctionType::new(
+                    type_row![FLOAT64_TYPE],
+                    vec![sum_with_error(int_tv(0)).into()],
+                ),
             ),
 
             convert_s | convert_u => PolyFuncType::new(

--- a/quantinuum-hugr/src/std_extensions/arithmetic/conversions/const_fold.rs
+++ b/quantinuum-hugr/src/std_extensions/arithmetic/conversions/const_fold.rs
@@ -5,12 +5,12 @@ use crate::{
         ConstFold, ConstFoldResult, OpDef,
     },
     ops,
+    ops::constant::CustomConst,
     std_extensions::arithmetic::{
         float_types::ConstF64,
         int_types::{get_log_width, ConstIntS, ConstIntU, INT_TYPES},
     },
     types::ConstTypeError,
-    values::CustomConst,
     IncomingPort,
 };
 

--- a/quantinuum-hugr/src/std_extensions/arithmetic/float_types.rs
+++ b/quantinuum-hugr/src/std_extensions/arithmetic/float_types.rs
@@ -4,8 +4,8 @@ use smol_str::SmolStr;
 
 use crate::{
     extension::{ExtensionId, ExtensionSet},
+    ops::constant::CustomConst,
     types::{CustomType, Type, TypeBound},
-    values::CustomConst,
     Extension,
 };
 use lazy_static::lazy_static;
@@ -13,7 +13,7 @@ use lazy_static::lazy_static;
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.float.types");
 
-/// Identfier for the 64-bit IEEE 754-2019 floating-point type.
+/// Identifier for the 64-bit IEEE 754-2019 floating-point type.
 const FLOAT_TYPE_ID: SmolStr = SmolStr::new_inline("float64");
 
 /// 64-bit IEEE 754-2019 floating-point type (as [CustomType])
@@ -61,7 +61,7 @@ impl CustomConst for ConstF64 {
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
-        crate::values::downcast_equal_consts(self, other)
+        crate::ops::constant::downcast_equal_consts(self, other)
     }
 
     fn extension_reqs(&self) -> ExtensionSet {

--- a/quantinuum-hugr/src/std_extensions/arithmetic/int_ops.rs
+++ b/quantinuum-hugr/src/std_extensions/arithmetic/int_ops.rs
@@ -107,7 +107,7 @@ impl MakeOpDef for IntOpDef {
             )
             .into(),
             inarrow_s | inarrow_u => CustomValidator::new_with_validator(
-                int_polytype(2, vec![int_tv(0)], vec![sum_with_error(int_tv(1))]),
+                int_polytype(2, vec![int_tv(0)], vec![sum_with_error(int_tv(1)).into()]),
                 IOValidator { f_ge_s: true },
             )
             .into(),
@@ -126,7 +126,7 @@ impl MakeOpDef for IntOpDef {
                 int_polytype(
                     2,
                     intpair.clone(),
-                    vec![sum_with_error(Type::new_tuple(intpair))],
+                    vec![sum_with_error(Type::new_tuple(intpair)).into()],
                 )
             }
             .into(),
@@ -139,13 +139,13 @@ impl MakeOpDef for IntOpDef {
             idiv_checked_u | idiv_checked_s => int_polytype(
                 2,
                 vec![int_tv(0), int_tv(1)],
-                vec![sum_with_error(int_tv(0))],
+                vec![sum_with_error(int_tv(0)).into()],
             )
             .into(),
             imod_checked_u | imod_checked_s => int_polytype(
                 2,
                 vec![int_tv(0), int_tv(1).clone()],
-                vec![sum_with_error(int_tv(1))],
+                vec![sum_with_error(int_tv(1)).into()],
             )
             .into(),
             imod_u | imod_s => {
@@ -372,7 +372,10 @@ mod test {
                 .to_extension_op()
                 .unwrap()
                 .signature(),
-            FunctionType::new(vec![int_type(ta(3))], vec![sum_with_error(int_type(ta(3)))],)
+            FunctionType::new(
+                vec![int_type(ta(3))],
+                vec![sum_with_error(int_type(ta(3))).into()],
+            )
         );
         assert!(
             IntOpDef::iwiden_u
@@ -388,7 +391,10 @@ mod test {
                 .to_extension_op()
                 .unwrap()
                 .signature(),
-            FunctionType::new(vec![int_type(ta(2))], vec![sum_with_error(int_type(ta(1)))],)
+            FunctionType::new(
+                vec![int_type(ta(2))],
+                vec![sum_with_error(int_type(ta(1))).into()],
+            )
         );
 
         assert!(IntOpDef::inarrow_u

--- a/quantinuum-hugr/src/std_extensions/arithmetic/int_types.rs
+++ b/quantinuum-hugr/src/std_extensions/arithmetic/int_types.rs
@@ -6,11 +6,11 @@ use smol_str::SmolStr;
 
 use crate::{
     extension::{ExtensionId, ExtensionSet},
+    ops::constant::CustomConst,
     types::{
         type_param::{TypeArg, TypeArgError, TypeParam},
         ConstTypeError, CustomType, Type, TypeBound,
     },
-    values::CustomConst,
     Extension,
 };
 use lazy_static::lazy_static;
@@ -150,7 +150,7 @@ impl CustomConst for ConstIntU {
         format!("u{}({})", self.log_width, self.value).into()
     }
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
-        crate::values::downcast_equal_consts(self, other)
+        crate::ops::constant::downcast_equal_consts(self, other)
     }
 
     fn extension_reqs(&self) -> ExtensionSet {
@@ -168,7 +168,7 @@ impl CustomConst for ConstIntS {
         format!("i{}({})", self.log_width, self.value).into()
     }
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
-        crate::values::downcast_equal_consts(self, other)
+        crate::ops::constant::downcast_equal_consts(self, other)
     }
 
     fn extension_reqs(&self) -> ExtensionSet {

--- a/quantinuum-hugr/src/std_extensions/collections.rs
+++ b/quantinuum-hugr/src/std_extensions/collections.rs
@@ -13,12 +13,12 @@ use crate::{
         ConstFold, ExtensionId, ExtensionRegistry, ExtensionSet, SignatureError, TypeDef,
         TypeDefBound,
     },
+    ops::constant::CustomConst,
     ops::{self, custom::ExtensionOp, OpName},
     types::{
         type_param::{TypeArg, TypeParam},
         CustomCheckFailure, CustomType, FunctionType, PolyFuncType, Type, TypeBound,
     },
-    values::CustomConst,
     Extension,
 };
 
@@ -92,7 +92,7 @@ impl CustomConst for ListValue {
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
-        crate::values::downcast_equal_consts(self, other)
+        crate::ops::constant::downcast_equal_consts(self, other)
     }
 
     fn extension_reqs(&self) -> ExtensionSet {

--- a/quantinuum-hugr/src/std_extensions/collections.rs
+++ b/quantinuum-hugr/src/std_extensions/collections.rs
@@ -5,6 +5,7 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
+use crate::ops::{Const, OpTrait};
 use crate::{
     algorithm::const_fold::sorted_consts,
     extension::{
@@ -17,7 +18,7 @@ use crate::{
         type_param::{TypeArg, TypeParam},
         CustomCheckFailure, CustomType, FunctionType, PolyFuncType, Type, TypeBound,
     },
-    values::{CustomConst, Value},
+    values::CustomConst,
     Extension,
 };
 
@@ -32,12 +33,12 @@ pub const EXTENSION_NAME: ExtensionId = ExtensionId::new_unchecked("Collections"
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// Dynamically sized list of values, all of the same type.
-pub struct ListValue(Vec<Value>, Type);
+pub struct ListValue(Vec<Const>, Type);
 
 impl ListValue {
     /// Create a new [CustomConst] for a list of values of type `typ`.
     /// That all values ore of type `typ` is not checked here.
-    pub fn new(typ: Type, contents: impl IntoIterator<Item = Value>) -> Self {
+    pub fn new(typ: Type, contents: impl IntoIterator<Item = Const>) -> Self {
         Self(contents.into_iter().collect_vec(), typ)
     }
 
@@ -76,14 +77,17 @@ impl CustomConst for ListValue {
             .map_err(|_| error())?;
 
         // constant can only hold classic type.
-        let [TypeArg::Type { ty: t }] = typ.args() else {
+        let [TypeArg::Type { ty }] = typ.args() else {
             return Err(error());
         };
 
         // check all values are instances of the element type
-        for val in &self.0 {
-            t.check_type(val).map_err(|_| error())?;
+        for v in &self.0 {
+            if v.const_type() != *ty {
+                return Err(error());
+            }
         }
+
         Ok(())
     }
 
@@ -92,7 +96,7 @@ impl CustomConst for ListValue {
     }
 
     fn extension_reqs(&self) -> ExtensionSet {
-        ExtensionSet::union_over(self.0.iter().map(Value::extension_reqs))
+        ExtensionSet::union_over(self.0.iter().map(Const::extension_delta))
             .union(EXTENSION_NAME.into())
     }
 }
@@ -102,17 +106,13 @@ struct PopFold;
 impl ConstFold for PopFold {
     fn fold(
         &self,
-        type_args: &[TypeArg],
+        _type_args: &[TypeArg],
         consts: &[(crate::IncomingPort, ops::Const)],
     ) -> crate::extension::ConstFoldResult {
-        let [TypeArg::Type { ty }] = type_args else {
-            return None;
-        };
         let [list]: [&ops::Const; 1] = sorted_consts(consts).try_into().ok()?;
         let list: &ListValue = list.get_custom_value().expect("Should be list value.");
         let mut list = list.clone();
         let elem = list.0.pop()?; // empty list fails to evaluate "pop"
-        let elem = ops::Const::new(elem, ty.clone()).unwrap();
 
         Some(vec![(0.into(), list.into()), (1.into(), elem)])
     }
@@ -129,7 +129,7 @@ impl ConstFold for PushFold {
         let [list, elem]: [&ops::Const; 2] = sorted_consts(consts).try_into().ok()?;
         let list: &ListValue = list.get_custom_value().expect("Should be list value.");
         let mut list = list.clone();
-        list.0.push(elem.value().clone());
+        list.0.push(elem.clone());
 
         Some(vec![(0.into(), list.into())])
     }

--- a/quantinuum-hugr/src/std_extensions/logic.rs
+++ b/quantinuum-hugr/src/std_extensions/logic.rs
@@ -151,10 +151,10 @@ fn extension() -> Extension {
     NotOp.add_to_extension(&mut extension).unwrap();
 
     extension
-        .add_value(FALSE_NAME, ops::Const::unit_sum(0, 2))
+        .add_value(FALSE_NAME, ops::Const::false_val())
         .unwrap();
     extension
-        .add_value(TRUE_NAME, ops::Const::unit_sum(1, 2))
+        .add_value(TRUE_NAME, ops::Const::true_val())
         .unwrap();
     extension
 }
@@ -253,7 +253,7 @@ pub(crate) mod test {
 
         for v in [false_val, true_val] {
             let simpl = v.typed_value().const_type();
-            assert_eq!(simpl, &BOOL_T);
+            assert_eq!(simpl, BOOL_T);
         }
     }
 

--- a/quantinuum-hugr/src/types.rs
+++ b/quantinuum-hugr/src/types.rs
@@ -8,7 +8,8 @@ mod signature;
 pub mod type_param;
 pub mod type_row;
 
-pub use check::{ConstTypeError, CustomCheckFailure};
+pub use crate::ops::constant::{ConstTypeError, CustomCheckFailure};
+pub use check::SumTypeError;
 pub use custom::CustomType;
 pub use poly_func::PolyFuncType;
 pub use signature::FunctionType;
@@ -135,6 +136,14 @@ impl SumType {
             SumType::Unit { size } if tag < (*size as usize) => Some(Type::EMPTY_TYPEROW_REF),
             SumType::General { rows } => rows.get(tag),
             _ => None,
+        }
+    }
+
+    /// Returns the number of variants in the sum type.
+    pub fn num_variants(&self) -> usize {
+        match self {
+            SumType::Unit { size } => *size as usize,
+            SumType::General { rows } => rows.len(),
         }
     }
 }

--- a/quantinuum-hugr/src/types/check.rs
+++ b/quantinuum-hugr/src/types/check.rs
@@ -42,7 +42,10 @@ pub enum SumTypeError {
 }
 
 impl super::SumType {
-    /// Check that a [`Value`] is a valid instance of this [`SumType`].
+    /// Check if a sum variant is a valid instance of this [`SumType`].
+    ///
+    /// Since [`Const::Sum`] variants always contain a tuple of values,
+    /// `val` must be a slice of [`Const`]s.
     ///
     ///   [`SumType`]: crate::types::SumType
     ///

--- a/quantinuum-hugr/src/types/check.rs
+++ b/quantinuum-hugr/src/types/check.rs
@@ -2,70 +2,43 @@
 
 use thiserror::Error;
 
-use crate::{
-    ops::{FuncDecl, FuncDefn, OpType},
-    values::Value,
-    Hugr, HugrView,
-};
-
-use super::{CustomType, PolyFuncType, Type, TypeEnum};
-
-/// Struct for custom type check fails.
-#[derive(Clone, Debug, PartialEq, Eq, Error)]
-pub enum CustomCheckFailure {
-    /// The value had a specific type that was not what was expected
-    #[error("Expected type: {expected} but value was of type: {found}")]
-    TypeMismatch {
-        /// The expected custom type.
-        expected: CustomType,
-        /// The custom type found when checking.
-        found: Type,
-    },
-    /// Any other message
-    #[error("{0}")]
-    Message(String),
-}
+use super::Type;
+use crate::ops::Const;
 
 /// Errors that arise from typechecking constants
 #[derive(Clone, Debug, PartialEq, Error)]
-pub enum ConstTypeError {
-    /// Found a Var type constructor when we're checking a const val
-    #[error("Type of a const value can't be Var")]
-    ConstCantBeVar,
-    /// Type we were checking against was an Alias.
-    /// This should have been resolved to an actual type.
-    #[error("Type of a const value can't be an Alias {0}")]
-    NoAliases(String),
-    /// The length of the tuple value doesn't match the length of the tuple type
-    #[error("Tuple of wrong length")]
-    TupleWrongLength,
+pub enum SumTypeError {
+    /// The type of the variant doesn't match the type of the value.
+    #[error("Expected type {expected} for element {index} of variant #{tag}, but found {}", .found.const_type())]
+    InvalidValueType {
+        /// Tag of the variant.
+        tag: usize,
+        /// The element in the tuple that was wrong.
+        index: usize,
+        /// The expected type.
+        expected: Type,
+        /// The value that was found.
+        found: Const,
+    },
     /// The length of the sum value doesn't match the length of the variant of
-    /// the sum type
-    #[error("Sum variant of wrong length")]
-    SumWrongLength,
-    /// Tag for a sum value exceeded the number of variants
-    #[error("Tag of Sum value is invalid")]
-    InvalidSumTag,
-    /// A mismatch between the type expected and the value.
-    #[error("Value {1:?} does not match expected type {0}")]
-    ValueCheckFail(Type, Value),
-    /// Error when checking a custom value.
-    #[error("Error when checking custom type: {0:?}")]
-    CustomCheckFail(#[from] CustomCheckFailure),
-}
-
-fn type_sig_equal(v: &Hugr, t: &PolyFuncType) -> bool {
-    // exact signature equality, in future this may need to be
-    // relaxed to be compatibility checks between the signatures.
-    let root_op = v.get_optype(v.root());
-    if let OpType::FuncDecl(FuncDecl { signature, .. })
-    | OpType::FuncDefn(FuncDefn { signature, .. }) = root_op
-    {
-        signature == t
-    } else {
-        v.get_function_type()
-            .is_some_and(|ft| &PolyFuncType::from(ft) == t)
-    }
+    /// the sum type.
+    #[error("Sum variant #{tag} should have length {expected}, but has length {found}")]
+    WrongVariantLength {
+        /// The variant index.
+        tag: usize,
+        /// The expected length of the sum variant.
+        expected: usize,
+        /// The length of the sum variant found.
+        found: usize,
+    },
+    /// Tag for a sum value exceeded the number of variants.
+    #[error("Invalid tag {tag} for sum type with {num_variants} variants")]
+    InvalidTag {
+        /// The tag of the sum value.
+        tag: usize,
+        /// The number of variants in the sum type.
+        num_variants: usize,
+    },
 }
 
 impl super::SumType {
@@ -76,60 +49,32 @@ impl super::SumType {
     /// # Errors
     ///
     /// This function will return an error if there is a type check error.
-    pub fn check_type(&self, tag: usize, val: &[Box<Value>]) -> Result<(), ConstTypeError> {
-        if self
+    pub fn check_type(&self, tag: usize, val: &[Const]) -> Result<(), SumTypeError> {
+        let variant = self
             .get_variant(tag)
-            .ok_or(ConstTypeError::InvalidSumTag)?
-            .len()
-            != val.len()
-        {
-            Err(ConstTypeError::SumWrongLength)?
+            .ok_or_else(|| SumTypeError::InvalidTag {
+                tag,
+                num_variants: self.num_variants(),
+            })?;
+
+        if variant.len() != val.len() {
+            Err(SumTypeError::WrongVariantLength {
+                tag,
+                expected: variant.len(),
+                found: val.len(),
+            })?;
         }
 
-        for (t, v) in itertools::zip_eq(
-            self.get_variant(tag)
-                .ok_or(ConstTypeError::InvalidSumTag)?
-                .iter(),
-            val.iter(),
-        ) {
-            t.check_type(v)?;
+        for (i, (t, v)) in itertools::zip_eq(variant.iter(), val.iter()).enumerate() {
+            if v.const_type() != *t {
+                Err(SumTypeError::InvalidValueType {
+                    tag,
+                    index: i,
+                    expected: t.clone(),
+                    found: v.clone(),
+                })?;
+            }
         }
         Ok(())
-    }
-}
-
-impl Type {
-    /// Check that a [`Value`] is a valid instance of this [`Type`].
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if there is a type check error.
-    pub fn check_type(&self, val: &Value) -> Result<(), ConstTypeError> {
-        match (&self.0, val) {
-            (TypeEnum::Extension(expected), Value::Extension { c: (e_val,) }) => {
-                let found = e_val.get_type();
-                if found == expected.clone().into() {
-                    Ok(e_val.validate()?)
-                } else {
-                    Err(CustomCheckFailure::TypeMismatch {
-                        expected: expected.clone(),
-                        found,
-                    }
-                    .into())
-                }
-            }
-            (TypeEnum::Function(t), Value::Function { hugr: v }) if type_sig_equal(v, t) => Ok(()),
-            (TypeEnum::Tuple(t), Value::Tuple { vs: t_v }) => {
-                if t.len() != t_v.len() {
-                    return Err(ConstTypeError::TupleWrongLength);
-                }
-                t_v.iter()
-                    .zip(t.iter())
-                    .try_for_each(|(elem, ty)| ty.check_type(elem))
-                    .map_err(|_| ConstTypeError::ValueCheckFail(self.clone(), val.clone()))
-            }
-            (TypeEnum::Sum(sum), Value::Sum { tag, values }) => sum.check_type(*tag, values),
-            _ => Err(ConstTypeError::ValueCheckFail(self.clone(), val.clone())),
-        }
     }
 }

--- a/quantinuum-hugr/src/types/check.rs
+++ b/quantinuum-hugr/src/types/check.rs
@@ -68,11 +68,11 @@ impl super::SumType {
             })?;
         }
 
-        for (i, (t, v)) in itertools::zip_eq(variant.iter(), val.iter()).enumerate() {
+        for (index, (t, v)) in itertools::zip_eq(variant.iter(), val.iter()).enumerate() {
             if v.const_type() != *t {
                 Err(SumTypeError::InvalidValueType {
                     tag,
-                    index: i,
+                    index,
                     expected: t.clone(),
                     found: v.clone(),
                 })?;

--- a/quantinuum-hugr/src/types/poly_func.rs
+++ b/quantinuum-hugr/src/types/poly_func.rs
@@ -12,7 +12,7 @@ use super::{FunctionType, Substitution};
 /// A polymorphic function type, e.g. of a [Graph], or perhaps an [OpDef].
 /// (Nodes/operations in the Hugr are not polymorphic.)
 ///
-/// [Graph]: crate::values::Value::Function
+/// [Graph]: crate::ops::constant::Const::Function
 /// [OpDef]: crate::extension::OpDef
 #[derive(
     Clone, PartialEq, Debug, Default, Eq, derive_more::Display, serde::Serialize, serde::Deserialize,

--- a/quantinuum-hugr/src/values.rs
+++ b/quantinuum-hugr/src/values.rs
@@ -6,139 +6,14 @@
 use std::any::Any;
 
 use downcast_rs::{impl_downcast, Downcast};
-use itertools::Itertools;
 use smol_str::SmolStr;
 
 use crate::extension::ExtensionSet;
 use crate::macros::impl_box_clone;
 
-use crate::{Hugr, HugrView};
-
 use crate::types::{CustomCheckFailure, Type};
 
-/// A value that can be stored as a static constant. Representing core types and
-/// extension types.
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "v")]
-pub enum Value {
-    /// An extension constant value.
-    // Note: the extra level of tupling is to avoid https://github.com/rust-lang/rust/issues/78808
-    Extension {
-        #[allow(missing_docs)]
-        c: (Box<dyn CustomConst>,),
-    },
-    /// A higher-order function value.
-    // TODO use a root parametrised hugr, e.g. Hugr<DFG>.
-    Function {
-        #[allow(missing_docs)]
-        hugr: Box<Hugr>,
-    },
-    /// A tuple
-    Tuple {
-        #[allow(missing_docs)]
-        vs: Vec<Value>,
-    },
-    /// A Sum variant -- for any Sum type where this value meets
-    /// the type of the variant indicated by the tag
-    Sum {
-        /// The tag index of the variant
-        tag: usize,
-        /// The value of the variant
-        values: Vec<Box<Value>>,
-    },
-}
-
-impl Value {
-    /// Returns the name of this [`Value`].
-    pub fn name(&self) -> String {
-        match self {
-            Value::Extension { c: e } => format!("const:custom:{}", e.0.name()),
-            Value::Function { hugr: h } => {
-                let Some(t) = h.get_function_type() else {
-                    panic!("HUGR root node isn't a valid function parent.");
-                };
-                format!("const:function:[{}]", t)
-            }
-            Value::Tuple { vs: vals } => {
-                let names: Vec<_> = vals.iter().map(Value::name).collect();
-                format!("const:seq:{{{}}}", names.join(", "))
-            }
-            Value::Sum { tag, values } => {
-                format!("const:sum:{{tag:{tag}, vals:{values:?}}}")
-            }
-        }
-    }
-
-    /// Description of the value.
-    pub fn description(&self) -> &str {
-        "Constant value"
-    }
-
-    /// Constant unit type (empty Tuple).
-    pub const fn unit() -> Self {
-        Self::Tuple { vs: vec![] }
-    }
-
-    /// Constant Sum of a unit value, used to control branches.
-    pub fn unit_sum(tag: usize) -> Self {
-        Self::sum(tag, [])
-    }
-
-    /// Constant Sum with just one variant of unit type
-    pub fn unary_unit_sum() -> Self {
-        Self::unit_sum(0)
-    }
-
-    /// Tuple of values.
-    pub fn tuple(items: impl IntoIterator<Item = Value>) -> Self {
-        Self::Tuple {
-            vs: items.into_iter().collect(),
-        }
-    }
-
-    /// Sum value (could be of any compatible type - i.e. a Sum type where the
-    /// `tag`th row is equal in length and compatible elementwise with `values`)
-    pub fn sum(tag: usize, values: impl IntoIterator<Item = Value>) -> Self {
-        Self::Sum {
-            tag,
-            values: values.into_iter().map(Box::new).collect_vec(),
-        }
-    }
-
-    /// New custom value (of type that implements [`CustomConst`]).
-    pub fn custom<C: CustomConst>(c: C) -> Self {
-        Self::Extension { c: (Box::new(c),) }
-    }
-
-    /// For a Const holding a CustomConst, extract the CustomConst by downcasting.
-    pub fn get_custom_value<T: CustomConst>(&self) -> Option<&T> {
-        if let Value::Extension { c: (custom,) } = self {
-            custom.downcast_ref()
-        } else {
-            None
-        }
-    }
-
-    /// The Extensions that must be supported to handle the value at runtime
-    pub fn extension_reqs(&self) -> ExtensionSet {
-        match self {
-            Value::Extension { c } => c.0.extension_reqs().clone(),
-            Value::Function { .. } => ExtensionSet::new(), // no extensions reqd to load Hugr (only to run)
-            Value::Tuple { vs } => ExtensionSet::union_over(vs.iter().map(Value::extension_reqs)),
-            Value::Sum { values, .. } => {
-                ExtensionSet::union_over(values.iter().map(|x| x.extension_reqs()))
-            }
-        }
-    }
-}
-
-impl<T: CustomConst> From<T> for Value {
-    fn from(v: T) -> Self {
-        Self::custom(v)
-    }
-}
-
-/// Constant value for opaque `[CustomType]`s.
+/// Constant value for opaque [`CustomType`]s.
 ///
 /// When implementing this trait, include the `#[typetag::serde]` attribute to
 /// enable serialization.
@@ -243,14 +118,10 @@ impl PartialEq for dyn CustomConst {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use rstest::rstest;
-
     use super::*;
-    use crate::builder::test::simple_dfg_hugr;
     use crate::ops::Const;
     use crate::std_extensions::arithmetic::float_types::{self, FLOAT64_TYPE};
-    use crate::type_row;
-    use crate::types::{CustomType, FunctionType, Type};
+    use crate::types::CustomType;
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 
@@ -278,18 +149,5 @@ pub(crate) mod test {
             extensions: float_types::EXTENSION_ID.into(),
         }
         .into()
-    }
-
-    #[rstest]
-    fn function_value(simple_dfg_hugr: Hugr) {
-        let v = Value::Function {
-            hugr: Box::new(simple_dfg_hugr),
-        };
-
-        let correct_type = Type::new_function(FunctionType::new_endo(type_row![
-            crate::extension::prelude::BOOL_T
-        ]));
-
-        assert!(correct_type.check_type(&v).is_ok());
     }
 }

--- a/specification/schema/hugr_schema_v1.json
+++ b/specification/schema/hugr_schema_v1.json
@@ -209,36 +209,6 @@
             "title": "Conditional",
             "type": "object"
         },
-        "Const": {
-            "description": "A constant value definition.",
-            "properties": {
-                "parent": {
-                    "title": "Parent",
-                    "type": "integer"
-                },
-                "input_extensions": {
-                    "$ref": "#/$defs/InputExtensions"
-                },
-                "op": {
-                    "const": "Const",
-                    "default": "Const",
-                    "title": "Op"
-                },
-                "value": {
-                    "$ref": "#/$defs/Value"
-                },
-                "typ": {
-                    "$ref": "#/$defs/Type"
-                }
-            },
-            "required": [
-                "parent",
-                "value",
-                "typ"
-            ],
-            "title": "Const",
-            "type": "object"
-        },
         "CustomOp": {
             "description": "A user-defined operation that can be downcasted by the extensions that define it.",
             "properties": {
@@ -417,28 +387,37 @@
             "title": "ExitBlock",
             "type": "object"
         },
-        "ExtensionVal": {
+        "ExtensionConst": {
             "description": "An extension constant value, that can check it is of a given [CustomType].",
             "properties": {
-                "v": {
-                    "const": "Extension",
-                    "default": "Extension",
-                    "title": "V"
+                "parent": {
+                    "title": "Parent",
+                    "type": "integer"
+                },
+                "input_extensions": {
+                    "$ref": "#/$defs/InputExtensions"
+                },
+                "op": {
+                    "const": "Const",
+                    "default": "Const",
+                    "title": "Op"
                 },
                 "c": {
-                    "maxItems": 1,
-                    "minItems": 1,
-                    "prefixItems": [
-                        {}
-                    ],
-                    "title": "C",
-                    "type": "array"
+                    "const": "Extension",
+                    "default": "Extension",
+                    "title": "ConstTag"
+                },
+                "e": {
+                    "title": "CustomConst"
                 }
             },
             "required": [
-                "c"
+                "parent",
+                "op",
+                "c",
+                "e"
             ],
-            "title": "ExtensionVal",
+            "title": "ExtensionConst",
             "type": "object"
         },
         "ExtensionsArg": {
@@ -522,6 +501,39 @@
             "title": "FuncDefn",
             "type": "object"
         },
+        "FunctionConst": {
+            "description": "A higher-order function value.",
+            "properties": {
+                "parent": {
+                    "title": "Parent",
+                    "type": "integer"
+                },
+                "input_extensions": {
+                    "$ref": "#/$defs/InputExtensions"
+                },
+                "op": {
+                    "const": "Const",
+                    "default": "Const",
+                    "title": "Op"
+                },
+                "c": {
+                    "const": "Function",
+                    "default": "Function",
+                    "title": "ConstTag"
+                },
+                "hugr": {
+                    "title": "Hugr"
+                }
+            },
+            "required": [
+                "parent",
+                "op",
+                "c",
+                "hugr"
+            ],
+            "title": "FunctionConst",
+            "type": "object"
+        },
         "FunctionType": {
             "description": "A graph encoded as a value. It contains a concrete signature and a set of required resources.",
             "properties": {
@@ -552,24 +564,6 @@
                 "output"
             ],
             "title": "FunctionType",
-            "type": "object"
-        },
-        "FunctionVal": {
-            "description": "A higher-order function value.",
-            "properties": {
-                "v": {
-                    "const": "Function",
-                    "default": "Function",
-                    "title": "V"
-                },
-                "hugr": {
-                    "title": "Hugr"
-                }
-            },
-            "required": [
-                "hugr"
-            ],
-            "title": "FunctionVal",
             "type": "object"
         },
         "GeneralSum": {
@@ -828,7 +822,31 @@
                     "CallIndirect": "#/$defs/CallIndirect",
                     "Case": "#/$defs/Case",
                     "Conditional": "#/$defs/Conditional",
-                    "Const": "#/$defs/Const",
+                    "Const": {
+                        "discriminator": {
+                            "mapping": {
+                                "Extension": "#/$defs/ExtensionConst",
+                                "Function": "#/$defs/FunctionConst",
+                                "Sum": "#/$defs/Sum",
+                                "Tuple": "#/$defs/Tuple"
+                            },
+                            "propertyName": "c"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/ExtensionConst"
+                            },
+                            {
+                                "$ref": "#/$defs/FunctionConst"
+                            },
+                            {
+                                "$ref": "#/$defs/Tuple"
+                            },
+                            {
+                                "$ref": "#/$defs/Sum"
+                            }
+                        ]
+                    },
                     "DFG": "#/$defs/DFG",
                     "DataflowBlock": "#/$defs/DataflowBlock",
                     "DummyOp": "#/$defs/DummyOp",
@@ -858,7 +876,29 @@
                     "$ref": "#/$defs/FuncDecl"
                 },
                 {
-                    "$ref": "#/$defs/Const"
+                    "discriminator": {
+                        "mapping": {
+                            "Extension": "#/$defs/ExtensionConst",
+                            "Function": "#/$defs/FunctionConst",
+                            "Sum": "#/$defs/Sum",
+                            "Tuple": "#/$defs/Tuple"
+                        },
+                        "propertyName": "c"
+                    },
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/ExtensionConst"
+                        },
+                        {
+                            "$ref": "#/$defs/FunctionConst"
+                        },
+                        {
+                            "$ref": "#/$defs/Tuple"
+                        },
+                        {
+                            "$ref": "#/$defs/Sum"
+                        }
+                    ]
                 },
                 {
                     "$ref": "#/$defs/DummyOp"
@@ -1062,22 +1102,68 @@
         "Sum": {
             "description": "A Sum variant For any Sum type where this value meets the type of the variant indicated by the tag.",
             "properties": {
-                "v": {
+                "parent": {
+                    "default": 0,
+                    "title": "Parent",
+                    "type": "integer"
+                },
+                "input_extensions": {
+                    "$ref": "#/$defs/InputExtensions"
+                },
+                "op": {
+                    "const": "Const",
+                    "default": "Const",
+                    "title": "Op"
+                },
+                "c": {
                     "const": "Sum",
                     "default": "Sum",
-                    "title": "V"
+                    "title": "ConstTag"
                 },
                 "tag": {
                     "title": "Tag",
                     "type": "integer"
                 },
-                "value": {
-                    "$ref": "#/$defs/Value"
+                "typ": {
+                    "$ref": "#/$defs/Type"
+                },
+                "vs": {
+                    "items": {
+                        "discriminator": {
+                            "mapping": {
+                                "Extension": "#/$defs/ExtensionConst",
+                                "Function": "#/$defs/FunctionConst",
+                                "Sum": "#/$defs/Sum",
+                                "Tuple": "#/$defs/Tuple"
+                            },
+                            "propertyName": "c"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/ExtensionConst"
+                            },
+                            {
+                                "$ref": "#/$defs/FunctionConst"
+                            },
+                            {
+                                "$ref": "#/$defs/Tuple"
+                            },
+                            {
+                                "$ref": "#/$defs/Sum"
+                            }
+                        ]
+                    },
+                    "title": "Vs",
+                    "type": "array"
                 }
             },
             "required": [
+                "parent",
+                "op",
+                "c",
                 "tag",
-                "value"
+                "typ",
+                "vs"
             ],
             "title": "Sum",
             "type": "object"
@@ -1166,22 +1252,59 @@
             "type": "object"
         },
         "Tuple": {
-            "description": "A tuple.",
+            "description": "A constant tuple value.",
             "properties": {
-                "v": {
+                "parent": {
+                    "title": "Parent",
+                    "type": "integer"
+                },
+                "input_extensions": {
+                    "$ref": "#/$defs/InputExtensions"
+                },
+                "op": {
+                    "const": "Const",
+                    "default": "Const",
+                    "title": "Op"
+                },
+                "c": {
                     "const": "Tuple",
                     "default": "Tuple",
-                    "title": "V"
+                    "title": "ConstTag"
                 },
                 "vs": {
                     "items": {
-                        "$ref": "#/$defs/Value"
+                        "discriminator": {
+                            "mapping": {
+                                "Extension": "#/$defs/ExtensionConst",
+                                "Function": "#/$defs/FunctionConst",
+                                "Sum": "#/$defs/Sum",
+                                "Tuple": "#/$defs/Tuple"
+                            },
+                            "propertyName": "c"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/ExtensionConst"
+                            },
+                            {
+                                "$ref": "#/$defs/FunctionConst"
+                            },
+                            {
+                                "$ref": "#/$defs/Tuple"
+                            },
+                            {
+                                "$ref": "#/$defs/Sum"
+                            }
+                        ]
                     },
                     "title": "Vs",
                     "type": "array"
                 }
             },
             "required": [
+                "parent",
+                "op",
+                "c",
                 "vs"
             ],
             "title": "Tuple",
@@ -1502,22 +1625,6 @@
             ],
             "title": "UnpackTuple",
             "type": "object"
-        },
-        "Value": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/ExtensionVal"
-                },
-                {
-                    "$ref": "#/$defs/FunctionVal"
-                },
-                {
-                    "$ref": "#/$defs/Tuple"
-                },
-                {
-                    "$ref": "#/$defs/Sum"
-                }
-            ]
         },
         "Variable": {
             "description": "A type variable identified by a de Bruijn index.",


### PR DESCRIPTION
`Const` was a struct with a `Value` + a defined type. In practice, the only `Value` that couldn't report its full type was `Sum`.

This PR merges the two structs, adding an explicit `sum_type` to the sum variant.

Also:

- Removes `Type::check_type`, as this is now unnecessary. 
- Splits and clarifies the type check and constant errors;
  `SumTypeError` is not a `ConstTypeError` is not a `CustomCheckFailure`.
  - Adds contexts to those errors, so we get better messages.
- `CustomConst` is now accessible from `::ops::custom` instead of `::values`.

This change breaks the serialisation format.

Closes #874.

BREAKING CHANGE: Removed `Value`, merged into `Const`