### PR TITLE
refactor!: No Ports in TypeRow

### DIFF
--- a/hugr/src/types/signature.rs
+++ b/hugr/src/types/signature.rs
@@ -7,6 +7,7 @@ use std::fmt::{self, Display, Write};
 use super::type_param::TypeParam;
 use super::{subst_row, Substitution, Type, TypeRow};
 
+use crate::core::PortIndex;
 use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
 use crate::{Direction, IncomingPort, OutgoingPort, Port};
 
@@ -98,28 +99,28 @@ impl FunctionType {
     /// of bounds.
     #[inline]
     pub fn in_port_type(&self, port: impl Into<IncomingPort>) -> Option<&Type> {
-        self.input.get(port.into())
+        self.input.get(port.into().index())
     }
 
     /// Returns the type of a value output [`Port`]. Returns `None` if the port is out
     /// of bounds.
     #[inline]
     pub fn out_port_type(&self, port: impl Into<OutgoingPort>) -> Option<&Type> {
-        self.output.get(port.into())
+        self.output.get(port.into().index())
     }
 
     /// Returns a mutable reference to the type of a value input [`Port`]. Returns `None` if the port is out
     /// of bounds.
     #[inline]
     pub fn in_port_type_mut(&mut self, port: impl Into<IncomingPort>) -> Option<&mut Type> {
-        self.input.get_mut(port.into())
+        self.input.get_mut(port.into().index())
     }
 
     /// Returns the type of a value output [`Port`]. Returns `None` if the port is out
     /// of bounds.
     #[inline]
     pub fn out_port_type_mut(&mut self, port: impl Into<OutgoingPort>) -> Option<&mut Type> {
-        self.output.get_mut(port.into())
+        self.output.get_mut(port.into().index())
     }
 
     /// Returns a mutable reference to the type of a value [`Port`].

--- a/hugr/src/types/type_row.rs
+++ b/hugr/src/types/type_row.rs
@@ -39,12 +39,6 @@ impl TypeRow {
 
     #[inline(always)]
     /// Returns the type at the specified index. Returns `None` if out of bounds.
-    pub fn get(&self, offset: usize) -> Option<&Type> {
-        self.types.get(offset)
-    }
-
-    #[inline(always)]
-    /// Returns the type at the specified index. Returns `None` if out of bounds.
     pub fn get_mut(&mut self, offset: usize) -> Option<&mut Type> {
         self.types.to_mut().get_mut(offset)
     }
@@ -75,6 +69,10 @@ impl TypeRow {
 
             /// Returns `true` if the row contains no types.
             pub fn is_empty(&self) -> bool ;
+
+            #[inline(always)]
+            /// Returns the type at the specified index. Returns `None` if out of bounds.
+            pub fn get(&self, offset: usize) -> Option<&Type>;
         }
     }
 }

--- a/hugr/src/types/type_row.rs
+++ b/hugr/src/types/type_row.rs
@@ -37,12 +37,6 @@ impl TypeRow {
         }
     }
 
-    #[inline(always)]
-    /// Returns the type at the specified index. Returns `None` if out of bounds.
-    pub fn get_mut(&mut self, offset: usize) -> Option<&mut Type> {
-        self.types.to_mut().get_mut(offset)
-    }
-
     /// Returns a new `TypeRow` with `xs` concatenated onto `self`.
     pub fn extend<'a>(&'a self, rest: impl IntoIterator<Item = &'a Type>) -> Self {
         self.iter().chain(rest).cloned().collect_vec().into()
@@ -73,6 +67,12 @@ impl TypeRow {
             #[inline(always)]
             /// Returns the type at the specified index. Returns `None` if out of bounds.
             pub fn get(&self, offset: usize) -> Option<&Type>;
+        }
+
+        to self.types.to_mut() {
+            #[inline(always)]
+            /// Returns the type at the specified index. Returns `None` if out of bounds.
+            pub fn get_mut(&mut self, offset: usize) -> Option<&mut Type>;
         }
     }
 }

--- a/hugr/src/types/type_row.rs
+++ b/hugr/src/types/type_row.rs
@@ -9,7 +9,6 @@ use std::{
 
 use super::Type;
 use crate::utils::display_list;
-use crate::PortIndex;
 use delegate::delegate;
 use itertools::Itertools;
 
@@ -39,15 +38,15 @@ impl TypeRow {
     }
 
     #[inline(always)]
-    /// Returns the port type given an offset. Returns `None` if the offset is out of bounds.
-    pub fn get(&self, offset: impl PortIndex) -> Option<&Type> {
-        self.types.get(offset.index())
+    /// Returns the type at the specified index. Returns `None` if out of bounds.
+    pub fn get(&self, offset: usize) -> Option<&Type> {
+        self.types.get(offset)
     }
 
     #[inline(always)]
-    /// Returns the port type given an offset. Returns `None` if the offset is out of bounds.
-    pub fn get_mut(&mut self, offset: impl PortIndex) -> Option<&mut Type> {
-        self.types.to_mut().get_mut(offset.index())
+    /// Returns the type at the specified index. Returns `None` if out of bounds.
+    pub fn get_mut(&mut self, offset: usize) -> Option<&mut Type> {
+        self.types.to_mut().get_mut(offset)
     }
 
     /// Returns a new `TypeRow` with `xs` concatenated onto `self`.


### PR DESCRIPTION
TypeRow is not just used for node input/output signatures, but also for elements of tuples/sums, and FunctionTypes that are not part of Nodes. So, using Port to index into it seems odd...

BREAKING CHANGE: get() and get_mut() now take only usize, so must call PortIndex::index() on the argument first