### PR TITLE
feat!: Add `non_exhaustive` to various enums

### DIFF
--- a/hugr/src/algorithm/nest_cfgs.rs
+++ b/hugr/src/algorithm/nest_cfgs.rs
@@ -278,6 +278,7 @@ impl<H: HugrMut> CfgNester<Node> for IdentityCfgMap<H> {
 
 /// An error trying to get the blocks of a SESE (single-entry-single-exit) region
 #[derive(Clone, Debug, Error)]
+#[non_exhaustive]
 pub enum RegionBlocksError<T> {
     /// The specified exit edge did not exist in the CFG
     ExitEdgeNotPresent(T, T),

--- a/hugr/src/builder/conditional.rs
+++ b/hugr/src/builder/conditional.rs
@@ -30,6 +30,7 @@ use thiserror::Error;
 pub type CaseBuilder<B> = DFGWrapper<B, BuildHandle<CaseID>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum ConditionalBuildError {
     /// Case already built.
     #[error("Case {case} of Conditional node {conditional:?} has already been built.")]

--- a/hugr/src/extension/declarative.rs
+++ b/hugr/src/extension/declarative.rs
@@ -175,6 +175,7 @@ struct DeclarationContext<'a> {
 
 /// Errors that can occur while loading an extension set.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ExtensionDeclarationError {
     /// An error occurred while deserializing the extension set.
     #[error("Error while parsing the extension set yaml: {0}")]

--- a/hugr/src/extension/infer.rs
+++ b/hugr/src/extension/infer.rs
@@ -63,6 +63,7 @@ enum Constraint {
 }
 
 #[derive(Debug, Clone, PartialEq, Error)]
+#[non_exhaustive]
 /// Errors which arise during unification
 pub enum InferExtensionError {
     #[error("Mismatched extension sets {expected} and {actual}")]

--- a/hugr/src/extension/simple_op.rs
+++ b/hugr/src/extension/simple_op.rs
@@ -20,6 +20,7 @@ use thiserror::Error;
 #[derive(Debug, Error, PartialEq)]
 #[error("{0}")]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum OpLoadError {
     #[error("Op with name {0} is not a member of this set.")]
     NotMember(String),

--- a/hugr/src/extension/validate.rs
+++ b/hugr/src/extension/validate.rs
@@ -159,6 +159,7 @@ impl ExtensionValidator {
 /// Errors that can occur while validating a Hugr.
 #[derive(Debug, Clone, PartialEq, Error)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum ExtensionError {
     /// Missing lift node
     #[error("Extensions at target node {to:?} ({to_extensions}) exceed those at source {from:?} ({from_extensions})")]

--- a/hugr/src/hugr/rewrite/consts.rs
+++ b/hugr/src/hugr/rewrite/consts.rs
@@ -14,6 +14,7 @@ pub struct RemoveLoadConstant(pub Node);
 
 /// Error from an [`RemoveConst`] or [`RemoveLoadConstant`] operation.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RemoveError {
     /// Invalid node.
     #[error("Node is invalid (either not in HUGR or not correct operation).")]

--- a/hugr/src/hugr/rewrite/inline_dfg.rs
+++ b/hugr/src/hugr/rewrite/inline_dfg.rs
@@ -11,6 +11,7 @@ pub struct InlineDFG(pub DfgID);
 
 /// Errors from an [InlineDFG] rewrite.
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum InlineDFGError {
     /// Node to inline was not a DFG. (E.g. node has been overwritten since the DfgID originated.)
     #[error("Node {0} was not a DFG")]

--- a/hugr/src/hugr/rewrite/insert_identity.rs
+++ b/hugr/src/hugr/rewrite/insert_identity.rs
@@ -32,6 +32,7 @@ impl IdentityInsertion {
 
 /// Error from an [`IdentityInsertion`] operation.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum IdentityInsertionError {
     /// Invalid parent node.
     #[error("Parent node is invalid.")]

--- a/hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr/src/hugr/rewrite/outline_cfg.rs
@@ -219,6 +219,7 @@ impl Rewrite for OutlineCfg {
 
 /// Errors that can occur in expressing an OutlineCfg rewrite.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum OutlineCfgError {
     /// The set of blocks were not siblings
     #[error("The nodes did not all have the same parent")]

--- a/hugr/src/hugr/rewrite/replace.rs
+++ b/hugr/src/hugr/rewrite/replace.rs
@@ -384,6 +384,7 @@ fn transfer_edges<'a>(
 
 /// Error in a [`Replacement`]
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum ReplaceError {
     /// The node(s) to replace had no parent i.e. were root(s).
     // (Perhaps if there is only one node to replace we should be able to?)

--- a/hugr/src/hugr/rewrite/simple_replace.rs
+++ b/hugr/src/hugr/rewrite/simple_replace.rs
@@ -181,6 +181,7 @@ impl Rewrite for SimpleReplacement {
 
 /// Error from a [`SimpleReplacement`] operation.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SimpleReplacementError {
     /// Invalid parent node.
     #[error("Parent node is invalid.")]

--- a/hugr/src/hugr/serialize.rs
+++ b/hugr/src/hugr/serialize.rs
@@ -61,6 +61,7 @@ struct SerHugrV1 {
 
 /// Errors that can occur while serializing a HUGR.
 #[derive(Debug, Clone, PartialEq, Error)]
+#[non_exhaustive]
 pub enum HUGRSerializationError {
     /// Unexpected hierarchy error.
     #[error("Failed to attach child to parent: {0:?}.")]

--- a/hugr/src/hugr/validate.rs
+++ b/hugr/src/hugr/validate.rs
@@ -591,6 +591,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
 /// Errors that can occur while validating a Hugr.
 #[derive(Debug, Clone, PartialEq, Error)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum ValidationError {
     /// The root node of the Hugr is not a root in the hierarchy.
     #[error("The root node of the Hugr {node:?} is not a root in the hierarchy.")]
@@ -706,6 +707,7 @@ pub enum ValidationError {
 /// Errors related to the inter-graph edge validations.
 #[derive(Debug, Clone, PartialEq, Error)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum InterGraphEdgeError {
     /// Inter-Graph edges can only carry copyable data.
     #[error("Inter-graph edges can only carry copyable data. In an inter-graph edge from {from:?} ({from_offset:?}) to {to:?} ({to_offset:?}) with type {ty:?}.")]

--- a/hugr/src/hugr/views/sibling_subgraph.rs
+++ b/hugr/src/hugr/views/sibling_subgraph.rs
@@ -625,6 +625,7 @@ fn has_other_edge<H: HugrView>(hugr: &H, node: Node, dir: Direction) -> bool {
 
 /// Errors that can occur while constructing a [`SimpleReplacement`].
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum InvalidReplacement {
     /// No DataflowParent root in replacement graph.
     #[error("No DataflowParent root in replacement graph.")]
@@ -642,6 +643,7 @@ pub enum InvalidReplacement {
 
 /// Errors that can occur while constructing a [`SiblingSubgraph`].
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum InvalidSubgraph {
     /// The subgraph is not convex.
     #[error("The subgraph is not convex.")]
@@ -659,6 +661,7 @@ pub enum InvalidSubgraph {
 
 /// Errors that can occur while constructing a [`SiblingSubgraph`].
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum InvalidSubgraphBoundary {
     /// A boundary port's node is not in the set of nodes.
     #[error("(node {0:?}, port {1:?}) is in the boundary, but node {0:?} is not in the set.")]

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -71,6 +71,7 @@ impl PartialEq for ExtensionConst {
 
 /// Struct for custom type check fails.
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum CustomCheckFailure {
     /// The value had a specific type that was not what was expected
     #[error("Expected type: {expected} but value was of type: {found}")]
@@ -87,6 +88,7 @@ pub enum CustomCheckFailure {
 
 /// Errors that arise from typechecking constants
 #[derive(Clone, Debug, PartialEq, Error)]
+#[non_exhaustive]
 pub enum ConstTypeError {
     /// Invalid sum type definition.
     #[error("{0}")]

--- a/hugr/src/ops/custom.rs
+++ b/hugr/src/ops/custom.rs
@@ -389,6 +389,7 @@ pub fn resolve_opaque_op(
 /// Errors that arise after loading a Hugr containing opaque ops (serialized just as their names)
 /// when trying to resolve the serialized names against a registry of known Extensions.
 #[derive(Clone, Debug, Error, PartialEq)]
+#[non_exhaustive]
 pub enum CustomOpError {
     /// The Extension was found but did not contain the expected OpDef
     #[error("Operation {0} not found in Extension {1}")]

--- a/hugr/src/ops/validate.rs
+++ b/hugr/src/ops/validate.rs
@@ -159,6 +159,7 @@ impl ValidateOp for super::CFG {
 /// Errors that can occur while checking the children of a node.
 #[derive(Debug, Clone, PartialEq, Error)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum ChildrenValidationError {
     /// An CFG graph has an exit operation as a non-second child.
     #[error("Exit basic blocks are only allowed as the second child in a CFG graph")]
@@ -208,6 +209,7 @@ impl ChildrenValidationError {
 /// Errors that can occur while checking the edges between children of a node.
 #[derive(Debug, Clone, PartialEq, Error)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum EdgeValidationError {
     /// The dataflow signature of two connected basic blocks does not match.
     #[error("The dataflow signature of two connected basic blocks does not match. Output signature: {source_op:?}, input signature: {target_op:?}",

--- a/hugr/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr/src/std_extensions/arithmetic/conversions.rs
@@ -26,6 +26,7 @@ pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.con
 /// Extension for conversions between floats and integers.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
 #[allow(missing_docs, non_camel_case_types)]
+#[non_exhaustive]
 pub enum ConvertOpDef {
     trunc_u,
     trunc_s,

--- a/hugr/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr/src/std_extensions/arithmetic/float_ops.rs
@@ -21,6 +21,7 @@ pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.flo
 /// Integer extension operation definitions.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
 #[allow(missing_docs, non_camel_case_types)]
+#[non_exhaustive]
 pub enum FloatOps {
     feq,
     fne,

--- a/hugr/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr/src/std_extensions/arithmetic/int_ops.rs
@@ -45,6 +45,7 @@ impl ValidateJustArgs for IOValidator {
 /// Integer extension operation definitions.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
 #[allow(missing_docs, non_camel_case_types)]
+#[non_exhaustive]
 pub enum IntOpDef {
     iwiden_u,
     iwiden_s,

--- a/hugr/src/std_extensions/collections.rs
+++ b/hugr/src/std_extensions/collections.rs
@@ -204,6 +204,7 @@ fn list_and_elem_type_vars(list_type_def: &TypeDef) -> (Type, Type) {
 
 /// A list operation
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum ListOp {
     /// Pop from end of list
     Pop,

--- a/hugr/src/std_extensions/logic.rs
+++ b/hugr/src/std_extensions/logic.rs
@@ -26,6 +26,7 @@ pub const TRUE_NAME: &str = "TRUE";
 /// Logic extension operation definitions.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum NaryLogic {
     And,
     Or,

--- a/hugr/src/types.rs
+++ b/hugr/src/types.rs
@@ -115,6 +115,7 @@ pub(crate) fn least_upper_bound(mut tags: impl Iterator<Item = TypeBound>) -> Ty
 
 #[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
 #[serde(tag = "s")]
+#[non_exhaustive]
 /// Representation of a Sum type.
 /// Either store the types of the variants, or in the special (but common) case
 /// of a UnitSum (sum over empty tuples), store only the size of the Sum.

--- a/hugr/src/types/check.rs
+++ b/hugr/src/types/check.rs
@@ -7,6 +7,7 @@ use crate::ops::Const;
 
 /// Errors that arise from typechecking constants
 #[derive(Clone, Debug, PartialEq, Error)]
+#[non_exhaustive]
 pub enum SumTypeError {
     /// The type of the variant doesn't match the type of the value.
     #[error("Expected type {expected} for element {index} of variant #{tag}, but found {}", .found.const_type())]

--- a/hugr/src/types/type_param.rs
+++ b/hugr/src/types/type_param.rs
@@ -340,6 +340,7 @@ pub fn check_type_args(args: &[TypeArg], params: &[TypeParam]) -> Result<(), Typ
 
 /// Errors that can occur fitting a [TypeArg] into a [TypeParam]
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum TypeArgError {
     #[allow(missing_docs)]
     /// For now, general case of a type arg not fitting a param.


### PR DESCRIPTION
Mainly to `std_extensions` definitions and error enums.

This missing caused #942 to be a breaking change, since it adds new variants to the `FloatOps` and `IntOpDef` extensions. See the failing semver-checks in #928.