### PR TITLE
refactor: remove `default_members` field in workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ lto = "thin"
 [workspace]
 resolver = "2"
 members = ["hugr", "hugr-core", "hugr-passes", "hugr-cli"]
-default-members = ["hugr", "hugr-core", "hugr-passes", "hugr-cli"]
 
 [workspace.package]
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ lto = "thin"
 [workspace]
 resolver = "2"
 members = ["hugr", "hugr-core", "hugr-passes", "hugr-cli"]
-default-members = ["hugr", "hugr-core", "hugr-passes"]
+default-members = ["hugr", "hugr-core", "hugr-passes", "hugr-cli"]
 
 [workspace.package]
 rust-version = "1.75"


### PR DESCRIPTION
All sub crates will be targeted 

specifically now `cargo run` will hit the cli binary