### PR TITLE
ci: always checkout the repo, even if we don't need the change detection

### DIFF
--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       python: ${{ github.ref_name == github.event.repository.default_branch || steps.filter.outputs.python }}
     steps:
-    # For pull requests it's not necessary to checkout the code
+    - uses: actions/checkout@v3
     - uses: dorny/paths-filter@v3
       id: filter
       with:
@@ -78,7 +78,7 @@ jobs:
   # even if they are skipped due to no changes in the relevant files.
   required-checks:
     name: Required checks 🐍
-    needs: [check]
+    needs: [changes, check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       rust: ${{ github.ref_name == github.event.repository.default_branch || steps.filter.outputs.rust }}
     steps:
-    # For pull requests it's not necessary to checkout the code
+    - uses: actions/checkout@v3
     - uses: dorny/paths-filter@v3
       id: filter
       with:
@@ -133,7 +133,7 @@ jobs:
   # even if they are skipped due to no changes in the relevant files.
   required-checks:
     name: Required checks 🦀
-    needs: [check, tests-stable]
+    needs: [changes, check, tests-stable]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The change detection job is failing for non-pull-request checks, because we need to explicitly checkout the repo on those cases.

See https://github.com/CQCL/hugr/actions/runs/8342261546/job/22830024125

I'm also adding `changes` as a requirement to the required check, so it fails on errors like this.