### PR TITLE
ci: Improve times by splitting stable test runs

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -75,11 +75,11 @@ jobs:
         run: cargo bench --verbose --no-run --workspace --all-features
 
   # Run tests on Rust stable
-  tests-stable:
+  tests-stable-no-features:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
-    name: tests (Rust stable)
+    name: tests (Rust stable, no features)
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.4
@@ -93,6 +93,22 @@ jobs:
         run: cargo test --verbose --workspace --no-default-features --no-run
       - name: Tests with no features
         run: cargo test --verbose --workspace --no-default-features
+
+  # Run tests on Rust stable
+  tests-stable-all-features:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    name: tests (Rust stable, all features)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mozilla-actions/sccache-action@v0.0.4
+      - id: toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 'stable'
+      - name: Configure default rust toolchain
+        run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Build with all features
         run: cargo test --verbose --workspace --all-features --no-run
       - name: Tests with all features
@@ -130,7 +146,7 @@ jobs:
   # even if they are skipped due to no changes in the relevant files.
   required-checks:
     name: Required checks 🦀
-    needs: [changes, check, tests-stable]
+    needs: [changes, check, tests-stable-no-features, tests-stable-all-features]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -142,7 +158,8 @@ jobs:
         if: |
           needs.changes.result == 'failure' || needs.changes.result == 'cancelled' ||
           needs.check.result == 'failure' || needs.check.result == 'cancelled' ||
-          needs.tests-stable.result == 'failure' || needs.tests-stable.result == 'cancelled'
+          needs.tests-stable-no-features.result == 'failure' || needs.tests-stable-no-features.result == 'cancelled' ||
+          needs.tests-stable-all-features.result == 'failure' || needs.tests-stable-all-features.result == 'cancelled'
         run: |
           echo "Required checks failed"
           echo "Please check the logs for more information"
@@ -152,7 +169,7 @@ jobs:
           echo "All required checks passed"
 
   coverage:
-    needs: [changes, tests-stable, tests-other, check]
+    needs: [changes, tests-stable-no-features, tests-stable-all-features, tests-other, check]
     # Run only if there are changes in the relevant files and the check job passed or was skipped
     if: always() && !failure() && !cancelled() && needs.changes.outputs.rust == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest

--- a/hugr/src/hugr/validate.rs
+++ b/hugr/src/hugr/validate.rs
@@ -64,7 +64,7 @@ impl Hugr {
 
     /// Validate extensions on the input and output edges of nodes. Check that
     /// the target ends of edges require the extensions from the sources, and
-    /// check extension deltas from parent nodes are reflected in their children
+    /// check extension deltas from parent nodes are reflected in their children.
     pub fn validate_extensions(&self, closure: ExtensionSolution) -> Result<(), ValidationError> {
         let validator = ExtensionValidator::new(self, closure);
         for src_node in self.nodes() {


### PR DESCRIPTION
Parallelises running stable tests with `--no-features` and `-all-features`.
This should reduce the critical path latency for the required checks.

I'm not doing this for the other compiler versions, as the delay is not that critical there and splitting workers pollutes the cache.

Closes #1064.