### PR TITLE
fix(py):  get rid of pydantic config deprecation warnings

### DIFF
--- a/hugr-py/src/hugr/serialization/ops.py
+++ b/hugr-py/src/hugr/serialization/ops.py
@@ -3,7 +3,7 @@ import sys
 from abc import ABC
 from typing import Any, Literal
 
-from pydantic import Field, RootModel
+from pydantic import Field, RootModel, ConfigDict
 
 from . import tys
 from .tys import (
@@ -108,15 +108,14 @@ class SumValue(ConfiguredBaseModel):
     tag: int
     typ: SumType
     vs: list["Value"]
-
-    class Config:
-        # Needed to avoid random '\n's in the pydantic description
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "description": (
                 "A Sum variant For any Sum type where this value meets the type "
                 "of the variant indicated by the tag."
             ),
         }
+    )
 
 
 class Value(RootModel):
@@ -126,8 +125,7 @@ class Value(RootModel):
         discriminator="v"
     )
 
-    class Config:
-        json_schema_extra = {"required": ["v"]}
+    model_config = ConfigDict(json_schema_extra={"required": ["v"]})
 
 
 class Const(BaseOp):
@@ -168,11 +166,13 @@ class DataflowBlock(BaseOp):
                 self.sum_rows.append(variant)
         self.other_outputs = outputs[1:]
 
-    class Config:
         # Needed to avoid random '\n's in the pydantic description
-        json_schema_extra = {
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "description": "A CFG basic block node. The signature is that of the internal Dataflow graph.",
         }
+    )
 
 
 class ExitBlock(BaseOp):
@@ -182,11 +182,12 @@ class ExitBlock(BaseOp):
     op: Literal["ExitBlock"] = "ExitBlock"
     cfg_outputs: TypeRow
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             # Needed to avoid random '\n's in the pydantic description
             "description": "The single exit node of the CFG, has no children, stores the types of the CFG node output.",
         }
+    )
 
 
 # ---------------------------------------------
@@ -234,9 +235,9 @@ class Call(DataflowOp):
     type_args: list[tys.TypeArg]
     instantiation: FunctionType
 
-    class Config:
+    model_config = ConfigDict(
         # Needed to avoid random '\n's in the pydantic description
-        json_schema_extra = {
+        json_schema_extra={
             "description": (
                 "Operation to call a function directly. The first port is "
                 "connected to the def/declare of the function being called directly, "
@@ -244,6 +245,7 @@ class Call(DataflowOp):
                 "ports matches the function being called."
             )
         }
+    )
 
 
 class CallIndirect(DataflowOp):
@@ -386,14 +388,15 @@ class CustomOp(DataflowOp):
     def display_name(self) -> str:
         return self.op_name
 
-    class Config:
+    model_config = ConfigDict(
         # Needed to avoid random '\n's in the pydantic description
-        json_schema_extra = {
+        json_schema_extra={
             "description": (
                 "A user-defined operation that can be downcasted by the extensions that "
                 "define it."
             )
         }
+    )
 
 
 class Noop(DataflowOp):
@@ -491,8 +494,7 @@ class OpType(RootModel):
         | AliasDefn
     ) = Field(discriminator="op")
 
-    class Config:
-        json_schema_extra = {"required": ["parent", "op"]}
+    model_config = ConfigDict(json_schema_extra={"required": ["parent", "op"]})
 
 
 # --------------------------------------

--- a/hugr-py/src/hugr/serialization/serial_hugr.py
+++ b/hugr-py/src/hugr/serialization/serial_hugr.py
@@ -42,8 +42,9 @@ class SerialHugr(ConfiguredBaseModel):
         my_classes[cls.__name__] = cls
         model_rebuild(my_classes, config=config, **kwargs)
 
-    class Config:
-        title = "Hugr"
-        json_schema_extra = {
+    model_config = ConfigDict(
+        title="Hugr",
+        json_schema_extra={
             "required": ["version", "nodes", "edges"],
-        }
+        },
+    )

--- a/hugr-py/src/hugr/serialization/tys.py
+++ b/hugr-py/src/hugr/serialization/tys.py
@@ -99,8 +99,7 @@ class TypeParam(RootModel):
         WrapValidator(_json_custom_error_validator),
     ] = Field(discriminator="tp")
 
-    class Config:
-        json_schema_extra = {"required": ["tp"]}
+    model_config = ConfigDict(json_schema_extra={"required": ["tp"]})
 
 
 # ------------------------------------------
@@ -153,8 +152,7 @@ class TypeArg(RootModel):
         WrapValidator(_json_custom_error_validator),
     ] = Field(discriminator="tya")
 
-    class Config:
-        json_schema_extra = {"required": ["tya"]}
+    model_config = ConfigDict(json_schema_extra={"required": ["tya"]})
 
 
 # --------------------------------------------
@@ -197,8 +195,7 @@ class SumType(RootModel):
     def t(self) -> str:
         return self.root.t
 
-    class Config:
-        json_schema_extra = {"required": ["s"]}
+    model_config = ConfigDict(json_schema_extra={"required": ["s"]})
 
 
 # ----------------------------------------------
@@ -235,14 +232,15 @@ class FunctionType(ConfiguredBaseModel):
     def empty(cls) -> "FunctionType":
         return FunctionType(input=[], output=[], extension_reqs=[])
 
-    class Config:
+    model_config = ConfigDict(
         # Needed to avoid random '\n's in the pydantic description
-        json_schema_extra = {
+        json_schema_extra={
             "description": (
                 "A graph encoded as a value. It contains a concrete signature and "
                 "a set of required resources."
             )
         }
+    )
 
 
 class PolyFuncType(ConfiguredBaseModel):
@@ -261,14 +259,15 @@ class PolyFuncType(ConfiguredBaseModel):
     def empty(cls) -> "PolyFuncType":
         return PolyFuncType(params=[], body=FunctionType.empty())
 
-    class Config:
+    model_config = ConfigDict(
         # Needed to avoid random '\n's in the pydantic description
-        json_schema_extra = {
+        json_schema_extra={
             "description": (
                 "A polymorphic type scheme, i.e. of a FuncDecl, FuncDefn or OpDef.  "
                 "(Nodes/operations in the Hugr are not polymorphic.)"
             )
         }
+    )
 
 
 class TypeBound(Enum):
@@ -326,8 +325,7 @@ class Type(RootModel):
         Field(discriminator="t"),
     ]
 
-    class Config:
-        json_schema_extra = {"required": ["t"]}
+    model_config = ConfigDict(json_schema_extra={"required": ["t"]})
 
 
 # -------------------------------------------

--- a/hugr-py/tests/serialization/test_basic.py
+++ b/hugr-py/tests/serialization/test_basic.py
@@ -1,3 +1,12 @@
-def test_it_works():
-    """TODO: Replace this with a real test."""
-    assert 2 + 2 != "🐟"
+from hugr.serialization import SerialHugr
+
+
+def test_empty():
+    h = SerialHugr(nodes=[], edges=[])
+    assert h.model_dump() == {
+        "version": "v1",
+        "nodes": [],
+        "edges": [],
+        "metadata": None,
+        "encoder": None,
+    }


### PR DESCRIPTION
add a test that triggers the warnings

https://docs.pydantic.dev/2.7/migration/#changes-to-config