### PR TITLE
ci: Stop `benches` ci job from always running

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -61,8 +61,9 @@ jobs:
           RUSTDOCFLAGS: "-Dwarnings"
 
   benches:
+    name: Build benchmarks 🏋️
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }} && github.event_name != 'merge_group'
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `benches` CI job likes to run even when it is not required
https://github.com/CQCL/hugr/actions/runs/9270412094

It seems the `if` statement is wrong. *Why* is it wrong escapes me.
Here I'm just copying the one from the other conditional tests, which we know works.

drive-by: Add a name to make clear it is not _running_ the benchmarks.