### PR TITLE
refactor!: Remove "Signature" from hugr-py

### DIFF
--- a/hugr-py/src/hugr/serialization/tys.py
+++ b/hugr-py/src/hugr/serialization/tys.py
@@ -364,7 +364,7 @@ class Signature(ConfiguredBaseModel):
     (value) of a call (constant).
     """
 
-    signature: "PolyFuncType"  # The underlying signature
+    signature: "FunctionType"  # The underlying signature
 
     # The extensions which are associated with all the inputs and carried through
     input_extensions: ExtensionSet

--- a/hugr-py/src/hugr/serialization/tys.py
+++ b/hugr-py/src/hugr/serialization/tys.py
@@ -352,24 +352,6 @@ class Type(RootModel):
 TypeRow = list[Type]
 
 
-# -------------------------------------------
-# --------------- Signature -----------------
-# -------------------------------------------
-
-
-class Signature(ConfiguredBaseModel):
-    """Describes the edges required to/from a node.
-
-    This includes both the concept of "signature" in the spec, and also the target
-    (value) of a call (constant).
-    """
-
-    signature: "FunctionType"  # The underlying signature
-
-    # The extensions which are associated with all the inputs and carried through
-    input_extensions: ExtensionSet
-
-
 # Now that all classes are defined, we need to update the ForwardRefs in all type
 # annotations. We use some inspect magic to find all classes defined in this file
 # and call model_rebuild()


### PR DESCRIPTION
I was originally suspicious why this contained a PolyFuncType not a FunctionType, but AFAICS this isn't used, turns out that it doesn't change what goes into `specification/schema/` at all...

BREAKING CHANGE: the Signature class is gone, but it's not clear how or why you might have been using it...