### PR TITLE
ci: fix the release-plz fix

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -26,6 +26,7 @@ release = true
 # Disabled until the first version is manually published
 publish = false
 git_tag_enable = false
+git_release_enable = false
 
 [[package]]
 name = "hugr-passes"
@@ -34,6 +35,7 @@ release = true
 # Disabled until the first version is manually published
 publish = false
 git_tag_enable = false
+git_release_enable = false
 
 [[package]]
 name = "hugr-cli"
@@ -42,3 +44,4 @@ release = true
 # Disabled until the first version is manually published
 publish = false
 git_tag_enable = false
+git_release_enable = false


### PR DESCRIPTION
> you can't create a git release without a git tag

So that was a lie. The releases [are still created](https://github.com/CQCL/hugr/actions/runs/9271742453/job/25507885562#step:4:281).

#1119 shouldn't have dropped the `git_release_enable` lines.