### PR TITLE
ci: Fix wheels job

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -51,7 +51,7 @@ jobs:
           poetry publish -r test-pypi --dist-dir ../dist --skip-existing --dry-run
 
       - name: Publish to PyPI
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{}-v', matrix.package)) }}
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.package)) }}
         run: |
           cd ${{ matrix.package }}
           poetry config repositories.test-pypi https://test.pypi.org/legacy/


### PR DESCRIPTION
The `format` template expression needs an index inside the `{}` placeholder.

See error: https://github.com/CQCL/hugr/actions/runs/8539664657/job/23394814844#step:9:1