### PR TITLE
refactor: Nonempty

### DIFF
--- a/quantinuum-hugr/Cargo.toml
+++ b/quantinuum-hugr/Cargo.toml
@@ -52,6 +52,7 @@ delegate = "0.12.0"
 paste = "1.0"
 strum = "0.26.1"
 strum_macros = "0.26.1"
+nonempty = "0.10.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/quantinuum-hugr/src/hugr/hugrmut.rs
+++ b/quantinuum-hugr/src/hugr/hugrmut.rs
@@ -4,6 +4,7 @@ use core::panic;
 use std::collections::HashMap;
 use std::ops::Range;
 
+use nonempty::NonEmpty;
 use portgraph::view::{NodeFilter, NodeFiltered};
 use portgraph::{LinkMut, NodeIndex, PortMut, PortView, SecondaryMap};
 
@@ -365,7 +366,7 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
         subgraph: &SiblingSubgraph,
     ) -> HashMap<Node, Node> {
         // Create a portgraph view with the explicit list of nodes defined by the subgraph.
-        let portgraph: NodeFiltered<_, NodeFilter<&[Node]>, &[Node]> =
+        let portgraph: NodeFiltered<_, NodeFilter<&NonEmpty<Node>>, &NonEmpty<Node>> =
             NodeFiltered::new_node_filtered(
                 other.portgraph(),
                 |node, ctx| ctx.contains(&node.into()),

--- a/quantinuum-hugr/src/hugr/rewrite/replace.rs
+++ b/quantinuum-hugr/src/hugr/rewrite/replace.rs
@@ -1,8 +1,8 @@
 //! Implementation of the `Replace` operation.
 
-use std::collections::{HashMap, HashSet, VecDeque};
-
 use itertools::Itertools;
+use nonempty::NonEmpty;
+use std::collections::{HashMap, HashSet, VecDeque};
 use thiserror::Error;
 
 use crate::hugr::hugrmut::InsertionResult;
@@ -59,7 +59,7 @@ pub struct Replacement {
     /// These must all have a common parent (i.e. be siblings).  Called "S" in the spec.
     /// Must be non-empty - otherwise there is no parent under which to place [Self::replacement],
     /// and there would be no possible [Self::mu_inp], [Self::mu_out] or [Self::adoptions].
-    pub removal: Vec<Node>,
+    pub removal: NonEmpty<Node>,
     /// A hugr (not necessarily valid, as it may be missing edges and/or nodes), whose root
     /// is the same type as the root of [Self::replacement].  "G" in the spec.
     pub replacement: Hugr,
@@ -440,6 +440,7 @@ mod test {
 
     use cool_asserts::assert_matches;
     use itertools::Itertools;
+    use nonempty::nonempty;
 
     use crate::algorithm::nest_cfgs::test::depth;
     use crate::builder::{
@@ -571,7 +572,7 @@ mod test {
         }
 
         h.apply_rewrite(Replacement {
-            removal: vec![entry.node(), bb2.node()],
+            removal: nonempty![entry.node(), bb2.node()],
             replacement,
             adoptions: HashMap::from([(r_df1.node(), entry.node()), (r_df2.node(), bb2.node())]),
             mu_inp: vec![],
@@ -700,7 +701,7 @@ mod test {
             },
         );
         let mut r = Replacement {
-            removal: vec![case1, case2],
+            removal: nonempty![case1, case2],
             replacement: rep1,
             adoptions: HashMap::from_iter([(r1, case1), (r2, baz_dfg.node())]),
             mu_inp: vec![],
@@ -724,14 +725,14 @@ mod test {
         // First, removed nodes...
         assert_eq!(
             verify_apply(Replacement {
-                removal: vec![h.root()],
+                removal: nonempty![h.root()],
                 ..r.clone()
             }),
             Err(ReplaceError::CantReplaceRoot)
         );
         assert_eq!(
             verify_apply(Replacement {
-                removal: vec![case1, baz_dfg.node()],
+                removal: nonempty![case1, baz_dfg.node()],
                 ..r.clone()
             }),
             Err(ReplaceError::MultipleParents(vec![cond.node(), case2]))

--- a/quantinuum-hugr/src/hugr/rewrite/simple_replace.rs
+++ b/quantinuum-hugr/src/hugr/rewrite/simple_replace.rs
@@ -196,7 +196,6 @@ pub enum SimpleReplacementError {
 #[cfg(test)]
 pub(in crate::hugr::rewrite) mod test {
     use itertools::Itertools;
-    use nonempty::NonEmpty;
     use rstest::{fixture, rstest};
     use std::collections::{HashMap, HashSet};
 
@@ -622,7 +621,7 @@ pub(in crate::hugr::rewrite) mod test {
         replacement.remove_node(in_);
         replacement.remove_node(out);
         Replacement {
-            removal: NonEmpty::from_slice(s.subgraph.nodes()).unwrap(),
+            removal: s.subgraph.nodes().clone(),
             replacement,
             adoptions: HashMap::new(),
             mu_inp,

--- a/quantinuum-hugr/src/hugr/rewrite/simple_replace.rs
+++ b/quantinuum-hugr/src/hugr/rewrite/simple_replace.rs
@@ -196,6 +196,7 @@ pub enum SimpleReplacementError {
 #[cfg(test)]
 pub(in crate::hugr::rewrite) mod test {
     use itertools::Itertools;
+    use nonempty::NonEmpty;
     use rstest::{fixture, rstest};
     use std::collections::{HashMap, HashSet};
 
@@ -621,7 +622,7 @@ pub(in crate::hugr::rewrite) mod test {
         replacement.remove_node(in_);
         replacement.remove_node(out);
         Replacement {
-            removal: s.subgraph.nodes().to_vec(),
+            removal: NonEmpty::from_slice(s.subgraph.nodes()).unwrap(),
             replacement,
             adoptions: HashMap::new(),
             mu_inp,


### PR DESCRIPTION
Replacements and SiblingSubgraph have nonempty vecs upon construction. Attempting to create them with empty vecs gives errors (InvalidSubgraph::EmptySubgraph) so following "illegal state unrepresentable".