### PR TITLE
ci: Move file change filter definitions to a file

### DIFF
--- a/.github/change-filters.yml
+++ b/.github/change-filters.yml
@@ -1,0 +1,13 @@
+# Filters used by [dorny/path-filters](https://github.com/dorny/paths-filter)
+# to detect changes in each subproject, and only run the corresponding jobs.
+
+rust:
+  - "hugr/**"
+  - "Cargo.toml"
+  - "specification/schema/**"
+
+python:
+  - "hugr-py/**"
+  - "pyproject.toml"
+  - "poetry.lock"
+  - "specification/schema/**"

--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -31,11 +31,7 @@ jobs:
     - uses: dorny/paths-filter@v3
       id: filter
       with:
-        filters: |
-          python:
-            - 'hugr-py/**'
-            - 'pyproject.toml'
-            - 'specification/schema/**'
+        filters: .github/change-filters.yml
 
   check:
     needs: changes

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -38,11 +38,7 @@ jobs:
     - uses: dorny/paths-filter@v3
       id: filter
       with:
-        filters: |
-          rust:
-            - 'hugr/**'
-            - 'Cargo.toml'
-            - 'specification/schema/**'
+        filters: .github/change-filters.yml
 
   check:
     needs: changes


### PR DESCRIPTION
Cleanup PR. Centralises the file filter used by `dorny/paths-filter` when detecting changes in a single `.yml`.