### PR TITLE
revert: Show new contributors in the changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -5,11 +5,6 @@
 # Configuration options are organized into tables and keys.
 # See documentation for more information on available options.
 
-[remote.github]
-owner = "CQCL"
-repo = "hugr"
-token = ""
-
 [changelog]
 # changelog header
 header = """
@@ -23,32 +18,12 @@ body = """
 {% else %}\
     ## Unreleased (XXXX-XX-XX)
 {% endif %}\
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}\
-  {% raw %}\n{% endraw -%}
-  New Contributors:
-  {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-    * @{{ contributor.username }} made their first contribution
-      {%- if contributor.pr_number %} in \
-        [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-      {%- endif %}
-  {%- endfor -%}
-  {% raw %}\n{% endraw -%}
-{%- endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | upper_first }}
     {% for commit in commits %}
-      - {% if commit.breaking %}[**breaking**] {% endif %}\
-        {{ commit.message | split(pat="\n") | first | trim }}\
-        {% if commit.github.pr_number %} \
-          ([#{{ commit.github.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.github.pr_number }})) \
-        {%- endif %}
-    {%- endfor -%}
-  {% raw %}\n{% endraw -%}
-{% endfor %}
-{% raw %}\n{% endraw -%}
-{%- macro remote_url() -%}
-  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
-{%- endmacro -%}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
 """
 # remove the leading and trailing whitespace from the template
 trim = true
@@ -63,7 +38,9 @@ filter_unconventional = true
 # process each line of a commit as an individual commit
 split_commits = false
 # regex for preprocessing the commit messages
-commit_preprocessors = [{ pattern = '\(#[0-9]+\)', replace = "" }]
+commit_preprocessors = [
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/CQCL/portgraph/issues/${2}))"}, # replace issue numbers
+]
 # regex for parsing and grouping commits
 commit_parsers = [
   { message = "^feat", group = "Features" },
@@ -85,7 +62,7 @@ filter_commits = false
 # glob pattern for matching git tags
 tag_pattern = "v[0-9.]*"
 # regex for skipping tags
-skip_tags = "beta|alpha"
+skip_tags = "v0.1.0-beta.1"
 # regex for ignoring tags
 ignore_tags = ""
 # sort the tags topologically


### PR DESCRIPTION
Reverts #893 

It seems git-cliff's github extension is not yet supported by release-plz >.<
See this PR: https://www.github.com/MarcoIeni/release-plz/pull/1305

I'll reopen the PR once this release-plz is updated.

This reverts commit 25b1013fa9943f4af90030d5842da1d682cc1286.