### PR TITLE
ci: Disable release-plz publishing hugr-passes for now

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -27,3 +27,6 @@ name = "hugr-passes"
 
 # Enable the changelog for this package
 changelog_update = true
+
+# Disabled until the first version is manually published
+publish = false


### PR DESCRIPTION
This is mainly to avoid fails on CI due to `hugr-passes` trying to use the published `hugr 0.4.0`

https://github.com/CQCL/hugr/actions/runs/9208802531/job/25331815962#step:4:325