### PR TITLE
fix: merge_bbs creating too many self-loop edges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ missing_docs = "warn"
 debug_assert_with_mut_call = "warn"
 
 [workspace.dependencies]
-portgraph = { version = "0.12.0" }
+portgraph = { version = "0.12.1" }
 insta = { version = "1.34.0" }
 bitvec = "1.0.1"
 cgmath = "0.18.0"
@@ -55,7 +55,7 @@ thiserror = "1.0.28"
 typetag = "0.2.7"
 urlencoding = "2.1.2"
 webbrowser = "1.0.0"
-clap = { version = "4.5.4"}
+clap = { version = "4.5.4" }
 clap-stdin = "0.4.0"
 clap-verbosity-flag = "2.2.0"
 assert_cmd = "2.0.14"

--- a/hugr-passes/src/merge_bbs.rs
+++ b/hugr-passes/src/merge_bbs.rs
@@ -204,7 +204,7 @@ mod test {
     }
 
     #[rstest]
-    //#[case(true)] // This currently failing, https://github.com/CQCL/hugr/issues/1143
+    #[case(true)]
     #[case(false)]
     fn in_loop(#[case] self_loop: bool) -> Result<(), Box<dyn std::error::Error>> {
         /* self_loop==False:


### PR DESCRIPTION
Updates `portgraph` to include the fix in https://github.com/CQCL/portgraph/pull/132.
Uncomments the previously-failing mentioned in #1143.

Fixes #1143.