### PR TITLE
ci: Fix release-plz field config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,7 +25,7 @@ release = true
 
 # Disabled until the first version is manually published
 publish = false
-github_release = false
+git_release_enable = false
 
 [[package]]
 name = "hugr-passes"
@@ -33,4 +33,4 @@ release = true
 
 # Disabled until the first version is manually published
 publish = false
-github_release = false
+git_release_enable = false


### PR DESCRIPTION
I set an invalid flag for release-plz...
https://release-plz.ieni.dev/docs/config#the-git_release_enable-field

This triggered an error in CI: https://github.com/CQCL/hugr/actions/runs/9270279819/job/25502921479#step:4:216
