### PR TITLE
refactor(hugr-py): simplify hugr replacement

### DIFF
--- a/hugr-py/src/hugr/_cfg.py
+++ b/hugr-py/src/hugr/_cfg.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Iterable, Sequence
-from ._hugr import Hugr, Node, ToNode, Wire
-from ._hugr import ParentBuilder
-from ._dfg import DfBase, _from_base
-from ._tys import FunctionType, TypeRow, Sum
-from ._exceptions import NoSiblingAncestor, NotInSameCfg
+from typing import Iterable, Mapping, Sequence
+
 import hugr._ops as ops
+
+from ._dfg import DfBase, _from_base
+from ._exceptions import NoSiblingAncestor, NotInSameCfg
+from ._hugr import Hugr, Node, ParentBuilder, ToNode, Wire
+from ._tys import FunctionType, Sum, TypeRow
 
 
 class Block(DfBase[ops.DataflowBlock]):
@@ -89,3 +91,10 @@ class Cfg(ParentBuilder):
 
     def branch(self, src: Wire, dst: ToNode) -> None:
         self.hugr.add_link(src.out_port(), dst.inp(0))
+
+    def _replace_hugr(self, mapping: Mapping[Node, Node], new_hugr: Hugr) -> None:
+        self.hugr = new_hugr
+        self.root = mapping[self.root]
+
+        self.exit = mapping[self.exit]
+        self._entry_block._replace_hugr(mapping, new_hugr)

--- a/hugr-py/src/hugr/_cfg.py
+++ b/hugr-py/src/hugr/_cfg.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Mapping, Sequence
+from typing import Iterable, Sequence
 
 import hugr._ops as ops
 
-from ._dfg import DfBase, _from_base
+from ._dfg import _DfBase
 from ._exceptions import NoSiblingAncestor, NotInSameCfg
 from ._hugr import Hugr, Node, ParentBuilder, ToNode, Wire
 from ._tys import FunctionType, Sum, TypeRow
 
 
-class Block(DfBase[ops.DataflowBlock]):
+class Block(_DfBase[ops.DataflowBlock]):
     def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
         self.set_outputs(branching, *other_outputs)
 
@@ -48,14 +48,36 @@ class Cfg(ParentBuilder):
 
     def __init__(self, input_types: TypeRow, output_types: TypeRow) -> None:
         root_op = ops.CFG(FunctionType(input=input_types, output=output_types))
-        self.hugr = Hugr(root_op)
-        self.root = self.hugr.root
+        hugr = Hugr(root_op)
+        self._init_impl(hugr, hugr.root, input_types, output_types)
+
+    def _init_impl(
+        self: Cfg, hugr: Hugr, root: Node, input_types: TypeRow, output_types: TypeRow
+    ) -> None:
+        self.hugr = hugr
+        self.root = root
         # to ensure entry is first child, add a dummy entry at the start
-        self._entry_block = _from_base(
-            Block, self.hugr.add_dfg(ops.DataflowBlock(input_types, []))
+        self._entry_block = Block.new_nested(
+            ops.DataflowBlock(input_types, []), hugr, root
         )
 
         self.exit = self.hugr.add_node(ops.ExitBlock(output_types), self.root)
+
+    @classmethod
+    def new_nested(
+        cls,
+        input_types: TypeRow,
+        output_types: TypeRow,
+        hugr: Hugr,
+        parent: ToNode | None = None,
+    ) -> Cfg:
+        new = cls.__new__(cls)
+        root = hugr.add_node(
+            ops.CFG(FunctionType(input=input_types, output=output_types)),
+            parent or hugr.root,
+        )
+        new._init_impl(hugr, root, input_types, output_types)
+        return new
 
     @property
     def entry(self) -> Node:
@@ -79,10 +101,12 @@ class Cfg(ParentBuilder):
     def add_block(
         self, input_types: TypeRow, sum_rows: Sequence[TypeRow], other_outputs: TypeRow
     ) -> Block:
-        new_block = self.hugr.add_dfg(
-            ops.DataflowBlock(input_types, list(sum_rows), other_outputs)
+        new_block = Block.new_nested(
+            ops.DataflowBlock(input_types, list(sum_rows), other_outputs),
+            self.hugr,
+            self.root,
         )
-        return _from_base(Block, new_block)
+        return new_block
 
     def simple_block(
         self, input_types: TypeRow, n_branches: int, other_outputs: TypeRow
@@ -91,10 +115,3 @@ class Cfg(ParentBuilder):
 
     def branch(self, src: Wire, dst: ToNode) -> None:
         self.hugr.add_link(src.out_port(), dst.inp(0))
-
-    def _replace_hugr(self, mapping: Mapping[Node, Node], new_hugr: Hugr) -> None:
-        self.hugr = new_hugr
-        self.root = mapping[self.root]
-
-        self.exit = mapping[self.exit]
-        self._entry_block._replace_hugr(mapping, new_hugr)

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import typing
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Iterable, Mapping, TypeVar, cast
-
+from typing import TYPE_CHECKING, Generic, Iterable, TypeVar, cast
+from typing_extensions import Self
 import hugr._ops as ops
 from hugr._tys import FunctionType, TypeRow
 
 from ._exceptions import NoSiblingAncestor
-from ._hugr import Hugr, Node, OutPort, ParentBuilder, Wire
+from ._hugr import Hugr, Node, OutPort, ParentBuilder, Wire, ToNode
 
 if TYPE_CHECKING:
     from ._cfg import Cfg
@@ -18,21 +17,33 @@ DP = TypeVar("DP", bound=ops.DfParentOp)
 
 
 @dataclass()
-class DfBase(ParentBuilder, Generic[DP]):
+class _DfBase(ParentBuilder, Generic[DP]):
     hugr: Hugr
     root: Node
     input_node: Node
     output_node: Node
 
     def __init__(self, root_op: DP) -> None:
-        input_types = root_op.input_types()
-        output_types = root_op.output_types()
         self.hugr = Hugr(root_op)
         self.root = self.hugr.root
+        self._init_io_nodes(root_op)
+
+    def _init_io_nodes(self, root_op: DP):
+        input_types = root_op.input_types()
+        output_types = root_op.output_types()
         self.input_node = self.hugr.add_node(
             ops.Input(input_types), self.root, len(input_types)
         )
         self.output_node = self.hugr.add_node(ops.Output(output_types), self.root)
+
+    @classmethod
+    def new_nested(cls, root_op: DP, hugr: Hugr, parent: ToNode | None = None) -> Self:
+        new = cls.__new__(cls)
+
+        new.hugr = hugr
+        new.root = hugr.add_node(root_op, parent or hugr.root)
+        new._init_io_nodes(root_op)
+        return new
 
     def _input_op(self) -> ops.Input:
         dop = self.hugr[self.input_node].op
@@ -69,11 +80,12 @@ class DfBase(ParentBuilder, Generic[DP]):
         output_types: TypeRow,
         *args: Wire,
     ) -> Dfg:
-        dfg = self.hugr.add_dfg(
-            ops.DFG(FunctionType(input=input_types, output=output_types))
-        )
+        from ._dfg import Dfg
+
+        root_op = ops.DFG(FunctionType(input=input_types, output=output_types))
+        dfg = Dfg.new_nested(root_op, self.hugr, self.root)
         self._wire_up(dfg.root, args)
-        return _from_base(Dfg, dfg)
+        return dfg
 
     def add_cfg(
         self,
@@ -81,7 +93,9 @@ class DfBase(ParentBuilder, Generic[DP]):
         output_types: TypeRow,
         *args: Wire,
     ) -> Cfg:
-        cfg = self.hugr.add_cfg(input_types, output_types)
+        from ._cfg import Cfg
+
+        cfg = Cfg.new_nested(input_types, output_types, self.hugr, self.root)
         self._wire_up(cfg.root, args)
         return cfg
 
@@ -110,27 +124,8 @@ class DfBase(ParentBuilder, Generic[DP]):
             self.add_state_order(src.node, node_ancestor)
         self.hugr.add_link(src, node.inp(offset))
 
-    def _replace_hugr(self, mapping: Mapping[Node, Node], new_hugr: Hugr) -> None:
-        self.hugr = new_hugr
-        self.root = mapping[self.root]
 
-        self.input_node = mapping[self.input_node]
-        self.output_node = mapping[self.output_node]
-
-
-C = TypeVar("C", bound=DfBase)
-
-
-def _from_base(cls: typing.Type[C], base: DfBase[DP]) -> C:
-    new = cls.__new__(cls)
-    new.hugr = base.hugr
-    new.root = base.root
-    new.input_node = base.input_node
-    new.output_node = base.output_node
-    return new
-
-
-class Dfg(DfBase[ops.DFG]):
+class Dfg(_DfBase[ops.DFG]):
     def __init__(self, input_types: TypeRow, output_types: TypeRow) -> None:
         root_op = ops.DFG(FunctionType(input=input_types, output=output_types))
         super().__init__(root_op)

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import Iterable, TYPE_CHECKING, Generic, TypeVar, cast
+
 import typing
-from ._hugr import Hugr, Node, Wire, OutPort, ParentBuilder
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, Iterable, Mapping, TypeVar, cast
 
 import hugr._ops as ops
-from ._exceptions import NoSiblingAncestor
 from hugr._tys import FunctionType, TypeRow
+
+from ._exceptions import NoSiblingAncestor
+from ._hugr import Hugr, Node, OutPort, ParentBuilder, Wire
 
 if TYPE_CHECKING:
     from ._cfg import Cfg
@@ -107,6 +109,13 @@ class DfBase(ParentBuilder, Generic[DP]):
         if node_ancestor != node:
             self.add_state_order(src.node, node_ancestor)
         self.hugr.add_link(src, node.inp(offset))
+
+    def _replace_hugr(self, mapping: Mapping[Node, Node], new_hugr: Hugr) -> None:
+        self.hugr = new_hugr
+        self.root = mapping[self.root]
+
+        self.input_node = mapping[self.input_node]
+        self.output_node = mapping[self.output_node]
 
 
 C = TypeVar("C", bound=DfBase)

--- a/hugr-py/src/hugr/_hugr.py
+++ b/hugr-py/src/hugr/_hugr.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import (
-    TYPE_CHECKING,
     ClassVar,
     Generic,
     Iterable,
@@ -18,16 +17,11 @@ from typing import (
 from typing_extensions import Self
 
 from hugr._ops import Op
-from hugr._tys import TypeRow
 from hugr.serialization.ops import OpType as SerialOp
 from hugr.serialization.serial_hugr import SerialHugr
 from hugr.utils import BiMap
 
 from ._exceptions import ParentBeforeChild
-
-if TYPE_CHECKING:
-    from ._dfg import DfBase, DP
-    from ._cfg import Cfg
 
 
 class Direction(Enum):
@@ -157,8 +151,6 @@ class ParentBuilder(ToNode, Protocol):
 
     def to_node(self) -> Node:
         return self.root
-
-    def _replace_hugr(self, mapping: Mapping[Node, Node], new_hugr: Hugr) -> None: ...
 
 
 @dataclass()
@@ -361,22 +353,6 @@ class Hugr(Mapping[Node, NodeData]):
                 mapping[dst.port.node].inp(dst.port.offset),
             )
         return mapping
-
-    def add_dfg(self, root_op: DP) -> DfBase[DP]:
-        from ._dfg import DfBase
-
-        dfg = DfBase(root_op)
-        mapping = self.insert_hugr(dfg.hugr, self.root)
-        dfg._replace_hugr(mapping, self)
-        return dfg
-
-    def add_cfg(self, input_types: TypeRow, output_types: TypeRow) -> Cfg:
-        from ._cfg import Cfg
-
-        cfg = Cfg(input_types, output_types)
-        mapping = self.insert_hugr(cfg.hugr, self.root)
-        cfg._replace_hugr(mapping, self)
-        return cfg
 
     def to_serial(self) -> SerialHugr:
         node_it = (node for node in self._nodes if node is not None)


### PR DESCRIPTION
this exists as a tension between global/compositional building. Inter-graph edges necessitate global, all-at-once building for some cases. ~These update functions are required when inserting graphs in to other ones~ Instead replaced with `new_nested` classmethods inspired by https://github.com/CQCL/hugr/pull/1192#discussion_r1642486028