### PR TITLE
tests: assert_matches with `=> X` treats X as a statement, not a bool expr

### DIFF
--- a/hugr/src/hugr.rs
+++ b/hugr/src/hugr.rs
@@ -345,9 +345,16 @@ pub enum HugrError {
 
 #[cfg(test)]
 mod test {
+    use cool_asserts::assert_matches;
+
     use super::{Hugr, HugrView};
     #[cfg(feature = "extension_inference")]
     use std::error::Error;
+
+    #[test]
+    fn test_assert_matches() {
+        assert_matches!(Some(5), Some(x) => x == 6);
+    }
 
     #[test]
     fn impls_send_and_sync() {


### PR DESCRIPTION
This is absolutely not intended to be merged, but note that it passes CI 👎  - and we have a few cases like this. So we need to rewrite
```assert_matches!(expr1, PatternThatBinds(x) => expr2(x))```
as either
```assert_matches!(expr1, PatternThatBinds(x) => assert!(expr2(x)))```
or else
```assert_matches!(expr1, PatternThatBinds(x) if expr2(x))```
Note the latter can just be
```assert!(matches!(expr1, PatternThatBinds(x) if expr2(x)))```
which to me suggests that we should probably aim to minimize uses of `assert_matches` (I'm not sure now that we have any cases where we need it)