### PR TITLE
feat!: Allow panic operation to have any input and output wires

### DIFF
--- a/hugr/src/extension/prelude.rs
+++ b/hugr/src/extension/prelude.rs
@@ -183,7 +183,16 @@ pub fn array_type(size: impl Into<TypeArg>, element_ty: Type) -> Type {
 
 /// Name of the operation in the prelude for creating new arrays.
 pub const NEW_ARRAY_OP_ID: OpName = OpName::new_inline("new_array");
+
 /// Name of the prelude panic operation.
+///
+/// This operation can have any input and any output wires; it is instantiated
+/// with two [TypeArg::Sequence]s representing these. The first input to the
+/// operation is always an error type; the remaining inputs correspond to the
+/// first sequence of types in its instantiation; the outputs correspond to the
+/// second sequence of types in its instantiation. Note that the inputs and
+/// outputs only exist so that structural constraints such as linearity can be
+/// satisfied.
 pub const PANIC_OP_ID: OpName = OpName::new_inline("panic");
 
 /// Initialize a new array op of element type `element_ty` of length `size`

--- a/hugr/src/extension/prelude.rs
+++ b/hugr/src/extension/prelude.rs
@@ -41,12 +41,6 @@ impl SignatureFromArgs for ArrayOpCustom {
     }
 }
 
-fn list_of_type() -> TypeParam {
-    TypeParam::List {
-        param: Box::new(TypeParam::Type { b: TypeBound::Any }),
-    }
-}
-
 struct GenericOpCustom;
 impl SignatureFromArgs for GenericOpCustom {
     fn compute_signature(&self, arg_values: &[TypeArg]) -> Result<PolyFuncType, SignatureError> {
@@ -77,6 +71,11 @@ impl SignatureFromArgs for GenericOpCustom {
     }
 
     fn static_params(&self) -> &[TypeParam] {
+        fn list_of_type() -> TypeParam {
+            TypeParam::List {
+                param: Box::new(TypeParam::Type { b: TypeBound::Any }),
+            }
+        }
         lazy_static! {
             static ref PARAMS: [TypeParam; 2] = [list_of_type(), list_of_type()];
         }


### PR DESCRIPTION
Closes #915 .

BREAKING CHANGE: `PANIC_OP_ID` now instantiated with expected input and output types.