### PR TITLE
ci: auto-release the new crates

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -23,19 +23,10 @@ release = true
 name = "hugr-core"
 release = true
 
-# Disabled until the first version is manually published
-publish = false
-
 [[package]]
 name = "hugr-passes"
 release = true
 
-# Disabled until the first version is manually published
-publish = false
-
 [[package]]
 name = "hugr-cli"
 release = true
-
-# Disabled until the first version is manually published
-publish = false


### PR DESCRIPTION
Now that the crates are published in crates.io, allow release-plz to push updates.

I updated the token to allow pushing updates to `hugr-*` crates.