### PR TITLE
ci: Wrap failing pre-commit command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
       - id: cargo-doc
         name: cargo doc
         description: Generate documentation with `cargo doc`.
-        entry: RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features --workspace
+        entry: sh -c "RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features --workspace"
         language: system
         files: \.rs$
         pass_filenames: false


### PR DESCRIPTION
pre-commit started failing to parse the `cargo doc` command;
```
cargo doc................................................................Failed
- hook id: cargo-doc
- exit code: 1

Executable `RUSTDOCFLAGS=-Dwarnings` not found
```
it may be related to a version update.

The solution, as we've done in other steps, is to wrap everything as a `sh -c` command.