### PR TITLE
ci: Unpin nightly

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -123,9 +123,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Pinned nightly version until this gets resolved:
-        # https://github.com/rust-lang/rust/issues/125474
-        rust: ['1.75', beta, 'nightly-2024-05-22']
+        rust: ['1.75', beta, 'nightly']
     name: tests (Rust ${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v4
@@ -182,10 +180,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           # Nightly is required to count doctests coverage
-          #
-          # Pinned nightly version until this gets resolved
-          # https://github.com/rust-lang/rust/issues/125474
-          toolchain: 'nightly-2024-05-22'
+          toolchain: 'nightly'
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/hugr-core/src/builder/tail_loop.rs
+++ b/hugr-core/src/builder/tail_loop.rs
@@ -26,7 +26,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
         Ok(TailLoopBuilder::from_dfg_builder(dfg_build))
     }
     /// Set the outputs of the [`ops::TailLoop`], with `out_variant` as the value of the
-    /// termination Sum, and `rest` being the remaining outputs
+    /// termination Sum, and `rest` being the remaining outputs.
     pub fn set_outputs(
         &mut self,
         out_variant: Wire,


### PR DESCRIPTION
The ICE on nightly got fixed with a revert commit
https://github.com/rust-lang/rust/commit/98489f2487465f3765e5dd28d7305ebfd40f0865