### PR TITLE
ci: Publish python package to pypi

### DIFF
--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -41,12 +41,12 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.python == 'true' }}
 
-    name: check python
+    name: check python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -1,0 +1,59 @@
+name: Build and publish python wheels
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+        - '*'
+
+jobs:
+  build-publish:
+    name: Build and publish wheels
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+          - 'quantinuum-hugr-py'
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.4
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python '3.10'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: "poetry"
+
+      - name: Build sdist and wheels
+        run: |
+          cd ${{ matrix.package }}
+          poetry build -o ../dist
+
+      - name: Upload the built packages as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.package }}-sdist
+          path: |
+            dist/*.tar.gz
+            dist/*.whl
+
+      - name: Publish to test instance of PyPI
+        if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'branch' ) }}
+        run: |
+          cd ${{ matrix.package }}
+          poetry config repositories.test-pypi https://test.pypi.org/legacy/
+          poetry config pypi-token.test-pypi ${{ secrets.PYPI_TEST_PUBLISH }}
+          poetry publish -r test-pypi --dist-dir ../dist --skip-existing
+
+      - name: Publish to PyPI
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{}-v', matrix.package)) }}
+        run: |
+          cd ${{ matrix.package }}
+          poetry config repositories.test-pypi https://test.pypi.org/legacy/
+          poetry config pypi-token.test-pypi ${{ secrets.PYPI_PUBLISH }}
+          poetry publish -r test-pypi --dist-dir ../dist --skip-existing

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -42,13 +42,13 @@ jobs:
             dist/*.tar.gz
             dist/*.whl
 
-      - name: Publish to test instance of PyPI
+      - name: Publish to test instance of PyPI (dry-run)
         if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'branch' ) }}
         run: |
           cd ${{ matrix.package }}
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
           poetry config pypi-token.test-pypi ${{ secrets.PYPI_TEST_PUBLISH }}
-          poetry publish -r test-pypi --dist-dir ../dist --skip-existing
+          poetry publish -r test-pypi --dist-dir ../dist --skip-existing --dry-run
 
       - name: Publish to PyPI
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{}-v', matrix.package)) }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "hugr-project"
 version = "0.0.0"
 authors = ["TKET development team <tket-support@cambridgequantum.com>"]
 readme = "README.md"
-packages = [{ include = "quantunuum_hugr", from = "quantunuum-hugr-py" }]
+packages = [{ include = "quantinuum_hugr", from = "quantinuum-hugr-py" }]
 package-mode = false
 
 [tool.poetry.group.main.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,9 @@
 description = "Namespace for the python packages in the HUGR repository. See the individual packages for more information."
 name = "hugr-project"
 version = "0.0.0"
-authors = []
+authors = ["TKET development team <tket-support@cambridgequantum.com>"]
 readme = "README.md"
-packages = []
-
+packages = [{ include = "quantunuum_hugr", from = "quantunuum-hugr-py" }]
 package-mode = false
 
 [tool.poetry.group.main.dependencies]

--- a/quantinuum-hugr-py/README.md
+++ b/quantinuum-hugr-py/README.md
@@ -22,9 +22,9 @@ The HUGR specification is [here](https://github.com/CQCL/hugr/blob/main/specific
 
 ## Installation
 
-The package name is `quantinuum_hugr`, it can be installed from PyPI:
+The package name is `quantinuum_hugr`. It can be installed from PyPI:
 ```bash
-pip install quantinuum_hugr"
+pip install quantinuum_hugr
 ```
 
 The current releases are in alpha stage, and the API is subject to change.

--- a/quantinuum-hugr-py/README.md
+++ b/quantinuum-hugr-py/README.md
@@ -22,14 +22,12 @@ The HUGR specification is [here](https://github.com/CQCL/hugr/blob/main/specific
 
 ## Installation
 
-TODO
-
-The package name is `quantinuum_hugr`, but it hasn't been published yet.
-The current experimental version can be installed from the source code:
-
+The package name is `quantinuum_hugr`, it can be installed from PyPI:
 ```bash
-pip install "quantinuum_hugr@git+https://github.com/CQCL/hugr.git@main#subdirectory=quantinuum-hugr-py"
+pip install quantinuum_hugr"
 ```
+
+The current releases are in alpha stage, and the API is subject to change.
 
 ## Usage
 

--- a/quantinuum-hugr-py/pyproject.toml
+++ b/quantinuum-hugr-py/pyproject.toml
@@ -1,11 +1,23 @@
 [tool.poetry]
+classifiers = [
+    "Environment :: Console",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering",
+]
 name = "quantinuum_hugr"
-version = "0.0.0"
+version = "0.1.0a1"
 description = "Quantinuum's common representation for quantum programs"
-classifiers = []                                                        # TODO
-keywords = []                                                           # TODO
-authors = []                                                            # TODO
-maintainers = []                                                        # TODO
+#keywords = []
+authors = ["TKET development team <tket-support@cambridgequantum.com>"]
+maintainers = ["TKET development team <tket-support@cambridgequantum.com>"]
 license = "Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/CQCL/hugr"


### PR DESCRIPTION
Adds a CI job that

- Publishes each push to main to the **test** pypi repository.

- When a `quantinuum-hugr-py-v*` tag is pushed, publishes the python package to pypi
  (this is done generically, so other python

Closes #907 

I will make another PR configuring `release-please`, to automate the changelog and releases side.
Until we are ready to publish `0.1.0`, we can publish alpha versions manually by pushing tags.