### PR TITLE
fix: Disallow non-finite values for `ConstF64`

### DIFF
--- a/hugr/src/algorithm/const_fold.rs
+++ b/hugr/src/algorithm/const_fold.rs
@@ -512,4 +512,39 @@ mod test {
         let expected = Value::true_val();
         assert_fully_folded(&h, &expected);
     }
+
+    #[test]
+    fn test_const_fold_to_nonfinite() {
+        // HUGR computing 1.0 / 1.0
+        let mut build =
+            DFGBuilder::new(FunctionType::new(type_row![], vec![FLOAT64_TYPE])).unwrap();
+        let x0 = build.add_load_const(Value::extension(ConstF64::new(1.0)));
+        let x1 = build.add_load_const(Value::extension(ConstF64::new(1.0)));
+        let x2 = build.add_dataflow_op(FloatOps::fdiv, [x0, x1]).unwrap();
+        let reg = ExtensionRegistry::try_new([
+            PRELUDE.to_owned(),
+            arithmetic::float_types::EXTENSION.to_owned(),
+        ])
+        .unwrap();
+        let mut h0 = build.finish_hugr_with_outputs(x2.outputs(), &reg).unwrap();
+        constant_fold_pass(&mut h0, &reg);
+        let expected = Value::extension(ConstF64::new(1.0));
+        assert_fully_folded(&h0, &expected);
+        assert_eq!(h0.node_count(), 5);
+
+        // HUGR computing 1.0 / 0.0
+        let mut build =
+            DFGBuilder::new(FunctionType::new(type_row![], vec![FLOAT64_TYPE])).unwrap();
+        let x0 = build.add_load_const(Value::extension(ConstF64::new(1.0)));
+        let x1 = build.add_load_const(Value::extension(ConstF64::new(0.0)));
+        let x2 = build.add_dataflow_op(FloatOps::fdiv, [x0, x1]).unwrap();
+        let reg = ExtensionRegistry::try_new([
+            PRELUDE.to_owned(),
+            arithmetic::float_types::EXTENSION.to_owned(),
+        ])
+        .unwrap();
+        let mut h1 = build.finish_hugr_with_outputs(x2.outputs(), &reg).unwrap();
+        constant_fold_pass(&mut h1, &reg);
+        assert_eq!(h1.node_count(), 8);
+    }
 }

--- a/hugr/src/algorithm/const_fold.rs
+++ b/hugr/src/algorithm/const_fold.rs
@@ -515,17 +515,18 @@ mod test {
 
     #[test]
     fn test_const_fold_to_nonfinite() {
+        let reg = ExtensionRegistry::try_new([
+            PRELUDE.to_owned(),
+            arithmetic::float_types::EXTENSION.to_owned(),
+        ])
+        .unwrap();
+
         // HUGR computing 1.0 / 1.0
         let mut build =
             DFGBuilder::new(FunctionType::new(type_row![], vec![FLOAT64_TYPE])).unwrap();
         let x0 = build.add_load_const(Value::extension(ConstF64::new(1.0)));
         let x1 = build.add_load_const(Value::extension(ConstF64::new(1.0)));
         let x2 = build.add_dataflow_op(FloatOps::fdiv, [x0, x1]).unwrap();
-        let reg = ExtensionRegistry::try_new([
-            PRELUDE.to_owned(),
-            arithmetic::float_types::EXTENSION.to_owned(),
-        ])
-        .unwrap();
         let mut h0 = build.finish_hugr_with_outputs(x2.outputs(), &reg).unwrap();
         constant_fold_pass(&mut h0, &reg);
         let expected = Value::extension(ConstF64::new(1.0));
@@ -538,11 +539,6 @@ mod test {
         let x0 = build.add_load_const(Value::extension(ConstF64::new(1.0)));
         let x1 = build.add_load_const(Value::extension(ConstF64::new(0.0)));
         let x2 = build.add_dataflow_op(FloatOps::fdiv, [x0, x1]).unwrap();
-        let reg = ExtensionRegistry::try_new([
-            PRELUDE.to_owned(),
-            arithmetic::float_types::EXTENSION.to_owned(),
-        ])
-        .unwrap();
         let mut h1 = build.finish_hugr_with_outputs(x2.outputs(), &reg).unwrap();
         constant_fold_pass(&mut h1, &reg);
         assert_eq!(h1.node_count(), 8);

--- a/hugr/src/hugr/serialize/test.rs
+++ b/hugr/src/hugr/serialize/test.rs
@@ -404,10 +404,6 @@ fn roundtrip_sumtype(#[case] sum_type: SumType) {
 #[case(Value::extension(ConstF64::new(-1.5)))]
 #[case(Value::extension(ConstF64::new(0.0)))]
 #[case(Value::extension(ConstF64::new(-0.0)))]
-// These cases fail
-// #[case(Value::extension(ConstF64::new(std::f64::NAN)))]
-// #[case(Value::extension(ConstF64::new(std::f64::INFINITY)))]
-// #[case(Value::extension(ConstF64::new(std::f64::NEG_INFINITY)))]
 #[case(Value::extension(ConstF64::new(f64::MIN_POSITIVE)))]
 #[case(Value::sum(1,[Value::extension(ConstInt::new_u(2,1).unwrap())], SumType::new([vec![], vec![INT_TYPES[2].clone()]])).unwrap())]
 #[case(Value::tuple([Value::false_val(), Value::extension(ConstInt::new_s(2,1).unwrap())]))]

--- a/hugr/src/std_extensions/arithmetic/float_ops/const_fold.rs
+++ b/hugr/src/std_extensions/arithmetic/float_ops/const_fold.rs
@@ -54,8 +54,11 @@ impl ConstFold for BinaryFold {
         consts: &[(IncomingPort, ops::Value)],
     ) -> ConstFoldResult {
         let [f1, f2] = get_floats(consts)?;
-
-        let res = ConstF64::new((self.0)(f1, f2));
+        let x: f64 = (self.0)(f1, f2);
+        if !x.is_finite() {
+            return None;
+        }
+        let res = ConstF64::new(x);
         Some(vec![(0.into(), res.into())])
     }
 }
@@ -115,7 +118,11 @@ impl ConstFold for UnaryFold {
         consts: &[(IncomingPort, ops::Value)],
     ) -> ConstFoldResult {
         let [f1] = get_floats(consts)?;
-        let res = ConstF64::new((self.0)(f1));
+        let x: f64 = (self.0)(f1);
+        if !x.is_finite() {
+            return None;
+        }
+        let res = ConstF64::new(x);
         Some(vec![(0.into(), res.into())])
     }
 }

--- a/hugr/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr/src/std_extensions/arithmetic/float_types.rs
@@ -40,7 +40,11 @@ impl std::ops::Deref for ConstF64 {
 
 impl ConstF64 {
     /// Create a new [`ConstF64`]
-    pub const fn new(value: f64) -> Self {
+    pub fn new(value: f64) -> Self {
+        // This function can't be `const` because `is_finite()` is not yet stable as a const function.
+        if !value.is_finite() {
+            panic!("ConstF64 must have a finite value.");
+        }
         Self { value }
     }
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1782,6 +1782,9 @@ Other operations:
 The `float64` type represents IEEE 754-2019 floating-point data of 64
 bits.
 
+Non-finite `float64` values (i.e. NaN and ±infinity) are not allowed in `Const`
+nodes.
+
 #### `arithmetic.float`
 
 Floating-point operations are defined as follows. All operations below


### PR DESCRIPTION
Fixes #1049 .

Other solutions (custom serialization/deserialization for `ConstF64`, or custom deserializer taking "null" to NaN) are difficult or otherwise problematic, and it may actually be a good thing to disallow non-finite float constants as it can catch bugs earlier.