### PR TITLE
test: Use assert_matches! less

### DIFF
--- a/hugr/src/builder/cfg.rs
+++ b/hugr/src/builder/cfg.rs
@@ -405,7 +405,6 @@ pub(crate) mod test {
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::hugr::ValidationError;
     use crate::{builder::test::NAT, type_row};
-    use cool_asserts::assert_matches;
 
     use super::*;
     #[test]
@@ -442,7 +441,7 @@ pub(crate) mod test {
     fn basic_cfg_hugr() -> Result<(), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
         build_basic_cfg(&mut cfg_builder)?;
-        assert_matches!(cfg_builder.finish_prelude_hugr(), Ok(_));
+        assert!(cfg_builder.finish_prelude_hugr().is_ok());
 
         Ok(())
     }
@@ -495,7 +494,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&entry, 0, &middle)?;
         cfg_builder.branch(&middle, 0, &exit)?;
-        assert_matches!(cfg_builder.finish_prelude_hugr(), Ok(_));
+        assert!(cfg_builder.finish_prelude_hugr().is_ok());
 
         Ok(())
     }
@@ -524,12 +523,12 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&entry, 0, &middle)?;
         cfg_builder.branch(&middle, 0, &exit)?;
-        assert_matches!(
+        assert!(matches!(
             cfg_builder.finish_prelude_hugr(),
             Err(ValidationError::InterGraphEdgeError(
                 InterGraphEdgeError::NonDominatedAncestor { .. }
             ))
-        );
+        ));
 
         Ok(())
     }

--- a/hugr/src/builder/circuit.rs
+++ b/hugr/src/builder/circuit.rs
@@ -235,7 +235,6 @@ impl<'a, T: Dataflow + ?Sized> CircuitBuilder<'a, T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use cool_asserts::assert_matches;
 
     use crate::utils::test_quantum_extension::{cx_gate, h_gate, measure, q_alloc, q_discard};
     use crate::{
@@ -273,7 +272,7 @@ mod test {
             },
         );
 
-        assert_matches!(build_res, Ok(_));
+        assert!(build_res.is_ok());
     }
 
     #[test]
@@ -305,7 +304,7 @@ mod test {
             },
         );
 
-        assert_matches!(build_res, Ok(_));
+        assert!(build_res.is_ok());
     }
 
     #[test]
@@ -341,7 +340,7 @@ mod test {
             },
         );
 
-        assert_matches!(build_res, Ok(_));
+        assert!(build_res.is_ok());
     }
 
     #[test]
@@ -354,25 +353,25 @@ mod test {
                 let invalid_index = 0xff;
 
                 // Passing an invalid linear index returns an error
-                assert_matches!(
+                assert!(matches!(
                     circ.append(cx_gate(), [q0, invalid_index]),
                     Err(BuildError::CircuitError(CircuitBuildError::InvalidWireIndex { op, invalid_index: idx }))
                     if op == Some(cx_gate().into()) && idx == invalid_index,
-                );
+                ));
 
                 // Untracking an invalid index returns an error
-                assert_matches!(
+                assert!(matches!(
                     circ.untrack_wire(invalid_index),
                     Err(CircuitBuildError::InvalidWireIndex { op: None, invalid_index: idx })
                     if idx == invalid_index,
-                );
+                ));
 
                 // Passing a linear index to an operation without a corresponding output returns an error
-                assert_matches!(
+                assert!(matches!(
                     circ.append(q_discard(), [q1]),
                     Err(BuildError::CircuitError(CircuitBuildError::MismatchedLinearInputs { op, index }))
                     if op == q_discard().into() && index == [q1],
-                );
+                ));
 
                 let outs = circ.finish();
 

--- a/hugr/src/builder/conditional.rs
+++ b/hugr/src/builder/conditional.rs
@@ -205,7 +205,6 @@ impl CaseBuilder<Hugr> {
 }
 #[cfg(test)]
 mod test {
-    use cool_asserts::assert_matches;
 
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
 
@@ -267,7 +266,7 @@ mod test {
             Ok(module_builder.finish_prelude_hugr()?)
         };
 
-        assert_matches!(build_result, Ok(_));
+        assert!(build_result.is_ok());
 
         Ok(())
     }
@@ -281,12 +280,12 @@ mod test {
             ExtensionSet::new(),
         )?;
         n_identity(builder.case_builder(0)?)?;
-        assert_matches!(
+        assert!(matches!(
             builder.finish_sub_container().map(|_| ()),
             Err(BuildError::ConditionalError(
                 ConditionalBuildError::NotAllCasesBuilt { .. }
             ))
-        );
+        ));
         Ok(())
     }
 
@@ -299,12 +298,12 @@ mod test {
             ExtensionSet::new(),
         )?;
         n_identity(builder.case_builder(0)?)?;
-        assert_matches!(
+        assert!(matches!(
             builder.case_builder(0).map(|_| ()),
             Err(BuildError::ConditionalError(
                 ConditionalBuildError::CaseBuilt { .. }
             ))
-        );
+        ));
         Ok(())
     }
 }

--- a/hugr/src/builder/dataflow.rs
+++ b/hugr/src/builder/dataflow.rs
@@ -202,6 +202,7 @@ impl<T> HugrBuilder for DFGWrapper<Hugr, T> {
 
 #[cfg(test)]
 pub(crate) mod test {
+
     use cool_asserts::assert_matches;
     use rstest::rstest;
     use serde_json::json;
@@ -391,7 +392,7 @@ pub(crate) mod test {
     #[rstest]
     fn dfg_hugr(simple_dfg_hugr: Hugr) {
         assert_eq!(simple_dfg_hugr.node_count(), 3);
-        assert_matches!(simple_dfg_hugr.root_type().tag(), OpTag::Dfg);
+        assert_eq!(simple_dfg_hugr.root_type().tag(), OpTag::Dfg);
     }
 
     #[test]

--- a/hugr/src/builder/dataflow.rs
+++ b/hugr/src/builder/dataflow.rs
@@ -330,8 +330,7 @@ pub(crate) mod test {
             Err(BuildError::OutputWiring {
                 error: BuilderWiringError::NoCopyLinear { typ, .. },
                 ..
-            })
-            if typ == QB
+            }) => assert_eq!(typ, QB)
         );
     }
 

--- a/hugr/src/builder/dataflow.rs
+++ b/hugr/src/builder/dataflow.rs
@@ -272,7 +272,7 @@ pub(crate) mod test {
 
             module_builder.finish_hugr(&EMPTY_REG)
         };
-        assert_matches!(build_result, Ok(_), "Failed on example: {}", msg);
+        assert!(build_result.is_ok(), "Failed on example: {}", msg);
 
         Ok(())
     }
@@ -356,7 +356,7 @@ pub(crate) mod test {
             f_build.finish_hugr_with_outputs([nested.out_wire(0)], &EMPTY_REG)
         };
 
-        assert_matches!(builder(), Ok(_));
+        assert!(builder().is_ok());
     }
 
     #[test]
@@ -377,13 +377,13 @@ pub(crate) mod test {
 
         // The error would anyway be caught in validation when we finish the Hugr,
         // but the builder catches it earlier
-        assert_matches!(
+        assert!(matches!(
             id_res.map(|bh| bh.handle().node()), // Transform into something that impl's Debug
             Err(BuildError::OperationWiring {
                 error: BuilderWiringError::NonCopyableIntergraph { .. },
                 ..
             })
-        );
+        ));
 
         Ok(())
     }
@@ -514,12 +514,12 @@ pub(crate) mod test {
 
         let res = b.finish_prelude_hugr_with_outputs([b_child_2_handle.out_wire(0)]);
 
-        assert_matches!(
+        assert!(matches!(
             res,
             Err(BuildError::InvalidHUGR(
                 ValidationError::InterGraphEdgeError(InterGraphEdgeError::NonCFGAncestor { .. })
             ))
-        );
+        ));
         Ok(())
     }
 
@@ -541,13 +541,13 @@ pub(crate) mod test {
 
         let res = b_child_2_child.finish_with_outputs([b_child_child_in_wire]);
 
-        assert_matches!(
+        assert!(matches!(
             res.map(|h| h.handle().node()), // map to something that implements Debug
             Err(BuildError::OutputWiring {
                 error: BuilderWiringError::NoRelationIntergraph { .. },
                 ..
             })
-        );
+        ));
         Ok(())
     }
 }

--- a/hugr/src/builder/module.rs
+++ b/hugr/src/builder/module.rs
@@ -162,7 +162,6 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
 
 #[cfg(test)]
 mod test {
-    use cool_asserts::assert_matches;
 
     use crate::{
         builder::{
@@ -191,7 +190,7 @@ mod test {
             f_build.finish_with_outputs(call.outputs())?;
             module_builder.finish_prelude_hugr()
         };
-        assert_matches!(build_result, Ok(_));
+        assert!(build_result.is_ok());
         Ok(())
     }
 
@@ -214,7 +213,7 @@ mod test {
             n_identity(f_build)?;
             module_builder.finish_hugr(&EMPTY_REG)
         };
-        assert_matches!(build_result, Ok(_));
+        assert!(build_result.is_ok());
         Ok(())
     }
 
@@ -240,7 +239,7 @@ mod test {
             f_build.finish_with_outputs(call.outputs())?;
             module_builder.finish_prelude_hugr()
         };
-        assert_matches!(build_result, Ok(_));
+        assert!(build_result.is_ok());
         Ok(())
     }
 }

--- a/hugr/src/builder/tail_loop.rs
+++ b/hugr/src/builder/tail_loop.rs
@@ -89,7 +89,6 @@ impl TailLoopBuilder<Hugr> {
 
 #[cfg(test)]
 mod test {
-    use cool_asserts::assert_matches;
 
     use crate::{
         builder::{
@@ -116,7 +115,7 @@ mod test {
             loop_b.finish_prelude_hugr()
         };
 
-        assert_matches!(build_result, Ok(_));
+        assert!(build_result.is_ok());
         Ok(())
     }
 
@@ -186,7 +185,7 @@ mod test {
             module_builder.finish_prelude_hugr()
         };
 
-        assert_matches!(build_result, Ok(_));
+        assert!(build_result.is_ok());
 
         Ok(())
     }

--- a/hugr/src/extension/infer/test.rs
+++ b/hugr/src/extension/infer/test.rs
@@ -23,7 +23,6 @@ use crate::{
 use crate::type_row;
 use crate::types::{FunctionType, Type, TypeRow};
 
-use cool_asserts::assert_matches;
 use itertools::Itertools;
 use portgraph::NodeIndex;
 
@@ -56,7 +55,7 @@ fn from_graph() -> Result<(), Box<dyn Error>> {
     let input = hugr.add_node_with_parent(hugr.root(), input);
     let output = hugr.add_node_with_parent(hugr.root(), output);
 
-    assert_matches!(hugr.get_io(hugr.root()), Some(_));
+    assert!(hugr.get_io(hugr.root()).is_some());
 
     let add_a_sig = FunctionType::new(type_row![NAT], type_row![NAT]).with_extension_delta(A);
 
@@ -178,10 +177,10 @@ fn missing_lift_node() {
     // Fail to catch the actual error because it's a difference between I/O
     // nodes and their parents and `report_mismatch` isn't yet smart enough
     // to handle that.
-    assert_matches!(
+    assert!(matches!(
         hugr.update_validate(&PRELUDE_REGISTRY),
         Err(ValidationError::CantInfer(_))
-    );
+    ));
 }
 
 #[test]
@@ -820,10 +819,10 @@ fn test_validate_with_closure() -> Result<(), Box<dyn Error>> {
 
     // All three can be inferred and validated, without writing solutions in:
     for inner in [&inner_open, &inner_prelude, &inner_other] {
-        assert_matches!(
+        assert!(matches!(
             inner.validate(&PRELUDE_REGISTRY),
             Err(ValidationError::ExtensionError(_))
-        );
+        ));
 
         let soln = infer_extensions(inner)?;
         inner.validate_with_extension_closure(soln, &PRELUDE_REGISTRY)?;
@@ -846,10 +845,10 @@ fn test_validate_with_closure() -> Result<(), Box<dyn Error>> {
     }
 
     // ...but fails if the inner DFG already has the 'wrong' extensions:
-    assert_matches!(
+    assert!(matches!(
         build_outer_prelude(inner_other.clone()).update_validate(&PRELUDE_REGISTRY),
         Err(ValidationError::CantInfer(_))
-    );
+    ));
 
     // If we do inference on the inner Hugr first, this (still) works if the
     // inner DFG already had the correct input-extensions:
@@ -861,10 +860,10 @@ fn test_validate_with_closure() -> Result<(), Box<dyn Error>> {
     // infers an incorrect (empty) solution:
     let mut inner_inferred = inner_open;
     inner_inferred.update_validate(&PRELUDE_REGISTRY)?;
-    assert_matches!(
+    assert!(matches!(
         build_outer_prelude(inner_inferred).update_validate(&PRELUDE_REGISTRY),
         Err(ValidationError::CantInfer(_))
-    );
+    ));
 
     Ok(())
 }
@@ -1051,12 +1050,12 @@ fn funcdefn_signature_mismatch() -> Result<(), Box<dyn Error>> {
     let [w] = lift.outputs_arr();
     func_builder.finish_with_outputs([w])?;
     let result = builder.finish_prelude_hugr();
-    assert_matches!(
+    assert!(matches!(
         result,
         Err(ValidationError::CantInfer(
             InferExtensionError::MismatchedConcreteWithLocations { .. }
         ))
-    );
+    ));
     Ok(())
 }
 
@@ -1078,6 +1077,6 @@ fn funcdefn_signature_mismatch2() -> Result<(), Box<dyn Error>> {
     let [w] = func_builder.input_wires_arr();
     func_builder.finish_with_outputs([w])?;
     let result = builder.finish_prelude_hugr();
-    assert_matches!(result, Err(ValidationError::CantInfer(..)));
+    assert!(matches!(result, Err(ValidationError::CantInfer(..))));
     Ok(())
 }

--- a/hugr/src/hugr.rs
+++ b/hugr/src/hugr.rs
@@ -361,10 +361,9 @@ mod test {
     #[test]
     fn io_node() {
         use crate::builder::test::simple_dfg_hugr;
-        use cool_asserts::assert_matches;
 
         let hugr = simple_dfg_hugr();
-        assert_matches!(hugr.get_io(hugr.root()), Some(_));
+        assert!(hugr.get_io(hugr.root()).is_some());
     }
 
     #[cfg(feature = "extension_inference")]

--- a/hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr/src/hugr/rewrite/outline_cfg.rs
@@ -280,7 +280,7 @@ mod test {
         h.validate(&PRELUDE_REGISTRY).unwrap();
         let backup = h.clone();
         let r = h.apply_rewrite(OutlineCfg::new([merge, tail]));
-        assert_matches!(r, Err(OutlineCfgError::MultipleExitEdges(_, _)));
+        assert!(matches!(r, Err(OutlineCfgError::MultipleExitEdges(_, _))));
         assert_eq!(h, backup);
 
         let [left, right]: [Node; 2] = h.output_neighbours(head).collect_vec().try_into().unwrap();

--- a/hugr/src/hugr/validate/test.rs
+++ b/hugr/src/hugr/validate/test.rs
@@ -238,18 +238,18 @@ fn test_ext_edge() {
     h.connect(input, 0, sub_dfg, 0);
     h.connect(sub_dfg, 0, output, 0);
 
-    assert_matches!(
+    assert!(matches!(
         h.update_validate(&EMPTY_REG),
         Err(ValidationError::UnconnectedPort { .. })
-    );
+    ));
 
     h.connect(input, 1, sub_op, 1);
-    assert_matches!(
+    assert!(matches!(
         h.update_validate(&EMPTY_REG),
         Err(ValidationError::InterGraphEdgeError(
             InterGraphEdgeError::MissingOrderEdge { .. }
         ))
-    );
+    ));
     //Order edge. This will need metadata indicating its purpose.
     h.add_other_edge(input, sub_dfg);
     h.update_validate(&EMPTY_REG).unwrap();
@@ -303,7 +303,10 @@ fn dfg_with_cycles() {
     h.connect(input, 1, not2, 0);
     h.connect(not2, 0, output, 0);
     // The graph contains a cycle:
-    assert_matches!(h.validate(&EMPTY_REG), Err(ValidationError::NotADag { .. }));
+    assert!(matches!(
+        h.validate(&EMPTY_REG),
+        Err(ValidationError::NotADag { .. })
+    ));
 }
 
 fn identity_hugr_with_type(t: Type) -> (Hugr, Node) {
@@ -486,7 +489,7 @@ fn nested_typevars() -> Result<(), Box<dyn std::error::Error>> {
         outer.finish_prelude_hugr_with_outputs([w])
     }
     assert!(build(Type::new_var_use(0, INNER_BOUND)).is_ok());
-    assert_matches!(
+    assert!(matches!(
         build(Type::new_var_use(1, OUTER_BOUND)).unwrap_err(),
         BuildError::InvalidHUGR(ValidationError::SignatureError {
             cause: SignatureError::FreeTypeVar {
@@ -495,7 +498,7 @@ fn nested_typevars() -> Result<(), Box<dyn std::error::Error>> {
             },
             ..
         })
-    );
+    ));
     assert_matches!(build(Type::new_var_use(0, OUTER_BOUND)).unwrap_err(),
         BuildError::InvalidHUGR(ValidationError::SignatureError { cause: SignatureError::TypeVarDoesNotMatchDeclaration { actual, cached }, .. }) =>
         {assert_eq!(actual, INNER_BOUND.into()); assert_eq!(cached, OUTER_BOUND.into())});
@@ -529,7 +532,7 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
     )));
     let cst = def.add_load_const(empty_list);
     let res = def.finish_hugr_with_outputs([cst], &reg);
-    assert_matches!(
+    assert!(matches!(
         res.unwrap_err(),
         BuildError::InvalidHUGR(ValidationError::SignatureError {
             cause: SignatureError::FreeTypeVar {
@@ -538,7 +541,7 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
             },
             ..
         })
-    );
+    ));
     Ok(())
 }
 
@@ -639,10 +642,10 @@ mod extension_tests {
             }),
         )
         .unwrap();
-        assert_matches!(
+        assert!(matches!(
             b.validate(&EMPTY_REG),
             Err(ValidationError::ContainerWithoutChildren { .. })
-        );
+        ));
         let cfg = copy;
 
         // Construct a valid CFG, with one BasicBlock node and one exit node
@@ -748,12 +751,12 @@ mod extension_tests {
         hugr.connect(lift, 0, output, 0);
 
         let result = hugr.validate(&PRELUDE_REGISTRY);
-        assert_matches!(
+        assert!(matches!(
             result,
             Err(ValidationError::ExtensionError(
                 ExtensionError::ParentIOExtensionMismatch { .. }
             ))
-        );
+        ));
     }
 
     #[test]
@@ -780,12 +783,12 @@ mod extension_tests {
         main.finish_with_outputs([f_output])?;
         let handle = module_builder.hugr().validate(&PRELUDE_REGISTRY);
 
-        assert_matches!(
+        assert!(matches!(
             handle,
             Err(ValidationError::ExtensionError(
                 ExtensionError::TgtExceedsSrcExtensionsAtPort { .. }
             ))
-        );
+        ));
         Ok(())
     }
 
@@ -810,12 +813,12 @@ mod extension_tests {
         let [f_output] = f_handle.outputs_arr();
         main.finish_with_outputs([f_output])?;
         let handle = module_builder.hugr().validate(&PRELUDE_REGISTRY);
-        assert_matches!(
+        assert!(matches!(
             handle,
             Err(ValidationError::ExtensionError(
                 ExtensionError::SrcExceedsTgtExtensionsAtPort { .. }
             ))
-        );
+        ));
         Ok(())
     }
 
@@ -863,12 +866,12 @@ mod extension_tests {
 
         main.finish_with_outputs([output])?;
         let handle = module_builder.hugr().validate(&PRELUDE_REGISTRY);
-        assert_matches!(
+        assert!(matches!(
             handle,
             Err(ValidationError::ExtensionError(
                 ExtensionError::TgtExceedsSrcExtensionsAtPort { .. }
             ))
-        );
+        ));
         Ok(())
     }
 
@@ -897,11 +900,11 @@ mod extension_tests {
         );
         hugr.connect(input, 0, output, 0);
 
-        assert_matches!(
+        assert!(matches!(
             hugr.validate(&PRELUDE_REGISTRY),
             Err(ValidationError::ExtensionError(
                 ExtensionError::TgtExceedsSrcExtensionsAtPort { .. }
             ))
-        );
+        ));
     }
 }

--- a/hugr/src/hugr/views/sibling_subgraph.rs
+++ b/hugr/src/hugr/views/sibling_subgraph.rs
@@ -684,8 +684,6 @@ pub enum InvalidSubgraphBoundary {
 mod tests {
     use std::error::Error;
 
-    use cool_asserts::assert_matches;
-
     use crate::extension::PRELUDE_REGISTRY;
     use crate::utils::test_quantum_extension::cx_gate;
     use crate::{
@@ -924,13 +922,14 @@ mod tests {
         let not1_out = hugr.node_outputs(not1).next().unwrap();
         let not3_inp = hugr.node_inputs(not3).next().unwrap();
         let not3_out = hugr.node_outputs(not3).next().unwrap();
-        assert_matches!(
+        assert_eq!(
             SiblingSubgraph::try_new(
                 vec![vec![(not1, not1_inp)], vec![(not3, not3_inp)]],
                 vec![(not1, not1_out), (not3, not3_out)],
                 &func
-            ),
-            Err(InvalidSubgraph::NotConvex)
+            )
+            .unwrap_err(),
+            InvalidSubgraph::NotConvex
         );
     }
 

--- a/hugr/src/hugr/views/sibling_subgraph.rs
+++ b/hugr/src/hugr/views/sibling_subgraph.rs
@@ -897,7 +897,7 @@ mod tests {
         let [inp, _] = hugr.get_io(func_root).unwrap();
         let first_cx_edge = hugr.node_outputs(inp).next().unwrap();
         // All graph but one edge
-        assert_matches!(
+        assert!(matches!(
             SiblingSubgraph::try_new(
                 vec![hugr
                     .linked_ports(inp, first_cx_edge)
@@ -909,7 +909,7 @@ mod tests {
             Err(InvalidSubgraph::InvalidBoundary(
                 InvalidSubgraphBoundary::DisconnectedBoundaryPort(_, _)
             ))
-        );
+        ));
     }
 
     #[test]
@@ -942,7 +942,7 @@ mod tests {
         let cx_edges_in = hugr.node_outputs(inp);
         let cx_edges_out = hugr.node_inputs(out);
         // All graph but the CX
-        assert_matches!(
+        assert!(matches!(
             SiblingSubgraph::try_new(
                 cx_edges_out.map(|p| vec![(out, p)]).collect(),
                 cx_edges_in.map(|p| (inp, p)).collect(),
@@ -951,7 +951,7 @@ mod tests {
             Err(InvalidSubgraph::InvalidBoundary(
                 InvalidSubgraphBoundary::DisconnectedBoundaryPort(_, _)
             ))
-        );
+        ));
     }
 
     #[test]

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -446,23 +446,23 @@ mod test {
         println!("{}", serde_json::to_string_pretty(&good_sum).unwrap());
 
         let res = Value::sum(0, [], pred_ty.clone());
-        assert_matches!(
+        assert!(matches!(
             res,
             Err(ConstTypeError::SumType(SumTypeError::WrongVariantLength {
                 tag: 0,
                 expected: 2,
                 found: 0
             }))
-        );
+        ));
 
         let res = Value::sum(4, [], pred_ty.clone());
-        assert_matches!(
+        assert!(matches!(
             res,
             Err(ConstTypeError::SumType(SumTypeError::InvalidTag {
                 tag: 4,
                 num_variants: 2
             }))
-        );
+        ));
 
         let res = Value::sum(0, [const_usize(), const_usize()], pred_ty);
         assert_matches!(

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -540,7 +540,7 @@ mod test {
             CustomSerialized::new(typ_int.clone(), YamlValue::Number(6.into()), ex_id.clone())
                 .into();
         let classic_t = Type::new_extension(typ_int.clone());
-        assert_matches!(classic_t.least_upper_bound(), TypeBound::Eq);
+        assert_eq!(classic_t.least_upper_bound(), TypeBound::Eq);
         assert_eq!(yaml_const.const_type(), classic_t);
 
         let typ_qb = CustomType::new("my_type", vec![], ex_id, TypeBound::Eq);

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -472,7 +472,7 @@ mod test {
                 index: 1,
                 expected,
                 found,
-            })) if expected == FLOAT64_TYPE && found == const_usize()
+            })) => {assert_eq!(expected, FLOAT64_TYPE); assert_eq!(found, const_usize())}
         );
     }
 

--- a/hugr/src/ops/validate.rs
+++ b/hugr/src/ops/validate.rs
@@ -377,11 +377,11 @@ mod test {
         );
         assert_matches!(
             validate_io_nodes(&out_types, &out_types, "test", make_iter(&children)),
-            Err(ChildrenValidationError::IOSignatureMismatch { child, .. }) if child.index() == 0
+            Err(ChildrenValidationError::IOSignatureMismatch { child, .. }) => assert_eq!(child.index(), 0)
         );
         assert_matches!(
             validate_io_nodes(&in_types, &in_types, "test", make_iter(&children)),
-            Err(ChildrenValidationError::IOSignatureMismatch { child, .. }) if child.index() == 1
+            Err(ChildrenValidationError::IOSignatureMismatch { child, .. }) => assert_eq!(child.index(), 1)
         );
 
         // Internal I/O nodes
@@ -394,7 +394,7 @@ mod test {
         ];
         assert_matches!(
             validate_io_nodes(&in_types, &out_types, "test", make_iter(&children)),
-            Err(ChildrenValidationError::InternalIOChildren { child, .. }) if child.index() == 3
+            Err(ChildrenValidationError::InternalIOChildren { child, .. }) => assert_eq!(child.index(), 3)
         );
     }
 

--- a/hugr/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr/src/std_extensions/arithmetic/int_types.rs
@@ -207,7 +207,6 @@ pub(super) fn int_tv(var_id: usize) -> Type {
 }
 #[cfg(test)]
 mod test {
-    use cool_asserts::assert_matches;
 
     use super::*;
 
@@ -222,13 +221,13 @@ mod test {
     #[test]
     fn test_int_widths() {
         let type_arg_32 = TypeArg::BoundedNat { n: 5 };
-        assert_matches!(get_log_width(&type_arg_32), Ok(5));
+        assert!(matches!(get_log_width(&type_arg_32), Ok(5)));
 
         let type_arg_128 = TypeArg::BoundedNat { n: 7 };
-        assert_matches!(
+        assert!(matches!(
             get_log_width(&type_arg_128),
             Err(TypeArgError::TypeMismatch { .. })
-        );
+        ));
     }
 
     #[test]
@@ -240,18 +239,18 @@ mod test {
         assert_ne!(const_u32_7, const_u32_8);
         assert_eq!(const_u32_7, ConstInt::new_u(5, 7));
 
-        assert_matches!(
+        assert!(matches!(
             ConstInt::new_u(3, 256),
             Err(ConstTypeError::CustomCheckFail(_))
-        );
-        assert_matches!(
+        ));
+        assert!(matches!(
             ConstInt::new_u(9, 256),
             Err(ConstTypeError::CustomCheckFail(_))
-        );
-        assert_matches!(
+        ));
+        assert!(matches!(
             ConstInt::new_s(3, 128),
             Err(ConstTypeError::CustomCheckFail(_))
-        );
+        ));
         assert!(ConstInt::new_s(3, -128).is_ok());
 
         let const_u32_7 = const_u32_7.unwrap();


### PR DESCRIPTION
There are downsides to `assert_matches!`:
* Extra dependency/import
* Reduced linting - see several cases here where converting to `assert!(matches!(...))` lead to `clippy` noticing that the match could be converted to `.is_ok()` or `.is_some()`
* Increased chance of accidents, see #1006 (preliminary to this)

Hence, this PR adopts the policy of "use `assert_matches` only when it's useful". Specifically, that means only when we can use
```
assert_matches!(SUBJECT, PATTERN => assert!(EXPR))
```
(and while we're at it, where `EXPR` is an equality, use `assert_eq!`), rather than
```
assert!(matches!(SUBJECT, PATTERN if EXPR))
```
because the former gives better error messages in case of failure.

(This is quite a small advantage, and noting the increased chance of accidents, one could also say - let's not use `assert_matches` at all....I'd be happy to do that, too.)