### PR TITLE
refactor: Remove "trait TypeParametrised"

### DIFF
--- a/hugr/src/extension.rs
+++ b/hugr/src/extension.rs
@@ -15,8 +15,7 @@ use crate::hugr::IdentList;
 use crate::ops::constant::{ValueName, ValueNameRef};
 use crate::ops::custom::{ExtensionOp, OpaqueOp};
 use crate::ops::{self, OpName, OpNameRef};
-use crate::types::type_param::{check_type_args, TypeArgError};
-use crate::types::type_param::{TypeArg, TypeParam};
+use crate::types::type_param::{TypeArg, TypeArgError, TypeParam};
 use crate::types::{check_typevar_decl, CustomType, Substitution, TypeBound, TypeName};
 use crate::types::{FunctionType, TypeNameRef};
 
@@ -243,10 +242,6 @@ trait TypeParametrised {
     fn params(&self) -> &[TypeParam];
     /// The parent extension.
     fn extension(&self) -> &ExtensionId;
-    /// Check provided type arguments are valid against parameters.
-    fn check_args_impl(&self, args: &[TypeArg]) -> Result<(), SignatureError> {
-        check_type_args(args, self.params()).map_err(SignatureError::TypeArgMismatch)
-    }
 }
 
 /// A constant value provided by a extension.

--- a/hugr/src/extension.rs
+++ b/hugr/src/extension.rs
@@ -232,18 +232,6 @@ impl CustomConcrete for CustomType {
     }
 }
 
-/// Type-parametrised functionality shared between [`TypeDef`] and [`OpDef`].
-trait TypeParametrised {
-    /// The concrete object built by binding type arguments to parameters
-    type Concrete: CustomConcrete;
-    /// The extension-unique name.
-    fn name(&self) -> &<Self::Concrete as CustomConcrete>::Identifier;
-    /// Type parameters.
-    fn params(&self) -> &[TypeParam];
-    /// The parent extension.
-    fn extension(&self) -> &ExtensionId;
-}
-
 /// A constant value provided by a extension.
 /// Must be an instance of a type available to the extension.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/hugr/src/extension/declarative/signature.rs
+++ b/hugr/src/extension/declarative/signature.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
 use crate::extension::prelude::PRELUDE_ID;
-use crate::extension::{CustomValidator, ExtensionSet, SignatureFunc, TypeDef, TypeParametrised};
+use crate::extension::{CustomValidator, ExtensionSet, SignatureFunc, TypeDef};
 use crate::types::type_param::TypeParam;
 use crate::types::{CustomType, FunctionType, PolyFuncType, Type, TypeRow};
 use crate::Extension;

--- a/hugr/src/extension/declarative/types.rs
+++ b/hugr/src/extension/declarative/types.rs
@@ -7,7 +7,7 @@
 //! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
 //! [`ExtensionSetDeclaration`]: super::ExtensionSetDeclaration
 
-use crate::extension::{TypeDef, TypeDefBound, TypeParametrised};
+use crate::extension::{TypeDef, TypeDefBound};
 use crate::types::type_param::TypeParam;
 use crate::types::{CustomType, TypeBound, TypeName};
 use crate::Extension;

--- a/hugr/src/extension/type_def.rs
+++ b/hugr/src/extension/type_def.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry;
 
 use super::{CustomConcrete, ExtensionBuildError};
-use super::{Extension, ExtensionId, SignatureError, TypeParametrised};
+use super::{Extension, ExtensionId, SignatureError};
 
 use crate::types::{least_upper_bound, CustomType, TypeName};
 
@@ -122,12 +122,10 @@ impl TypeDef {
             }
         }
     }
-}
 
-impl TypeParametrised for TypeDef {
-    type Concrete = CustomType;
-
-    fn params(&self) -> &[TypeParam] {
+    /// The static parameters to the TypeDef; a [TypeArg] appropriate for each
+    /// must be provided to produce an actual type.
+    pub fn params(&self) -> &[TypeParam] {
         &self.params
     }
 

--- a/hugr/src/extension/type_def.rs
+++ b/hugr/src/extension/type_def.rs
@@ -5,7 +5,7 @@ use super::{Extension, ExtensionId, SignatureError, TypeParametrised};
 
 use crate::types::{least_upper_bound, CustomType, TypeName};
 
-use crate::types::type_param::TypeArg;
+use crate::types::type_param::{check_type_args, TypeArg};
 
 use crate::types::type_param::TypeParam;
 
@@ -49,7 +49,7 @@ pub struct TypeDef {
 impl TypeDef {
     /// Check provided type arguments are valid against parameters.
     pub fn check_args(&self, args: &[TypeArg]) -> Result<(), SignatureError> {
-        self.check_args_impl(args)
+        check_type_args(args, &self.params).map_err(SignatureError::TypeArgMismatch)
     }
 
     /// Check [`CustomType`] is a valid instantiation of this definition.
@@ -72,7 +72,7 @@ impl TypeDef {
             ));
         }
 
-        self.check_args_impl(custom.type_args())?;
+        check_type_args(custom.type_args(), &self.params)?;
 
         let calc_bound = self.bound(custom.args());
         if calc_bound == custom.bound() {
@@ -93,7 +93,7 @@ impl TypeDef {
     /// valid instances of the type parameters.
     pub fn instantiate(&self, args: impl Into<Vec<TypeArg>>) -> Result<CustomType, SignatureError> {
         let args = args.into();
-        self.check_args_impl(&args)?;
+        check_type_args(&args, &self.params)?;
         let bound = self.bound(&args);
         Ok(CustomType::new(
             self.name().clone(),


### PR DESCRIPTION
The docs say it was intended for sharing code between OpDef and TypeDef, but it was actually impl'd only by TypeDef (following earlier cleanups I think). So, simplify by removing it...(nothing here was ever `pub`)