### PR TITLE
fix: Missing re-exports in `hugr::hugr`

### DIFF
--- a/hugr/src/hugr.rs
+++ b/hugr/src/hugr.rs
@@ -2,6 +2,7 @@
 
 // Exports everything except the `internal` module.
 pub use hugr_core::hugr::{
-    hugrmut, rewrite, serialize, validate, views, Hugr, HugrError, NodeMetadata, NodeMetadataMap,
-    NodeType, DEFAULT_NODETYPE,
+    hugrmut, rewrite, serialize, validate, views, Hugr, HugrError, HugrView, IdentList,
+    InvalidIdentifier, NodeMetadata, NodeMetadataMap, NodeType, Rewrite, RootTagged,
+    SimpleReplacement, SimpleReplacementError, ValidationError, DEFAULT_NODETYPE,
 };


### PR DESCRIPTION
#1122 missed re-exporting some `pub use`s from `hugr_core::hugr`.