### PR TITLE
feat: merge basic blocks algorithm

### DIFF
--- a/hugr/src/algorithm.rs
+++ b/hugr/src/algorithm.rs
@@ -2,4 +2,5 @@
 
 pub mod const_fold;
 mod half_node;
+pub mod merge_bbs;
 pub mod nest_cfgs;

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -88,7 +88,7 @@ fn mk_rep(
             signature: succ_sig.clone(),
         },
     );
-    for (i, _) in succ_sig.output.into_iter().enumerate() {
+    for (i, _) in succ_sig.output.iter().enumerate() {
         replacement.connect(dfg2, i, output, i)
     }
 
@@ -102,10 +102,10 @@ fn mk_rep(
     );
     replacement.connect(dfg1, 0, unp, 0);
     let other_start = tuple_elems.len();
-    for (i, _) in tuple_elems.into_iter().enumerate() {
+    for (i, _) in tuple_elems.iter().enumerate() {
         replacement.connect(unp, i, dfg2, i)
     }
-    for (i, _) in pred_ty.other_outputs.into_iter().enumerate() {
+    for (i, _) in pred_ty.other_outputs.iter().enumerate() {
         replacement.connect(dfg1, i + 1, dfg2, i + other_start)
     }
 

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -29,10 +29,12 @@ pub fn merge_basic_blocks(cfg: &mut impl HugrMut<RootHandle = CfgID>) {
             continue;
         };
         let (rep, dfg1, dfg2) = mk_rep(cfg, n, succ);
-        let node_map = cfg.apply_rewrite(rep).unwrap();
+        let node_map = cfg.hugr_mut().apply_rewrite(rep).unwrap();
         for dfg_id in [dfg1, dfg2] {
             let n_id = *node_map.get(&dfg_id).unwrap();
-            cfg.apply_rewrite(InlineDFG(n_id.into())).unwrap();
+            cfg.hugr_mut()
+                .apply_rewrite(InlineDFG(n_id.into()))
+                .unwrap();
         }
     }
 }

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -208,6 +208,7 @@ mod test {
         let mut h = h.finish_hugr(&reg)?;
         let r = h.root();
         merge_basic_blocks(&mut SiblingMut::<CfgID>::try_new(&mut h, r)?);
+        h.validate(&reg).unwrap();
         assert_eq!(r, h.root());
         assert!(matches!(h.get_optype(r), OpType::CFG(_)));
         let [entry, exit, no_b2] = h.children(r).collect::<Vec<_>>().try_into().unwrap();

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -6,9 +6,9 @@ use itertools::Itertools;
 
 use crate::hugr::rewrite::inline_dfg::InlineDFG;
 use crate::hugr::rewrite::replace::{NewEdgeKind, NewEdgeSpec, Replacement};
+use crate::hugr::{HugrMut, RootTagged};
 use crate::ops::{handle::CfgID, DataflowBlock, DataflowParent, DFG};
-use crate::Node;
-use crate::{hugr::HugrMut, Hugr, HugrView};
+use crate::{Hugr, HugrView, Node};
 
 /// Merge any basic blocks that are direct children of the specified CFG
 /// i.e. where a basic block B has a single successor B' whose only predecessor
@@ -22,11 +22,20 @@ pub fn merge_basic_blocks(cfg: &mut impl HugrMut<RootHandle = CfgID>) {
             continue;
         };
         assert_eq!(n, p);
-        merge_bbs(cfg, n, succ);
+        let (rep, dfg1, dfg2) = mk_rep(cfg, n, succ);
+        let node_map = cfg.apply_rewrite(rep).unwrap();
+        for dfg_id in [dfg1, dfg2] {
+            let n_id = *node_map.get(&dfg_id).unwrap();
+            cfg.apply_rewrite(InlineDFG(n_id.into())).unwrap();
+        }
     }
 }
 
-fn merge_bbs(cfg: &mut impl HugrMut<RootHandle = CfgID>, pred: Node, succ: Node) {
+fn mk_rep(
+    cfg: &impl RootTagged<RootHandle = CfgID>,
+    pred: Node,
+    succ: Node,
+) -> (Replacement, Node, Node) {
     let pred_ty = cfg.get_optype(pred).as_dataflow_block().unwrap();
     let succ_ty = cfg.get_optype(succ).as_dataflow_block().unwrap().clone();
     let signature = succ_ty.inner_signature().clone();
@@ -52,37 +61,32 @@ fn merge_bbs(cfg: &mut impl HugrMut<RootHandle = CfgID>, pred: Node, succ: Node)
     for (i, _) in pred_ty.inner_signature().output().iter().enumerate() {
         replacement.connect(dfg1, i, dfg2, i)
     }
-    let node_map = cfg
-        .apply_rewrite(Replacement {
-            removal: vec![pred, succ],
-            replacement,
-            adoptions: HashMap::from([(dfg1, pred), (dfg2, succ)]),
-            mu_inp: cfg
-                .all_linked_outputs(pred)
-                .map(|(src, src_pos)| NewEdgeSpec {
-                    src,
-                    tgt: merged,
-                    kind: NewEdgeKind::ControlFlow { src_pos },
-                })
-                .collect(),
-            mu_out: cfg
-                .node_outputs(succ)
-                .map(|src_pos| NewEdgeSpec {
-                    src: merged,
-                    tgt: cfg
-                        .linked_inputs(succ, src_pos)
-                        .exactly_one()
-                        .ok()
-                        .unwrap()
-                        .0,
-                    kind: NewEdgeKind::ControlFlow { src_pos },
-                })
-                .collect(),
-            mu_new: vec![],
-        })
-        .unwrap();
-    for dfg_id in [dfg1, dfg2] {
-        let n_id = *node_map.get(&dfg_id).unwrap();
-        cfg.apply_rewrite(InlineDFG(n_id.into())).unwrap();
-    }
+    let rep = Replacement {
+        removal: vec![pred, succ],
+        replacement,
+        adoptions: HashMap::from([(dfg1, pred), (dfg2, succ)]),
+        mu_inp: cfg
+            .all_linked_outputs(pred)
+            .map(|(src, src_pos)| NewEdgeSpec {
+                src,
+                tgt: merged,
+                kind: NewEdgeKind::ControlFlow { src_pos },
+            })
+            .collect(),
+        mu_out: cfg
+            .node_outputs(succ)
+            .map(|src_pos| NewEdgeSpec {
+                src: merged,
+                tgt: cfg
+                    .linked_inputs(succ, src_pos)
+                    .exactly_one()
+                    .ok()
+                    .unwrap()
+                    .0,
+                kind: NewEdgeKind::ControlFlow { src_pos },
+            })
+            .collect(),
+        mu_new: vec![],
+    };
+    (rep, dfg1, dfg2)
 }

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -1,0 +1,88 @@
+//! Merge BBs along control-flow edges where the source BB has no other successors
+//! and the target BB has no other predecessors.
+use std::collections::HashMap;
+
+use itertools::Itertools;
+
+use crate::hugr::rewrite::inline_dfg::InlineDFG;
+use crate::hugr::rewrite::replace::{NewEdgeKind, NewEdgeSpec, Replacement};
+use crate::ops::{handle::CfgID, DataflowBlock, DataflowParent, DFG};
+use crate::Node;
+use crate::{hugr::HugrMut, Hugr, HugrView};
+
+/// Merge any basic blocks that are direct children of the specified CFG
+/// i.e. where a basic block B has a single successor B' whose only predecessor
+/// is B, B and B' can be combined.
+pub fn merge_basic_blocks(cfg: &mut impl HugrMut<RootHandle = CfgID>) {
+    for n in cfg.nodes().collect::<Vec<_>>().into_iter() {
+        let Ok(succ) = cfg.output_neighbours(n).exactly_one() else {
+            continue;
+        };
+        let Ok(p) = cfg.input_neighbours(succ).exactly_one() else {
+            continue;
+        };
+        assert_eq!(n, p);
+        merge_bbs(cfg, n, succ);
+    }
+}
+
+fn merge_bbs(cfg: &mut impl HugrMut<RootHandle = CfgID>, pred: Node, succ: Node) {
+    let pred_ty = cfg.get_optype(pred).as_dataflow_block().unwrap();
+    let succ_ty = cfg.get_optype(succ).as_dataflow_block().unwrap().clone();
+    let signature = succ_ty.inner_signature().clone();
+    let mut replacement: Hugr = Hugr::new(cfg.root_type().clone());
+    let merged = replacement.add_node_with_parent(
+        replacement.root(),
+        DataflowBlock {
+            inputs: pred_ty.inputs.clone(),
+            extension_delta: pred_ty
+                .extension_delta
+                .clone()
+                .union(succ_ty.extension_delta),
+            ..succ_ty
+        },
+    );
+    let dfg1 = replacement.add_node_with_parent(
+        merged,
+        DFG {
+            signature: signature.clone(),
+        },
+    );
+    let dfg2 = replacement.add_node_with_parent(merged, DFG { signature });
+    for (i, _) in pred_ty.inner_signature().output().iter().enumerate() {
+        replacement.connect(dfg1, i, dfg2, i)
+    }
+    let node_map = cfg
+        .apply_rewrite(Replacement {
+            removal: vec![pred, succ],
+            replacement,
+            adoptions: HashMap::from([(dfg1, pred), (dfg2, succ)]),
+            mu_inp: cfg
+                .all_linked_outputs(pred)
+                .map(|(src, src_pos)| NewEdgeSpec {
+                    src,
+                    tgt: merged,
+                    kind: NewEdgeKind::ControlFlow { src_pos },
+                })
+                .collect(),
+            mu_out: cfg
+                .node_outputs(succ)
+                .map(|src_pos| NewEdgeSpec {
+                    src: merged,
+                    tgt: cfg
+                        .linked_inputs(succ, src_pos)
+                        .exactly_one()
+                        .ok()
+                        .unwrap()
+                        .0,
+                    kind: NewEdgeKind::ControlFlow { src_pos },
+                })
+                .collect(),
+            mu_new: vec![],
+        })
+        .unwrap();
+    for dfg_id in [dfg1, dfg2] {
+        let n_id = *node_map.get(&dfg_id).unwrap();
+        cfg.apply_rewrite(InlineDFG(n_id.into())).unwrap();
+    }
+}

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -421,6 +421,20 @@ mod test {
             .ok()
             .unwrap();
         assert_eq!(h.get_parent(tst), Some(bb));
+
+        let inp = h
+            .nodes()
+            .filter(|n| matches!(h.get_optype(*n), OpType::Input(_)))
+            .exactly_one()
+            .ok()
+            .unwrap();
+        let mut tst_inputs = h.input_neighbours(tst).collect::<Vec<_>>();
+        tst_inputs.remove(tst_inputs.iter().find_position(|n| **n == inp).unwrap().0);
+        let [other_input] = tst_inputs.try_into().unwrap();
+        assert_eq!(
+            h.get_optype(other_input),
+            &(LoadConstant { datatype: USIZE_T }.into())
+        );
         Ok(())
     }
 }

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -16,7 +16,6 @@ use crate::{Hugr, HugrView, Node};
 /// i.e. where a basic block B has a single successor B' whose only predecessor
 /// is B, B and B' can be combined.
 pub fn merge_basic_blocks(cfg: &mut impl HugrMut<RootHandle = CfgID>) {
-    let entry_exit = cfg.nodes().take(2).collect::<Vec<_>>();
     for n in cfg.nodes().collect::<Vec<_>>().into_iter() {
         let Ok(succ) = cfg.output_neighbours(n).exactly_one() else {
             continue;
@@ -24,7 +23,7 @@ pub fn merge_basic_blocks(cfg: &mut impl HugrMut<RootHandle = CfgID>) {
         if cfg.input_neighbours(succ).take(2).collect::<Vec<_>>() != vec![n] {
             continue;
         };
-        if entry_exit.contains(&succ) {
+        if cfg.nodes().take(2).contains(&succ) {
             // entry block has an additional in-edge, so cannot merge with predecessor.
             // if succ is exit block, nodes in n==p should move *outside* the CFG
             // - a separate normalization from merging BBs.

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -363,7 +363,6 @@ mod test {
         let tst = bb3.add_dataflow_op(tst_op, [q, u])?;
         let pred = lifted_unary_unit_sum(&mut bb3);
         let bb3 = bb3.finish_with_outputs(pred, tst.outputs())?;
-        println!("ALAN bb1 {bb1:?} bb2 {bb2:?} bb3 {bb3:?}");
         // Now add control-flow edges between basic blocks
         h.branch(&bb1, 0, &bb2)?;
         h.branch(&bb2, 0, &bb3)?;

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -23,7 +23,7 @@ pub fn merge_basic_blocks(cfg: &mut impl HugrMut<RootHandle = CfgID>) {
         if cfg.input_neighbours(succ).take(2).collect::<Vec<_>>() != vec![n] {
             continue;
         };
-        if cfg.nodes().take(2).contains(&succ) {
+        if cfg.children(cfg.root()).take(2).contains(&succ) {
             // entry block has an additional in-edge, so cannot merge with predecessor.
             // if succ is exit block, nodes in n==p should move *outside* the CFG
             // - a separate normalization from merging BBs.
@@ -403,6 +403,8 @@ mod test {
         h.connect(bb3, 0, exit, 0);
         let reg = ExtensionRegistry::try_new([e, PRELUDE.to_owned()])?;
         h.update_validate(&reg)?;
+        let root = h.root();
+        merge_basic_blocks(&mut SiblingMut::try_new(&mut h, root)?);
         Ok(())
     }
 }

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -401,10 +401,22 @@ mod test {
         h.connect(bb1, 0, bb2, 0);
         h.connect(bb2, 0, bb3, 0);
         h.connect(bb3, 0, exit, 0);
+
         let reg = ExtensionRegistry::try_new([e, PRELUDE.to_owned()])?;
         h.update_validate(&reg)?;
         let root = h.root();
         merge_basic_blocks(&mut SiblingMut::try_new(&mut h, root)?);
+        h.validate(&reg)?;
+
+        // Should only be one BB left
+        let [bb, _exit] = h.children(h.root()).collect::<Vec<_>>().try_into().unwrap();
+        let tst = h
+            .nodes()
+            .filter(|n| matches!(h.get_optype(*n), OpType::CustomOp(_)))
+            .exactly_one()
+            .ok()
+            .unwrap();
+        assert_eq!(h.get_parent(tst), Some(bb));
         Ok(())
     }
 }

--- a/hugr/src/algorithm/merge_bbs.rs
+++ b/hugr/src/algorithm/merge_bbs.rs
@@ -90,3 +90,65 @@ fn mk_rep(
     };
     (rep, dfg1, dfg2)
 }
+
+#[cfg(test)]
+mod test {
+    use crate::builder::{CFGBuilder, Dataflow, HugrBuilder};
+    use crate::extension::prelude::{QB_T, USIZE_T};
+    use crate::extension::{ExtensionRegistry, ExtensionSet, PRELUDE};
+    use crate::ops::{Const, Noop};
+    use crate::types::{FunctionType, Type, TypeRow};
+    use crate::{const_extension_ids, type_row, Extension};
+
+    const_extension_ids! {
+        const EXT_ID: ExtensionId = "TestExt";
+    }
+    #[test]
+    fn in_loop() -> Result<(), Box<dyn std::error::Error>> {
+        /* Noop -> Test -> Exit      NoopTest -> Exit
+           |       |            =>   |    |
+           \-<---<-/                 \<-<-/
+        */
+        let loop_variants = type_row![QB_T];
+        let exit_types = type_row![USIZE_T];
+        let mut e = Extension::new(EXT_ID);
+        e.add_op(
+            "Test".into(),
+            String::new(),
+            FunctionType::new(
+                loop_variants.clone(),
+                TypeRow::from(vec![Type::new_sum(vec![
+                    loop_variants.clone(),
+                    exit_types.clone(),
+                ])]),
+            ),
+        )?;
+        let reg = ExtensionRegistry::try_new([PRELUDE.to_owned(), e])?;
+        let e = reg.get(&EXT_ID.to_string()).unwrap();
+        let mut h = CFGBuilder::new(FunctionType::new(loop_variants.clone(), exit_types.clone()))?;
+        let mut noop_block =
+            h.simple_entry_builder(loop_variants.clone(), 1, ExtensionSet::new())?;
+        let n = noop_block.add_dataflow_op(Noop { ty: QB_T }, noop_block.input_wires())?;
+        let br = noop_block.add_load_const(Const::unary_unit_sum());
+        let noop_block = noop_block.finish_with_outputs(br, n.outputs())?;
+        let mut test_block = h.block_builder(
+            loop_variants.clone(),
+            vec![loop_variants.clone(), exit_types],
+            ExtensionSet::singleton(&EXT_ID),
+            type_row![],
+        )?;
+        let [tst] = test_block
+            .add_dataflow_op(
+                e.instantiate_extension_op("Test", [], &reg)?,
+                test_block.input_wires(),
+            )?
+            .outputs_arr();
+        let test_block = test_block.finish_with_outputs(tst, [])?;
+        let exit_block = h.exit_block();
+        h.branch(&noop_block, 0, &test_block)?;
+        h.branch(&test_block, 0, &noop_block)?;
+        h.branch(&test_block, 1, &exit_block)?;
+        h.finish_hugr(&reg)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Any basic block with a single successor that has no other predecessors can be merged. (So long as the successor is not the exit block; nor the entry block, as that implicitly has another predecessor).

Implement via Replace (2 BBs - > one BB containing 2 DFGs, which adopt the original BB's children) and 2*InlineDFG.

Closes #561.