### PR TITLE
refactor!: Separate Signature from FunctionType

### DIFF
--- a/hugr-passes/src/merge_bbs.rs
+++ b/hugr-passes/src/merge_bbs.rs
@@ -76,7 +76,7 @@ fn mk_rep(
     let output = replacement.add_node_with_parent(
         merged,
         Output {
-            types: succ_sig.output.clone(),
+            types: succ_sig.output().clone(),
         },
     );
 
@@ -96,7 +96,7 @@ fn mk_rep(
             signature: succ_sig.clone(),
         },
     );
-    for (i, _) in succ_sig.output.iter().enumerate() {
+    for i in 0..succ_sig.output_count() {
         replacement.connect(dfg2, i, output, i)
     }
 
@@ -318,8 +318,8 @@ mod test {
         let [res_t] = tst_op
             .dataflow_signature()
             .unwrap()
-            .output
-            .into_owned()
+            .output()
+            .to_vec()
             .try_into()
             .unwrap();
         let mut h = CFGBuilder::new(

--- a/hugr/src/builder.rs
+++ b/hugr/src/builder.rs
@@ -85,6 +85,8 @@
 //! # }
 //! # doctest().unwrap();
 //! ```
+use std::convert::Infallible;
+
 use thiserror::Error;
 
 use crate::extension::SignatureError;
@@ -181,6 +183,13 @@ pub enum BuildError {
         #[source]
         error: BuilderWiringError,
     },
+}
+
+impl From<Infallible> for BuildError {
+    fn from(value: Infallible) -> Self {
+        match value {
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Error)]

--- a/hugr/src/builder.rs
+++ b/hugr/src/builder.rs
@@ -231,7 +231,7 @@ pub(crate) mod test {
 
     use crate::hugr::{views::HugrView, HugrMut, NodeType};
     use crate::ops;
-    use crate::types::{FunctionType, PolyFuncType, Type};
+    use crate::types::{FunctionType, PolyFuncType, Signature, Type};
     use crate::{type_row, Hugr};
 
     use super::handle::BuildHandle;

--- a/hugr/src/builder.rs
+++ b/hugr/src/builder.rs
@@ -276,21 +276,11 @@ pub(crate) mod test {
     /// inference. Using DFGBuilder will default to a root node with an open
     /// extension variable
     pub(crate) fn closed_dfg_root_hugr(signature: FunctionType) -> Hugr {
-        let mut hugr = Hugr::new(NodeType::new_pure(ops::DFG {
-            signature: signature.clone(),
-        }));
-        hugr.add_node_with_parent(
-            hugr.root(),
-            ops::Input {
-                types: signature.input,
-            },
-        );
-        hugr.add_node_with_parent(
-            hugr.root(),
-            ops::Output {
-                types: signature.output,
-            },
-        );
+        let in_types = signature.input().clone();
+        let out_types = signature.output().clone();
+        let mut hugr = Hugr::new(NodeType::new_pure(ops::DFG { signature }));
+        hugr.add_node_with_parent(hugr.root(), ops::Input { types: in_types });
+        hugr.add_node_with_parent(hugr.root(), ops::Output { types: out_types });
         hugr
     }
 }

--- a/hugr/src/builder.rs
+++ b/hugr/src/builder.rs
@@ -245,7 +245,7 @@ pub(crate) mod test {
     }
 
     pub(super) fn build_main(
-        signature: PolyFuncType,
+        signature: PolyFuncType<false>,
         f: impl FnOnce(FunctionBuilder<&mut Hugr>) -> Result<BuildHandle<FuncID<true>>, BuildError>,
     ) -> Result<Hugr, BuildError> {
         let mut module_builder = ModuleBuilder::new();
@@ -275,7 +275,7 @@ pub(crate) mod test {
     /// for tests which want to avoid having open extension variables after
     /// inference. Using DFGBuilder will default to a root node with an open
     /// extension variable
-    pub(crate) fn closed_dfg_root_hugr(signature: FunctionType) -> Hugr {
+    pub(crate) fn closed_dfg_root_hugr(signature: Signature) -> Hugr {
         let in_types = signature.input().clone();
         let out_types = signature.output().clone();
         let mut hugr = Hugr::new(NodeType::new_pure(ops::DFG { signature }));

--- a/hugr/src/builder/build_traits.rs
+++ b/hugr/src/builder/build_traits.rs
@@ -85,7 +85,7 @@ pub trait Container {
     fn define_function(
         &mut self,
         name: impl Into<String>,
-        signature: PolyFuncType,
+        signature: PolyFuncType<false>,
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
         let body = signature.body().clone();
         let f_node = self.add_child_node(NodeType::new_pure(ops::FuncDefn {
@@ -296,7 +296,7 @@ pub trait Dataflow: Container {
     // TODO: Should this be one function, or should there be a temporary "op" one like with the others?
     fn dfg_builder(
         &mut self,
-        signature: FunctionType,
+        signature: Signature,
         input_extensions: Option<ExtensionSet>,
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<DFGBuilder<&mut Hugr>, BuildError> {

--- a/hugr/src/builder/build_traits.rs
+++ b/hugr/src/builder/build_traits.rs
@@ -336,7 +336,7 @@ pub trait Dataflow: Container {
             self,
             NodeType::new(
                 ops::CFG {
-                    signature: FunctionType::new(inputs.clone(), output_types.clone())
+                    signature: Signature::try_new(inputs.clone(), output_types.clone())?
                         .with_extension_delta(extension_delta),
                 },
                 input_extensions.into(),

--- a/hugr/src/builder/build_traits.rs
+++ b/hugr/src/builder/build_traits.rs
@@ -647,15 +647,6 @@ fn add_node_with_wires<T: Dataflow + ?Sized>(
     inputs: impl IntoIterator<Item = Wire>,
 ) -> Result<(Node, usize), BuildError> {
     let nodetype: NodeType = nodetype.into();
-    // Check there are no row variables, as that would prevent us
-    // from indexing into the node's ports in order to wire up
-    nodetype
-        .op_signature()
-        .as_ref()
-        .and_then(FunctionType::find_rowvar)
-        .map_or(Ok(()), |(idx, _)| {
-            Err(SignatureError::RowVarWhereTypeExpected { idx })
-        })?;
     let num_outputs = nodetype.op().value_output_count();
     let op_node = data_builder.add_child_node(nodetype.clone());
 

--- a/hugr/src/builder/cfg.rs
+++ b/hugr/src/builder/cfg.rs
@@ -154,13 +154,13 @@ impl<H: AsMut<Hugr> + AsRef<Hugr>> SubContainer for CFGBuilder<H> {
 impl CFGBuilder<Hugr> {
     /// New CFG rooted HUGR builder
     pub fn new(signature: FunctionType) -> Result<Self, BuildError> {
-        let cfg_op = ops::CFG {
-            signature: signature.clone(),
-        };
+        let input = signature.input().clone();
+        let output = signature.output().clone();
+        let cfg_op = ops::CFG { signature };
 
         let base = Hugr::new(NodeType::new_open(cfg_op));
         let cfg_node = base.root();
-        CFGBuilder::create(base, cfg_node, signature.input, signature.output)
+        CFGBuilder::create(base, cfg_node, input, output)
     }
 }
 
@@ -254,12 +254,8 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
         signature: FunctionType,
         n_cases: usize,
     ) -> Result<BlockBuilder<&mut Hugr>, BuildError> {
-        self.block_builder(
-            signature.input,
-            vec![type_row![]; n_cases],
-            signature.extension_reqs,
-            signature.output,
-        )
+        let (input, extension_reqs, output) = signature.into_tuple();
+        self.block_builder(input, vec![type_row![]; n_cases], extension_reqs, output)
     }
 
     /// Return a builder for the entry [`DataflowBlock`] child graph with `inputs`

--- a/hugr/src/builder/cfg.rs
+++ b/hugr/src/builder/cfg.rs
@@ -153,7 +153,7 @@ impl<H: AsMut<Hugr> + AsRef<Hugr>> SubContainer for CFGBuilder<H> {
 
 impl CFGBuilder<Hugr> {
     /// New CFG rooted HUGR builder
-    pub fn new(signature: FunctionType) -> Result<Self, BuildError> {
+    pub fn new(signature: Signature) -> Result<Self, BuildError> {
         let input = signature.input().clone();
         let output = signature.output().clone();
         let cfg_op = ops::CFG { signature };
@@ -251,7 +251,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
     /// This function will return an error if there is an error adding the node.
     pub fn simple_block_builder(
         &mut self,
-        signature: FunctionType,
+        signature: Signature,
         n_cases: usize,
     ) -> Result<BlockBuilder<&mut Hugr>, BuildError> {
         let (input, extension_reqs, output) = signature.into_tuple();

--- a/hugr/src/builder/cfg.rs
+++ b/hugr/src/builder/cfg.rs
@@ -5,7 +5,7 @@ use super::{
     BasicBlockID, BuildError, CfgID, Container, Dataflow, HugrBuilder, Wire,
 };
 
-use crate::ops::{self, handle::NodeHandle, DataflowBlock, DataflowParent, ExitBlock, OpType};
+use crate::{ops::{self, handle::NodeHandle, DataflowBlock, DataflowParent, ExitBlock, OpType}, types::Signature};
 use crate::{
     extension::{ExtensionRegistry, ExtensionSet},
     types::FunctionType,

--- a/hugr/src/builder/conditional.rs
+++ b/hugr/src/builder/conditional.rs
@@ -1,7 +1,7 @@
 use crate::extension::ExtensionRegistry;
 use crate::hugr::views::HugrView;
 use crate::ops::dataflow::DataflowOpTrait;
-use crate::types::{FunctionType, TypeRow};
+use crate::types::{FunctionType, Signature, TypeRow};
 
 use crate::ops;
 use crate::ops::handle::CaseID;
@@ -192,7 +192,7 @@ impl ConditionalBuilder<Hugr> {
 
 impl CaseBuilder<Hugr> {
     /// Initialize a Case rooted HUGR
-    pub fn new(signature: FunctionType) -> Result<Self, BuildError> {
+    pub fn new(signature: Signature) -> Result<Self, BuildError> {
         let op = ops::Case {
             signature: signature.clone(),
         };

--- a/hugr/src/builder/dataflow.rs
+++ b/hugr/src/builder/dataflow.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use crate::hugr::{HugrView, NodeType, ValidationError};
 use crate::ops;
 
-use crate::types::{FunctionType, PolyFuncType};
+use crate::types::{FunctionType, PolyFuncType, Signature};
 
 use crate::extension::{ExtensionRegistry, ExtensionSet};
 use crate::Node;
@@ -26,7 +26,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> DFGBuilder<T> {
     pub(super) fn create_with_io(
         mut base: T,
         parent: Node,
-        signature: FunctionType,
+        signature: Signature,
         input_extensions: Option<ExtensionSet>,
     ) -> Result<Self, BuildError> {
         let num_in_wires = signature.input().len();
@@ -75,7 +75,7 @@ impl DFGBuilder<Hugr> {
     /// # Errors
     ///
     /// Error in adding DFG child nodes.
-    pub fn new(signature: FunctionType) -> Result<DFGBuilder<Hugr>, BuildError> {
+    pub fn new(signature: Signature) -> Result<DFGBuilder<Hugr>, BuildError> {
         let dfg_op = ops::DFG {
             signature: signature.clone(),
         };
@@ -146,7 +146,10 @@ impl FunctionBuilder<Hugr> {
     /// # Errors
     ///
     /// Error in adding DFG child nodes.
-    pub fn new(name: impl Into<String>, signature: PolyFuncType) -> Result<Self, BuildError> {
+    pub fn new(
+        name: impl Into<String>,
+        signature: PolyFuncType<false>,
+    ) -> Result<Self, BuildError> {
         let body = signature.body().clone();
         let op = ops::FuncDefn {
             signature,

--- a/hugr/src/builder/module.rs
+++ b/hugr/src/builder/module.rs
@@ -105,7 +105,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
     pub fn declare(
         &mut self,
         name: impl Into<String>,
-        signature: PolyFuncType,
+        signature: PolyFuncType<false>,
     ) -> Result<FuncID<false>, BuildError> {
         // TODO add param names to metadata
         let declare_n = self.add_child_node(NodeType::new_pure(ops::FuncDecl {

--- a/hugr/src/builder/tail_loop.rs
+++ b/hugr/src/builder/tail_loop.rs
@@ -20,7 +20,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
         loop_node: Node,
         tail_loop: &ops::TailLoop,
     ) -> Result<Self, BuildError> {
-        let signature = FunctionType::new(tail_loop.body_input_row(), tail_loop.body_output_row());
+        let signature = Signature::new(tail_loop.body_input_row(), tail_loop.body_output_row())?;
         let dfg_build = DFGBuilder::create_with_io(base, loop_node, signature, None)?;
 
         Ok(TailLoopBuilder::from_dfg_builder(dfg_build))

--- a/hugr/src/builder/tail_loop.rs
+++ b/hugr/src/builder/tail_loop.rs
@@ -20,7 +20,8 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
         loop_node: Node,
         tail_loop: &ops::TailLoop,
     ) -> Result<Self, BuildError> {
-        let signature = Signature::new(tail_loop.body_input_row(), tail_loop.body_output_row())?;
+        // ALAN this could be a new_unchecked *iff* TailLoop checked there were noRVs
+        let signature = Signature::try_new(tail_loop.body_input_row(), tail_loop.body_output_row())?;
         let dfg_build = DFGBuilder::create_with_io(base, loop_node, signature, None)?;
 
         Ok(TailLoopBuilder::from_dfg_builder(dfg_build))

--- a/hugr/src/builder/tail_loop.rs
+++ b/hugr/src/builder/tail_loop.rs
@@ -1,7 +1,7 @@
 use crate::ops;
 
 use crate::hugr::{views::HugrView, NodeType};
-use crate::types::{FunctionType, TypeRow};
+use crate::types::{FunctionType, Signature, TypeRow};
 use crate::{Hugr, Node};
 
 use super::build_traits::SubContainer;

--- a/hugr/src/extension.rs
+++ b/hugr/src/extension.rs
@@ -16,6 +16,7 @@ use crate::ops::constant::{ValueName, ValueNameRef};
 use crate::ops::custom::{ExtensionOp, OpaqueOp};
 use crate::ops::{self, OpName, OpNameRef};
 use crate::types::type_param::{TypeArg, TypeArgError, TypeParam};
+use crate::types::Signature;
 use crate::types::{check_typevar_decl, CustomType, Substitution, TypeBound, TypeName};
 use crate::types::{FunctionType, TypeNameRef};
 
@@ -172,8 +173,8 @@ pub enum SignatureError {
         "Incorrect result of type application in Call - cached {cached} but expected {expected}"
     )]
     CallIncorrectlyAppliesType {
-        cached: FunctionType,
-        expected: FunctionType,
+        cached: Signature,
+        expected: Signature,
     },
     /// The result of the type application stored in a [LoadFunction]
     /// is not what we get by applying the type-args to the polymorphic function
@@ -183,8 +184,8 @@ pub enum SignatureError {
         "Incorrect result of type application in LoadFunction - cached {cached} but expected {expected}"
     )]
     LoadFunctionIncorrectlyAppliesType {
-        cached: FunctionType,
-        expected: FunctionType,
+        cached: Signature,
+        expected: Signature,
     },
 }
 

--- a/hugr/src/extension/declarative/signature.rs
+++ b/hugr/src/extension/declarative/signature.rs
@@ -50,11 +50,8 @@ impl SignatureDeclaration {
                 Ok(types.into())
             };
 
-        let body = FunctionType {
-            input: make_type_row(&self.inputs)?,
-            output: make_type_row(&self.outputs)?,
-            extension_reqs: self.extensions.clone(),
-        };
+        let body = FunctionType::new(make_type_row(&self.inputs)?, make_type_row(&self.outputs)?)
+            .with_extension_delta(self.extensions.clone());
 
         let poly_func = PolyFuncType::new(op_params, body);
         Ok(SignatureFunc::TypeScheme(CustomValidator::from_polyfunc(

--- a/hugr/src/extension/infer/test.rs
+++ b/hugr/src/extension/infer/test.rs
@@ -286,18 +286,9 @@ fn create_with_io(
     let op: OpType = op.into();
 
     let node = hugr.add_node_with_parent(parent, op);
-    let input = hugr.add_node_with_parent(
-        node,
-        ops::Input {
-            types: op_sig.input,
-        },
-    );
-    let output = hugr.add_node_with_parent(
-        node,
-        ops::Output {
-            types: op_sig.output,
-        },
-    );
+    let (in_types, _, out_types) = op_sig.into_tuple();
+    let input = hugr.add_node_with_parent(node, ops::Input { types: in_types });
+    let output = hugr.add_node_with_parent(node, ops::Output { types: out_types });
     Ok([node, input, output])
 }
 

--- a/hugr/src/extension/infer/test.rs
+++ b/hugr/src/extension/infer/test.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 use crate::type_row;
-use crate::types::{FunctionType, Type, TypeRow};
+use crate::types::{FunctionType, Signature, Type, TypeRow};
 
 use cool_asserts::assert_matches;
 use itertools::Itertools;
@@ -281,7 +281,7 @@ fn create_with_io(
     hugr: &mut Hugr,
     parent: Node,
     op: impl Into<OpType>,
-    op_sig: FunctionType,
+    op_sig: Signature,
 ) -> Result<[Node; 3], Box<dyn Error>> {
     let op: OpType = op.into();
 
@@ -429,7 +429,7 @@ fn extension_adding_sequence() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn make_opaque(extension: impl Into<ExtensionId>, signature: FunctionType) -> CustomOp {
+fn make_opaque(extension: impl Into<ExtensionId>, signature: Signature) -> CustomOp {
     ops::custom::OpaqueOp::new(extension.into(), "", "".into(), vec![], signature).into()
 }
 

--- a/hugr/src/extension/op_def.rs
+++ b/hugr/src/extension/op_def.rs
@@ -11,7 +11,7 @@ use super::{
 
 use crate::ops::{OpName, OpNameRef};
 use crate::types::type_param::{check_type_args, TypeArg, TypeParam};
-use crate::types::{FunctionType, PolyFuncType};
+use crate::types::{FunctionType, PolyFuncType, Signature};
 use crate::Hugr;
 
 /// Trait necessary for binary computations of OpDef signature
@@ -490,9 +490,8 @@ mod test {
     use crate::extension::{SignatureError, EMPTY_REG, PRELUDE_REGISTRY};
     use crate::ops::{CustomOp, OpName};
     use crate::std_extensions::collections::{EXTENSION, LIST_TYPENAME};
-    use crate::types::type_param::TypeArgError;
-    use crate::types::{type_param::TypeParam, FunctionType, PolyFuncType, TypeArg, TypeBound};
-    use crate::types::{FunctionType, Type};
+    use crate::types::type_param::{TypeArgError, TypeParam};
+    use crate::types::{FunctionType, PolyFuncType, TypeArg, TypeBound, Type};
     use crate::{const_extension_ids, Extension};
 
     const_extension_ids! {

--- a/hugr/src/hugr.rs
+++ b/hugr/src/hugr.rs
@@ -108,7 +108,7 @@ impl NodeType {
     }
 
     /// Get the function type from the embedded op
-    pub fn op_signature(&self) -> Option<FunctionType> {
+    pub fn op_signature(&self) -> Option<Signature> {
         self.op.dataflow_signature()
     }
 

--- a/hugr/src/hugr.rs
+++ b/hugr/src/hugr.rs
@@ -30,7 +30,7 @@ use crate::extension::infer_extensions;
 use crate::extension::{ExtensionRegistry, ExtensionSet, ExtensionSolution, InferExtensionError};
 use crate::ops::custom::resolve_extension_ops;
 use crate::ops::{OpTag, OpTrait, OpType, DEFAULT_OPTYPE};
-use crate::types::FunctionType;
+use crate::types::{FunctionType, Signature};
 use crate::{Direction, Node};
 
 use delegate::delegate;

--- a/hugr/src/hugr/rewrite/replace.rs
+++ b/hugr/src/hugr/rewrite/replace.rs
@@ -627,12 +627,12 @@ mod test {
         let mut bb = if entry {
             assert_eq!(
                 match h.hugr().get_optype(h.container_node()) {
-                    OpType::CFG(c) => &c.signature.input,
+                    OpType::CFG(c) => c.signature.input(),
                     _ => panic!(),
                 },
                 op_sig.input()
             );
-            h.simple_entry_builder(op_sig.output, 1, op_sig.extension_reqs.clone())?
+            h.simple_entry_builder(op_sig.output().clone(), 1, op_sig.extension_reqs.clone())?
         } else {
             h.simple_block_builder(op_sig, 1)?
         };

--- a/hugr/src/hugr/serialize/test.rs
+++ b/hugr/src/hugr/serialize/test.rs
@@ -446,7 +446,7 @@ fn polyfunctype2() -> PolyFuncType {
     [TypeParam::new_list(TypeBound::Any)],
     FunctionType::new_endo(Type::new_tuple(Type::new_row_var_use(0, TypeBound::Any)))))]
 #[case(polyfunctype2())]
-fn roundtrip_polyfunctype(#[case] poly_func_type: PolyFuncType) {
+fn roundtrip_polyfunctype<const RV:bool>(#[case] poly_func_type: PolyFuncType<RV>) {
     check_testing_roundtrip(poly_func_type)
 }
 

--- a/hugr/src/hugr/validate.rs
+++ b/hugr/src/hugr/validate.rs
@@ -321,7 +321,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
             // Allow function "value" to have unknown arity. A Call node will have to provide
             // TypeArgs that produce a known arity, but a LoadFunction might pass the function
             // value ("function pointer") around without knowing how to call it.
-            EdgeKind::Function(pf) => pf.validate_var_len(self.extension_registry),
+            EdgeKind::Function(pf) => pf.validate(self.extension_registry),
             _ => Ok(()),
         }
     }

--- a/hugr/src/hugr/validate.rs
+++ b/hugr/src/hugr/validate.rs
@@ -211,19 +211,6 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
             }
         }
 
-        // Secondly, check that the node signature does not contain any row variables.
-        // (We do this here so it's before we try indexing into the ports of any nodes).
-        op_type
-            .dataflow_signature()
-            .as_ref()
-            .and_then(FunctionType::find_rowvar)
-            .map_or(Ok(()), |(idx, _)| {
-                Err(ValidationError::SignatureError {
-                    node,
-                    cause: SignatureError::RowVarWhereTypeExpected { idx },
-                })
-            })?;
-
         // Thirdly that the node has correct children
         self.validate_children(node, node_type)?;
 

--- a/hugr/src/hugr/views.rs
+++ b/hugr/src/hugr/views.rs
@@ -31,7 +31,7 @@ use crate::extension::ExtensionRegistry;
 use crate::ops::handle::NodeHandle;
 use crate::ops::{OpParent, OpTag, OpTrait, OpType};
 
-use crate::types::{EdgeKind, FunctionType};
+use crate::types::{EdgeKind, FunctionType, Signature};
 use crate::types::{PolyFuncType, Type};
 use crate::{Direction, IncomingPort, Node, OutgoingPort, Port};
 

--- a/hugr/src/hugr/views.rs
+++ b/hugr/src/hugr/views.rs
@@ -339,7 +339,7 @@ pub trait HugrView: sealed::HugrInternals {
     ///
     /// In contrast to [`get_function_type`][HugrView::get_function_type], this
     /// method always return a concrete [`FunctionType`].
-    fn get_df_function_type(&self) -> Option<FunctionType> {
+    fn get_df_function_type(&self) -> Option<FunctionType<false>> {
         let op = self.get_optype(self.root());
         op.inner_function_type()
     }
@@ -354,7 +354,7 @@ pub trait HugrView: sealed::HugrInternals {
     /// of the function.
     ///
     /// Otherwise, returns `None`.
-    fn get_function_type(&self) -> Option<PolyFuncType> {
+    fn get_function_type(&self) -> Option<PolyFuncType<false>> {
         let op = self.get_optype(self.root());
         match op {
             OpType::FuncDecl(decl) => Some(decl.signature.clone()),
@@ -438,7 +438,7 @@ pub trait HugrView: sealed::HugrInternals {
 
     /// Get the "signature" (incoming and outgoing types) of a node, non-Value
     /// kind ports will be missing.
-    fn signature(&self, node: Node) -> Option<FunctionType> {
+    fn signature(&self, node: Node) -> Option<Signature> {
         self.get_optype(node).dataflow_signature()
     }
 

--- a/hugr/src/hugr/views/sibling_subgraph.rs
+++ b/hugr/src/hugr/views/sibling_subgraph.rs
@@ -18,11 +18,12 @@ use portgraph::{view::Subgraph, Direction, PortView};
 use thiserror::Error;
 
 use crate::builder::{Container, FunctionBuilder};
+use crate::extension::SignatureError;
 use crate::hugr::{HugrMut, HugrView, RootTagged};
 use crate::ops::dataflow::DataflowOpTrait;
 use crate::ops::handle::{ContainerHandle, DataflowOpID};
 use crate::ops::{OpTag, OpTrait};
-use crate::types::{FunctionType, Type};
+use crate::types::{FunctionType, Signature, Type};
 use crate::{Hugr, IncomingPort, Node, OutgoingPort, Port, SimpleReplacement};
 
 /// A non-empty convex subgraph of a HUGR sibling graph.
@@ -289,7 +290,7 @@ impl SiblingSubgraph {
     }
 
     /// The signature of the subgraph.
-    pub fn signature(&self, hugr: &impl HugrView) -> FunctionType {
+    pub fn signature(&self, hugr: &impl HugrView) -> Signature {
         let input = self
             .inputs
             .iter()

--- a/hugr/src/hugr/views/sibling_subgraph.rs
+++ b/hugr/src/hugr/views/sibling_subgraph.rs
@@ -308,6 +308,7 @@ impl SiblingSubgraph {
                 sig.port_type(p).cloned().expect("must be dataflow edge")
             })
             .collect_vec();
+        // ALAN could be a new_unchecked, all the input/output types come from a Signature
         FunctionType::new(input, output)
     }
 

--- a/hugr/src/ops.rs
+++ b/hugr/src/ops.rs
@@ -405,7 +405,7 @@ pub trait OpParent {
     /// sibling graph.
     ///
     /// Non-container ops like `FuncDecl` return `None` even though they represent a function.
-    fn inner_function_type(&self) -> Option<FunctionType> {
+    fn inner_function_type(&self) -> Option<Signature> {
         None
     }
 }

--- a/hugr/src/ops.rs
+++ b/hugr/src/ops.rs
@@ -10,7 +10,7 @@ pub mod module;
 pub mod tag;
 pub mod validate;
 use crate::extension::ExtensionSet;
-use crate::types::{EdgeKind, FunctionType};
+use crate::types::{EdgeKind, FunctionType, Signature};
 use crate::{Direction, OutgoingPort, Port};
 use crate::{IncomingPort, PortIndex};
 use paste::paste;
@@ -342,7 +342,7 @@ pub trait OpTrait {
     /// The signature of the operation.
     ///
     /// Only dataflow operations have a signature, otherwise returns None.
-    fn dataflow_signature(&self) -> Option<FunctionType> {
+    fn dataflow_signature(&self) -> Option<Signature> {
         None
     }
 
@@ -411,7 +411,7 @@ pub trait OpParent {
 }
 
 impl<T: DataflowParent> OpParent for T {
-    fn inner_function_type(&self) -> Option<FunctionType> {
+    fn inner_function_type(&self) -> Option<Signature> {
         Some(DataflowParent::inner_signature(self))
     }
 }

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -5,7 +5,7 @@ mod custom;
 use super::{NamedOp, OpName, OpTrait, StaticTag};
 use super::{OpTag, OpType};
 use crate::extension::ExtensionSet;
-use crate::types::{CustomType, EdgeKind, FunctionType, SumType, SumTypeError, Type};
+use crate::types::{CustomType, EdgeKind, Signature, SumType, SumTypeError, Type};
 use crate::{Hugr, HugrView};
 
 use delegate::delegate;
@@ -267,7 +267,7 @@ pub enum ConstTypeError {
 }
 
 /// Hugrs (even functions) inside Consts must be monomorphic
-fn mono_fn_type(h: &Hugr) -> Result<FunctionType, ConstTypeError> {
+fn mono_fn_type(h: &Hugr) -> Result<Signature, ConstTypeError> {
     if let Some(pf) = h.get_function_type() {
         if let Ok(ft) = pf.try_into() {
             return Ok(ft);

--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -434,6 +434,7 @@ mod test {
     use super::Value;
     use crate::builder::test::simple_dfg_hugr;
     use crate::std_extensions::arithmetic::int_types::ConstInt;
+    use crate::types::FunctionType;
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
         extension::{

--- a/hugr/src/ops/controlflow.rs
+++ b/hugr/src/ops/controlflow.rs
@@ -1,7 +1,7 @@
 //! Control flow operations.
 
 use crate::extension::ExtensionSet;
-use crate::types::{EdgeKind, FunctionType, Type, TypeRow};
+use crate::types::{EdgeKind, FunctionType, Signature, Type, TypeRow};
 use crate::Direction;
 
 use super::dataflow::{DataflowOpTrait, DataflowParent};
@@ -29,7 +29,7 @@ impl DataflowOpTrait for TailLoop {
         "A tail-controlled loop"
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         let [inputs, outputs] =
             [&self.just_inputs, &self.just_outputs].map(|row| row.extend(self.rest.iter()));
         FunctionType::new(inputs, outputs)
@@ -73,7 +73,7 @@ impl DataflowOpTrait for Conditional {
         "HUGR conditional operation"
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         let mut inputs = self.other_inputs.clone();
         inputs
             .to_mut()
@@ -95,7 +95,7 @@ impl Conditional {
 #[allow(missing_docs)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct CFG {
-    pub signature: FunctionType,
+    pub signature: Signature,
 }
 
 impl_op_name!(CFG);
@@ -107,7 +107,7 @@ impl DataflowOpTrait for CFG {
         "A dataflow node defined by a child CFG"
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         self.signature.clone()
     }
 }
@@ -153,7 +153,7 @@ impl StaticTag for ExitBlock {
 }
 
 impl DataflowParent for DataflowBlock {
-    fn inner_signature(&self) -> FunctionType {
+    fn inner_signature(&self) -> Signature {
         // The node outputs a Sum before the data outputs of the block node
         let sum_type = Type::new_sum(self.sum_rows.clone());
         let mut node_outputs = vec![sum_type];
@@ -250,7 +250,7 @@ impl BasicBlock for ExitBlock {
 /// Case ops - nodes valid inside Conditional nodes.
 pub struct Case {
     /// The signature of the contained dataflow graph.
-    pub signature: FunctionType,
+    pub signature: Signature,
 }
 
 impl_op_name!(Case);
@@ -260,7 +260,7 @@ impl StaticTag for Case {
 }
 
 impl DataflowParent for Case {
-    fn inner_signature(&self) -> FunctionType {
+    fn inner_signature(&self) -> Signature {
         self.signature.clone()
     }
 }

--- a/hugr/src/ops/controlflow.rs
+++ b/hugr/src/ops/controlflow.rs
@@ -282,11 +282,11 @@ impl OpTrait for Case {
 impl Case {
     /// The input signature of the contained dataflow graph.
     pub fn dataflow_input(&self) -> &TypeRow {
-        &self.signature.input
+        self.signature.input()
     }
 
     /// The output signature of the contained dataflow graph.
     pub fn dataflow_output(&self) -> &TypeRow {
-        &self.signature.output
+        self.signature.output()
     }
 }

--- a/hugr/src/ops/custom.rs
+++ b/hugr/src/ops/custom.rs
@@ -11,8 +11,8 @@ use {
 use crate::extension::{ConstFoldResult, ExtensionId, ExtensionRegistry, OpDef, SignatureError};
 use crate::hugr::hugrmut::sealed::HugrMutInternals;
 use crate::hugr::{HugrView, NodeType};
-use crate::types::EdgeKind;
 use crate::types::{type_param::TypeArg, FunctionType};
+use crate::types::{EdgeKind, Signature};
 use crate::{ops, Hugr, IncomingPort, Node};
 
 use super::dataflow::DataflowOpTrait;
@@ -129,7 +129,7 @@ impl DataflowOpTrait for CustomOp {
     }
 
     /// The signature of the operation.
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         match self {
             Self::Opaque(op) => op.signature.clone(),
             Self::Extension(ext_op) => ext_op.signature(),
@@ -175,7 +175,7 @@ impl From<ExtensionOp> for CustomOp {
 pub struct ExtensionOp {
     def: Arc<OpDef>,
     args: Vec<TypeArg>,
-    signature: FunctionType, // Cache
+    signature: Signature, // Cache
 }
 
 impl ExtensionOp {
@@ -265,7 +265,7 @@ impl DataflowOpTrait for ExtensionOp {
         self.def().description()
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         self.signature.clone()
     }
 }
@@ -280,7 +280,7 @@ pub struct OpaqueOp {
     #[cfg_attr(test, proptest(strategy = "any_nonempty_string()"))]
     description: String, // cache in advance so description() can return &str
     args: Vec<TypeArg>,
-    signature: FunctionType,
+    signature: Signature,
 }
 
 fn qualify_name(res_id: &ExtensionId, op_name: &OpNameRef) -> OpName {
@@ -294,7 +294,7 @@ impl OpaqueOp {
         op_name: impl Into<OpName>,
         description: String,
         args: impl Into<Vec<TypeArg>>,
-        signature: FunctionType,
+        signature: Signature,
     ) -> Self {
         Self {
             extension,
@@ -336,7 +336,7 @@ impl DataflowOpTrait for OpaqueOp {
         &self.description
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         self.signature.clone()
     }
 }
@@ -417,8 +417,8 @@ pub enum CustomOpError {
     SignatureMismatch {
         extension: ExtensionId,
         op: OpName,
-        stored: FunctionType,
-        computed: FunctionType,
+        stored: Signature,
+        computed: Signature,
     },
 }
 

--- a/hugr/src/ops/dataflow.rs
+++ b/hugr/src/ops/dataflow.rs
@@ -372,7 +372,7 @@ impl LoadFunction {
 
     #[inline]
     /// Return the type of the function loaded by this op.
-    pub fn function_type(&self) -> &PolyFuncType {
+    pub fn function_type(&self) -> &PolyFuncType<false> {
         &self.func_sig
     }
 

--- a/hugr/src/ops/dataflow.rs
+++ b/hugr/src/ops/dataflow.rs
@@ -265,11 +265,12 @@ impl DataflowOpTrait for CallIndirect {
     }
 
     fn signature(&self) -> FunctionType {
-        let mut s = self.signature.clone();
-        s.input
+        let mut input = self.signature.input().clone();
+        input
             .to_mut()
             .insert(0, Type::new_function(self.signature.clone()));
-        s
+        FunctionType::new(input, self.signature.output().clone())
+            .with_extension_delta(self.signature.extension_reqs.clone())
     }
 }
 

--- a/hugr/src/ops/dataflow.rs
+++ b/hugr/src/ops/dataflow.rs
@@ -362,7 +362,8 @@ impl LoadFunction {
     ) -> Result<Self, SignatureError> {
         let type_args = type_args.into();
         let instantiation = func_sig.instantiate(&type_args, exts)?;
-        let signature = FunctionType::new(TypeRow::new(), vec![Type::new_function(instantiation)]);
+        // ALAN No possibility of error here - consider new_unchecked:
+        let signature = Signature::try_new(TypeRow::new(), vec![Type::new_function(instantiation)])?;
         Ok(Self {
             func_sig,
             type_args,

--- a/hugr/src/ops/dataflow.rs
+++ b/hugr/src/ops/dataflow.rs
@@ -201,7 +201,7 @@ impl Call {
 
     #[inline]
     /// Return the signature of the function called by this op.
-    pub fn called_function_type(&self) -> &PolyFuncType {
+    pub fn called_function_type(&self) -> &PolyFuncType<false> {
         &self.func_sig
     }
 

--- a/hugr/src/ops/dataflow.rs
+++ b/hugr/src/ops/dataflow.rs
@@ -4,7 +4,7 @@ use super::{impl_op_name, OpTag, OpTrait};
 
 use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
 use crate::ops::StaticTag;
-use crate::types::{EdgeKind, FunctionType, PolyFuncType, Type, TypeArg, TypeRow};
+use crate::types::{EdgeKind, FunctionType, PolyFuncType, Signature, Type, TypeArg, TypeRow};
 use crate::IncomingPort;
 
 #[cfg(test)]
@@ -13,7 +13,7 @@ use ::proptest_derive::Arbitrary;
 pub(crate) trait DataflowOpTrait {
     const TAG: OpTag;
     fn description(&self) -> &str;
-    fn signature(&self) -> FunctionType;
+    fn signature(&self) -> Signature;
 
     /// The edge kind for the non-dataflow or constant inputs of the operation,
     /// not described by the signature.
@@ -99,7 +99,7 @@ impl DataflowOpTrait for Input {
         None
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         FunctionType::new(TypeRow::new(), self.types.clone())
     }
 }
@@ -112,7 +112,7 @@ impl DataflowOpTrait for Output {
 
     // Note: We know what the input extensions should be, so we *could* give an
     // instantiated Signature instead
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         FunctionType::new(self.types.clone(), TypeRow::new())
     }
 
@@ -128,7 +128,7 @@ impl<T: DataflowOpTrait> OpTrait for T {
     fn tag(&self) -> OpTag {
         T::TAG
     }
-    fn dataflow_signature(&self) -> Option<FunctionType> {
+    fn dataflow_signature(&self) -> Option<Signature> {
         Some(DataflowOpTrait::signature(self))
     }
     fn extension_delta(&self) -> ExtensionSet {
@@ -159,9 +159,9 @@ impl<T: DataflowOpTrait> StaticTag for T {
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Call {
     /// Signature of function being called
-    func_sig: PolyFuncType,
+    func_sig: PolyFuncType<false>,
     type_args: Vec<TypeArg>,
-    instantiation: FunctionType, // Cache, so we can fail in try_new() not in signature()
+    instantiation: Signature, // Cache, so we can fail in try_new() not in signature()
 }
 impl_op_name!(Call);
 
@@ -172,7 +172,7 @@ impl DataflowOpTrait for Call {
         "Call a function directly"
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         self.instantiation.clone()
     }
 
@@ -186,7 +186,7 @@ impl Call {
     ///
     /// [TypeParam]: crate::types::type_param::TypeParam
     pub fn try_new(
-        func_sig: PolyFuncType,
+        func_sig: PolyFuncType<false>,
         type_args: impl Into<Vec<TypeArg>>,
         exts: &ExtensionRegistry,
     ) -> Result<Self, SignatureError> {
@@ -253,7 +253,7 @@ impl Call {
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct CallIndirect {
     /// Signature of function being called
-    pub signature: FunctionType,
+    pub signature: Signature,
 }
 impl_op_name!(CallIndirect);
 
@@ -264,7 +264,7 @@ impl DataflowOpTrait for CallIndirect {
         "Call a function indirectly"
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         let mut input = self.signature.input().clone();
         input
             .to_mut()
@@ -289,7 +289,7 @@ impl DataflowOpTrait for LoadConstant {
         "Load a static constant in to the local dataflow graph"
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         FunctionType::new(TypeRow::new(), vec![self.datatype.clone()])
     }
 
@@ -330,9 +330,9 @@ impl LoadConstant {
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct LoadFunction {
     /// Signature of the function
-    func_sig: PolyFuncType,
+    func_sig: PolyFuncType<false>,
     type_args: Vec<TypeArg>,
-    signature: FunctionType, // Cache, so we can fail in try_new() not in signature()
+    signature: Signature, // Cache, so we can fail in try_new() not in signature()
 }
 impl_op_name!(LoadFunction);
 impl DataflowOpTrait for LoadFunction {
@@ -342,7 +342,7 @@ impl DataflowOpTrait for LoadFunction {
         "Load a static function in to the local dataflow graph"
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         self.signature.clone()
     }
 
@@ -356,7 +356,7 @@ impl LoadFunction {
     ///
     /// [TypeParam]: crate::types::type_param::TypeParam
     pub fn try_new(
-        func_sig: PolyFuncType,
+        func_sig: PolyFuncType<false>,
         type_args: impl Into<Vec<TypeArg>>,
         exts: &ExtensionRegistry,
     ) -> Result<Self, SignatureError> {
@@ -409,7 +409,7 @@ impl LoadFunction {
 /// Operations that is the parent of a dataflow graph.
 pub trait DataflowParent {
     /// Signature of the inner dataflow graph.
-    fn inner_signature(&self) -> FunctionType;
+    fn inner_signature(&self) -> Signature;
 }
 
 /// A simply nested dataflow graph.
@@ -417,13 +417,13 @@ pub trait DataflowParent {
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct DFG {
     /// Signature of DFG node
-    pub signature: FunctionType,
+    pub signature: Signature,
 }
 
 impl_op_name!(DFG);
 
 impl DataflowParent for DFG {
-    fn inner_signature(&self) -> FunctionType {
+    fn inner_signature(&self) -> Signature {
         self.signature.clone()
     }
 }
@@ -435,7 +435,7 @@ impl DataflowOpTrait for DFG {
         "A simply nested dataflow graph"
     }
 
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         self.inner_signature()
     }
 }

--- a/hugr/src/ops/leaf.rs
+++ b/hugr/src/ops/leaf.rs
@@ -119,7 +119,7 @@ impl DataflowOpTrait for Noop {
     }
 
     /// The signature of the operation.
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         FunctionType::new(vec![self.ty.clone()], vec![self.ty.clone()])
     }
 
@@ -141,7 +141,7 @@ impl DataflowOpTrait for MakeTuple {
     }
 
     /// The signature of the operation.
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         FunctionType::new(self.tys.clone(), vec![Type::new_tuple(self.tys.clone())])
     }
 
@@ -163,7 +163,7 @@ impl DataflowOpTrait for UnpackTuple {
     }
 
     /// The signature of the operation.
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         FunctionType::new(vec![Type::new_tuple(self.tys.clone())], self.tys.clone())
     }
 
@@ -185,7 +185,7 @@ impl DataflowOpTrait for Tag {
     }
 
     /// The signature of the operation.
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         FunctionType::new(
             self.variants
                 .get(self.tag)
@@ -213,7 +213,7 @@ impl DataflowOpTrait for Lift {
     }
 
     /// The signature of the operation.
-    fn signature(&self) -> FunctionType {
+    fn signature(&self) -> Signature {
         FunctionType::new(self.type_row.clone(), self.type_row.clone())
             .with_extension_delta(ExtensionSet::singleton(&self.new_extension))
     }

--- a/hugr/src/ops/leaf.rs
+++ b/hugr/src/ops/leaf.rs
@@ -5,6 +5,7 @@ use super::{impl_op_name, OpTag};
 
 use crate::extension::ExtensionSet;
 
+use crate::types::Signature;
 use crate::{
     extension::ExtensionId,
     types::{EdgeKind, FunctionType, Type, TypeRow},

--- a/hugr/src/ops/module.rs
+++ b/hugr/src/ops/module.rs
@@ -7,7 +7,7 @@ use {
     ::proptest_derive::Arbitrary,
 };
 
-use crate::types::{EdgeKind, FunctionType, PolyFuncType};
+use crate::types::{EdgeKind, FunctionType, PolyFuncType, Signature};
 use crate::types::{Type, TypeBound};
 
 use super::dataflow::DataflowParent;
@@ -45,7 +45,7 @@ pub struct FuncDefn {
     #[cfg_attr(test, proptest(strategy = "any_nonempty_string()"))]
     pub name: String,
     /// Signature of the function
-    pub signature: PolyFuncType,
+    pub signature: PolyFuncType<false>,
 }
 
 impl_op_name!(FuncDefn);
@@ -54,7 +54,7 @@ impl StaticTag for FuncDefn {
 }
 
 impl DataflowParent for FuncDefn {
-    fn inner_signature(&self) -> FunctionType {
+    fn inner_signature(&self) -> Signature {
         self.signature.body().clone()
     }
 }
@@ -81,7 +81,7 @@ pub struct FuncDecl {
     #[cfg_attr(test, proptest(strategy = "any_nonempty_string()"))]
     pub name: String,
     /// Signature of the function
-    pub signature: PolyFuncType,
+    pub signature: PolyFuncType<false>,
 }
 
 impl_op_name!(FuncDecl);

--- a/hugr/src/ops/validate.rs
+++ b/hugr/src/ops/validate.rs
@@ -94,7 +94,7 @@ impl ValidateOp for super::Conditional {
                 .as_case()
                 .expect("Child check should have already checked valid ops.");
             let sig = &case_op.inner_signature();
-            if sig.input != self.case_input_row(i).unwrap() || sig.output != self.outputs {
+            if sig.input() != &self.case_input_row(i).unwrap() || sig.output() != &self.outputs {
                 return Err(ChildrenValidationError::ConditionalCaseSignature {
                     child,
                     optype: optype.clone(),
@@ -264,7 +264,7 @@ impl<T: DataflowParent> ValidateOp for T {
         children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
     ) -> Result<(), ChildrenValidationError> {
         let sig = self.inner_signature();
-        validate_io_nodes(&sig.input, &sig.output, "DataflowParent", children)
+        validate_io_nodes(sig.input(), sig.output(), "DataflowParent", children)
     }
 }
 
@@ -282,10 +282,10 @@ fn validate_io_nodes<'a>(
     let (second, second_optype) = children.next().unwrap();
 
     let first_sig = first_optype.dataflow_signature().unwrap_or_default();
-    if &first_sig.output != expected_input {
+    if first_sig.output() != expected_input {
         return Err(ChildrenValidationError::IOSignatureMismatch {
             child: first,
-            actual: first_sig.output,
+            actual: first_sig.output().clone(),
             expected: expected_input.clone(),
             node_desc: "Input",
             container_desc,
@@ -293,10 +293,10 @@ fn validate_io_nodes<'a>(
     }
     let second_sig = second_optype.dataflow_signature().unwrap_or_default();
 
-    if &second_sig.input != expected_output {
+    if second_sig.input() != expected_output {
         return Err(ChildrenValidationError::IOSignatureMismatch {
             child: second,
-            actual: second_sig.input,
+            actual: second_sig.input().clone(),
             expected: expected_output.clone(),
             node_desc: "Output",
             container_desc,

--- a/hugr/src/types.rs
+++ b/hugr/src/types.rs
@@ -14,7 +14,7 @@ use crate::utils::display_list_with_separator;
 pub use check::SumTypeError;
 pub use custom::CustomType;
 pub use poly_func::PolyFuncType;
-pub use signature::FunctionType;
+pub use signature::{FunctionType, Signature};
 use smol_str::SmolStr;
 pub use type_param::TypeArg;
 pub use type_row::TypeRow;
@@ -51,7 +51,7 @@ pub enum EdgeKind {
     ///
     /// [FuncDecl]: crate::ops::FuncDecl
     /// [FuncDefn]: crate::ops::FuncDefn
-    Function(PolyFuncType),
+    Function(PolyFuncType<false>),
     /// Explicitly enforce an ordering between nodes in a DDG.
     StateOrder,
 }
@@ -395,9 +395,7 @@ impl Type {
             TypeEnum::Sum(SumType::Unit { .. }) => Ok(()), // No leaves there
             TypeEnum::Alias(_) => Ok(()),
             TypeEnum::Extension(custy) => custy.validate(extension_registry, var_decls),
-            // Function values may be passed around without knowing their arity
-            // (i.e. with row vars) as long as they are not called:
-            TypeEnum::Function(ft) => ft.validate_var_len(extension_registry, var_decls),
+            TypeEnum::Function(ft) => ft.validate(extension_registry, var_decls),
             TypeEnum::Variable(idx, bound) => check_typevar_decl(var_decls, *idx, &(*bound).into()),
             TypeEnum::RowVariable(idx, bound) => {
                 if allow_row_vars {

--- a/hugr/src/types/poly_func.rs
+++ b/hugr/src/types/poly_func.rs
@@ -28,7 +28,7 @@ use super::Substitution;
     "params.iter().map(ToString::to_string).join(\" \")",
     "body"
 )]
-pub struct PolyFuncType<const ROWVARS: bool> {
+pub struct PolyFuncType<const ROWVARS: bool = true> {
     /// The declared type parameters, i.e., these must be instantiated with
     /// the same number of [TypeArg]s before the function can be called. This
     /// defines the indices used by variables inside the body.
@@ -99,7 +99,7 @@ impl<const RV: bool> PolyFuncType<RV> {
     }
 }
 
-impl PolyFuncType<true> {
+impl PolyFuncType {
     /// Validates this instance, checking that the types in the body are
     /// wellformed with respect to the registry, and the type variables declared.
     /// Allows both inputs and outputs to contain [RowVariable]s
@@ -135,7 +135,7 @@ pub(crate) mod test {
             ExtensionRegistry::try_new([PRELUDE.to_owned(), EXTENSION.to_owned()]).unwrap();
     }
 
-    impl PolyFuncType<true> {
+    impl PolyFuncType {
         fn new_validated(
             params: impl Into<Vec<TypeParam>>,
             body: FunctionType,

--- a/hugr/src/types/signature.rs
+++ b/hugr/src/types/signature.rs
@@ -22,12 +22,10 @@ use {crate::proptest::RecursionDepth, ::proptest::prelude::*, proptest_derive::A
 ///
 /// [Graph]: crate::ops::constant::Value::Function
 pub struct FunctionType {
-    /// Value inputs of the function.
     #[cfg_attr(test, proptest(strategy = "any_with::<TypeRow>(params)"))]
-    pub input: TypeRow,
-    /// Value outputs of the function.
+    input: TypeRow,
     #[cfg_attr(test, proptest(strategy = "any_with::<TypeRow>(params)"))]
-    pub output: TypeRow,
+    output: TypeRow,
     /// The extension requirements which are added by the operation
     pub extension_reqs: ExtensionSet,
 }
@@ -180,15 +178,20 @@ impl FunctionType {
     }
 
     #[inline]
-    /// Returns the input row
+    /// Returns a row of the value inputs of the function.
     pub fn input(&self) -> &TypeRow {
         &self.input
     }
 
     #[inline]
-    /// Returns the output row
+    /// Returns a row of the value outputs of the function.
     pub fn output(&self) -> &TypeRow {
         &self.output
+    }
+
+    /// Converts to a tuple of the value inputs, extension delta, and value outputs
+    pub fn into_tuple(self) -> (TypeRow, ExtensionSet, TypeRow) {
+        (self.input, self.extension_reqs, self.output)
     }
 }
 

--- a/hugr/src/types/signature.rs
+++ b/hugr/src/types/signature.rs
@@ -16,12 +16,14 @@ use {crate::proptest::RecursionDepth, ::proptest::prelude::*, proptest_derive::A
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(Arbitrary), proptest(params = "RecursionDepth"))]
-/// Describes the edges required to/from a node, and thus, also the type of a [Graph].
-/// This includes both the concept of "signature" in the spec,
-/// and also the target (value) of a call (static).
+/// Describes the edges required to/from a node (when ROWVARS=false);
+/// or (when ROWVARS=true) the type of a [Graph] or the inputs/outputs from an OpDef
+///
+/// ROWVARS specifies whether it may contain [RowVariable]s or not.
 ///
 /// [Graph]: crate::ops::constant::Value::Function
-pub struct FunctionType {
+/// [RowVariable]: crate::types::TypeEnum::RowVariable
+pub struct FunctionType<const ROWVARS: bool = true> {
     #[cfg_attr(test, proptest(strategy = "any_with::<TypeRow>(params)"))]
     input: TypeRow,
     #[cfg_attr(test, proptest(strategy = "any_with::<TypeRow>(params)"))]
@@ -30,14 +32,28 @@ pub struct FunctionType {
     pub extension_reqs: ExtensionSet,
 }
 
-impl FunctionType {
+/// The concept of "signature" in the spec - the edges required to/from a node or graph
+/// and also the target (value) of a call (static).
+pub type Signature = FunctionType<false>; // TODO: rename to "Signature"
+
+impl<const RV: bool> FunctionType<RV> {
     /// Builder method, add extension_reqs to an FunctionType
     pub fn with_extension_delta(mut self, rs: impl Into<ExtensionSet>) -> Self {
         self.extension_reqs = self.extension_reqs.union(rs.into());
         self
     }
 
-    pub(super) fn validate_var_len(
+    pub(crate) fn substitute(&self, tr: &Substitution) -> Self {
+        Self {
+            input: self.input.substitute(tr),
+            output: self.output.substitute(tr),
+            extension_reqs: self.extension_reqs.substitute(tr),
+        }
+    }
+}
+
+impl FunctionType {
+    pub(super) fn validate(
         &self,
         extension_registry: &ExtensionRegistry,
         var_decls: &[TypeParam],
@@ -47,38 +63,82 @@ impl FunctionType {
             .validate_var_len(extension_registry, var_decls)?;
         self.extension_reqs.validate(var_decls)
     }
-
-    pub(crate) fn substitute(&self, tr: &Substitution) -> Self {
-        FunctionType {
-            input: self.input.substitute(tr),
-            output: self.output.substitute(tr),
-            extension_reqs: self.extension_reqs.substitute(tr),
-        }
-    }
-}
-
-impl FunctionType {
-    /// The number of wires in the signature.
-    #[inline(always)]
-    pub fn is_empty(&self) -> bool {
-        self.input.is_empty() && self.output.is_empty()
-    }
-}
-
-impl FunctionType {
-    /// Create a new signature with specified inputs and outputs.
     pub fn new(input: impl Into<TypeRow>, output: impl Into<TypeRow>) -> Self {
         Self {
             input: input.into(),
             output: output.into(),
-            extension_reqs: ExtensionSet::new(),
+            extension_reqs: ExtensionSet::default(),
         }
+    }
+
+    pub fn new_endo(row: impl Into<TypeRow>) -> Self {
+        let row = row.into();
+        Self::new(row.clone(), row)
+    }
+
+    /// If this FunctionType contains any row variables, return one.
+    pub fn find_rowvar(&self) -> Option<(usize, TypeBound)> {
+        self.input
+            .iter()
+            .chain(self.output.iter())
+            .find_map(|t| match t.0 {
+                TypeEnum::RowVariable(idx, bound) => Some((idx, bound)),
+                _ => None,
+            })
+    }    
+}
+
+impl<const RV: bool> FunctionType<RV> {
+    /// True if both inputs and outputs are necessarily empty.
+    /// (For [FunctionType], even after any possible substitution of row variables)
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.input.is_empty() && self.output.is_empty()
+    }
+
+    #[inline]
+    /// Returns a row of the value inputs of the function.
+    pub fn input(&self) -> &TypeRow {
+        &self.input
+    }
+
+    #[inline]
+    /// Returns a row of the value outputs of the function.
+    pub fn output(&self) -> &TypeRow {
+        &self.output
+    }
+
+    /// Converts to a tuple of the value inputs, extension delta, and value outputs
+    pub fn into_tuple(self) -> (TypeRow, ExtensionSet, TypeRow) {
+        (self.input, self.extension_reqs, self.output)
+    }    
+}
+
+impl Signature {
+    /// Create a new signature with specified inputs and outputs.
+    pub fn try_new(
+        input: impl Into<TypeRow>,
+        output: impl Into<TypeRow>,
+    ) -> Result<Self, SignatureError> {
+        let input = input.into();
+        let output = output.into();
+        for t in input.iter().chain(output.iter()) {
+            if let TypeEnum::RowVariable(idx, _) = t.0 {
+                return Err(SignatureError::RowVarWhereTypeExpected { idx });
+            }
+        }
+        let extension_reqs = ExtensionSet::default();
+        Ok(Self {
+            input,
+            output,
+            extension_reqs,
+        })
     }
     /// Create a new signature with the same input and output types (signature of an endomorphic
     /// function).
-    pub fn new_endo(linear: impl Into<TypeRow>) -> Self {
+    pub fn try_new_endo(linear: impl Into<TypeRow>) -> Result<Self, SignatureError> {
         let linear = linear.into();
-        Self::new(linear.clone(), linear)
+        Self::try_new(linear.clone(), linear)
     }
 
     /// Returns the type of a value [`Port`]. Returns `None` if the port is out
@@ -96,7 +156,6 @@ impl FunctionType {
     /// of bounds.
     #[inline]
     pub fn in_port_type(&self, port: impl Into<IncomingPort>) -> Option<&Type> {
-        debug_assert!(self.find_rowvar().is_none());
         self.input.get(port.into().index())
     }
 
@@ -104,7 +163,6 @@ impl FunctionType {
     /// of bounds.
     #[inline]
     pub fn out_port_type(&self, port: impl Into<OutgoingPort>) -> Option<&Type> {
-        debug_assert!(self.find_rowvar().is_none());
         self.output.get(port.into().index())
     }
 
@@ -112,7 +170,6 @@ impl FunctionType {
     /// of bounds.
     #[inline]
     pub fn in_port_type_mut(&mut self, port: impl Into<IncomingPort>) -> Option<&mut Type> {
-        debug_assert!(self.find_rowvar().is_none());
         self.input.get_mut(port.into().index())
     }
 
@@ -120,7 +177,6 @@ impl FunctionType {
     /// of bounds.
     #[inline]
     pub fn out_port_type_mut(&mut self, port: impl Into<OutgoingPort>) -> Option<&mut Type> {
-        debug_assert!(self.find_rowvar().is_none());
         self.output.get_mut(port.into().index())
     }
 
@@ -177,36 +233,6 @@ impl FunctionType {
         self.types(Direction::Outgoing)
     }
 
-    #[inline]
-    /// Returns a row of the value inputs of the function.
-    pub fn input(&self) -> &TypeRow {
-        &self.input
-    }
-
-    #[inline]
-    /// Returns a row of the value outputs of the function.
-    pub fn output(&self) -> &TypeRow {
-        &self.output
-    }
-
-    /// Converts to a tuple of the value inputs, extension delta, and value outputs
-    pub fn into_tuple(self) -> (TypeRow, ExtensionSet, TypeRow) {
-        (self.input, self.extension_reqs, self.output)
-    }
-}
-
-impl FunctionType {
-    /// If this FunctionType contains any row variables, return one.
-    pub fn find_rowvar(&self) -> Option<(usize, TypeBound)> {
-        self.input
-            .iter()
-            .chain(self.output.iter())
-            .find_map(|t| match t.0 {
-                TypeEnum::RowVariable(idx, bound) => Some((idx, bound)),
-                _ => None,
-            })
-    }
-
     /// Returns the `Port`s in the signature for a given direction.
     #[inline]
     pub fn ports(&self, dir: Direction) -> impl Iterator<Item = Port> {
@@ -228,7 +254,7 @@ impl FunctionType {
     }
 }
 
-impl Display for FunctionType {
+impl<const RV: bool> Display for FunctionType<RV> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if !self.input.is_empty() {
             self.input.fmt(f)?;
@@ -241,14 +267,28 @@ impl Display for FunctionType {
     }
 }
 
+impl TryFrom<FunctionType> for Signature {
+    type Error = SignatureError;
+
+    fn try_from(value: FunctionType) -> Result<Self, Self::Error> {
+        Ok(Self::try_new(value.input, value.output)?.with_extension_delta(value.extension_reqs))
+    }
+}
+
+impl From<Signature> for FunctionType {
+    fn from(value: Signature) -> Self {
+        Self::new(value.input, value.output).with_extension_delta(value.extension_reqs)
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use crate::{extension::prelude::USIZE_T, type_row};
+    use crate::extension::prelude::USIZE_T;
 
     use super::*;
     #[test]
     fn test_function_type() {
-        let mut f_type = FunctionType::new(type_row![Type::UNIT], type_row![Type::UNIT]);
+        let mut f_type = FunctionType::try_new(Type::UNIT, Type::UNIT).unwrap();
         assert_eq!(f_type.input_count(), 1);
         assert_eq!(f_type.output_count(), 1);
 

--- a/hugr/src/types/signature.rs
+++ b/hugr/src/types/signature.rs
@@ -281,6 +281,12 @@ impl From<Signature> for FunctionType {
     }
 }
 
+impl PartialEq<FunctionType> for Signature {
+    fn eq(&self, other: &FunctionType) -> bool {
+        self.input == other.input && self.output == other.output && self.extension_reqs == other.extension_reqs
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::extension::prelude::USIZE_T;


### PR DESCRIPTION
Goal is to solve #1094 but not even building yet!

Plan?
* Maybe make FunctionType `inputs`, `outputs` and `extension_reqs` non-`pub` in a first PR, we should probably do that anyway
* Can we implement PartialEq to allow comparing FunctionType's vs Signature's (likely only one way round) so that we can compile without changes the great number of tests that compare (maybe a fixed-len Signature) against a `FunctionType::new(...)` (that although nominally variable-length, don't actually contain any row-vars)?