### PR TITLE
chore: Declare ci_run flag in build.rs

### DIFF
--- a/hugr/build.rs
+++ b/hugr/build.rs
@@ -1,0 +1,7 @@
+//! Build script for the `hugr` crate.
+
+fn main() {
+    // We use a `ci_run` RUSTFLAG to indicate that we are running a CI check,
+    // so we can reject debug code using some tools defined in `utils.rs`.
+    println!("cargo:rustc-check-cfg=cfg(ci_run)");
+}


### PR DESCRIPTION
Rust 1.80 will require pre-declaring configuration flags that we want to set via RUSTFLAGS.
See the [blog post](https://blog.rust-lang.org/2024/05/06/check-cfg.html).

Fixes #1067.