### PR TITLE
chore: Run pytest on pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,3 +82,10 @@ repos:
         language: system
         files: \.rs$
         pass_filenames: false
+      - id: py-test
+        name: pytest
+        description: Run python tests
+        entry: sh -c "poetry install && poetry run pytest"
+        language: system
+        files: \.py$
+        pass_filenames: false


### PR DESCRIPTION
hugr-py has no actual tests yet, but we should start running pytest here before it does.