### PR TITLE
fix: Do not require matching extension_reqs when creating a replacement

### DIFF
--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -345,7 +345,12 @@ impl SiblingSubgraph {
         let Some([rep_input, rep_output]) = replacement.get_io(rep_root) else {
             return Err(InvalidReplacement::InvalidDataflowParent);
         };
-        if dfg_optype.dataflow_signature() != Some(self.signature(hugr)) {
+
+        let current_signature = self.signature(hugr);
+        let new_signature = dfg_optype.dataflow_signature();
+        if new_signature.as_ref().map(|s| &s.input) != Some(&current_signature.input)
+            || new_signature.as_ref().map(|s| &s.output) != Some(&current_signature.output)
+        {
             return Err(InvalidReplacement::InvalidSignature);
         }
 


### PR DESCRIPTION
Fixes #1175 

Signatures have three components:
- The input type row
- The output type row
- The set of extensions used by the local operations

Many interesting replacements in a graph changes the latter, but `SiblingSubgraph::create_simple_replacement` required the signatures to match exactly.