### PR TITLE
chore: Add cargo doc check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,10 @@ repos:
         language: system
         files: \.rs$
         pass_filenames: false
+      - id: cargo-doc
+        name: cargo doc
+        description: Generate documentation with `cargo doc`.
+        entry: cargo doc --no-deps --all-features --workspace
+        language: system
+        files: \.rs$
+        pass_filenames: false


### PR DESCRIPTION
This is the check run in CI, so it should be also included in the hooks