### PR TITLE
feat(hugr-py): automatically add state order edges for inter-graph edges

### DIFF
--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -76,7 +76,7 @@ class Dfg:
             node_ancestor = _ancestral_sibling(self.hugr, src.node, node)
             if node_ancestor is None:
                 raise NoSiblingAncestor(src.node.idx, node.idx)
-            if node_ancestor != src.node:
+            if node_ancestor != node:
                 self.add_state_order(src.node, node_ancestor)
             self.hugr.add_link(src, node.inp(i))
 

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -76,3 +76,14 @@ class Dfg:
         for i, p in enumerate(ports):
             src = p.out_port()
             self.hugr.add_link(src, node.inp(i))
+
+
+def _ancestral_sibling(h: Hugr, src: Node, tgt: Node) -> Node | None:
+    src_parent = h[src].parent
+
+    while (tgt_parent := h[tgt].parent) is not None:
+        if tgt_parent == src_parent:
+            return tgt
+        tgt = tgt_parent
+
+    return None

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -4,6 +4,7 @@ from typing import Sequence, Iterable
 from ._hugr import Hugr, Node, Wire, OutPort
 
 from ._ops import Op, Command, Input, Output, DFG
+from ._exceptions import NoSiblingAncestor
 from hugr.serialization.tys import FunctionType, Type
 
 
@@ -72,6 +73,11 @@ class Dfg:
     def _wire_up(self, node: Node, ports: Iterable[Wire]):
         for i, p in enumerate(ports):
             src = p.out_port()
+            node_ancestor = _ancestral_sibling(self.hugr, src.node, node)
+            if node_ancestor is None:
+                raise NoSiblingAncestor(src.node.idx, node.idx)
+            if node_ancestor != src.node:
+                self.add_state_order(src.node, node_ancestor)
             self.hugr.add_link(src, node.inp(i))
 
 

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -67,10 +67,7 @@ class Dfg:
 
     def add_state_order(self, src: Node, dst: Node) -> None:
         # adds edge to the right of all existing edges
-        # breaks if further edges are added
-        self.hugr.add_link(
-            src.out(self.hugr.num_outgoing(src)), dst.inp(self.hugr.num_incoming(dst))
-        )
+        self.hugr.add_link(src.out(-1), dst.inp(-1))
 
     def _wire_up(self, node: Node, ports: Iterable[Wire]):
         for i, p in enumerate(ports):

--- a/hugr-py/src/hugr/_exceptions.py
+++ b/hugr-py/src/hugr/_exceptions.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class NoSiblingAncestor(Exception):
+    src: int
+    tgt: int
+
+    @property
+    def msg(self):
+        return f"Source {self.src} has no sibling ancestor of target {self.tgt}, so cannot wire up."

--- a/hugr-py/src/hugr/_hugr.py
+++ b/hugr-py/src/hugr/_hugr.py
@@ -260,6 +260,12 @@ class Hugr(Mapping[Node, NodeData]):
 
     # TODO: single linked port
 
+    def outgoing_order_links(self, node: Node) -> Iterable[Node]:
+        return (p.node for p in self.linked_ports(node.out(-1)))
+
+    def incoming_order_links(self, node: Node) -> Iterable[Node]:
+        return (p.node for p in self.linked_ports(node.inp(-1)))
+
     def _node_links(
         self, node: Node, links: dict[_SubPort[P], _SubPort[K]]
     ) -> Iterable[tuple[P, list[K]]]:
@@ -269,7 +275,6 @@ class Hugr(Mapping[Node, NodeData]):
             return
         # iterate over known offsets
         for offset in range(self.num_ports(node, direction)):
-            # TODO should this also look for -1 state order edges?
             port = cast(P, node.port(offset, direction))
             yield port, list(self._linked_ports(port, links))
 

--- a/hugr-py/src/hugr/_hugr.py
+++ b/hugr-py/src/hugr/_hugr.py
@@ -269,6 +269,7 @@ class Hugr(Mapping[Node, NodeData]):
             return
         # iterate over known offsets
         for offset in range(self.num_ports(node, direction)):
+            # TODO should this also look for -1 state order edges?
             port = cast(P, node.port(offset, direction))
             yield port, list(self._linked_ports(port, links))
 

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 import subprocess
 import os
 import pathlib
-from hugr._hugr import Hugr, Node, Wire
+from hugr._hugr import Hugr, Node, Wire, _SubPort
 from hugr._dfg import Dfg, _ancestral_sibling
 from hugr._ops import Custom, Command
 import hugr._ops as ops
@@ -232,11 +232,11 @@ def test_build_inter_graph():
 
     nt = nested.add(Not(a))
     nested.set_outputs(nt)
-    # TODO a context manager could add this state order edge on
-    # exit by tracking parents of source nodes
-    h.add_state_order(h.input_node, nested.root)
+
     h.set_outputs(nested.root, b)
 
+    assert _SubPort(h.input_node.out(-1)) in h.hugr._links
+    assert h.hugr.num_outgoing(h.input_node) == 2  # doesn't count state order
     _validate(h.hugr, True)
 
 

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -226,8 +226,8 @@ def test_build_nested():
 
 
 def test_build_inter_graph():
-    h = Dfg.endo([BOOL_T])
-    (a,) = h.inputs()
+    h = Dfg.endo([BOOL_T, BOOL_T])
+    (a, b) = h.inputs()
     nested = h.add_nested([], [BOOL_T])
 
     nt = nested.add(Not(a))
@@ -235,9 +235,9 @@ def test_build_inter_graph():
     # TODO a context manager could add this state order edge on
     # exit by tracking parents of source nodes
     h.add_state_order(h.input_node, nested.root)
-    h.set_outputs(nested.root)
+    h.set_outputs(nested.root, b)
 
-    _validate(h.hugr)
+    _validate(h.hugr, True)
 
 
 def test_ancestral_sibling():

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -4,7 +4,7 @@ import subprocess
 import os
 import pathlib
 from hugr._hugr import Hugr, Node, Wire
-from hugr._dfg import Dfg
+from hugr._dfg import Dfg, _ancestral_sibling
 from hugr._ops import Custom, Command
 import hugr._ops as ops
 from hugr.serialization import SerialHugr
@@ -238,3 +238,13 @@ def test_build_inter_graph():
     h.set_outputs(nested.root)
 
     _validate(h.hugr)
+
+
+def test_ancestral_sibling():
+    h = Dfg.endo([BOOL_T])
+    (a,) = h.inputs()
+    nested = h.add_nested([], [BOOL_T])
+
+    nt = nested.add(Not(a))
+
+    assert _ancestral_sibling(h.hugr, h.input_node, nt) == nested.root

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -235,9 +235,13 @@ def test_build_inter_graph():
 
     h.set_outputs(nested.root, b)
 
+    _validate(h.hugr, True)
+
     assert _SubPort(h.input_node.out(-1)) in h.hugr._links
     assert h.hugr.num_outgoing(h.input_node) == 2  # doesn't count state order
-    _validate(h.hugr, True)
+    assert len(list(h.hugr.outgoing_order_links(h.input_node))) == 1
+    assert len(list(h.hugr.incoming_order_links(nested.root))) == 1
+    assert len(list(h.hugr.incoming_order_links(h.output_node))) == 0
 
 
 def test_ancestral_sibling():


### PR DESCRIPTION
uses a slightly dodgy -1 offset hack

hack currently means if you query the hugr for outgoing edges the state order edges are ignored.