### PR TITLE
ci: Fix rust checks running for python-only changes

### DIFF
--- a/.github/change-filters.yml
+++ b/.github/change-filters.yml
@@ -3,7 +3,9 @@
 
 rust:
   - "hugr/**"
-  - "hugr-*/**"
+  - "hugr-cli/**"
+  - "hugr-core/**"
+  - "hugr-passes/**"
   - "Cargo.toml"
   - "specification/schema/**"
 


### PR DESCRIPTION
The clever `hugr-*` filter also catches changes from `hugr-py` -.-