### PR TITLE
fix: Remove insert_port_types for LoadFunction

### DIFF
--- a/hugr-py/src/hugr/serialization/ops.py
+++ b/hugr-py/src/hugr/serialization/ops.py
@@ -298,10 +298,7 @@ class LoadFunction(DataflowOp):
     op: Literal["LoadFunction"] = "LoadFunction"
     func_sig: PolyFuncType
     type_args: list[tys.TypeArg]
-    signature: FunctionType = Field(default_factory=FunctionType.empty)
-
-    def insert_port_types(self, in_types: TypeRow, out_types: TypeRow) -> None:
-        self.signature = FunctionType(input=list(in_types), output=list(out_types))
+    signature: FunctionType
 
 
 class DFG(DataflowOp):

--- a/specification/schema/hugr_schema_strict_v1.json
+++ b/specification/schema/hugr_schema_strict_v1.json
@@ -1208,7 +1208,8 @@
             "required": [
                 "parent",
                 "func_sig",
-                "type_args"
+                "type_args",
+                "signature"
             ],
             "title": "LoadFunction",
             "type": "object"

--- a/specification/schema/hugr_schema_v1.json
+++ b/specification/schema/hugr_schema_v1.json
@@ -1208,7 +1208,8 @@
             "required": [
                 "parent",
                 "func_sig",
-                "type_args"
+                "type_args",
+                "signature"
             ],
             "title": "LoadFunction",
             "type": "object"

--- a/specification/schema/testing_hugr_schema_strict_v1.json
+++ b/specification/schema/testing_hugr_schema_strict_v1.json
@@ -1208,7 +1208,8 @@
             "required": [
                 "parent",
                 "func_sig",
-                "type_args"
+                "type_args",
+                "signature"
             ],
             "title": "LoadFunction",
             "type": "object"

--- a/specification/schema/testing_hugr_schema_v1.json
+++ b/specification/schema/testing_hugr_schema_v1.json
@@ -1208,7 +1208,8 @@
             "required": [
                 "parent",
                 "func_sig",
-                "type_args"
+                "type_args",
+                "signature"
             ],
             "title": "LoadFunction",
             "type": "object"


### PR DESCRIPTION
The existing implementation of `insert_port_types` was wrong, we can just get rid of it