### PR TITLE
feat!: Infer extension deltas for Case, Cfg, Conditional, DataflowBlock, Dfg, TailLoop 

### DIFF
--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -406,6 +406,8 @@ pub enum ExtensionBuildError {
 pub struct ExtensionSet(BTreeSet<ExtensionId>);
 
 impl ExtensionSet {
+    pub const TO_BE_INFERRED: ExtensionId = ExtensionId::new_unchecked("TO_BE_INFERRED");
+
     /// Creates a new empty extension set.
     pub const fn new() -> Self {
         Self(BTreeSet::new())

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -405,9 +405,20 @@ pub enum ExtensionBuildError {
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ExtensionSet(BTreeSet<ExtensionId>);
 
-impl ExtensionSet {
-    pub const TO_BE_INFERRED: ExtensionId = ExtensionId::new_unchecked("TO_BE_INFERRED");
+/// A special ExtensionId which indicates that the delta of a non-Function
+/// container node should be computed by extension inference.
+/// Usable only in non-Function container nodes
+/// ([Case], [CFG], [Conditional], [DataflowBlock], [DFG], [TailLoop])
+///
+/// [Case]: crate::ops::Case
+/// [CFG]: crate::ops::CFG
+/// [Conditional]: crate::ops::Conditional
+/// [DataflowBlock]: crate::ops::DataflowBlock
+/// [DFG]: crate::ops::DFG
+/// [TailLoop]: crate::ops::TailLoop
+pub const TO_BE_INFERRED: ExtensionId = ExtensionId::new_unchecked("TO_BE_INFERRED");
 
+impl ExtensionSet {
     /// Creates a new empty extension set.
     pub const fn new() -> Self {
         Self(BTreeSet::new())

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -406,16 +406,10 @@ pub enum ExtensionBuildError {
 pub struct ExtensionSet(BTreeSet<ExtensionId>);
 
 /// A special ExtensionId which indicates that the delta of a non-Function
-/// container node should be computed by extension inference.
-/// Usable only in non-Function container nodes
-/// ([Case], [CFG], [Conditional], [DataflowBlock], [DFG], [TailLoop])
+/// container node should be computed by extension inference. See [`infer_extensions`]
+/// which lists the container nodes to which this can be applied.
 ///
-/// [Case]: crate::ops::Case
-/// [CFG]: crate::ops::CFG
-/// [Conditional]: crate::ops::Conditional
-/// [DataflowBlock]: crate::ops::DataflowBlock
-/// [DFG]: crate::ops::DFG
-/// [TailLoop]: crate::ops::TailLoop
+/// [`infer_extensions`]: crate::hugr::Hugr::infer_extensions
 pub const TO_BE_INFERRED: ExtensionId = ExtensionId::new_unchecked(".TO_BE_INFERRED");
 
 impl ExtensionSet {

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -416,7 +416,7 @@ pub struct ExtensionSet(BTreeSet<ExtensionId>);
 /// [DataflowBlock]: crate::ops::DataflowBlock
 /// [DFG]: crate::ops::DFG
 /// [TailLoop]: crate::ops::TailLoop
-pub const TO_BE_INFERRED: ExtensionId = ExtensionId::new_unchecked("TO_BE_INFERRED");
+pub const TO_BE_INFERRED: ExtensionId = ExtensionId::new_unchecked(".TO_BE_INFERRED");
 
 impl ExtensionSet {
     /// Creates a new empty extension set.

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -13,7 +13,6 @@ use std::collections::VecDeque;
 use std::iter;
 
 pub(crate) use self::hugrmut::HugrMut;
-use self::validate::ExtensionError;
 pub use self::validate::ValidationError;
 
 pub use ident::{IdentList, InvalidIdentifier};
@@ -25,7 +24,7 @@ use thiserror::Error;
 
 pub use self::views::{HugrView, RootTagged};
 use crate::core::NodeIndex;
-use crate::extension::ExtensionRegistry;
+use crate::extension::{ExtensionRegistry, ExtensionSet};
 use crate::ops::custom::resolve_extension_ops;
 use crate::ops::OpTag;
 pub use crate::ops::{OpType, DEFAULT_OPTYPE};
@@ -201,6 +200,16 @@ impl Hugr {
         // This step is not strictly necessary.
         self.graph.compact_nodes(|_, _| {});
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Error)]
+#[error("Parent node {parent} has extensions {parent_extensions} that are too restrictive for child node {child}, they must include child extensions {child_extensions}")]
+/// An error in the extension deltas.
+pub struct ExtensionError {
+    parent: Node,
+    parent_extensions: ExtensionSet,
+    child: Node,
+    child_extensions: ExtensionSet,
 }
 
 /// Errors that can occur while manipulating a Hugr.

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -419,7 +419,7 @@ mod test {
     #[case([XA], [TO_BE_INFERRED], true, [XA])]
     // Success: delta inferred for parent is subset of grandparent
     #[case([XA, XB], [TO_BE_INFERRED], true, [XA])]
-    // Base case failure: infers [XA] for parent but grandparent has disjoint et
+    // Base case failure: infers [XA] for parent but grandparent has disjoint set
     #[case([XB], [TO_BE_INFERRED], false, [XA])]
     // Failure: as previous, but extra "lower bound" on parent that has no effect
     #[case([XB], [XA, TO_BE_INFERRED], false, [XA])]

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -337,25 +337,25 @@ mod test {
         #[case] result: ExtensionSet,
     ) {
         let parent = ExtensionSet::from_iter(parent).union(TO_BE_INFERRED.into());
-        let (mut h, _) = build_ext_cfg(parent);
+        let (mut h, _) = build_ext_dfg(parent);
         h.infer_extensions(remove).unwrap();
-        assert_eq!(h, build_ext_cfg(result).0);
+        assert_eq!(h, build_ext_dfg(result).0);
     }
 
     #[test]
     fn infer_removes_from_delta() {
         let parent = ExtensionSet::from_iter([XA, XB]);
-        let mut h = build_ext_cfg(parent.clone()).0;
+        let mut h = build_ext_dfg(parent.clone()).0;
         let backup = h.clone();
         h.infer_extensions(false).unwrap();
         assert_eq!(h, backup); // did nothing
         h.infer_extensions(true).unwrap();
-        assert_eq!(h, build_ext_cfg(XA.into()).0);
+        assert_eq!(h, build_ext_dfg(XA.into()).0);
     }
 
     #[test]
     fn infer_bad_remove() {
-        let (mut h, mid) = build_ext_cfg(XB.into());
+        let (mut h, mid) = build_ext_dfg(XB.into());
         let backup = h.clone();
         h.infer_extensions(false).unwrap();
         assert_eq!(h, backup); // did nothing
@@ -378,7 +378,7 @@ mod test {
         assert_eq!(inf_res, Err(expected_err));
     }
 
-    fn build_ext_cfg(parent: ExtensionSet) -> (Hugr, Node) {
+    fn build_ext_dfg(parent: ExtensionSet) -> (Hugr, Node) {
         let ty = Type::new_function(FunctionType::new_endo(type_row![]));
         let mut h = Hugr::new(ops::DFG {
             signature: FunctionType::new_endo(ty.clone()).with_extension_delta(parent.clone()),

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -414,16 +414,22 @@ mod test {
     }
 
     #[rstest]
-    #[case([XA], [XB, TO_BE_INFERRED], false, [XA, XB])]
+    // Base case success: delta inferred for parent equals grandparent.
     #[case([XA], [TO_BE_INFERRED], true, [XA])]
-    #[case([XB], [TO_BE_INFERRED], false, [XA])]
-    #[case([XB], [XA, TO_BE_INFERRED], false, [XA])]
-    #[case([XA, XB], [XB, TO_BE_INFERRED], true, [XA, XB])]
+    // Success: delta inferred for parent is subset of grandparent
     #[case([XA, XB], [TO_BE_INFERRED], true, [XA])]
+    // Base case failure: infers [XA] for parent but grandparent has disjoint et
+    #[case([XB], [TO_BE_INFERRED], false, [XA])]
+    // Failure: as previous, but extra "lower bound" on parent that has no effect
+    #[case([XB], [XA, TO_BE_INFERRED], false, [XA])]
+    // Failure: grandparent ok wrt. child but parent specifies extra lower-bound XB
+    #[case([XA], [XB, TO_BE_INFERRED], false, [XA, XB])]
+    // Success: grandparent includes extra XB required for parent's "lower bound"
+    #[case([XA, XB], [XB, TO_BE_INFERRED], true, [XA, XB])]
+    // Success: grandparent is also inferred so can include 'extra' XB from parent
     #[case([TO_BE_INFERRED], [TO_BE_INFERRED, XB], true, [XA, XB])]
-    // This one just tests removal:
+    // No inference: extraneous XB in parent is removed so all become [XA].
     #[case([XA], [XA, XB], true, [XA])]
-    // TODO: Consider adding a separate expected-grandparent so we can have something different?
     fn infer_three_generations(
         #[case] grandparent: impl IntoIterator<Item = ExtensionId>,
         #[case] parent: impl IntoIterator<Item = ExtensionId>,

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 
 pub use self::views::{HugrView, RootTagged};
 use crate::core::NodeIndex;
-use crate::extension::{ExtensionRegistry, ExtensionSet};
+use crate::extension::{ExtensionRegistry, ExtensionSet, TO_BE_INFERRED};
 use crate::ops::custom::resolve_extension_ops;
 use crate::ops::{OpTag, OpTrait};
 pub use crate::ops::{OpType, DEFAULT_OPTYPE};
@@ -124,7 +124,7 @@ impl Hugr {
             let Some(es) = delta_mut(h.op_types.get_mut(node.pg_index())) else {
                 return Ok(h.get_optype(node).extension_delta());
             };
-            if es.contains(&ExtensionSet::TO_BE_INFERRED) {
+            if es.contains(&TO_BE_INFERRED) {
                 // Do not remove anything from current delta - any other elements are a lower bound
                 child_sets.push((node, es.clone())); // "child_sets" now misnamed but we discard fst
             } else if remove {
@@ -143,7 +143,7 @@ impl Hugr {
                 return Ok(es.clone()); // Can't neither add nor remove, so nothing to do
             }
             let merged = ExtensionSet::union_over(child_sets.into_iter().map(|(_, e)| e));
-            *es = ExtensionSet::singleton(&ExtensionSet::TO_BE_INFERRED).missing_from(&merged);
+            *es = ExtensionSet::singleton(&TO_BE_INFERRED).missing_from(&merged);
 
             Ok(es.clone())
         }

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -97,8 +97,25 @@ impl Hugr {
         Ok(())
     }
 
-    /// Leaving this here as in the future we plan for it to infer deltas
-    /// of container nodes e.g. [OpType::DFG]. For the moment it does nothing.
+    /// Infers an extension-delta for any non-function container node
+    /// whose current [extension_delta] contains [TO_BE_INFERRED]. The inferred delta
+    /// will be the smallest delta compatible with its children and that includes any
+    /// other [ExtensionId]s in the current delta.
+    ///
+    /// If `remove` is true, for such container nodes *without* [TO_BE_INFERRED],
+    /// ExtensionIds are removed from the delta if they are *not* used by any child node.
+    ///
+    /// The non-function container nodes are:
+    /// [Case], [CFG], [Conditional], [DataflowBlock], [DFG], [TailLoop]
+    ///
+    /// [Case]: crate::ops::Case
+    /// [CFG]: crate::ops::CFG
+    /// [Conditional]: crate::ops::Conditional
+    /// [DataflowBlock]: crate::ops::DataflowBlock
+    /// [DFG]: crate::ops::DFG
+    /// [TailLoop]: crate::ops::TailLoop
+    /// [extension_delta]: crate::ops::OpType::extension_delta
+    /// [ExtensionId]: crate::extension::ExtensionId
     pub fn infer_extensions(&mut self, remove: bool) -> Result<(), ExtensionError> {
         fn delta_mut(optype: &mut OpType) -> Option<&mut ExtensionSet> {
             match optype {

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -9,7 +9,7 @@ use petgraph::visit::{Topo, Walker};
 use portgraph::{LinkView, PortView};
 use thiserror::Error;
 
-use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
+use crate::extension::{ExtensionRegistry, SignatureError, TO_BE_INFERRED};
 
 use crate::ops::custom::{resolve_opaque_op, CustomOp, CustomOpError};
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
@@ -60,10 +60,7 @@ impl Hugr {
     pub fn validate_extensions(&self) -> Result<(), ValidationError> {
         for parent in self.nodes() {
             let parent_op = self.get_optype(parent);
-            if parent_op
-                .extension_delta()
-                .contains(&ExtensionSet::TO_BE_INFERRED)
-            {
+            if parent_op.extension_delta().contains(&TO_BE_INFERRED) {
                 return Err(ValidationError::ExtensionsNotInferred { node: parent });
             }
             let parent_extensions = match parent_op.inner_function_type() {

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -747,8 +747,8 @@ pub enum ValidationError {
     /// There are errors in the extension deltas.
     #[error(transparent)]
     ExtensionError(#[from] ExtensionError),
-    /// A node claims to still be awaiting extension inference. Perhaps it is not acted upon by inference...
-    #[error("Node {node:?} needs a concrete ExtensionSet - inference will provide this for TailLoop/Conditional/CFG/DFG/BasicBlock only")]
+    /// A node claims to still be awaiting extension inference. Perhaps it is not acted upon by inference.
+    #[error("Node {node:?} needs a concrete ExtensionSet - inference will provide this for Case/CFG/Conditional/DataflowBlock/DFG/TailLoop only")]
     ExtensionsNotInferred { node: Node },
     /// Error in a node signature
     #[error("Error in signature of node {node:?}: {cause}")]

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -9,7 +9,7 @@ use petgraph::visit::{Topo, Walker};
 use portgraph::{LinkView, PortView};
 use thiserror::Error;
 
-use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
+use crate::extension::{ExtensionRegistry, SignatureError};
 
 use crate::ops::custom::{resolve_opaque_op, CustomOp, CustomOpError};
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
@@ -19,6 +19,7 @@ use crate::types::{EdgeKind, FunctionType};
 use crate::{Direction, Hugr, Node, Port};
 
 use super::views::{HierarchyView, HugrView, SiblingGraph};
+use super::ExtensionError;
 
 /// Structure keeping track of pre-computed information used in the validation
 /// process.
@@ -813,16 +814,6 @@ pub enum InterGraphEdgeError {
         from_parent: Node,
         ancestor: Node,
     },
-}
-
-#[derive(Debug, Clone, PartialEq, Error)]
-#[error("Parent node {parent} has extensions {parent_extensions} that are too restrictive for child node {child}, they must include child extensions {child_extensions}")]
-/// An error in the extension deltas.
-pub struct ExtensionError {
-    parent: Node,
-    parent_extensions: ExtensionSet,
-    child: Node,
-    child_extensions: ExtensionSet,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* Add an ExtensionId TO_BE_INFERRED
* On Case, Cfg, Conditional, DataflowBlock, Dfg, TailLoop, `Hugr::infer_extensions` replaces TO_BE_INFERRED with the smallest set of ExtensionIds that's correct wrt. its child nodes (i.e., the union of the child node deltas). If there are other ExtensionIds alongside TO_BE_INFERRED these will be kept (allowing a "lower bound" to be specified for individual nodes)
* `Hugr::infer_extensions` also takes a `remove: bool` which, if true, modifies deltas of the same OpTypes that do *not* have TO_BE_INFERRED, by removing ExtensionIds. (Thus, non-inferred deltas act as upper bounds).

Relates to #640 but does not address the builder where this should be the default behaviour.

BREAKING CHANGE: ExtensionError moved from hugr::validate to hugr; Hugr::infer_extensions takes bool parameter