### PR TITLE
feat: `HugrView::extract_hugr` to extract regions into owned hugrs.

### DIFF
--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -263,6 +263,12 @@ impl Hugr {
         }
     }
 
+    /// Set the root node of the hugr.
+    pub(crate) fn set_root(&mut self, root: Node) {
+        self.hierarchy.detach(self.root);
+        self.root = root.pg_index();
+    }
+
     /// Add a node to the graph.
     pub(crate) fn add_node(&mut self, nodetype: NodeType) -> Node {
         let node = self

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -9,7 +9,7 @@ use crate::hugr::HugrError;
 use crate::ops::handle::NodeHandle;
 use crate::{Direction, Hugr, Node, Port};
 
-use super::{check_tag, HierarchyView, HugrInternals, HugrView, RootTagged};
+use super::{check_tag, ExtractHugr, HierarchyView, HugrInternals, HugrView, RootTagged};
 
 type RegionGraph<'g> = portgraph::view::Region<'g, &'g MultiPortGraph>;
 
@@ -174,6 +174,8 @@ where
         })
     }
 }
+
+impl<'g, Root: NodeHandle> ExtractHugr for DescendantsGraph<'g, Root> {}
 
 impl<'g, Root> super::HugrInternals for DescendantsGraph<'g, Root>
 where


### PR DESCRIPTION
Add a `extract_hugr` method to extract regions into owned `Hugr`s.
The implementation is short-circuited for `Hugr` to avoid unnecessary clones.

Closes #1171.