### PR TITLE
fix: polymorphic calls

### DIFF
--- a/quantinuum-hugr/src/builder/build_traits.rs
+++ b/quantinuum-hugr/src/builder/build_traits.rs
@@ -576,8 +576,7 @@ pub trait Dataflow: Container {
                 })
             }
         };
-        let signature = type_scheme.instantiate(type_args, exts)?;
-        let op: OpType = ops::Call { signature }.into();
+        let op: OpType = ops::Call::try_new(type_scheme, type_args, exts)?.into();
         let const_in_port = op.static_input_port().unwrap();
         let op_id = self.add_dataflow_op(op, input_wires)?;
         let src_port = self.hugr_mut().num_outputs(function.node()) - 1;

--- a/quantinuum-hugr/src/hugr/validate/test.rs
+++ b/quantinuum-hugr/src/hugr/validate/test.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::builder::test::closed_dfg_root_hugr;
 use crate::builder::{
     BuildError, Container, Dataflow, DataflowHugr, DataflowSubContainer, FunctionBuilder,
+    HugrBuilder, ModuleBuilder,
 };
 use crate::extension::prelude::{BOOL_T, PRELUDE, USIZE_T};
 use crate::extension::{Extension, ExtensionId, TypeDefBound, EMPTY_REG, PRELUDE_REGISTRY};
@@ -537,6 +538,23 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
             ..
         })
     );
+    Ok(())
+}
+
+#[test]
+fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
+    let mut m = ModuleBuilder::new();
+    let id = m.declare(
+        "id",
+        PolyFuncType::new(
+            vec![TypeBound::Any.into()],
+            FunctionType::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
+        ),
+    )?;
+    let mut f = m.define_function("main", FunctionType::new_endo(vec![USIZE_T]).into())?;
+    let c = f.call(&id, &[USIZE_T.into()], f.input_wires(), &PRELUDE_REGISTRY)?;
+    f.finish_with_outputs(c.outputs())?;
+    let _ = m.finish_prelude_hugr()?;
     Ok(())
 }
 

--- a/quantinuum-hugr/src/ops/dataflow.rs
+++ b/quantinuum-hugr/src/ops/dataflow.rs
@@ -223,7 +223,11 @@ impl Call {
     }
 }
 
-/// Call a function indirectly. Like call, but the first input is a standard dataflow graph type.
+/// Call a function indirectly. Like call, but the function input is a value
+/// (runtime, not static) dataflow edge, and we assume all its binders have
+/// already been given [TypeArg]s by [TypeApply] nodes.
+///
+/// [TypeApply]: crate::ops::LeafOp::TypeApply
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CallIndirect {
     /// Signature of function being called


### PR DESCRIPTION
* Store the polymorphic type of the called function in Call node, use for the static input
* Also store the typeargs, and the cache of the instantiation

BREAKING CHANGE: `Call` nodes now constructed via `try_new` function