### PR TITLE
ci: Fix release-please not creating draft PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
     "include-component-in-tag": true,
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
-    "draft-pull-request": true,
     "initial-version": "0.0.0",
     "packages": {
         "hugr-py": {
@@ -12,7 +11,8 @@
             "package-name": "hugr",
             "include-component-in-tag": true,
             "draft": false,
-            "prerelease": false
+            "prerelease": false,
+            "draft-pull-request": true
         }
     },
     "changelog-sections": [


### PR DESCRIPTION
This setting should make release-please create it's PRs as draft requests (to avoid annoying reviewers unnecessarily), but it doesn't seem to have worked https://github.com/CQCL/hugr/pull/1092

The config json schema seemed to validate this as a global option, but it seems the value is not picked from there :/

This change moves the "use a draft PR" option to the project-specific section.