### PR TITLE
chore: Unskip test now that input_extensions is no more

### DIFF
--- a/hugr-core/src/builder/circuit.rs
+++ b/hugr-core/src/builder/circuit.rs
@@ -258,10 +258,6 @@ mod test {
     };
 
     #[test]
-    #[cfg_attr(
-        feature = "extension_inference",
-        ignore = "Extension validation fails when mixing in the float extension"
-    )]
     fn simple_linear() {
         let build_res = build_main(
             FunctionType::new(type_row![QB, QB], type_row![QB, QB])


### PR DESCRIPTION
Removes the conditional test skip introduced in https://github.com/CQCL/hugr/pull/1168#issuecomment-2154936867, now that #1142 is merged.