### PR TITLE
refactor!: Replace SmolStr identifiers with wrapper types.

### DIFF
--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -52,6 +52,7 @@ delegate = "0.12.0"
 paste = "1.0"
 strum = "0.26.1"
 strum_macros = "0.26.1"
+string-newtype = { version = "0.1.0", features = ["smol_str", "serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -52,7 +52,6 @@ delegate = "0.12.0"
 paste = "1.0"
 strum = "0.26.1"
 strum_macros = "0.26.1"
-string-newtype = { version = "0.1.1", features = ["smol_str", "serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -52,7 +52,7 @@ delegate = "0.12.0"
 paste = "1.0"
 strum = "0.26.1"
 strum_macros = "0.26.1"
-string-newtype = { version = "0.1.0", features = ["smol_str", "serde"] }
+string-newtype = { version = "0.1.1", features = ["smol_str", "serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/hugr/src/builder.rs
+++ b/hugr/src/builder.rs
@@ -91,7 +91,7 @@ use thiserror::Error;
 use crate::extension::SignatureError;
 use crate::hugr::ValidationError;
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
-use crate::ops::{OpName, OpType};
+use crate::ops::{NamedOp, OpType};
 use crate::types::ConstTypeError;
 use crate::types::Type;
 use crate::{Node, Port, Wire};

--- a/hugr/src/builder/circuit.rs
+++ b/hugr/src/builder/circuit.rs
@@ -3,7 +3,7 @@ use std::mem;
 
 use thiserror::Error;
 
-use crate::ops::{OpName, OpType};
+use crate::ops::{NamedOp, OpType};
 use crate::utils::collect_array;
 
 use super::{BuildError, Dataflow};

--- a/hugr/src/core.rs
+++ b/hugr/src/core.rs
@@ -6,6 +6,7 @@ pub use itertools::Either;
 
 use derive_more::From;
 use itertools::Either::{Left, Right};
+use smol_str::SmolStr;
 
 use crate::hugr::HugrError;
 
@@ -324,3 +325,71 @@ macro_rules! impl_display_from_debug {
     };
 }
 impl_display_from_debug!(Node, Port, IncomingPort, OutgoingPort, Wire, CircuitUnit);
+
+/// A common trait for identifier strings.
+///
+/// See [`TypeName`], [`OpName`], [`ParameterName`].
+pub trait Identifier:
+    From<SmolStr>
+    + From<String>
+    + for<'a> From<&'a str>
+    + AsRef<str>
+    + std::fmt::Display
+    + std::borrow::Borrow<str>
+    + Default
+{
+}
+
+/// Implements the `Identifier` trait and related `From` and `Into` traits on a
+/// `SmolStr` wrapper.
+///
+/// First argument is the type to implement the trait for. Second argument is
+/// the attribute name for the wrapped SmolStr.
+macro_rules! impl_identifier {
+    ($t:ty, $attr:tt) => {
+        impl $crate::core::Identifier for $t {}
+
+        impl From<smol_str::SmolStr> for $t {
+            fn from(value: smol_str::SmolStr) -> Self {
+                Self {
+                    $attr: value.into(),
+                }
+            }
+        }
+
+        impl From<String> for $t {
+            fn from(value: String) -> Self {
+                Self {
+                    $attr: value.into(),
+                }
+            }
+        }
+
+        impl<'a> From<&'a str> for $t {
+            fn from(value: &'a str) -> Self {
+                Self {
+                    $attr: value.into(),
+                }
+            }
+        }
+
+        impl std::borrow::Borrow<str> for $t {
+            fn borrow(&self) -> &str {
+                self.$attr.borrow()
+            }
+        }
+
+        impl AsRef<str> for $t {
+            fn as_ref(&self) -> &str {
+                self.$attr.as_ref()
+            }
+        }
+
+        impl std::fmt::Display for $t {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.$attr.fmt(f)
+            }
+        }
+    };
+}
+pub(crate) use impl_identifier;

--- a/hugr/src/core.rs
+++ b/hugr/src/core.rs
@@ -6,7 +6,6 @@ pub use itertools::Either;
 
 use derive_more::From;
 use itertools::Either::{Left, Right};
-use smol_str::SmolStr;
 
 use crate::hugr::HugrError;
 
@@ -325,71 +324,3 @@ macro_rules! impl_display_from_debug {
     };
 }
 impl_display_from_debug!(Node, Port, IncomingPort, OutgoingPort, Wire, CircuitUnit);
-
-/// A common trait for identifier strings.
-///
-/// See [`TypeName`], [`OpName`], [`ParameterName`].
-pub trait Identifier:
-    From<SmolStr>
-    + From<String>
-    + for<'a> From<&'a str>
-    + AsRef<str>
-    + std::fmt::Display
-    + std::borrow::Borrow<str>
-    + Default
-{
-}
-
-/// Implements the `Identifier` trait and related `From` and `Into` traits on a
-/// `SmolStr` wrapper.
-///
-/// First argument is the type to implement the trait for. Second argument is
-/// the attribute name for the wrapped SmolStr.
-macro_rules! impl_identifier {
-    ($t:ty, $attr:tt) => {
-        impl $crate::core::Identifier for $t {}
-
-        impl From<smol_str::SmolStr> for $t {
-            fn from(value: smol_str::SmolStr) -> Self {
-                Self {
-                    $attr: value.into(),
-                }
-            }
-        }
-
-        impl From<String> for $t {
-            fn from(value: String) -> Self {
-                Self {
-                    $attr: value.into(),
-                }
-            }
-        }
-
-        impl<'a> From<&'a str> for $t {
-            fn from(value: &'a str) -> Self {
-                Self {
-                    $attr: value.into(),
-                }
-            }
-        }
-
-        impl std::borrow::Borrow<str> for $t {
-            fn borrow(&self) -> &str {
-                self.$attr.borrow()
-            }
-        }
-
-        impl AsRef<str> for $t {
-            fn as_ref(&self) -> &str {
-                self.$attr.as_ref()
-            }
-        }
-
-        impl std::fmt::Display for $t {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                self.$attr.fmt(f)
-            }
-        }
-    };
-}
-pub(crate) use impl_identifier;

--- a/hugr/src/extension.rs
+++ b/hugr/src/extension.rs
@@ -12,13 +12,13 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::hugr::IdentList;
-use crate::ops::constant::{ValueName, ValueNameSlice};
+use crate::ops::constant::{ValueName, ValueNameRef};
 use crate::ops::custom::{ExtensionOp, OpaqueOp};
-use crate::ops::{self, OpName, OpNameSlice};
+use crate::ops::{self, OpName, OpNameRef};
 use crate::types::type_param::{check_type_args, TypeArgError};
 use crate::types::type_param::{TypeArg, TypeParam};
 use crate::types::{check_typevar_decl, CustomType, Substitution, TypeBound, TypeName};
-use crate::types::{FunctionType, TypeNameSlice};
+use crate::types::{FunctionType, TypeNameRef};
 
 #[allow(dead_code)]
 mod infer;
@@ -309,17 +309,17 @@ impl Extension {
     }
 
     /// Allows read-only access to the operations in this Extension
-    pub fn get_op(&self, op_name: &OpNameSlice) -> Option<&Arc<op_def::OpDef>> {
+    pub fn get_op(&self, op_name: &OpNameRef) -> Option<&Arc<op_def::OpDef>> {
         self.operations.get(op_name)
     }
 
     /// Allows read-only access to the types in this Extension
-    pub fn get_type(&self, type_name: &TypeNameSlice) -> Option<&type_def::TypeDef> {
+    pub fn get_type(&self, type_name: &TypeNameRef) -> Option<&type_def::TypeDef> {
         self.types.get(type_name)
     }
 
     /// Allows read-only access to the values in this Extension
-    pub fn get_value(&self, value_name: &ValueNameSlice) -> Option<&ExtensionValue> {
+    pub fn get_value(&self, value_name: &ValueNameRef) -> Option<&ExtensionValue> {
         self.values.get(value_name)
     }
 
@@ -360,7 +360,7 @@ impl Extension {
     /// Instantiate an [`ExtensionOp`] which references an [`OpDef`] in this extension.
     pub fn instantiate_extension_op(
         &self,
-        op_name: &OpNameSlice,
+        op_name: &OpNameRef,
         args: impl Into<Vec<TypeArg>>,
         ext_reg: &ExtensionRegistry,
     ) -> Result<ExtensionOp, SignatureError> {

--- a/hugr/src/extension.rs
+++ b/hugr/src/extension.rs
@@ -177,6 +177,7 @@ pub enum SignatureError {
 
 /// Concrete instantiations of types and operations defined in extensions.
 trait CustomConcrete {
+    /// The identifier type for the concrete object.
     type Identifier;
     /// A generic identifier to the element.
     ///
@@ -191,7 +192,7 @@ trait CustomConcrete {
 impl CustomConcrete for OpaqueOp {
     type Identifier = OpName;
 
-    fn def_name(&self) -> &Self::Identifier {
+    fn def_name(&self) -> &OpName {
         self.name()
     }
 
@@ -207,7 +208,7 @@ impl CustomConcrete for OpaqueOp {
 impl CustomConcrete for CustomType {
     type Identifier = TypeName;
 
-    fn def_name(&self) -> &Self::Identifier {
+    fn def_name(&self) -> &TypeName {
         // Casts the `TypeName` to a generic string.
         self.name()
     }

--- a/hugr/src/extension/declarative.rs
+++ b/hugr/src/extension/declarative.rs
@@ -32,6 +32,7 @@ use std::fs::File;
 use std::path::Path;
 
 use crate::extension::prelude::PRELUDE_ID;
+use crate::ops::OpName;
 use crate::types::TypeName;
 use crate::Extension;
 
@@ -221,7 +222,7 @@ pub enum ExtensionDeclarationError {
         /// The extension that referenced the unsupported op parameter.
         ext: ExtensionId,
         /// The operation.
-        op: SmolStr,
+        op: OpName,
     },
     /// Operation definitions with no signature are not currently supported.
     ///
@@ -233,7 +234,7 @@ pub enum ExtensionDeclarationError {
         /// The extension containing the operation.
         ext: ExtensionId,
         /// The operation with no signature.
-        op: SmolStr,
+        op: OpName,
     },
     /// An unknown type was specified in a signature.
     #[error("Type {ty} is not in scope. In extension {ext}.")]
@@ -261,7 +262,7 @@ pub enum ExtensionDeclarationError {
         /// The extension.
         ext: crate::hugr::IdentList,
         /// The operation with the lowering definition.
-        op: SmolStr,
+        op: OpName,
     },
 }
 

--- a/hugr/src/extension/declarative/ops.rs
+++ b/hugr/src/extension/declarative/ops.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
 use crate::extension::{OpDef, SignatureFunc};
+use crate::ops::OpName;
 use crate::types::type_param::TypeParam;
 use crate::Extension;
 
@@ -25,7 +26,7 @@ use super::{DeclarationContext, ExtensionDeclarationError};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(super) struct OperationDeclaration {
     /// The identifier the operation.
-    name: SmolStr,
+    name: OpName,
     /// A description for the operation.
     #[serde(default)]
     #[serde(skip_serializing_if = "crate::utils::is_default")]

--- a/hugr/src/extension/declarative/signature.rs
+++ b/hugr/src/extension/declarative/signature.rs
@@ -200,8 +200,8 @@ impl TypeDeclaration {
         // Some hard-coded prelude types are supported.
         let prelude = ctx.registry.get(&PRELUDE_ID).unwrap();
         match self.0.as_str() {
-            "USize" => return prelude.get_type(&"usize".into()),
-            "Q" => return prelude.get_type(&"qubit".into()),
+            "USize" => return prelude.get_type("usize".into()),
+            "Q" => return prelude.get_type("qubit".into()),
             _ => {}
         }
 

--- a/hugr/src/extension/declarative/signature.rs
+++ b/hugr/src/extension/declarative/signature.rs
@@ -14,7 +14,7 @@ use smol_str::SmolStr;
 use crate::extension::prelude::PRELUDE_ID;
 use crate::extension::{CustomValidator, ExtensionSet, SignatureFunc, TypeDef, TypeParametrised};
 use crate::types::type_param::TypeParam;
-use crate::types::{CustomType, FunctionType, PolyFuncType, Type, TypeName, TypeRow};
+use crate::types::{CustomType, FunctionType, PolyFuncType, Type, TypeRow};
 use crate::Extension;
 
 use super::{DeclarationContext, ExtensionDeclarationError};
@@ -205,20 +205,14 @@ impl TypeDeclaration {
             _ => {}
         }
 
-        let type_name: TypeName = self.0.clone().into();
-
         // Try to resolve the type in the current extension.
-        if let Some(ty) = ext.get_type(&type_name) {
+        if let Some(ty) = ext.get_type(&self.0) {
             return Some(ty);
         }
 
         // Try to resolve the type in the other extensions in scope.
         for ext in ctx.scope.iter() {
-            if let Some(ty) = ctx
-                .registry
-                .get(ext)
-                .and_then(|ext| ext.get_type(&type_name))
-            {
+            if let Some(ty) = ctx.registry.get(ext).and_then(|ext| ext.get_type(&self.0)) {
                 return Some(ty);
             }
         }

--- a/hugr/src/extension/declarative/signature.rs
+++ b/hugr/src/extension/declarative/signature.rs
@@ -14,7 +14,7 @@ use smol_str::SmolStr;
 use crate::extension::prelude::PRELUDE_ID;
 use crate::extension::{CustomValidator, ExtensionSet, SignatureFunc, TypeDef, TypeParametrised};
 use crate::types::type_param::TypeParam;
-use crate::types::{CustomType, FunctionType, PolyFuncType, Type, TypeRow};
+use crate::types::{CustomType, FunctionType, PolyFuncType, Type, TypeName, TypeRow};
 use crate::Extension;
 
 use super::{DeclarationContext, ExtensionDeclarationError};
@@ -200,13 +200,15 @@ impl TypeDeclaration {
         // Some hard-coded prelude types are supported.
         let prelude = ctx.registry.get(&PRELUDE_ID).unwrap();
         match self.0.as_str() {
-            "USize" => return prelude.get_type("usize"),
-            "Q" => return prelude.get_type("qubit"),
+            "USize" => return prelude.get_type(&"usize".into()),
+            "Q" => return prelude.get_type(&"qubit".into()),
             _ => {}
         }
 
+        let type_name: TypeName = self.0.clone().into();
+
         // Try to resolve the type in the current extension.
-        if let Some(ty) = ext.get_type(self.0.as_str()) {
+        if let Some(ty) = ext.get_type(&type_name) {
             return Some(ty);
         }
 
@@ -215,7 +217,7 @@ impl TypeDeclaration {
             if let Some(ty) = ctx
                 .registry
                 .get(ext)
-                .and_then(|ext| ext.get_type(self.0.as_str()))
+                .and_then(|ext| ext.get_type(&type_name))
             {
                 return Some(ty);
             }

--- a/hugr/src/extension/declarative/signature.rs
+++ b/hugr/src/extension/declarative/signature.rs
@@ -200,8 +200,8 @@ impl TypeDeclaration {
         // Some hard-coded prelude types are supported.
         let prelude = ctx.registry.get(&PRELUDE_ID).unwrap();
         match self.0.as_str() {
-            "USize" => return prelude.get_type("usize".into()),
-            "Q" => return prelude.get_type("qubit".into()),
+            "USize" => return prelude.get_type("usize"),
+            "Q" => return prelude.get_type("qubit"),
             _ => {}
         }
 

--- a/hugr/src/extension/op_def.rs
+++ b/hugr/src/extension/op_def.rs
@@ -9,7 +9,7 @@ use super::{
     ExtensionSet, SignatureError,
 };
 
-use crate::ops::{OpName, OpNameSlice};
+use crate::ops::{OpName, OpNameRef};
 use crate::types::type_param::{check_type_args, TypeArg, TypeParam};
 use crate::types::{FunctionType, PolyFuncType};
 use crate::Hugr;
@@ -107,7 +107,7 @@ pub trait CustomLowerFunc: Send + Sync {
     /// TODO: some error type to indicate Extensions required?
     fn try_lower(
         &self,
-        name: &OpNameSlice,
+        name: &OpNameRef,
         arg_values: &[TypeArg],
         misc: &HashMap<String, serde_yaml::Value>,
         available_extensions: &ExtensionSet,

--- a/hugr/src/extension/op_def.rs
+++ b/hugr/src/extension/op_def.rs
@@ -9,7 +9,7 @@ use super::{
     ExtensionSet, SignatureError,
 };
 
-use crate::ops::OpName;
+use crate::ops::{OpName, OpNameSlice};
 use crate::types::type_param::{check_type_args, TypeArg, TypeParam};
 use crate::types::{FunctionType, PolyFuncType};
 use crate::Hugr;
@@ -107,7 +107,7 @@ pub trait CustomLowerFunc: Send + Sync {
     /// TODO: some error type to indicate Extensions required?
     fn try_lower(
         &self,
-        name: &OpName,
+        name: &OpNameSlice,
         arg_values: &[TypeArg],
         misc: &HashMap<String, serde_yaml::Value>,
         available_extensions: &ExtensionSet,

--- a/hugr/src/extension/op_def.rs
+++ b/hugr/src/extension/op_def.rs
@@ -4,13 +4,12 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use smol_str::SmolStr;
-
 use super::{
     ConstFold, ConstFoldResult, Extension, ExtensionBuildError, ExtensionId, ExtensionRegistry,
     ExtensionSet, SignatureError,
 };
 
+use crate::ops::OpName;
 use crate::types::type_param::{check_type_args, TypeArg, TypeParam};
 use crate::types::{FunctionType, PolyFuncType};
 use crate::Hugr;
@@ -108,7 +107,7 @@ pub trait CustomLowerFunc: Send + Sync {
     /// TODO: some error type to indicate Extensions required?
     fn try_lower(
         &self,
-        name: &SmolStr,
+        name: &OpName,
         arg_values: &[TypeArg],
         misc: &HashMap<String, serde_yaml::Value>,
         available_extensions: &ExtensionSet,
@@ -295,7 +294,7 @@ pub struct OpDef {
     extension: ExtensionId,
     /// Unique identifier of the operation. Used to look up OpDefs in the registry
     /// when deserializing nodes (which store only the name).
-    name: SmolStr,
+    name: OpName,
     /// Human readable description of the operation.
     description: String,
     /// Miscellaneous data associated with the operation.
@@ -376,7 +375,7 @@ impl OpDef {
     }
 
     /// Returns a reference to the name of this [`OpDef`].
-    pub fn name(&self) -> &SmolStr {
+    pub fn name(&self) -> &OpName {
         &self.name
     }
 
@@ -442,7 +441,7 @@ impl Extension {
     /// function for computing the signature given type arguments (`impl [CustomSignatureFunc]`).
     pub fn add_op(
         &mut self,
-        name: SmolStr,
+        name: OpName,
         description: String,
         signature_func: impl Into<SignatureFunc>,
     ) -> Result<&mut OpDef, ExtensionBuildError> {
@@ -468,15 +467,13 @@ impl Extension {
 mod test {
     use std::num::NonZeroU64;
 
-    use smol_str::SmolStr;
-
     use super::SignatureFromArgs;
     use crate::builder::{DFGBuilder, Dataflow, DataflowHugr};
     use crate::extension::op_def::LowerFunc;
     use crate::extension::prelude::USIZE_T;
     use crate::extension::{ExtensionRegistry, ExtensionSet, PRELUDE};
     use crate::extension::{SignatureError, EMPTY_REG, PRELUDE_REGISTRY};
-    use crate::ops::CustomOp;
+    use crate::ops::{CustomOp, OpName};
     use crate::std_extensions::collections::{EXTENSION, LIST_TYPENAME};
     use crate::types::Type;
     use crate::types::{type_param::TypeParam, FunctionType, PolyFuncType, TypeArg, TypeBound};
@@ -494,7 +491,7 @@ mod test {
         const TP: TypeParam = TypeParam::Type { b: TypeBound::Any };
         let list_of_var =
             Type::new_extension(list_def.instantiate(vec![TypeArg::new_var_use(0, TP)])?);
-        const OP_NAME: SmolStr = SmolStr::new_inline("Reverse");
+        const OP_NAME: OpName = OpName::new_inline("Reverse");
         let type_scheme = PolyFuncType::new(vec![TP], FunctionType::new_endo(vec![list_of_var]));
 
         let def = e.add_op(OP_NAME, "desc".into(), type_scheme)?;

--- a/hugr/src/extension/prelude.rs
+++ b/hugr/src/extension/prelude.rs
@@ -333,7 +333,7 @@ mod test {
 
         let error_val = ConstError::new(2, "my message");
 
-        assert_eq!(error_val.name().as_str(), "ConstError(2, \"my message\")");
+        assert_eq!(error_val.name(), "ConstError(2, \"my message\")");
 
         assert!(error_val.validate().is_ok());
 
@@ -368,7 +368,7 @@ mod test {
         let string_type: Type = Type::new_extension(string_custom_type);
         assert_eq!(string_type, STRING_TYPE);
         let string_const: ConstString = ConstString::new("Lorem ipsum".into());
-        assert_eq!(string_const.name().as_str(), "ConstString(\"Lorem ipsum\")");
+        assert_eq!(string_const.name(), "ConstString(\"Lorem ipsum\")");
         assert!(string_const.validate().is_ok());
         assert_eq!(
             string_const.extension_reqs(),

--- a/hugr/src/extension/prelude.rs
+++ b/hugr/src/extension/prelude.rs
@@ -1,10 +1,10 @@
 //! Prelude extension - available in all contexts, defining common types,
 //! operations and constants.
 use lazy_static::lazy_static;
-use smol_str::SmolStr;
 
-use crate::ops::CustomOp;
-use crate::types::SumType;
+use crate::ops::constant::ValueName;
+use crate::ops::{CustomOp, OpName};
+use crate::types::{SumType, TypeName};
 use crate::{
     extension::{ExtensionId, TypeDefBound},
     ops::constant::CustomConst,
@@ -48,7 +48,7 @@ lazy_static! {
         let mut prelude = Extension::new(PRELUDE_ID);
         prelude
             .add_type(
-                SmolStr::new_inline("usize"),
+                TypeName::new_inline("usize"),
                 vec![],
                 "usize".into(),
                 TypeDefBound::Explicit(crate::types::TypeBound::Eq),
@@ -62,13 +62,13 @@ lazy_static! {
             )
             .unwrap();
         prelude.add_op(
-            SmolStr::new_inline(PRINT_OP_ID),
+            PRINT_OP_ID,
             "Print the string to standard output".to_string(),
             FunctionType::new(type_row![STRING_TYPE], type_row![]),
             )
             .unwrap();
         prelude.add_type(
-                SmolStr::new_inline("array"),
+                TypeName::new_inline("array"),
                 vec![ TypeParam::max_nat(), TypeBound::Any.into()],
                 "array".into(),
                 TypeDefBound::FromParams(vec![1]),
@@ -76,7 +76,7 @@ lazy_static! {
             .unwrap();
         prelude
             .add_op(
-                SmolStr::new_inline(NEW_ARRAY_OP_ID),
+                NEW_ARRAY_OP_ID,
                 "Create a new array from elements".to_string(),
                 ArrayOpCustom,
             )
@@ -84,7 +84,7 @@ lazy_static! {
 
         prelude
             .add_type(
-                SmolStr::new_inline("qubit"),
+                TypeName::new_inline("qubit"),
                 vec![],
                 "qubit".into(),
                 TypeDefBound::Explicit(TypeBound::Any),
@@ -100,7 +100,7 @@ lazy_static! {
         .unwrap();
         prelude
         .add_op(
-            SmolStr::new_inline(PANIC_OP_ID),
+            PANIC_OP_ID,
             "Panic with input error".to_string(),
             FunctionType::new(type_row![Type::new_extension(ERROR_CUSTOM_TYPE)], type_row![]),
         )
@@ -117,10 +117,10 @@ lazy_static! {
 }
 
 pub(crate) const USIZE_CUSTOM_T: CustomType =
-    CustomType::new_simple(SmolStr::new_inline("usize"), PRELUDE_ID, TypeBound::Eq);
+    CustomType::new_simple(TypeName::new_inline("usize"), PRELUDE_ID, TypeBound::Eq);
 
 pub(crate) const QB_CUSTOM_T: CustomType =
-    CustomType::new_simple(SmolStr::new_inline("qubit"), PRELUDE_ID, TypeBound::Any);
+    CustomType::new_simple(TypeName::new_inline("qubit"), PRELUDE_ID, TypeBound::Any);
 
 /// Qubit type.
 pub const QB_T: Type = Type::new_extension(QB_CUSTOM_T);
@@ -131,7 +131,7 @@ pub const BOOL_T: Type = Type::new_unit_sum(2);
 
 /// Initialize a new array of element type `element_ty` of length `size`
 pub fn array_type(size: TypeArg, element_ty: Type) -> Type {
-    let array_def = PRELUDE.get_type("array").unwrap();
+    let array_def = PRELUDE.get_type(&"array".into()).unwrap();
     let custom_t = array_def
         .instantiate(vec![size, TypeArg::Type { ty: element_ty }])
         .unwrap();
@@ -139,15 +139,15 @@ pub fn array_type(size: TypeArg, element_ty: Type) -> Type {
 }
 
 /// Name of the operation in the prelude for creating new arrays.
-pub const NEW_ARRAY_OP_ID: &str = "new_array";
+pub const NEW_ARRAY_OP_ID: OpName = OpName::new_inline("new_array");
 /// Name of the prelude panic operation.
-pub const PANIC_OP_ID: &str = "panic";
+pub const PANIC_OP_ID: OpName = OpName::new_inline("panic");
 
 /// Initialize a new array op of element type `element_ty` of length `size`
 pub fn new_array_op(element_ty: Type, size: u64) -> CustomOp {
     PRELUDE
         .instantiate_extension_op(
-            NEW_ARRAY_OP_ID,
+            &NEW_ARRAY_OP_ID,
             vec![
                 TypeArg::BoundedNat { n: size },
                 TypeArg::Type { ty: element_ty },
@@ -159,7 +159,7 @@ pub fn new_array_op(element_ty: Type, size: u64) -> CustomOp {
 }
 
 /// Name of the string type.
-pub const STRING_TYPE_NAME: SmolStr = SmolStr::new_inline("string");
+pub const STRING_TYPE_NAME: TypeName = TypeName::new_inline("string");
 
 /// Custom type for strings.
 pub const STRING_CUSTOM_TYPE: CustomType =
@@ -186,7 +186,7 @@ impl ConstString {
 
 #[typetag::serde]
 impl CustomConst for ConstString {
-    fn name(&self) -> SmolStr {
+    fn name(&self) -> ValueName {
         format!("ConstString({:?})", self.0).into()
     }
 
@@ -204,7 +204,7 @@ impl CustomConst for ConstString {
 }
 
 /// Name of the print operation
-pub const PRINT_OP_ID: &str = "print";
+pub const PRINT_OP_ID: OpName = OpName::new_inline("print");
 
 /// The custom type for Errors.
 pub const ERROR_CUSTOM_TYPE: CustomType =
@@ -213,7 +213,7 @@ pub const ERROR_CUSTOM_TYPE: CustomType =
 pub const ERROR_TYPE: Type = Type::new_extension(ERROR_CUSTOM_TYPE);
 
 /// The string name of the error type.
-pub const ERROR_TYPE_NAME: SmolStr = SmolStr::new_inline("error");
+pub const ERROR_TYPE_NAME: TypeName = TypeName::new_inline("error");
 
 /// Return a Sum type with the first variant as the given type and the second an Error.
 pub fn sum_with_error(ty: Type) -> SumType {
@@ -238,7 +238,7 @@ impl ConstUsize {
 
 #[typetag::serde]
 impl CustomConst for ConstUsize {
-    fn name(&self) -> SmolStr {
+    fn name(&self) -> ValueName {
         format!("ConstUsize({:?})", self.0).into()
     }
 
@@ -276,7 +276,7 @@ impl ConstError {
 
 #[typetag::serde]
 impl CustomConst for ConstError {
-    fn name(&self) -> SmolStr {
+    fn name(&self) -> ValueName {
         format!("ConstError({:?}, {:?})", self.signal, self.message).into()
     }
 
@@ -333,7 +333,7 @@ mod test {
 
         let error_val = ConstError::new(2, "my message");
 
-        assert_eq!(error_val.name(), "ConstError(2, \"my message\")");
+        assert_eq!(error_val.name().as_ref(), "ConstError(2, \"my message\")");
 
         assert!(error_val.validate().is_ok());
 
@@ -349,7 +349,7 @@ mod test {
         let err = b.add_load_value(error_val);
 
         let op = PRELUDE
-            .instantiate_extension_op(PANIC_OP_ID, [], &PRELUDE_REGISTRY)
+            .instantiate_extension_op(&PANIC_OP_ID, [], &PRELUDE_REGISTRY)
             .unwrap();
 
         b.add_dataflow_op(op, [err]).unwrap();
@@ -368,7 +368,7 @@ mod test {
         let string_type: Type = Type::new_extension(string_custom_type);
         assert_eq!(string_type, STRING_TYPE);
         let string_const: ConstString = ConstString::new("Lorem ipsum".into());
-        assert_eq!(string_const.name(), "ConstString(\"Lorem ipsum\")");
+        assert_eq!(string_const.name().as_ref(), "ConstString(\"Lorem ipsum\")");
         assert!(string_const.validate().is_ok());
         assert_eq!(
             string_const.extension_reqs(),
@@ -385,7 +385,7 @@ mod test {
         let greeting: ConstString = ConstString::new("Hello, world!".into());
         let greeting_out: Wire = b.add_load_value(greeting);
         let print_op = PRELUDE
-            .instantiate_extension_op(PRINT_OP_ID, [], &PRELUDE_REGISTRY)
+            .instantiate_extension_op(&PRINT_OP_ID, [], &PRELUDE_REGISTRY)
             .unwrap();
         b.add_dataflow_op(print_op, [greeting_out]).unwrap();
         b.finish_prelude_hugr_with_outputs([]).unwrap();

--- a/hugr/src/extension/prelude.rs
+++ b/hugr/src/extension/prelude.rs
@@ -131,7 +131,7 @@ pub const BOOL_T: Type = Type::new_unit_sum(2);
 
 /// Initialize a new array of element type `element_ty` of length `size`
 pub fn array_type(size: TypeArg, element_ty: Type) -> Type {
-    let array_def = PRELUDE.get_type(&"array".into()).unwrap();
+    let array_def = PRELUDE.get_type("array".into()).unwrap();
     let custom_t = array_def
         .instantiate(vec![size, TypeArg::Type { ty: element_ty }])
         .unwrap();
@@ -333,7 +333,7 @@ mod test {
 
         let error_val = ConstError::new(2, "my message");
 
-        assert_eq!(error_val.name().as_ref(), "ConstError(2, \"my message\")");
+        assert_eq!(error_val.name().as_str(), "ConstError(2, \"my message\")");
 
         assert!(error_val.validate().is_ok());
 
@@ -368,7 +368,7 @@ mod test {
         let string_type: Type = Type::new_extension(string_custom_type);
         assert_eq!(string_type, STRING_TYPE);
         let string_const: ConstString = ConstString::new("Lorem ipsum".into());
-        assert_eq!(string_const.name().as_ref(), "ConstString(\"Lorem ipsum\")");
+        assert_eq!(string_const.name().as_str(), "ConstString(\"Lorem ipsum\")");
         assert!(string_const.validate().is_ok());
         assert_eq!(
             string_const.extension_reqs(),

--- a/hugr/src/extension/prelude.rs
+++ b/hugr/src/extension/prelude.rs
@@ -131,7 +131,7 @@ pub const BOOL_T: Type = Type::new_unit_sum(2);
 
 /// Initialize a new array of element type `element_ty` of length `size`
 pub fn array_type(size: TypeArg, element_ty: Type) -> Type {
-    let array_def = PRELUDE.get_type("array".into()).unwrap();
+    let array_def = PRELUDE.get_type("array").unwrap();
     let custom_t = array_def
         .instantiate(vec![size, TypeArg::Type { ty: element_ty }])
         .unwrap();

--- a/hugr/src/extension/simple_op.rs
+++ b/hugr/src/extension/simple_op.rs
@@ -2,7 +2,7 @@
 
 use strum::IntoEnumIterator;
 
-use crate::ops::{OpName, OpNameSlice};
+use crate::ops::{OpName, OpNameRef};
 use crate::{
     ops::{custom::ExtensionOp, NamedOp, OpType},
     types::TypeArg,
@@ -138,11 +138,11 @@ impl<T: MakeOpDef> MakeExtensionOp for T {
 
 /// Load an [MakeOpDef] from its name.
 /// See [strum_macros::EnumString].
-pub fn try_from_name<T>(name: &OpNameSlice) -> Result<T, OpLoadError>
+pub fn try_from_name<T>(name: &OpNameRef) -> Result<T, OpLoadError>
 where
     T: std::str::FromStr + MakeOpDef,
 {
-    T::from_str(name.into()).map_err(|_| OpLoadError::NotMember(name.to_string()))
+    T::from_str(name).map_err(|_| OpLoadError::NotMember(name.to_string()))
 }
 
 /// Wrap an [MakeExtensionOp] with an extension registry to allow type computation.

--- a/hugr/src/extension/simple_op.rs
+++ b/hugr/src/extension/simple_op.rs
@@ -1,10 +1,10 @@
 //! A trait that enum for op definitions that gathers up some shared functionality.
 
-use smol_str::SmolStr;
 use strum::IntoEnumIterator;
 
+use crate::ops::OpName;
 use crate::{
-    ops::{custom::ExtensionOp, OpName, OpType},
+    ops::{custom::ExtensionOp, NamedOp, OpType},
     types::TypeArg,
     Extension,
 };
@@ -28,11 +28,11 @@ pub enum OpLoadError {
     InvalidArgs(#[from] SignatureError),
 }
 
-impl<T> OpName for T
+impl<T> NamedOp for T
 where
     for<'a> &'a T: Into<&'static str>,
 {
-    fn name(&self) -> SmolStr {
+    fn name(&self) -> OpName {
         let s = self.into();
         s.into()
     }
@@ -42,7 +42,7 @@ where
 /// [`OpDef`]s or load themselves from an [`OpDef`].
 /// Particularly useful with C-style enums that implement [strum::IntoEnumIterator],
 /// as then all definitions can be added to an extension at once.
-pub trait MakeOpDef: OpName {
+pub trait MakeOpDef: NamedOp {
     /// Try to load one of the operations of this set from an [OpDef].
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError>
     where
@@ -84,7 +84,7 @@ pub trait MakeOpDef: OpName {
 
 /// Traits implemented by types which can be loaded from [`ExtensionOp`]s,
 /// i.e. concrete instances of [`OpDef`]s, with defined type arguments.
-pub trait MakeExtensionOp: OpName {
+pub trait MakeExtensionOp: NamedOp {
     /// Try to load one of the operations of this set from an [OpDef].
     fn from_extension_op(ext_op: &ExtensionOp) -> Result<Self, OpLoadError>
     where
@@ -138,11 +138,11 @@ impl<T: MakeOpDef> MakeExtensionOp for T {
 
 /// Load an [MakeOpDef] from its name.
 /// See [strum_macros::EnumString].
-pub fn try_from_name<T>(name: &str) -> Result<T, OpLoadError>
+pub fn try_from_name<T>(name: &OpName) -> Result<T, OpLoadError>
 where
     T: std::str::FromStr + MakeOpDef,
 {
-    T::from_str(name).map_err(|_| OpLoadError::NotMember(name.to_string()))
+    T::from_str(name.as_ref()).map_err(|_| OpLoadError::NotMember(name.to_string()))
 }
 
 /// Wrap an [MakeExtensionOp] with an extension registry to allow type computation.
@@ -181,7 +181,7 @@ impl<T: MakeExtensionOp> RegisteredOp<'_, T> {
     delegate! {
         to self.op {
             /// Name of the operation - derived from strum serialization.
-            pub fn name(&self) -> SmolStr;
+            pub fn name(&self) -> OpName;
             /// Any type args which define this operation. Default is no type arguments.
             pub fn type_args(&self) -> Vec<TypeArg>;
         }

--- a/hugr/src/extension/simple_op.rs
+++ b/hugr/src/extension/simple_op.rs
@@ -2,7 +2,7 @@
 
 use strum::IntoEnumIterator;
 
-use crate::ops::OpName;
+use crate::ops::{OpName, OpNameSlice};
 use crate::{
     ops::{custom::ExtensionOp, NamedOp, OpType},
     types::TypeArg,
@@ -138,11 +138,11 @@ impl<T: MakeOpDef> MakeExtensionOp for T {
 
 /// Load an [MakeOpDef] from its name.
 /// See [strum_macros::EnumString].
-pub fn try_from_name<T>(name: &OpName) -> Result<T, OpLoadError>
+pub fn try_from_name<T>(name: &OpNameSlice) -> Result<T, OpLoadError>
 where
     T: std::str::FromStr + MakeOpDef,
 {
-    T::from_str(name.as_ref()).map_err(|_| OpLoadError::NotMember(name.to_string()))
+    T::from_str(name.into()).map_err(|_| OpLoadError::NotMember(name.to_string()))
 }
 
 /// Wrap an [MakeExtensionOp] with an extension registry to allow type computation.

--- a/hugr/src/extension/type_def.rs
+++ b/hugr/src/extension/type_def.rs
@@ -157,7 +157,7 @@ impl Extension {
             bound,
         };
         match self.types.entry(ty.name.clone()) {
-            Entry::Occupied(_) => Err(ExtensionBuildError::OpDefExists(ty.name)),
+            Entry::Occupied(_) => Err(ExtensionBuildError::TypeDefExists(ty.name)),
             Entry::Vacant(ve) => Ok(ve.insert(ty)),
         }
     }

--- a/hugr/src/hugr/rewrite/replace.rs
+++ b/hugr/src/hugr/rewrite/replace.rs
@@ -480,11 +480,11 @@ mod test {
                 .unwrap(),
         );
         let pop: CustomOp = collections::EXTENSION
-            .instantiate_extension_op("pop".into(), [TypeArg::Type { ty: USIZE_T }], &reg)
+            .instantiate_extension_op("pop", [TypeArg::Type { ty: USIZE_T }], &reg)
             .unwrap()
             .into();
         let push: CustomOp = collections::EXTENSION
-            .instantiate_extension_op("push".into(), [TypeArg::Type { ty: USIZE_T }], &reg)
+            .instantiate_extension_op("push", [TypeArg::Type { ty: USIZE_T }], &reg)
             .unwrap()
             .into();
         let just_list = TypeRow::from(vec![listy.clone()]);

--- a/hugr/src/hugr/rewrite/replace.rs
+++ b/hugr/src/hugr/rewrite/replace.rs
@@ -480,11 +480,11 @@ mod test {
                 .unwrap(),
         );
         let pop: CustomOp = collections::EXTENSION
-            .instantiate_extension_op(&"pop".into(), [TypeArg::Type { ty: USIZE_T }], &reg)
+            .instantiate_extension_op("pop".into(), [TypeArg::Type { ty: USIZE_T }], &reg)
             .unwrap()
             .into();
         let push: CustomOp = collections::EXTENSION
-            .instantiate_extension_op(&"push".into(), [TypeArg::Type { ty: USIZE_T }], &reg)
+            .instantiate_extension_op("push".into(), [TypeArg::Type { ty: USIZE_T }], &reg)
             .unwrap()
             .into();
         let just_list = TypeRow::from(vec![listy.clone()]);

--- a/hugr/src/hugr/rewrite/replace.rs
+++ b/hugr/src/hugr/rewrite/replace.rs
@@ -474,17 +474,17 @@ mod test {
                 .unwrap();
         let listy = Type::new_extension(
             collections::EXTENSION
-                .get_type(collections::LIST_TYPENAME.as_str())
+                .get_type(&collections::LIST_TYPENAME)
                 .unwrap()
                 .instantiate([TypeArg::Type { ty: USIZE_T }])
                 .unwrap(),
         );
         let pop: CustomOp = collections::EXTENSION
-            .instantiate_extension_op("pop", [TypeArg::Type { ty: USIZE_T }], &reg)
+            .instantiate_extension_op(&"pop".into(), [TypeArg::Type { ty: USIZE_T }], &reg)
             .unwrap()
             .into();
         let push: CustomOp = collections::EXTENSION
-            .instantiate_extension_op("push", [TypeArg::Type { ty: USIZE_T }], &reg)
+            .instantiate_extension_op(&"push".into(), [TypeArg::Type { ty: USIZE_T }], &reg)
             .unwrap()
             .into();
         let just_list = TypeRow::from(vec![listy.clone()]);

--- a/hugr/src/hugr/validate/test.rs
+++ b/hugr/src/hugr/validate/test.rs
@@ -271,7 +271,7 @@ fn test_local_const() {
         })
     );
     let const_op: ops::Const = logic::EXTENSION
-        .get_value(logic::TRUE_NAME)
+        .get_value(&logic::TRUE_NAME)
         .unwrap()
         .typed_value()
         .clone()

--- a/hugr/src/hugr/views/render.rs
+++ b/hugr/src/hugr/views/render.rs
@@ -4,7 +4,7 @@
 use portgraph::render::{EdgeStyle, NodeStyle, PortStyle};
 use portgraph::{LinkView, NodeIndex, PortIndex, PortView};
 
-use crate::ops::OpName;
+use crate::ops::NamedOp;
 use crate::types::EdgeKind;
 use crate::HugrView;
 

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -36,14 +36,12 @@
 //! // The type of qubits, `QB_T` is in the prelude but, by default, no gateset
 //! // is defined. This module provides Hadamard and CX gates.
 //! mod mini_quantum_extension {
-//!     use smol_str::SmolStr;
-//!
 //!     use hugr::{
 //!         extension::{
 //!             prelude::{BOOL_T, QB_T},
 //!             ExtensionId, ExtensionRegistry, PRELUDE,
 //!         },
-//!         ops::CustomOp,
+//!         ops::{CustomOp, OpName},
 //!         type_row,
 //!         types::{FunctionType, PolyFuncType},
 //!         Extension,
@@ -64,16 +62,16 @@
 //!         let mut extension = Extension::new(EXTENSION_ID);
 //!
 //!         extension
-//!             .add_op(SmolStr::new_inline("H"), "Hadamard".into(), one_qb_func())
+//!             .add_op(OpName::new_inline("H"), "Hadamard".into(), one_qb_func())
 //!             .unwrap();
 //!
 //!         extension
-//!             .add_op(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
+//!             .add_op(OpName::new_inline("CX"), "CX".into(), two_qb_func())
 //!             .unwrap();
 //!
 //!         extension
 //!             .add_op(
-//!                 SmolStr::new_inline("Measure"),
+//!                 OpName::new_inline("Measure"),
 //!                 "Measure a qubit, returning the qubit and the measurement result.".into(),
 //!                 FunctionType::new(type_row![QB_T], type_row![QB_T, BOOL_T]),
 //!             )
@@ -89,9 +87,9 @@
 //!             ExtensionRegistry::try_new([EXTENSION.to_owned(), PRELUDE.to_owned()]).unwrap();
 //!
 //!     }
-//!     fn get_gate(gate_name: &str) -> CustomOp {
+//!     fn get_gate(gate_name: impl Into<OpName>) -> CustomOp {
 //!         EXTENSION
-//!             .instantiate_extension_op(gate_name, [], &REG)
+//!             .instantiate_extension_op(&gate_name.into(), [], &REG)
 //!             .unwrap()
 //!             .into()
 //!     }

--- a/hugr/src/ops.rs
+++ b/hugr/src/ops.rs
@@ -9,7 +9,6 @@ pub mod leaf;
 pub mod module;
 pub mod tag;
 pub mod validate;
-use crate::core::impl_identifier;
 use crate::extension::ExtensionSet;
 use crate::types::{EdgeKind, FunctionType};
 use crate::{Direction, OutgoingPort, Port};
@@ -17,7 +16,6 @@ use crate::{IncomingPort, PortIndex};
 use paste::paste;
 
 use portgraph::NodeIndex;
-use smol_str::SmolStr;
 
 use enum_dispatch::enum_dispatch;
 
@@ -302,28 +300,14 @@ macro_rules! impl_op_name {
 
 use impl_op_name;
 
-/// A unique identifier for a type.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[serde(transparent)]
-pub struct OpName(SmolStr);
+/// Marker for the [`OpName`] wrapper.
+pub enum OpNameMarker {}
 
-impl_identifier!(OpName, 0);
+/// A unique identifier for a operation.
+pub type OpName = string_newtype::SmolStrBuf<OpNameMarker>;
 
-impl OpName {
-    /// Create a new OpName from a string.
-    pub fn new(name: impl Into<String>) -> Self {
-        Self(SmolStr::new(name.into()))
-    }
-
-    /// Create a constant-initialized OpName.
-    ///
-    /// # Panics
-    ///
-    /// If the string length is greater than 23.
-    pub const fn new_inline(name: &'static str) -> Self {
-        Self(SmolStr::new_inline(name))
-    }
-}
+/// Slice of a [`OpName`] operation identifier.
+pub type OpNameSlice = string_newtype::SmolStrRef<OpNameMarker>;
 
 #[enum_dispatch]
 /// Trait for setting name of OpType variants.

--- a/hugr/src/ops.rs
+++ b/hugr/src/ops.rs
@@ -301,10 +301,6 @@ macro_rules! impl_op_name {
 
 use impl_op_name;
 
-/// Marker for the [`OpName`] wrapper.
-#[doc(hidden)]
-pub enum OpNameMarker {}
-
 /// A unique identifier for a operation.
 pub type OpName = SmolStr;
 

--- a/hugr/src/ops.rs
+++ b/hugr/src/ops.rs
@@ -301,6 +301,7 @@ macro_rules! impl_op_name {
 use impl_op_name;
 
 /// Marker for the [`OpName`] wrapper.
+#[doc(hidden)]
 pub enum OpNameMarker {}
 
 /// A unique identifier for a operation.

--- a/hugr/src/ops.rs
+++ b/hugr/src/ops.rs
@@ -25,6 +25,7 @@ pub use custom::CustomOp;
 pub use dataflow::{Call, CallIndirect, DataflowParent, Input, LoadConstant, Output, DFG};
 pub use leaf::{Lift, MakeTuple, Noop, Tag, UnpackTuple};
 pub use module::{AliasDecl, AliasDefn, FuncDecl, FuncDefn, Module};
+use smol_str::SmolStr;
 pub use tag::OpTag;
 
 #[enum_dispatch(OpTrait, NamedOp, ValidateOp, OpParent)]
@@ -305,10 +306,10 @@ use impl_op_name;
 pub enum OpNameMarker {}
 
 /// A unique identifier for a operation.
-pub type OpName = string_newtype::SmolStrBuf<OpNameMarker>;
+pub type OpName = SmolStr;
 
 /// Slice of a [`OpName`] operation identifier.
-pub type OpNameSlice = string_newtype::SmolStrRef<OpNameMarker>;
+pub type OpNameRef = str;
 
 #[enum_dispatch]
 /// Trait for setting name of OpType variants.

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -339,6 +339,7 @@ where
 }
 
 /// Marker for the [`ValueName`] wrapper.
+#[doc(hidden)]
 pub enum ValueNameMarker {}
 
 /// A unique identifier for a constant value.

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -301,11 +301,12 @@ impl Value {
     }
 }
 
-impl OpName for Const {
-    fn name(&self) -> SmolStr {
+impl NamedOp for Const {
+    fn name(&self) -> OpName {
         self.value().name()
     }
 }
+
 impl StaticTag for Const {
     const TAG: OpTag = OpTag::Const;
 }

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -9,6 +9,7 @@ use crate::types::{CustomType, EdgeKind, FunctionType, SumType, SumTypeError, Ty
 use crate::{Hugr, HugrView};
 
 use itertools::Itertools;
+use smol_str::SmolStr;
 use thiserror::Error;
 
 pub use custom::{downcast_equal_consts, CustomConst, CustomSerialized};
@@ -344,10 +345,10 @@ where
 pub enum ValueNameMarker {}
 
 /// A unique identifier for a constant value.
-pub type ValueName = string_newtype::SmolStrBuf<ValueNameMarker>;
+pub type ValueName = SmolStr;
 
 /// Slice of a [`ValueName`] constant value identifier.
-pub type ValueNameSlice = string_newtype::SmolStrRef<ValueNameMarker>;
+pub type ValueNameRef = str;
 
 #[cfg(test)]
 mod test {

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -277,10 +277,7 @@ impl Value {
             }
             Self::Tuple { vs: vals } => {
                 let names: Vec<_> = vals.iter().map(Value::name).collect();
-                format!(
-                    "const:seq:{{{}}}",
-                    names.iter().map(OpName::as_str).join(", ")
-                )
+                format!("const:seq:{{{}}}", names.iter().join(", "))
             }
             Self::Sum { tag, values, .. } => {
                 format!("const:sum:{{tag:{tag}, vals:{values:?}}}")
@@ -339,10 +336,6 @@ where
         Self::extension(value)
     }
 }
-
-/// Marker for the [`ValueName`] wrapper.
-#[doc(hidden)]
-pub enum ValueNameMarker {}
 
 /// A unique identifier for a constant value.
 pub type ValueName = SmolStr;
@@ -492,7 +485,7 @@ mod test {
         ]));
 
         assert_eq!(v.const_type(), correct_type);
-        assert!(v.name().as_str().starts_with("const:function:"))
+        assert!(v.name().starts_with("const:function:"))
     }
 
     #[fixture]
@@ -518,7 +511,7 @@ mod test {
         assert_eq!(const_value.const_type(), expected_type);
         let name = const_value.name();
         assert!(
-            name.as_str().starts_with(name_prefix),
+            name.starts_with(name_prefix),
             "{name} does not start with {name_prefix}"
         );
     }

--- a/hugr/src/ops/constant/custom.rs
+++ b/hugr/src/ops/constant/custom.rs
@@ -7,12 +7,13 @@
 use std::any::Any;
 
 use downcast_rs::{impl_downcast, Downcast};
-use smol_str::SmolStr;
 
 use crate::extension::ExtensionSet;
 use crate::macros::impl_box_clone;
 
 use crate::types::{CustomCheckFailure, Type};
+
+use super::ValueName;
 
 /// Constant value for opaque [`CustomType`]s.
 ///
@@ -25,7 +26,7 @@ pub trait CustomConst:
     Send + Sync + std::fmt::Debug + CustomConstBoxClone + Any + Downcast
 {
     /// An identifier for the constant.
-    fn name(&self) -> SmolStr;
+    fn name(&self) -> ValueName;
 
     /// The extension(s) defining the custom constant
     /// (a set to allow, say, a [List] of [USize])
@@ -96,7 +97,7 @@ impl CustomSerialized {
 
 #[typetag::serde]
 impl CustomConst for CustomSerialized {
-    fn name(&self) -> SmolStr {
+    fn name(&self) -> ValueName {
         format!("yaml:{:?}", self.value).into()
     }
 

--- a/hugr/src/ops/controlflow.rs
+++ b/hugr/src/ops/controlflow.rs
@@ -1,14 +1,12 @@
 //! Control flow operations.
 
-use smol_str::SmolStr;
-
 use crate::extension::ExtensionSet;
 use crate::types::{EdgeKind, FunctionType, Type, TypeRow};
 use crate::Direction;
 
 use super::dataflow::{DataflowOpTrait, DataflowParent};
-use super::OpTag;
-use super::{impl_op_name, OpName, OpTrait, StaticTag};
+use super::{impl_op_name, NamedOp, OpTrait, StaticTag};
+use super::{OpName, OpTag};
 
 /// Tail-controlled loop.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -129,14 +127,14 @@ pub struct ExitBlock {
     pub cfg_outputs: TypeRow,
 }
 
-impl OpName for DataflowBlock {
-    fn name(&self) -> SmolStr {
+impl NamedOp for DataflowBlock {
+    fn name(&self) -> OpName {
         "DataflowBlock".into()
     }
 }
 
-impl OpName for ExitBlock {
-    fn name(&self) -> SmolStr {
+impl NamedOp for ExitBlock {
+    fn name(&self) -> OpName {
         "ExitBlock".into()
     }
 }

--- a/hugr/src/ops/custom.rs
+++ b/hugr/src/ops/custom.rs
@@ -12,7 +12,7 @@ use crate::{ops, Hugr, IncomingPort, Node};
 
 use super::dataflow::DataflowOpTrait;
 use super::tag::OpTag;
-use super::{NamedOp, OpName, OpTrait, OpType};
+use super::{NamedOp, OpName, OpNameSlice, OpTrait, OpType};
 
 /// A user-defined operation defined in an extension.
 ///
@@ -273,7 +273,7 @@ pub struct OpaqueOp {
     signature: FunctionType,
 }
 
-fn qualify_name(res_id: &ExtensionId, op_name: &OpName) -> OpName {
+fn qualify_name(res_id: &ExtensionId, op_name: &OpNameSlice) -> OpName {
     format!("{}.{}", res_id, op_name).into()
 }
 

--- a/hugr/src/ops/custom.rs
+++ b/hugr/src/ops/custom.rs
@@ -1,6 +1,5 @@
 //! Extensible operations.
 
-use smol_str::SmolStr;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -13,7 +12,7 @@ use crate::{ops, Hugr, IncomingPort, Node};
 
 use super::dataflow::DataflowOpTrait;
 use super::tag::OpTag;
-use super::{OpName, OpTrait, OpType};
+use super::{NamedOp, OpName, OpTrait, OpType};
 
 /// A user-defined operation defined in an extension.
 ///
@@ -102,9 +101,9 @@ impl CustomOp {
     }
 }
 
-impl OpName for CustomOp {
+impl NamedOp for CustomOp {
     /// The name of the operation.
-    fn name(&self) -> SmolStr {
+    fn name(&self) -> OpName {
         let (res_id, op_name) = match self {
             Self::Opaque(op) => (&op.extension, &op.op_name),
             Self::Extension(ext) => (ext.def.extension(), ext.def.name()),
@@ -268,13 +267,13 @@ impl DataflowOpTrait for ExtensionOp {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct OpaqueOp {
     extension: ExtensionId,
-    op_name: SmolStr,
+    op_name: OpName,
     description: String, // cache in advance so description() can return &str
     args: Vec<TypeArg>,
     signature: FunctionType,
 }
 
-fn qualify_name(res_id: &ExtensionId, op_name: &SmolStr) -> SmolStr {
+fn qualify_name(res_id: &ExtensionId, op_name: &OpName) -> OpName {
     format!("{}.{}", res_id, op_name).into()
 }
 
@@ -282,7 +281,7 @@ impl OpaqueOp {
     /// Creates a new OpaqueOp from all the fields we'd expect to serialize.
     pub fn new(
         extension: ExtensionId,
-        op_name: impl Into<SmolStr>,
+        op_name: impl Into<OpName>,
         description: String,
         args: impl Into<Vec<TypeArg>>,
         signature: FunctionType,
@@ -299,7 +298,7 @@ impl OpaqueOp {
 
 impl OpaqueOp {
     /// Unique name of the operation.
-    pub fn name(&self) -> &SmolStr {
+    pub fn name(&self) -> &OpName {
         &self.op_name
     }
 
@@ -401,13 +400,13 @@ pub fn resolve_opaque_op(
 pub enum CustomOpError {
     /// The Extension was found but did not contain the expected OpDef
     #[error("Operation {0} not found in Extension {1}")]
-    OpNotFoundInExtension(SmolStr, ExtensionId),
+    OpNotFoundInExtension(OpName, ExtensionId),
     /// Extension and OpDef found, but computed signature did not match stored
     #[error("Conflicting signature: resolved {op} in extension {extension} to a concrete implementation which computed {computed} but stored signature was {stored}")]
     #[allow(missing_docs)]
     SignatureMismatch {
         extension: ExtensionId,
-        op: SmolStr,
+        op: OpName,
         stored: FunctionType,
         computed: FunctionType,
     },
@@ -431,7 +430,7 @@ mod test {
             sig.clone(),
         )
         .into();
-        assert_eq!(op.name(), "res.op");
+        assert_eq!(op.name(), "res.op".into());
         assert_eq!(DataflowOpTrait::description(&op), "desc");
         assert_eq!(op.args(), &[TypeArg::Type { ty: USIZE_T }]);
         assert_eq!(op.signature(), sig);

--- a/hugr/src/ops/custom.rs
+++ b/hugr/src/ops/custom.rs
@@ -12,7 +12,7 @@ use crate::{ops, Hugr, IncomingPort, Node};
 
 use super::dataflow::DataflowOpTrait;
 use super::tag::OpTag;
-use super::{NamedOp, OpName, OpNameSlice, OpTrait, OpType};
+use super::{NamedOp, OpName, OpNameRef, OpTrait, OpType};
 
 /// A user-defined operation defined in an extension.
 ///
@@ -273,7 +273,7 @@ pub struct OpaqueOp {
     signature: FunctionType,
 }
 
-fn qualify_name(res_id: &ExtensionId, op_name: &OpNameSlice) -> OpName {
+fn qualify_name(res_id: &ExtensionId, op_name: &OpNameRef) -> OpName {
     format!("{}.{}", res_id, op_name).into()
 }
 
@@ -430,7 +430,7 @@ mod test {
             sig.clone(),
         )
         .into();
-        assert_eq!(op.name(), "res.op".into());
+        assert_eq!(op.name(), "res.op");
         assert_eq!(DataflowOpTrait::description(&op), "desc");
         assert_eq!(op.args(), &[TypeArg::Type { ty: USIZE_T }]);
         assert_eq!(op.signature(), sig);

--- a/hugr/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr/src/std_extensions/arithmetic/conversions.rs
@@ -1,8 +1,8 @@
 //! Conversions between integer and floating-point values.
 
-use smol_str::SmolStr;
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
+use crate::ops::OpName;
 use crate::{
     extension::{
         prelude::sum_with_error,
@@ -10,7 +10,7 @@ use crate::{
         ExtensionId, ExtensionRegistry, ExtensionSet, OpDef, SignatureError, SignatureFunc,
         PRELUDE,
     },
-    ops::{custom::ExtensionOp, OpName},
+    ops::{custom::ExtensionOp, NamedOp},
     type_row,
     types::{FunctionType, PolyFuncType, TypeArg},
     Extension,
@@ -90,8 +90,8 @@ pub struct ConvertOpType {
     log_width: u64,
 }
 
-impl OpName for ConvertOpType {
-    fn name(&self) -> SmolStr {
+impl NamedOp for ConvertOpType {
+    fn name(&self) -> OpName {
         self.def.name()
     }
 }
@@ -160,7 +160,7 @@ mod test {
         assert_eq!(r.name() as &str, "arithmetic.conversions");
         assert_eq!(r.types().count(), 0);
         for (name, _) in r.operations() {
-            assert!(name.starts_with("convert") || name.starts_with("trunc"));
+            assert!(name.as_ref().starts_with("convert") || name.as_ref().starts_with("trunc"));
         }
     }
 }

--- a/hugr/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr/src/std_extensions/arithmetic/conversions.rs
@@ -160,7 +160,7 @@ mod test {
         assert_eq!(r.name() as &str, "arithmetic.conversions");
         assert_eq!(r.types().count(), 0);
         for (name, _) in r.operations() {
-            assert!(name.as_ref().starts_with("convert") || name.as_ref().starts_with("trunc"));
+            assert!(name.as_str().starts_with("convert") || name.as_str().starts_with("trunc"));
         }
     }
 }

--- a/hugr/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr/src/std_extensions/arithmetic/float_ops.rs
@@ -134,7 +134,7 @@ mod test {
         assert_eq!(r.name() as &str, "arithmetic.float");
         assert_eq!(r.types().count(), 0);
         for (name, _) in r.operations() {
-            assert!(name.as_ref().starts_with('f'));
+            assert!(name.as_str().starts_with('f'));
         }
     }
 }

--- a/hugr/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr/src/std_extensions/arithmetic/float_ops.rs
@@ -134,7 +134,7 @@ mod test {
         assert_eq!(r.name() as &str, "arithmetic.float");
         assert_eq!(r.types().count(), 0);
         for (name, _) in r.operations() {
-            assert!(name.starts_with('f'));
+            assert!(name.as_ref().starts_with('f'));
         }
     }
 }

--- a/hugr/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr/src/std_extensions/arithmetic/float_types.rs
@@ -1,7 +1,7 @@
 //! Basic floating-point types
 
-use smol_str::SmolStr;
-
+use crate::ops::constant::ValueName;
+use crate::types::TypeName;
 use crate::{
     extension::{ExtensionId, ExtensionSet},
     ops::constant::CustomConst,
@@ -14,7 +14,7 @@ use lazy_static::lazy_static;
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.float.types");
 
 /// Identifier for the 64-bit IEEE 754-2019 floating-point type.
-const FLOAT_TYPE_ID: SmolStr = SmolStr::new_inline("float64");
+const FLOAT_TYPE_ID: TypeName = TypeName::new_inline("float64");
 
 /// 64-bit IEEE 754-2019 floating-point type (as [CustomType])
 pub const FLOAT64_CUSTOM_TYPE: CustomType =
@@ -52,7 +52,7 @@ impl ConstF64 {
 
 #[typetag::serde]
 impl CustomConst for ConstF64 {
-    fn name(&self) -> SmolStr {
+    fn name(&self) -> ValueName {
         format!("f64({})", self.value).into()
     }
 
@@ -105,7 +105,7 @@ mod test {
 
         assert_eq!(const_f64_1.value(), 1.0);
         assert_eq!(*const_f64_2, 2.0);
-        assert_eq!(const_f64_1.name(), "f64(1)");
+        assert_eq!(const_f64_1.name().as_ref(), "f64(1)");
         assert!(const_f64_1.equal_consts(&ConstF64::new(1.0)));
         assert_ne!(const_f64_1, const_f64_2);
         assert_eq!(const_f64_1, ConstF64::new(1.0));

--- a/hugr/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr/src/std_extensions/arithmetic/float_types.rs
@@ -105,7 +105,7 @@ mod test {
 
         assert_eq!(const_f64_1.value(), 1.0);
         assert_eq!(*const_f64_2, 2.0);
-        assert_eq!(const_f64_1.name().as_str(), "f64(1)");
+        assert_eq!(const_f64_1.name(), "f64(1)");
         assert!(const_f64_1.equal_consts(&ConstF64::new(1.0)));
         assert_ne!(const_f64_1, const_f64_2);
         assert_eq!(const_f64_1, ConstF64::new(1.0));

--- a/hugr/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr/src/std_extensions/arithmetic/float_types.rs
@@ -105,7 +105,7 @@ mod test {
 
         assert_eq!(const_f64_1.value(), 1.0);
         assert_eq!(*const_f64_2, 2.0);
-        assert_eq!(const_f64_1.name().as_ref(), "f64(1)");
+        assert_eq!(const_f64_1.name().as_str(), "f64(1)");
         assert!(const_f64_1.equal_consts(&ConstF64::new(1.0)));
         assert_ne!(const_f64_1, const_f64_2);
         assert_eq!(const_f64_1, ConstF64::new(1.0));

--- a/hugr/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr/src/std_extensions/arithmetic/int_ops.rs
@@ -7,7 +7,7 @@ use crate::extension::{
     CustomValidator, ExtensionRegistry, OpDef, SignatureFunc, ValidateJustArgs, PRELUDE,
 };
 use crate::ops::custom::ExtensionOp;
-use crate::ops::OpName;
+use crate::ops::{NamedOp, OpName};
 use crate::type_row;
 use crate::types::{FunctionType, PolyFuncType};
 use crate::utils::collect_array;
@@ -19,7 +19,6 @@ use crate::{
 };
 
 use lazy_static::lazy_static;
-use smol_str::SmolStr;
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 /// The extension identifier.
@@ -279,8 +278,8 @@ pub struct IntOpType {
     second_width: Option<u64>,
 }
 
-impl OpName for IntOpType {
-    fn name(&self) -> SmolStr {
+impl NamedOp for IntOpType {
+    fn name(&self) -> OpName {
         self.def.name()
     }
 }
@@ -351,7 +350,7 @@ mod test {
         assert_eq!(EXTENSION.types().count(), 0);
         assert_eq!(EXTENSION.operations().count(), 47);
         for (name, _) in EXTENSION.operations() {
-            assert!(name.starts_with('i'));
+            assert!(name.as_ref().starts_with('i'));
         }
     }
 

--- a/hugr/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr/src/std_extensions/arithmetic/int_ops.rs
@@ -350,7 +350,7 @@ mod test {
         assert_eq!(EXTENSION.types().count(), 0);
         assert_eq!(EXTENSION.operations().count(), 47);
         for (name, _) in EXTENSION.operations() {
-            assert!(name.as_str().starts_with('i'));
+            assert!(name.starts_with('i'));
         }
     }
 

--- a/hugr/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr/src/std_extensions/arithmetic/int_ops.rs
@@ -350,7 +350,7 @@ mod test {
         assert_eq!(EXTENSION.types().count(), 0);
         assert_eq!(EXTENSION.operations().count(), 47);
         for (name, _) in EXTENSION.operations() {
-            assert!(name.as_ref().starts_with('i'));
+            assert!(name.as_str().starts_with('i'));
         }
     }
 

--- a/hugr/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr/src/std_extensions/arithmetic/int_types.rs
@@ -2,8 +2,8 @@
 
 use std::num::NonZeroU64;
 
-use smol_str::SmolStr;
-
+use crate::ops::constant::ValueName;
+use crate::types::TypeName;
 use crate::{
     extension::{ExtensionId, ExtensionSet},
     ops::constant::CustomConst,
@@ -18,7 +18,7 @@ use lazy_static::lazy_static;
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.int.types");
 
 /// Identifier for the integer type.
-pub const INT_TYPE_ID: SmolStr = SmolStr::new_inline("int");
+pub const INT_TYPE_ID: TypeName = TypeName::new_inline("int");
 
 pub(crate) fn int_custom_type(width_arg: TypeArg) -> CustomType {
     CustomType::new(INT_TYPE_ID, [width_arg], EXTENSION_ID, TypeBound::Eq)
@@ -158,7 +158,7 @@ impl ConstInt {
 
 #[typetag::serde]
 impl CustomConst for ConstInt {
-    fn name(&self) -> SmolStr {
+    fn name(&self) -> ValueName {
         format!("u{}({})", 1u8 << self.log_width, self.value).into()
     }
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
@@ -260,7 +260,7 @@ mod test {
         assert_eq!(const_u32_7.value_u(), 7);
         assert!(const_u32_7.validate().is_ok());
 
-        assert_eq!(const_u32_7.name(), "u32(7)");
+        assert_eq!(const_u32_7.name(), "u5(7)".into());
 
         let const_i32_2 = ConstInt::new_s(5, -2).unwrap();
         assert!(const_i32_2.equal_consts(&ConstInt::new_s(5, -2).unwrap()));

--- a/hugr/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr/src/std_extensions/arithmetic/int_types.rs
@@ -260,14 +260,14 @@ mod test {
         assert_eq!(const_u32_7.value_u(), 7);
         assert!(const_u32_7.validate().is_ok());
 
-        assert_eq!(const_u32_7.name(), "u5(7)".into());
+        assert_eq!(const_u32_7.name(), "u32(7)".into());
 
         let const_i32_2 = ConstInt::new_s(5, -2).unwrap();
         assert!(const_i32_2.equal_consts(&ConstInt::new_s(5, -2).unwrap()));
         assert_eq!(const_i32_2.log_width(), 5);
         assert_eq!(const_i32_2.value_s(), -2);
         assert!(const_i32_2.validate().is_ok());
-        assert_eq!(const_i32_2.name(), "u32(4294967294)");
+        assert_eq!(const_i32_2.name().as_str(), "u32(4294967294)");
 
         ConstInt::new_s(50, -2).unwrap_err();
         ConstInt::new_u(50, 2).unwrap_err();

--- a/hugr/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr/src/std_extensions/arithmetic/int_types.rs
@@ -260,7 +260,7 @@ mod test {
         assert_eq!(const_u32_7.value_u(), 7);
         assert!(const_u32_7.validate().is_ok());
 
-        assert_eq!(const_u32_7.name(), "u32(7)".into());
+        assert_eq!(const_u32_7.name(), "u32(7)");
 
         let const_i32_2 = ConstInt::new_s(5, -2).unwrap();
         assert!(const_i32_2.equal_consts(&ConstInt::new_s(5, -2).unwrap()));

--- a/hugr/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr/src/std_extensions/arithmetic/int_types.rs
@@ -267,7 +267,7 @@ mod test {
         assert_eq!(const_i32_2.log_width(), 5);
         assert_eq!(const_i32_2.value_s(), -2);
         assert!(const_i32_2.validate().is_ok());
-        assert_eq!(const_i32_2.name().as_str(), "u32(4294967294)");
+        assert_eq!(const_i32_2.name(), "u32(4294967294)");
 
         ConstInt::new_s(50, -2).unwrap_err();
         ConstInt::new_u(50, 2).unwrap_err();

--- a/hugr/src/std_extensions/collections.rs
+++ b/hugr/src/std_extensions/collections.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 use crate::ops::constant::ValueName;
-use crate::ops::{OpName, OpTrait, Value};
+use crate::ops::{OpName, Value};
 use crate::types::TypeName;
 use crate::{
     algorithm::const_fold::sorted_consts,

--- a/hugr/src/std_extensions/collections.rs
+++ b/hugr/src/std_extensions/collections.rs
@@ -3,9 +3,10 @@
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use smol_str::SmolStr;
 
-use crate::ops::Value;
+use crate::ops::constant::ValueName;
+use crate::ops::{OpName, OpTrait, Value};
+use crate::types::TypeName;
 use crate::{
     algorithm::const_fold::sorted_consts,
     extension::{
@@ -14,7 +15,7 @@ use crate::{
         TypeDefBound,
     },
     ops::constant::CustomConst,
-    ops::{self, custom::ExtensionOp, OpName},
+    ops::{self, custom::ExtensionOp, NamedOp},
     types::{
         type_param::{TypeArg, TypeParam},
         CustomCheckFailure, CustomType, FunctionType, PolyFuncType, Type, TypeBound,
@@ -23,11 +24,11 @@ use crate::{
 };
 
 /// Reported unique name of the list type.
-pub const LIST_TYPENAME: SmolStr = SmolStr::new_inline("List");
+pub const LIST_TYPENAME: TypeName = TypeName::new_inline("List");
 /// Pop operation name.
-pub const POP_NAME: SmolStr = SmolStr::new_inline("pop");
+pub const POP_NAME: OpName = OpName::new_inline("pop");
 /// Push operation name.
-pub const PUSH_NAME: SmolStr = SmolStr::new_inline("push");
+pub const PUSH_NAME: OpName = OpName::new_inline("push");
 /// Reported unique name of the extension
 pub const EXTENSION_NAME: ExtensionId = ExtensionId::new_unchecked("Collections");
 
@@ -55,8 +56,8 @@ impl ListValue {
 
 #[typetag::serde]
 impl CustomConst for ListValue {
-    fn name(&self) -> SmolStr {
-        SmolStr::new_inline("list")
+    fn name(&self) -> ValueName {
+        ValueName::new_inline("list")
     }
 
     fn get_type(&self) -> Type {
@@ -229,8 +230,8 @@ pub struct ListOpInst {
     elem_type: Type,
 }
 
-impl OpName for ListOpInst {
-    fn name(&self) -> SmolStr {
+impl NamedOp for ListOpInst {
+    fn name(&self) -> OpName {
         match self.op {
             ListOp::Pop => POP_NAME,
             ListOp::Push => PUSH_NAME,

--- a/hugr/src/std_extensions/logic.rs
+++ b/hugr/src/std_extensions/logic.rs
@@ -2,6 +2,8 @@
 
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
+use crate::ops::constant::ValueName;
+use crate::ops::OpName;
 use crate::{
     algorithm::const_fold::sorted_consts,
     extension::{
@@ -9,7 +11,7 @@ use crate::{
         simple_op::{try_from_name, MakeExtensionOp, MakeOpDef, MakeRegisteredOp, OpLoadError},
         ExtensionId, ExtensionRegistry, OpDef, SignatureError, SignatureFromArgs, SignatureFunc,
     },
-    ops::{self, custom::ExtensionOp, OpName},
+    ops::{self, custom::ExtensionOp, NamedOp},
     type_row,
     types::{
         type_param::{TypeArg, TypeParam},
@@ -19,9 +21,9 @@ use crate::{
 };
 use lazy_static::lazy_static;
 /// Name of extension false value.
-pub const FALSE_NAME: &str = "FALSE";
+pub const FALSE_NAME: ValueName = ValueName::new_inline("FALSE");
 /// Name of extension true value.
-pub const TRUE_NAME: &str = "TRUE";
+pub const TRUE_NAME: ValueName = ValueName::new_inline("TRUE");
 
 /// Logic extension operation definitions.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
@@ -76,8 +78,8 @@ impl NaryLogic {
         ConcreteLogicOp(self, n)
     }
 }
-impl OpName for ConcreteLogicOp {
-    fn name(&self) -> smol_str::SmolStr {
+impl NamedOp for ConcreteLogicOp {
+    fn name(&self) -> OpName {
         self.0.name()
     }
 }
@@ -98,8 +100,8 @@ impl MakeExtensionOp for ConcreteLogicOp {
 /// Not operation.
 #[derive(Debug, Copy, Clone)]
 pub struct NotOp;
-impl OpName for NotOp {
-    fn name(&self) -> smol_str::SmolStr {
+impl NamedOp for NotOp {
+    fn name(&self) -> OpName {
         "Not".into()
     }
 }
@@ -215,7 +217,7 @@ pub(crate) mod test {
             prelude::BOOL_T,
             simple_op::{MakeExtensionOp, MakeOpDef, MakeRegisteredOp},
         },
-        ops::OpName,
+        ops::NamedOp,
         Extension,
     };
 
@@ -249,8 +251,8 @@ pub(crate) mod test {
     #[test]
     fn test_values() {
         let r: Extension = extension();
-        let false_val = r.get_value(FALSE_NAME).unwrap();
-        let true_val = r.get_value(TRUE_NAME).unwrap();
+        let false_val = r.get_value(&FALSE_NAME).unwrap();
+        let true_val = r.get_value(&TRUE_NAME).unwrap();
 
         for v in [false_val, true_val] {
             let simpl = v.typed_value().const_type();

--- a/hugr/src/types.rs
+++ b/hugr/src/types.rs
@@ -8,6 +8,7 @@ mod signature;
 pub mod type_param;
 pub mod type_row;
 
+use crate::core::impl_identifier;
 pub use crate::ops::constant::{ConstTypeError, CustomCheckFailure};
 use crate::types::type_param::check_type_arg;
 use crate::utils::display_list_with_separator;
@@ -26,12 +27,31 @@ use serde::{Deserialize, Serialize};
 use crate::extension::{ExtensionRegistry, SignatureError};
 use crate::ops::AliasDecl;
 use crate::type_row;
-use std::fmt::Debug;
 
 use self::type_param::TypeParam;
 
 /// A unique identifier for a type.
-pub type TypeName = SmolStr;
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct TypeName(SmolStr);
+
+impl_identifier!(TypeName, 0);
+
+impl TypeName {
+    /// Create a new type name.
+    pub fn new(name: impl Into<SmolStr>) -> Self {
+        Self(name.into())
+    }
+
+    /// Get the name of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is longer than 23 characters.
+    pub const fn new_inline(name: &'static str) -> Self {
+        Self(SmolStr::new_inline(name))
+    }
+}
 
 /// The kinds of edges in a HUGR, excluding Hierarchy.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]

--- a/hugr/src/types.rs
+++ b/hugr/src/types.rs
@@ -29,6 +29,7 @@ use crate::type_row;
 use self::type_param::TypeParam;
 
 /// Marker for the [`TypeName`] wrapper.
+#[doc(hidden)]
 pub enum TypeNameMarker {}
 
 /// A unique identifier for a type.

--- a/hugr/src/types.rs
+++ b/hugr/src/types.rs
@@ -15,6 +15,7 @@ pub use check::SumTypeError;
 pub use custom::CustomType;
 pub use poly_func::PolyFuncType;
 pub use signature::FunctionType;
+use smol_str::SmolStr;
 pub use type_param::TypeArg;
 pub use type_row::TypeRow;
 
@@ -33,10 +34,10 @@ use self::type_param::TypeParam;
 pub enum TypeNameMarker {}
 
 /// A unique identifier for a type.
-pub type TypeName = string_newtype::SmolStrBuf<TypeNameMarker>;
+pub type TypeName = SmolStr;
 
 /// Slice of a [`TypeName`] type identifier.
-pub type TypeNameSlice = string_newtype::SmolStrRef<TypeNameMarker>;
+pub type TypeNameRef = str;
 
 /// The kinds of edges in a HUGR, excluding Hierarchy.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]

--- a/hugr/src/types.rs
+++ b/hugr/src/types.rs
@@ -8,7 +8,6 @@ mod signature;
 pub mod type_param;
 pub mod type_row;
 
-use crate::core::impl_identifier;
 pub use crate::ops::constant::{ConstTypeError, CustomCheckFailure};
 use crate::types::type_param::check_type_arg;
 use crate::utils::display_list_with_separator;
@@ -16,7 +15,6 @@ pub use check::SumTypeError;
 pub use custom::CustomType;
 pub use poly_func::PolyFuncType;
 pub use signature::FunctionType;
-use smol_str::SmolStr;
 pub use type_param::TypeArg;
 pub use type_row::TypeRow;
 
@@ -30,28 +28,14 @@ use crate::type_row;
 
 use self::type_param::TypeParam;
 
+/// Marker for the [`TypeName`] wrapper.
+pub enum TypeNameMarker {}
+
 /// A unique identifier for a type.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[serde(transparent)]
-pub struct TypeName(SmolStr);
+pub type TypeName = string_newtype::SmolStrBuf<TypeNameMarker>;
 
-impl_identifier!(TypeName, 0);
-
-impl TypeName {
-    /// Create a new type name.
-    pub fn new(name: impl Into<SmolStr>) -> Self {
-        Self(name.into())
-    }
-
-    /// Get the name of the type.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the name is longer than 23 characters.
-    pub const fn new_inline(name: &'static str) -> Self {
-        Self(SmolStr::new_inline(name))
-    }
-}
+/// Slice of a [`TypeName`] type identifier.
+pub type TypeNameSlice = string_newtype::SmolStrRef<TypeNameMarker>;
 
 /// The kinds of edges in a HUGR, excluding Hierarchy.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]

--- a/hugr/src/types.rs
+++ b/hugr/src/types.rs
@@ -29,10 +29,6 @@ use crate::type_row;
 
 use self::type_param::TypeParam;
 
-/// Marker for the [`TypeName`] wrapper.
-#[doc(hidden)]
-pub enum TypeNameMarker {}
-
 /// A unique identifier for a type.
 pub type TypeName = SmolStr;
 

--- a/hugr/src/types/poly_func.rs
+++ b/hugr/src/types/poly_func.rs
@@ -163,7 +163,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_mismatched_args() -> Result<(), SignatureError> {
-        let ar_def = PRELUDE.get_type("array".into()).unwrap();
+        let ar_def = PRELUDE.get_type("array").unwrap();
         let typarams = [TypeParam::max_nat(), TypeBound::Any.into()];
         let [tyvar, szvar] =
             [0, 1].map(|i| TypeArg::new_var_use(i, typarams.get(i).unwrap().clone()));

--- a/hugr/src/types/poly_func.rs
+++ b/hugr/src/types/poly_func.rs
@@ -163,7 +163,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_mismatched_args() -> Result<(), SignatureError> {
-        let ar_def = PRELUDE.get_type(&"array".into()).unwrap();
+        let ar_def = PRELUDE.get_type("array".into()).unwrap();
         let typarams = [TypeParam::max_nat(), TypeBound::Any.into()];
         let [tyvar, szvar] =
             [0, 1].map(|i| TypeArg::new_var_use(i, typarams.get(i).unwrap().clone()));

--- a/hugr/src/types/poly_func.rs
+++ b/hugr/src/types/poly_func.rs
@@ -101,7 +101,6 @@ pub(crate) mod test {
     use std::num::NonZeroU64;
 
     use lazy_static::lazy_static;
-    use smol_str::SmolStr;
 
     use crate::extension::prelude::{PRELUDE_ID, USIZE_CUSTOM_T, USIZE_T};
     use crate::extension::{
@@ -109,7 +108,7 @@ pub(crate) mod test {
     };
     use crate::std_extensions::collections::{EXTENSION, LIST_TYPENAME};
     use crate::types::type_param::{TypeArg, TypeArgError, TypeParam};
-    use crate::types::{CustomType, FunctionType, Type, TypeBound};
+    use crate::types::{CustomType, FunctionType, Type, TypeBound, TypeName};
     use crate::Extension;
 
     use super::PolyFuncType;
@@ -164,7 +163,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_mismatched_args() -> Result<(), SignatureError> {
-        let ar_def = PRELUDE.get_type("array").unwrap();
+        let ar_def = PRELUDE.get_type(&"array".into()).unwrap();
         let typarams = [TypeParam::max_nat(), TypeBound::Any.into()];
         let [tyvar, szvar] =
             [0, 1].map(|i| TypeArg::new_var_use(i, typarams.get(i).unwrap().clone()));
@@ -262,7 +261,7 @@ pub(crate) mod test {
         rejected: &[TypeParam],
     ) -> Result<(), SignatureError> {
         const EXT_ID: ExtensionId = ExtensionId::new_unchecked("my_ext");
-        const TYPE_NAME: SmolStr = SmolStr::new_inline("MyType");
+        const TYPE_NAME: TypeName = TypeName::new_inline("MyType");
 
         let mut e = Extension::new(EXT_ID);
         e.add_type(

--- a/hugr/src/utils.rs
+++ b/hugr/src/utils.rs
@@ -98,7 +98,7 @@ pub(crate) fn is_default<T: Default + PartialEq>(t: &T) -> bool {
 
 #[cfg(test)]
 pub(crate) mod test_quantum_extension {
-    use crate::ops::OpName;
+    use crate::ops::{OpName, OpNameRef};
     use crate::{
         extension::{
             prelude::{BOOL_T, QB_T},
@@ -174,9 +174,9 @@ pub(crate) mod test_quantum_extension {
 
     }
 
-    fn get_gate(gate_name: impl Into<OpName>) -> CustomOp {
+    fn get_gate(gate_name: &OpNameRef) -> CustomOp {
         EXTENSION
-            .instantiate_extension_op(&gate_name.into(), [], &REG)
+            .instantiate_extension_op(gate_name, [], &REG)
             .unwrap()
             .into()
     }

--- a/hugr/src/utils.rs
+++ b/hugr/src/utils.rs
@@ -98,8 +98,7 @@ pub(crate) fn is_default<T: Default + PartialEq>(t: &T) -> bool {
 
 #[cfg(test)]
 pub(crate) mod test_quantum_extension {
-    use smol_str::SmolStr;
-
+    use crate::ops::OpName;
     use crate::{
         extension::{
             prelude::{BOOL_T, QB_T},
@@ -127,23 +126,23 @@ pub(crate) mod test_quantum_extension {
         let mut extension = Extension::new(EXTENSION_ID);
 
         extension
-            .add_op(SmolStr::new_inline("H"), "Hadamard".into(), one_qb_func())
+            .add_op(OpName::new_inline("H"), "Hadamard".into(), one_qb_func())
             .unwrap();
         extension
             .add_op(
-                SmolStr::new_inline("RzF64"),
+                OpName::new_inline("RzF64"),
                 "Rotation specified by float".into(),
                 FunctionType::new(type_row![QB_T, float_types::FLOAT64_TYPE], type_row![QB_T]),
             )
             .unwrap();
 
         extension
-            .add_op(SmolStr::new_inline("CX"), "CX".into(), two_qb_func())
+            .add_op(OpName::new_inline("CX"), "CX".into(), two_qb_func())
             .unwrap();
 
         extension
             .add_op(
-                SmolStr::new_inline("Measure"),
+                OpName::new_inline("Measure"),
                 "Measure a qubit, returning the qubit and the measurement result.".into(),
                 FunctionType::new(type_row![QB_T], type_row![QB_T, BOOL_T]),
             )
@@ -151,7 +150,7 @@ pub(crate) mod test_quantum_extension {
 
         extension
             .add_op(
-                SmolStr::new_inline("QAlloc"),
+                OpName::new_inline("QAlloc"),
                 "Allocate a new qubit.".into(),
                 FunctionType::new(type_row![], type_row![QB_T]),
             )
@@ -159,7 +158,7 @@ pub(crate) mod test_quantum_extension {
 
         extension
             .add_op(
-                SmolStr::new_inline("QDiscard"),
+                OpName::new_inline("QDiscard"),
                 "Discard a qubit.".into(),
                 FunctionType::new(type_row![QB_T], type_row![]),
             )
@@ -174,9 +173,10 @@ pub(crate) mod test_quantum_extension {
         static ref REG: ExtensionRegistry = ExtensionRegistry::try_new([EXTENSION.to_owned(), PRELUDE.to_owned(), float_types::EXTENSION.to_owned()]).unwrap();
 
     }
-    fn get_gate(gate_name: &str) -> CustomOp {
+
+    fn get_gate(gate_name: impl Into<OpName>) -> CustomOp {
         EXTENSION
-            .instantiate_extension_op(gate_name, [], &REG)
+            .instantiate_extension_op(&gate_name.into(), [], &REG)
             .unwrap()
             .into()
     }


### PR DESCRIPTION
Uses [`string_newtype`](https://github.com/ABorgna/string-newtype) to define `TypeName`, `OpName`, and `ValueName` types, to avoid using stringly-typed methods everywhere.
Also defines `TypeNameSlice`, `OpNameSlice`, `ValueNameSlice`. These that act like `str` to a `String`, or lke `Path` to a `PathBuf`; unsized slice types used through references. 

- Renames the `OpName` trait to `NamedOp`. Now `NamedOp::name` returns an `OpName` value. 

Closes #834.

As an example of why this is useful, I caught some cases where `ExtensionBuildError` was being built with the wrong variant due to mixing up the different identifiers, since everything used `SmolStr`.