### PR TITLE
ci: fix package name in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
     name: Create release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4.1
+      - uses: google-github-actions/release-please-action@v4
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
-            target-branch: ${{ github.event.ref }}
+            config-file: release-please-config.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
           (?x)^(
             specification/schema/.*|
             .*.snap|
-            .*.snap.new
+            .*.snap.new|
+            .release-please-manifest.json
           )$
       - id: trailing-whitespace
         exclude: |

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-    "quantinuum-hugr-py": "0.1.0a1"
+    "hugr-py": "0.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,13 +3,15 @@
     "include-component-in-tag": true,
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
-    "initial-version": "0.1.0",
+    "initial-version": "0.0.0",
     "packages": {
-        "quantinuum-hugr-py": {
+        "hugr-py": {
             "release-type": "python",
+            "component": "hugr-py",
             "package-name": "hugr",
+            "include-component-in-tag": true,
             "draft": false,
-            "prerelease": false
+            "prerelease": true
         }
     },
     "changelog-sections": [


### PR DESCRIPTION
Fixes some config in release-please so now it looks for the right version tags `hugr-py-v*.*.*`. It doesn't seem to like alphas though, so the first releases will need some manual tweaking (it tries to do 0.1.0 otherwise).

The CI job is failing with some github permission error... I copied the guppy one to try and fix that, but I can run it locally via the CLI if needed for these first releases.