### PR TITLE
ci: Debug logging on python wheels job

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     tags:
-        - '*'
+        - '**'
 
 jobs:
   build-publish:
@@ -45,6 +45,11 @@ jobs:
       - name: Publish to test instance of PyPI (dry-run)
         if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'branch' ) }}
         run: |
+          echo "Doing a dry-run publish to test-pypi..."
+          echo "Based on the following workflow variables, this is not a hugr-py version tag push:"
+          echo "  - event_name: ${{ github.event_name }}"
+          echo "  - ref_type: ${{ github.ref_type }}"
+          echo "  - ref: ${{ github.ref }}"
           cd ${{ matrix.package }}
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
           poetry config pypi-token.test-pypi ${{ secrets.PYPI_TEST_PUBLISH }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,7 @@
             "package-name": "hugr",
             "include-component-in-tag": true,
             "draft": false,
-            "prerelease": true
+            "prerelease": false
         }
     },
     "changelog-sections": [


### PR DESCRIPTION
Try to debug why why the release of https://github.com/CQCL/hugr/releases/tag/hugr-py-v0.1.0 didn't trigger a the wheels publishing action.

I relaxed the tag filter from `*` to `**` (i.e. include sub-paths) to see if that works.

drive-by: Unset `prerelease` flag in release please, so the release gets the published status.