### PR TITLE
test: Reorg OutlineCfg/nest_cfgs tests so hugr doesn't depend on algorithm

### DIFF
--- a/hugr/src/algorithm/nest_cfgs.rs
+++ b/hugr/src/algorithm/nest_cfgs.rs
@@ -930,20 +930,19 @@ pub(crate) mod test {
         )?;
         let (split, merge) = build_if_then_else_merge(cfg_builder, &pred_const, &const_unit)?;
 
-        let (head, tail) = if separate_headers {
+        let head = if separate_headers {
             let head = n_identity(
                 cfg_builder
                     .simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?,
                 &const_unit,
             )?;
-            let tail = build_loop_from_header(cfg_builder, &pred_const, head)?;
             cfg_builder.branch(&head, 0, &split)?;
-            (head, tail)
+            head
         } else {
             // Combine loop header with split.
-            let tail = build_loop_from_header(cfg_builder, &pred_const, split)?;
-            (split, tail)
+            split
         };
+        let tail = build_loop_from_header(cfg_builder, &pred_const, head)?;
         cfg_builder.branch(&merge, 0, &tail)?;
 
         let exit = cfg_builder.exit_block();

--- a/hugr/src/algorithm/nest_cfgs.rs
+++ b/hugr/src/algorithm/nest_cfgs.rs
@@ -865,7 +865,7 @@ pub(crate) mod test {
     }
 
     // Result is merge and tail; loop header is (merge, if separate==true; unique successor of merge, if separate==false)
-    pub fn build_cond_then_loop_cfg(
+    fn build_cond_then_loop_cfg(
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;

--- a/hugr/src/algorithm/nest_cfgs.rs
+++ b/hugr/src/algorithm/nest_cfgs.rs
@@ -604,7 +604,7 @@ pub(crate) mod test {
         //               /-> left --\
         // entry -> split            > merge -> head -> tail -> exit
         //               \-> right -/             \-<--<-/
-        let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
+        let mut cfg_builder = CFGBuilder::new(FunctionType::new_endo(NAT))?;
 
         let pred_const = cfg_builder.add_constant(Value::unit_sum(0, 2).expect("0 < 2"));
         let const_unit = cfg_builder.add_constant(Value::unary_unit_sum());
@@ -616,8 +616,7 @@ pub(crate) mod test {
         let (split, merge) = build_if_then_else_merge(&mut cfg_builder, &pred_const, &const_unit)?;
         cfg_builder.branch(&entry, 0, &split)?;
         let head = n_identity(
-            cfg_builder
-                .simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?,
+            cfg_builder.simple_block_builder(FunctionType::new_endo(NAT), 1)?,
             &const_unit,
         )?;
         let tail = n_identity(
@@ -830,7 +829,7 @@ pub(crate) mod test {
         unit_const: &ConstID,
     ) -> Result<(BasicBlockID, BasicBlockID), BuildError> {
         let split = n_identity(
-            cfg.simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 2)?,
+            cfg.simple_block_builder(FunctionType::new_endo(NAT), 2)?,
             const_pred,
         )?;
         let merge = build_then_else_merge_from_if(cfg, unit_const, split)?;
@@ -843,15 +842,15 @@ pub(crate) mod test {
         split: BasicBlockID,
     ) -> Result<BasicBlockID, BuildError> {
         let merge = n_identity(
-            cfg.simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?,
+            cfg.simple_block_builder(FunctionType::new_endo(NAT), 1)?,
             unit_const,
         )?;
         let left = n_identity(
-            cfg.simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?,
+            cfg.simple_block_builder(FunctionType::new_endo(NAT), 1)?,
             unit_const,
         )?;
         let right = n_identity(
-            cfg.simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?,
+            cfg.simple_block_builder(FunctionType::new_endo(NAT), 1)?,
             unit_const,
         )?;
         cfg.branch(&split, 0, &left)?;
@@ -866,7 +865,7 @@ pub(crate) mod test {
     //      \-> right -/     \-<--<-/
     // Result is Hugr plus merge and tail blocks
     fn build_cond_then_loop_cfg() -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
-        let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
+        let mut cfg_builder = CFGBuilder::new(FunctionType::new_endo(NAT))?;
         let pred_const = cfg_builder.add_constant(Value::unit_sum(0, 2).expect("0 < 2"));
         let const_unit = cfg_builder.add_constant(Value::unary_unit_sum());
 
@@ -893,7 +892,7 @@ pub(crate) mod test {
     pub(crate) fn build_conditional_in_loop_cfg(
         separate_headers: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
-        let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
+        let mut cfg_builder = CFGBuilder::new(FunctionType::new_endo(NAT))?;
         let (head, tail) = build_conditional_in_loop(&mut cfg_builder, separate_headers)?;
         let h = cfg_builder.finish_prelude_hugr()?;
         Ok((h, head, tail))
@@ -914,8 +913,7 @@ pub(crate) mod test {
 
         let head = if separate_headers {
             let head = n_identity(
-                cfg_builder
-                    .simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?,
+                cfg_builder.simple_block_builder(FunctionType::new_endo(NAT), 1)?,
                 &const_unit,
             )?;
             cfg_builder.branch(&head, 0, &split)?;

--- a/hugr/src/algorithm/nest_cfgs.rs
+++ b/hugr/src/algorithm/nest_cfgs.rs
@@ -620,7 +620,11 @@ pub(crate) mod test {
                 .simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?,
             &const_unit,
         )?;
-        let tail = build_loop_from_header(&mut cfg_builder, &pred_const, head)?;
+        let tail = n_identity(
+            cfg_builder.simple_block_builder(FunctionType::new_endo(NAT), 2)?,
+            &pred_const,
+        )?;
+        cfg_builder.branch(&tail, 1, &head)?;
         cfg_builder.branch(&head, 0, &tail)?; // trivial "loop body"
         cfg_builder.branch(&merge, 0, &head)?;
         let exit = cfg_builder.exit_block();
@@ -860,20 +864,6 @@ pub(crate) mod test {
         Ok(merge)
     }
 
-    // Returns loop tail - caller must link header to tail, and provide 0th successor of tail
-    fn build_loop_from_header<T: AsMut<Hugr> + AsRef<Hugr>>(
-        cfg: &mut CFGBuilder<T>,
-        const_pred: &ConstID,
-        header: BasicBlockID,
-    ) -> Result<BasicBlockID, BuildError> {
-        let tail = n_identity(
-            cfg.simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 2)?,
-            const_pred,
-        )?;
-        cfg.branch(&tail, 1, &header)?;
-        Ok(tail)
-    }
-
     // Result is merge and tail; loop header is (merge, if separate==true; unique successor of merge, if separate==false)
     pub fn build_cond_then_loop_cfg(
         separate: bool,
@@ -898,7 +888,11 @@ pub(crate) mod test {
         } else {
             merge
         };
-        let tail = build_loop_from_header(&mut cfg_builder, &pred_const, head)?;
+        let tail = n_identity(
+            cfg_builder.simple_block_builder(FunctionType::new_endo(NAT), 2)?,
+            &pred_const,
+        )?;
+        cfg_builder.branch(&tail, 1, &head)?;
         cfg_builder.branch(&head, 0, &tail)?; // trivial "loop body"
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
@@ -942,7 +936,11 @@ pub(crate) mod test {
             // Combine loop header with split.
             split
         };
-        let tail = build_loop_from_header(cfg_builder, &pred_const, head)?;
+        let tail = n_identity(
+            cfg_builder.simple_block_builder(FunctionType::new_endo(NAT), 2)?,
+            &pred_const,
+        )?;
+        cfg_builder.branch(&tail, 1, &head)?;
         cfg_builder.branch(&merge, 0, &tail)?;
 
         let exit = cfg_builder.exit_block();

--- a/hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr/src/hugr/rewrite/outline_cfg.rs
@@ -332,12 +332,19 @@ mod test {
 
         let [left, right]: [Node; 2] = h.output_neighbours(entry).collect_vec().try_into().unwrap();
         let r = h.apply_rewrite(OutlineCfg::new([entry, left, right]));
-        assert_matches!(r, Err(OutlineCfgError::MultipleExitNodes(a,b)) => assert_eq!(HashSet::from([a,b]), HashSet::from_iter([left, right])));
+        assert_matches!(r, Err(OutlineCfgError::MultipleExitNodes(a,b))
+            => assert_eq!(HashSet::from([a,b]), HashSet::from_iter([left, right])));
         assert_eq!(h, backup);
 
         let r = h.apply_rewrite(OutlineCfg::new([left, right, merge]));
-        assert_matches!(r, Err(OutlineCfgError::MultipleEntryNodes(a,b)) => assert_eq!(HashSet::from([a,b]), HashSet::from([left, right])));
+        assert_matches!(r, Err(OutlineCfgError::MultipleEntryNodes(a,b))
+            => assert_eq!(HashSet::from([a,b]), HashSet::from([left, right])));
         assert_eq!(h, backup);
+
+        // The entry node implicitly has an extra incoming edge
+        let r = h.apply_rewrite(OutlineCfg::new([entry, left, merge]));
+        assert_matches!(r, Err(OutlineCfgError::MultipleEntryNodes(a,b))
+            => assert_eq!(HashSet::from([a,b]), HashSet::from([entry, merge])));
     }
 
     #[test]

--- a/hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr/src/hugr/rewrite/outline_cfg.rs
@@ -349,7 +349,7 @@ mod test {
 
         let (mut h, merge, tail) = build_cond_then_loop_cfg().unwrap();
         let (merge, tail) = (merge.node(), tail.node());
-        let exit = h.children(h.root()).skip(1).next().unwrap();
+        let exit = h.children(h.root()).nth(1).unwrap();
         let head = h.input_neighbours(tail).exactly_one().unwrap();
         assert_eq!(h.output_neighbours(merge.node()).collect_vec(), vec![head]);
 
@@ -383,7 +383,7 @@ mod test {
             assert_eq!(b.get_parent(n), Some(new_cfg));
         }
         assert!(b.get_optype(new_cfg).is_cfg());
-        let exit_block = b.children(new_cfg).skip(1).next().unwrap();
+        let exit_block = b.children(new_cfg).nth(1).unwrap();
         assert!(b.get_optype(exit_block).is_exit_block());
         (new_block, new_cfg, exit_block)
     }
@@ -405,7 +405,7 @@ mod test {
         fbuild.finish_with_outputs(cfg.outputs()).unwrap();
         let mut h = module_builder.finish_prelude_hugr().unwrap();
         let cfg = cfg.node();
-        let exit_node = h.children(cfg).skip(1).next().unwrap();
+        let exit_node = h.children(cfg).nth(1).unwrap();
         let tail = h.input_neighbours(exit_node).exactly_one().unwrap();
         let head = h.input_neighbours(tail).exactly_one().unwrap();
         // Just sanity-check we have the correct nodes

--- a/hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr/src/hugr/rewrite/outline_cfg.rs
@@ -248,7 +248,6 @@ pub enum OutlineCfgError {
 mod test {
     use std::collections::HashSet;
 
-    use crate::algorithm::nest_cfgs::test::depth;
     use crate::builder::{
         BlockBuilder, BuildError, CFGBuilder, Container, Dataflow, DataflowSubContainer,
         HugrBuilder, ModuleBuilder,
@@ -358,36 +357,38 @@ mod test {
         assert_eq!(h.output_neighbours(merge.node()).collect_vec(), vec![head]);
         h.update_validate(&PRELUDE_REGISTRY).unwrap();
         let root = h.root();
-        let (new_block, new_cfg) = outline_cfg_check_parents(&mut h, root, vec![head, tail]);
+        let (new_block, _, exit_block) = outline_cfg_check_parents(&mut h, root, vec![head, tail]);
         assert_eq!(h.output_neighbours(merge).collect_vec(), vec![new_block]);
         assert_eq!(h.input_neighbours(exit).collect_vec(), vec![new_block]);
-        let mut tail_outs = h.output_neighbours(tail).collect::<HashSet<Node>>();
-        assert!(tail_outs.remove(&head));
-        let new_exit = tail_outs.into_iter().exactly_one().unwrap();
-        assert_eq!(h.get_parent(new_exit), Some(new_cfg)); // no, new cfg
-        assert!(h.get_optype(new_exit).is_exit_block());
+        assert_eq!(
+            h.output_neighbours(tail).collect::<HashSet<Node>>(),
+            HashSet::from([head, exit_block])
+        );
     }
 
     fn outline_cfg_check_parents(
         h: &mut impl HugrMut,
         cfg: Node,
         blocks: Vec<Node>,
-    ) -> (Node, Node) {
+    ) -> (Node, Node, Node) {
         let mut other_blocks = h.children(cfg).collect::<HashSet<_>>();
         assert!(blocks.iter().all(|b| other_blocks.remove(b)));
         let (new_block, new_cfg) = h.apply_rewrite(OutlineCfg::new(blocks.clone())).unwrap();
-        // The .base_hugr() here in the asserts is to cope with `h`` potentially being a SiblingMut
-        for n in blocks {
-            assert_eq!(h.base_hugr().get_parent(n), Some(new_cfg));
-        }
-        assert_eq!(h.base_hugr().get_parent(new_cfg), Some(new_block));
-        assert_eq!(h.get_parent(new_block), Some(cfg));
+
         for n in other_blocks {
             assert_eq!(h.get_parent(n), Some(cfg))
         }
+        assert_eq!(h.get_parent(new_block), Some(cfg));
         assert!(h.get_optype(new_block).is_dataflow_block());
-        assert!(h.base_hugr().get_optype(new_cfg).is_cfg());
-        (new_block, new_cfg)
+        let b = h.base_hugr(); // To cope with `h`` potentially being a SiblingMut
+        assert_eq!(b.get_parent(new_cfg), Some(new_block));
+        for n in blocks {
+            assert_eq!(b.get_parent(n), Some(new_cfg));
+        }
+        assert!(b.get_optype(new_cfg).is_cfg());
+        let exit_block = b.children(new_cfg).skip(1).next().unwrap();
+        assert!(b.get_optype(exit_block).is_exit_block());
+        (new_block, new_cfg, exit_block)
     }
 
     #[test]
@@ -426,30 +427,17 @@ mod test {
     fn test_outline_cfg_move_entry() {
         let (mut h, merge, tail) = build_cond_then_loop_cfg().unwrap();
 
-        let (entry, exit) = h.children(h.root()).take(2).collect_tuple().unwrap();
+        let (entry, _) = h.children(h.root()).take(2).collect_tuple().unwrap();
         let (left, right) = h.output_neighbours(entry).take(2).collect_tuple().unwrap();
-        let (merge, tail) = (merge.node(), tail.node());
+        let (merge, _) = (merge.node(), tail.node());
         let head = h.output_neighbours(merge).exactly_one().unwrap();
 
         h.validate(&PRELUDE_REGISTRY).unwrap();
-        let blocks_to_move = [entry, left, right, merge];
-        let other_blocks = [head, tail, exit];
-        for &n in blocks_to_move.iter().chain(other_blocks.iter()) {
-            assert_eq!(depth(&h, n), 1);
-        }
-        let (new_block, new_cfg) = h
-            .apply_rewrite(OutlineCfg::new(blocks_to_move.iter().copied()))
-            .unwrap();
+        let root = h.root();
+        let (new_block, _, _) =
+            outline_cfg_check_parents(&mut h, root, vec![entry, left, right, merge]);
         h.update_validate(&PRELUDE_REGISTRY).unwrap();
         assert_eq!(new_block, h.children(h.root()).next().unwrap());
-        assert!(h.get_optype(new_block).is_dataflow_block());
-        assert_eq!(h.get_parent(new_cfg), Some(new_block));
-        assert!(h.get_optype(new_cfg).is_cfg());
-        for n in other_blocks {
-            assert_eq!(depth(&h, n), 1);
-        }
-        for n in blocks_to_move {
-            assert_eq!(h.get_parent(n).unwrap(), new_cfg);
-        }
+        assert_eq!(h.output_neighbours(new_block).collect_vec(), [head]);
     }
 }

--- a/hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr/src/hugr/rewrite/outline_cfg.rs
@@ -510,7 +510,7 @@ mod test {
         }
         assert_eq!(h.get_parent(new_block), Some(cfg));
         assert!(h.get_optype(new_block).is_dataflow_block());
-        let b = h.base_hugr(); // To cope with `h`` potentially being a SiblingMut
+        let b = h.base_hugr(); // To cope with `h` potentially being a SiblingMut
         assert_eq!(b.get_parent(new_cfg), Some(new_block));
         for n in blocks {
             assert_eq!(b.get_parent(n), Some(new_cfg));

--- a/hugr/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr/src/hugr/rewrite/outline_cfg.rs
@@ -342,9 +342,10 @@ mod test {
         assert_eq!(h, backup);
 
         // The entry node implicitly has an extra incoming edge
-        let r = h.apply_rewrite(OutlineCfg::new([entry, left, merge]));
+        let r = h.apply_rewrite(OutlineCfg::new([entry, left, right, merge, head]));
         assert_matches!(r, Err(OutlineCfgError::MultipleEntryNodes(a,b))
-            => assert_eq!(HashSet::from([a,b]), HashSet::from([entry, merge])));
+            => assert_eq!(HashSet::from([a,b]), HashSet::from([entry, head])));
+        assert_eq!(h, backup);
     }
 
     #[test]


### PR DESCRIPTION
This is in preparation for moving `algorithm` out to a separate crate.
* Rewrite tests in `outline_cfg.rs` to use a single CFG, specific to that test
* Add a test where the outlined cfg has multiple incoming edges (to the same node)
* And another where there is an incoming edge and also the entry node (another implicit edge, making this illegal)
* Tidy the left-behind test code in `nest_cfg.rs`
   * Now that the OutlineCfg tests don't depend, `build_cond_then_loop_cfg(bool)` is only called with `false`, so fold
   * Also inline/remove a few other "helpers" whose interface contract is more confusing than helpful
   * And, e.g., use `FunctionType::new_endo` (and remove now-unnecessary `type_row!`)