### PR TITLE
ci: Pin nightly rust version

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -122,7 +122,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust: ['1.75', beta, nightly]
+        # Pinned nightly version until this gets resolved:
+        # https://github.com/rust-lang/rust/issues/125474
+        rust: ['1.75', beta, nightly-2024-05-22]
     name: tests (Rust ${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v4
@@ -176,9 +178,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain
         with:
           components: llvm-tools-preview
+          # Nightly is required to count doctests coverage
+          #
+          # Pinned nightly version until this gets resolved:
+          # https://github.com/rust-lang/rust/issues/125474
+          toolchain: nightly-2024-05-22
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run tests with coverage instrumentation

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -124,7 +124,7 @@ jobs:
       matrix:
         # Pinned nightly version until this gets resolved:
         # https://github.com/rust-lang/rust/issues/125474
-        rust: ['1.75', beta]
+        rust: ['1.75', beta, 'nightly-2024-05-22']
     name: tests (Rust ${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v4
@@ -178,8 +178,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          # Nightly is required to count doctests coverage
+          #
+          # Pinned nightly version until this gets resolved
+          # https://github.com/rust-lang/rust/issues/125474
+          toolchain: 'nightly-2024-05-22'
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -180,12 +180,12 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.4
       - uses: dtolnay/rust-toolchain
         with:
-          components: llvm-tools-preview
           # Nightly is required to count doctests coverage
           #
           # Pinned nightly version until this gets resolved
           # https://github.com/rust-lang/rust/issues/125474
           toolchain: 'nightly-2024-05-22'
+          components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run tests with coverage instrumentation

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -124,7 +124,7 @@ jobs:
       matrix:
         # Pinned nightly version until this gets resolved:
         # https://github.com/rust-lang/rust/issues/125474
-        rust: ['1.75', beta, 'nightly-2024-05-22']
+        rust: ['1.75', beta]
     name: tests (Rust ${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -124,7 +124,7 @@ jobs:
       matrix:
         # Pinned nightly version until this gets resolved:
         # https://github.com/rust-lang/rust/issues/125474
-        rust: ['1.75', beta, nightly-2024-05-22]
+        rust: ['1.75', beta, 'nightly-2024-05-22']
     name: tests (Rust ${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v4
@@ -183,9 +183,9 @@ jobs:
           components: llvm-tools-preview
           # Nightly is required to count doctests coverage
           #
-          # Pinned nightly version until this gets resolved:
+          # Pinned nightly version until this gets resolved
           # https://github.com/rust-lang/rust/issues/125474
-          toolchain: nightly-2024-05-22
+          toolchain: 'nightly-2024-05-22'
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run tests with coverage instrumentation

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -178,13 +178,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.4
-      - uses: dtolnay/rust-toolchain
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          # Nightly is required to count doctests coverage
-          #
-          # Pinned nightly version until this gets resolved
-          # https://github.com/rust-lang/rust/issues/125474
-          toolchain: 'nightly-2024-05-22'
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -222,7 +222,7 @@ pub trait HugrMut: HugrMutInternals {
 }
 
 /// Records the result of inserting a Hugr or view
-/// via [HugrMut::insert_hugr] or [HugrMut::insert_from_view]
+/// via [HugrMut::insert_hugr] or [HugrMut::insert_from_view].
 pub struct InsertionResult {
     /// The node, after insertion, that was the root of the inserted Hugr.
     ///


### PR DESCRIPTION
Nightly rust tests are failing, seemingly due to [rust-lang/rust#125474](https://github.com/rust-lang/rust/issues/125474).

This PR fixes the toolchain to the last working nightly until the problem is resolved.


CI fail: https://github.com/CQCL/hugr/actions/runs/9281876942/job/25538729650#step:6:856