### PR TITLE
ci: Notify coverage changes only once a week

### DIFF
--- a/.github/workflows/notify-coverage.yml
+++ b/.github/workflows/notify-coverage.yml
@@ -6,7 +6,7 @@ name: Notify coverage changes
 
 on:
   schedule:
-    # 04:00 daily
+    # 04:00 every Monday
     - cron: '0 4 * * 1'
   workflow_dispatch: {}
 

--- a/.github/workflows/notify-coverage.yml
+++ b/.github/workflows/notify-coverage.yml
@@ -7,7 +7,7 @@ name: Notify coverage changes
 on:
   schedule:
     # 04:00 daily
-    - cron: '0 4 * * *'
+    - cron: '0 4 * * 1'
   workflow_dispatch: {}
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
           workflow: 'notify-coverage.yml'
           name: head-sha.txt
           if_no_artifact_found: ignore
-      - name: Get today's and yesterday's coverage trends from codecov
+      - name: Get today's and last run's coverage trends from codecov
         id: get_coverage
         # API reference: https://docs.codecov.com/reference/repos_totals_retrieve
         run: |


### PR DESCRIPTION
Reduces the frequency of the slack notification from daily to once a week (Mondays at 4h).

Closes #1106 