### PR TITLE
ci: Enable crates.io auto-release, but require certain people to approve the PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,8 @@
 
 # Add specific rules below.
 # Lower the rule, higher the precedence
+
+# The release PRs that trigger publication to crates.io or PyPI always modify the changelog.
+# We require those PRs to be approved by someone with release permissions.
+hugr/CHANGELOG.md @aborgna-q @ss2165
+hugr-py/CHANGELOG.md @aborgna-q @ss2165

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,7 +23,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
-        with:
-          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This setups a restricted ownership over the changelog files, so the release PRs by `release-please` or `release-plz` have to be approved by a restricted set of people.

We can then enable auto-releases for rust (for python is already enabled).

Feel free to suggest other users to add to the list.