### PR TITLE
ci: publish to pypi on releases or workflow_dispatch for tags

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -1,12 +1,22 @@
 name: Build and publish python wheels
+# Builds and publishes the wheels on pypi.
+#
+# When running on a push-to-main event, or as a workflow dispatch on a branch,
+# this workflow will do a dry-run publish to test-pypi.
+#
+# When running on a release event or as a workflow dispatch for a tag,
+# and if the tag matches `hugr-py-v*`,
+# this workflow will publish the wheels to pypi.
+# If the version is already published, pypi just ignores it.
 
 on:
   workflow_dispatch:
   push:
     branches:
       - main
-    tags:
-        - '**'
+  release:
+    types:
+      - published
 
 jobs:
   build-publish:
@@ -43,7 +53,9 @@ jobs:
             dist/*.whl
 
       - name: Publish to test instance of PyPI (dry-run)
-        if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'branch' ) }}
+        if: |
+          ${{ github.event_name == 'push' && github.ref_type == 'branch' }} ||
+          ${{ github.event_name == 'workflow_dispatch' && github.ref_type == 'branch'}}
         run: |
           echo "Doing a dry-run publish to test-pypi..."
           echo "Based on the following workflow variables, this is not a hugr-py version tag push:"
@@ -56,7 +68,9 @@ jobs:
           poetry publish -r test-pypi --dist-dir ../dist --skip-existing --dry-run
 
       - name: Publish to PyPI
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.package)) }}
+        if: |
+          ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.package)))}} ||
+          ${{ (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.package)))}} ||
         run: |
           cd ${{ matrix.package }}
           poetry config pypi-token.pypi ${{ secrets.PYPI_PUBLISH }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,5 +18,6 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:
-            token: ${{ secrets.GITHUB_TOKEN }}
+            # Using a personal access token so releases created by this workflow can trigger the deployment workflow
+            token: ${{ secrets.RELEASE_PLEASE_PAT }}
             config-file: release-please-config.json


### PR DESCRIPTION
Fixes merging release-please PRs not triggering the pypi release workflow.
  This is due to workflows not triggering other workflows when using the default `GITHUB_TOKEN`.
  
The pypi release workflow ran when a tag matching `hugr-py-v**` was pushed by anyone. This was a bit dangerous and prone to fat-fingering.
Now the workflow is triggered either by new releases with a matching tag (as created by release-please), or by manually triggering the workflow on a tag (so we can still trigger it if needed).
This should be harder to trigger by accident.