### PR TITLE
test: fix some bad assert_matches

### DIFF
--- a/hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr/src/hugr/rewrite/outline_cfg.rs
@@ -285,7 +285,7 @@ mod test {
 
         let [left, right]: [Node; 2] = h.output_neighbours(head).collect_vec().try_into().unwrap();
         let r = h.apply_rewrite(OutlineCfg::new([left, right, head]));
-        assert_matches!(r, Err(OutlineCfgError::MultipleExitNodes(a,b)) => HashSet::from([a,b]) == HashSet::from_iter([left, right, head]));
+        assert_matches!(r, Err(OutlineCfgError::MultipleExitNodes(a,b)) => assert_eq!(HashSet::from([a,b]), HashSet::from_iter([left, right])));
         assert_eq!(h, backup);
 
         let r = h.apply_rewrite(OutlineCfg::new([left, right, merge]));

--- a/hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr/src/hugr/rewrite/outline_cfg.rs
@@ -289,7 +289,7 @@ mod test {
         assert_eq!(h, backup);
 
         let r = h.apply_rewrite(OutlineCfg::new([left, right, merge]));
-        assert_matches!(r, Err(OutlineCfgError::MultipleEntryNodes(a,b)) => HashSet::from([a,b]) == HashSet::from([left, right]));
+        assert_matches!(r, Err(OutlineCfgError::MultipleEntryNodes(a,b)) => assert_eq!(HashSet::from([a,b]), HashSet::from([left, right])));
         assert_eq!(h, backup);
     }
 

--- a/hugr/src/hugr/rewrite/replace.rs
+++ b/hugr/src/hugr/rewrite/replace.rs
@@ -803,7 +803,7 @@ mod test {
                 mu_new: vec![bad_order_edge.clone()],
                 ..rep.clone()
             }),
-            ReplaceError::BadEdgeKind(_, e) => e == bad_order_edge
+            ReplaceError::BadEdgeKind(_, e) => assert_eq!(e, bad_order_edge)
         );
         let op = OutgoingPort::from(0);
         let (tgt, ip) = h.linked_inputs(cond.node(), op).next().unwrap();

--- a/hugr/src/hugr/validate/test.rs
+++ b/hugr/src/hugr/validate/test.rs
@@ -498,7 +498,7 @@ fn nested_typevars() -> Result<(), Box<dyn std::error::Error>> {
     );
     assert_matches!(build(Type::new_var_use(0, OUTER_BOUND)).unwrap_err(),
         BuildError::InvalidHUGR(ValidationError::SignatureError { cause: SignatureError::TypeVarDoesNotMatchDeclaration { actual, cached }, .. }) =>
-        actual == INNER_BOUND.into() && cached == OUTER_BOUND.into());
+        {assert_eq!(actual, INNER_BOUND.into()); assert_eq!(cached, OUTER_BOUND.into())});
     Ok(())
 }
 


### PR DESCRIPTION
Turns out that `assert_matches!(subject, pattern => STMT)` executes STMT and drops the result....

We have several cases where STMT returns a bool and we were expecting this to be true, but in fact assert_matches doesn't check the bool. So, change these to `=> assert_eq!`

Indeed, there was one case here where the bool was actually false - fix that assert....