### PR TITLE
feat!: Disallow nonlocal value edges into FuncDefn's

### DIFF
--- a/hugr/src/hugr/validate/test.rs
+++ b/hugr/src/hugr/validate/test.rs
@@ -274,7 +274,20 @@ fn no_ext_edge_into_func() -> Result<(), Box<dyn std::error::Error>> {
     let func = func.finish_with_outputs(and_op.outputs())?;
     let loadfn = dfg.load_func(func.handle(), &[], &EMPTY_REG)?;
     let dfg = dfg.finish_with_outputs([loadfn])?;
-    h.finish_hugr_with_outputs(dfg.outputs(), &EMPTY_REG)?;
+    let res = h.finish_hugr_with_outputs(dfg.outputs(), &EMPTY_REG);
+    assert_eq!(
+        res,
+        Err(BuildError::InvalidHUGR(
+            ValidationError::InterGraphEdgeError(InterGraphEdgeError::ValueEdgeIntoFunc {
+                from: input.node(),
+                from_offset: input.source().into(),
+                to: and_op.node(),
+                to_offset: IncomingPort::from(1).into(),
+                //to_offset: Port::new(Direction::Incoming, 1),
+                func: func.node()
+            })
+        ))
+    );
     Ok(())
 }
 

--- a/hugr/src/hugr/validate/test.rs
+++ b/hugr/src/hugr/validate/test.rs
@@ -283,7 +283,6 @@ fn no_ext_edge_into_func() -> Result<(), Box<dyn std::error::Error>> {
                 from_offset: input.source().into(),
                 to: and_op.node(),
                 to_offset: IncomingPort::from(1).into(),
-                //to_offset: Port::new(Direction::Incoming, 1),
                 func: func.node()
             })
         ))

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -557,7 +557,7 @@ Each of these localities have additional constraints as follows:
    parent<sup>i</sup>(n<sub>2</sub>) for some i\>1, *and* for Value edges only:
      * there must be a order edge from n<sub>1</sub> to
        parent<sup>i-1</sup>(n<sub>2</sub>).
-     * None of the parent<sup>j</sup>(n<sub>2</sub>), for 1\>=j\>i,
+     * None of the parent<sup>j</sup>(n<sub>2</sub>), for i\>j\>=1,
        may be a FuncDefn node
 
    The order edge records the
@@ -581,6 +581,8 @@ Each of these localities have additional constraints as follows:
    parent(n<sub>1</sub>) \!= parent<sup>i-1</sup>(n<sub>2</sub>). (The
    i\>1 allows the node to target an arbitrarily-deep descendant of the
    dominated block, similar to an Ext edge.)
+
+   The same FuncDefn restriction also applies here, on the parent(<sup>j</sup>)(n<sub>2</sub>) for i\>j\>=1 (of course j=i is the CFG and j=i-1 is the basic block).
 
 Specifically, these rules allow for edges where in a given execution of
 the HUGR the source of the edge executes once, but the target may

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -554,8 +554,11 @@ parent(n<sub>2</sub>) when the edge's locality is:
 Each of these localities have additional constraints as follows:
 
 1. For Ext edges, we require parent(n<sub>1</sub>) ==
-   parent<sup>i</sup>(n<sub>2</sub>) for some i\>1, *and* for Value edges only there must be a order edge from n<sub>1</sub> to
-   parent<sup>i-1</sup>(n<sub>2</sub>).
+   parent<sup>i</sup>(n<sub>2</sub>) for some i\>1, *and* for Value edges only:
+     * there must be a order edge from n<sub>1</sub> to
+       parent<sup>i-1</sup>(n<sub>2</sub>).
+     * None of the parent<sup>j</sup>(n<sub>2</sub>), for 1\>=j\>i,
+       may be a FuncDefn node
 
    The order edge records the
    ordering requirement that results, i.e. it must be possible to
@@ -567,6 +570,9 @@ Each of these localities have additional constraints as follows:
 
    For Static edges this order edge is not required since the source is
    guaranteed to causally precede the target.
+
+   The FuncDefn restriction means that FuncDefn really are static,
+   and do not capture runtime values from their environment.
 
 2. For Dom edges, we must have that parent<sup>2</sup>(n<sub>1</sub>)
    == parent<sup>i</sup>(n<sub>2</sub>) is a CFG-node, for some i\>1,


### PR DESCRIPTION
Closes #936 

Test for `ext` edges only in this PR. (Would be good to have one for `dom` edges too but that can follow.)

BREAKING CHANGE: Hugr's with nonlocal ("Inter-Graph") edges that enter FuncDefns will now fail validation