### PR TITLE
feat(hugr-py): only require input type annotations when building

### DIFF
--- a/hugr-py/src/hugr/_cfg.py
+++ b/hugr-py/src/hugr/_cfg.py
@@ -116,9 +116,7 @@ class Cfg(ParentBuilder[ops.CFG]):
         src = src.out_port()
         self.hugr.add_link(src, self.exit.inp(0))
 
-        src_block: ops.DataflowBlock = self.hugr._get_typed_op(
-            src.node, ops.DataflowBlock
-        )
+        src_block = self.hugr._get_typed_op(src.node, ops.DataflowBlock)
         out_types = src_block.nth_outputs(src.offset)
         if self._exit_op._cfg_outputs is not None:
             if self._exit_op._cfg_outputs != out_types:

--- a/hugr-py/src/hugr/_cfg.py
+++ b/hugr-py/src/hugr/_cfg.py
@@ -77,9 +77,11 @@ class Cfg(ParentBuilder[ops.CFG]):
     def entry(self) -> Node:
         return self._entry_block.parent_node
 
+    @property
     def _entry_op(self) -> ops.DataflowBlock:
         return self.hugr._get_typed_op(self.entry, ops.DataflowBlock)
 
+    @property
     def _exit_op(self) -> ops.ExitBlock:
         return self.hugr._get_typed_op(self.exit, ops.ExitBlock)
 
@@ -101,11 +103,11 @@ class Cfg(ParentBuilder[ops.CFG]):
         if dst == self.exit:
             src_block = self.hugr._get_typed_op(src.node, ops.DataflowBlock)
             out_types = [*src_block.sum_rows[src.offset], *src_block.other_outputs]
-            if self._exit_op()._cfg_outputs is not None:
-                if self._exit_op()._cfg_outputs != out_types:
+            if self._exit_op._cfg_outputs is not None:
+                if self._exit_op._cfg_outputs != out_types:
                     raise MismatchedExit(src.node.idx)
             else:
-                self._exit_op()._cfg_outputs = out_types
-                self.parent_op().signature = replace(
-                    self.parent_op().signature, output=out_types
+                self._exit_op._cfg_outputs = out_types
+                self.parent_op.signature = replace(
+                    self.parent_op.signature, output=out_types
                 )

--- a/hugr-py/src/hugr/_cfg.py
+++ b/hugr-py/src/hugr/_cfg.py
@@ -84,9 +84,10 @@ class Cfg(ParentBuilder):
         return self._entry_block.root
 
     def _entry_op(self) -> ops.DataflowBlock:
-        dop = self.hugr[self.entry].op
-        assert isinstance(dop, ops.DataflowBlock)
-        return dop
+        return self.hugr._get_typed_op(self.entry, ops.DataflowBlock)
+
+    def _exit_op(self) -> ops.ExitBlock:
+        return self.hugr._get_typed_op(self.exit, ops.ExitBlock)
 
     def add_entry(self, sum_rows: Sequence[TypeRow], other_outputs: TypeRow) -> Block:
         # update entry block types

--- a/hugr-py/src/hugr/_cfg.py
+++ b/hugr-py/src/hugr/_cfg.py
@@ -54,11 +54,9 @@ class Cfg(ParentBuilder[ops.CFG]):
         self.hugr = hugr
         self.parent_node = root
         # to ensure entry is first child, add a dummy entry at the start
-        self._entry_block = Block.new_nested(
-            ops.DataflowBlock(input_types, []), hugr, root
-        )
+        self._entry_block = Block.new_nested(ops.DataflowBlock(input_types), hugr, root)
 
-        self.exit = self.hugr.add_node(ops.ExitBlock([]), self.parent_node)
+        self.exit = self.hugr.add_node(ops.ExitBlock(), self.parent_node)
 
     @classmethod
     def new_nested(
@@ -90,7 +88,7 @@ class Cfg(ParentBuilder[ops.CFG]):
 
     def add_block(self, input_types: TypeRow) -> Block:
         new_block = Block.new_nested(
-            ops.DataflowBlock(input_types, [], []),
+            ops.DataflowBlock(input_types),
             self.hugr,
             self.parent_node,
         )
@@ -103,11 +101,11 @@ class Cfg(ParentBuilder[ops.CFG]):
         if dst == self.exit:
             src_block = self.hugr._get_typed_op(src.node, ops.DataflowBlock)
             out_types = [*src_block.sum_rows[src.offset], *src_block.other_outputs]
-            if self._exit_op().cfg_outputs:
-                if self._exit_op().cfg_outputs != out_types:
+            if self._exit_op()._cfg_outputs is not None:
+                if self._exit_op()._cfg_outputs != out_types:
                     raise MismatchedExit(src.node.idx)
             else:
-                self._exit_op().cfg_outputs = out_types
+                self._exit_op()._cfg_outputs = out_types
                 self.parent_op().signature = replace(
                     self.parent_op().signature, output=out_types
                 )

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -55,14 +55,10 @@ class _DfBase(ParentBuilder, Generic[DP]):
         return new
 
     def _input_op(self) -> ops.Input:
-        dop = self.hugr[self.input_node].op
-        assert isinstance(dop, ops.Input)
-        return dop
+        return self.hugr._get_typed_op(self.input_node, ops.Input)
 
     def _output_op(self) -> ops.Output:
-        dop = self.hugr[self.output_node].op
-        assert isinstance(dop, ops.Output)
-        return dop
+        return self.hugr._get_typed_op(self.output_node, ops.Output)
 
     def root_op(self) -> DP:
         return cast(DP, self.hugr[self.root].op)

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -29,13 +29,13 @@ class _DfBase(ParentBuilder[DP]):
     input_node: Node
     output_node: Node
 
-    def __init__(self, root_op: DP) -> None:
-        self.hugr = Hugr(root_op)
+    def __init__(self, parent_op: DP) -> None:
+        self.hugr = Hugr(parent_op)
         self.parent_node = self.hugr.root
-        self._init_io_nodes(root_op)
+        self._init_io_nodes(parent_op)
 
-    def _init_io_nodes(self, root_op: DP):
-        inputs = root_op._inputs()
+    def _init_io_nodes(self, parent_op: DP):
+        inputs = parent_op._inputs()
 
         self.input_node = self.hugr.add_node(
             ops.Input(inputs), self.parent_node, len(inputs)
@@ -43,12 +43,14 @@ class _DfBase(ParentBuilder[DP]):
         self.output_node = self.hugr.add_node(ops.Output(), self.parent_node)
 
     @classmethod
-    def new_nested(cls, root_op: DP, hugr: Hugr, parent: ToNode | None = None) -> Self:
+    def new_nested(
+        cls, parent_op: DP, hugr: Hugr, parent: ToNode | None = None
+    ) -> Self:
         new = cls.__new__(cls)
 
         new.hugr = hugr
-        new.parent_node = hugr.add_node(root_op, parent or hugr.root)
-        new._init_io_nodes(root_op)
+        new.parent_node = hugr.add_node(parent_op, parent or hugr.root)
+        new._init_io_nodes(parent_op)
         return new
 
     def _input_op(self) -> ops.Input:
@@ -82,8 +84,8 @@ class _DfBase(ParentBuilder[DP]):
 
         input_types = [self._get_dataflow_type(w) for w in args]
 
-        root_op = ops.DFG(list(input_types))
-        dfg = Dfg.new_nested(root_op, self.hugr, self.parent_node)
+        parent_op = ops.DFG(list(input_types))
+        dfg = Dfg.new_nested(parent_op, self.hugr, self.parent_node)
         self._wire_up(dfg.parent_node, args)
         return dfg
 
@@ -136,8 +138,8 @@ class _DfBase(ParentBuilder[DP]):
 
 class Dfg(_DfBase[ops.DFG]):
     def __init__(self, *input_types: Type) -> None:
-        root_op = ops.DFG(list(input_types))
-        super().__init__(root_op)
+        parent_op = ops.DFG(list(input_types))
+        super().__init__(parent_op)
 
 
 def _ancestral_sibling(h: Hugr, src: Node, tgt: Node) -> Node | None:

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -97,7 +97,7 @@ class _DfBase(ParentBuilder[DP]):
     ) -> Cfg:
         from ._cfg import Cfg
 
-        cfg = Cfg.new_nested(input_types, output_types, self.hugr, self.parent_node)
+        cfg = Cfg.new_nested(input_types, self.hugr, self.parent_node)
         self._wire_up(cfg.parent_node, args)
         return cfg
 

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -105,7 +105,7 @@ class _DfBase(ParentBuilder[DP]):
 
     def set_outputs(self, *args: Wire) -> None:
         self._wire_up(self.output_node, args)
-        self.parent_op()._set_out_types(self._output_op().types)
+        self.parent_op._set_out_types(self._output_op().types)
 
     def add_state_order(self, src: Node, dst: Node) -> None:
         # adds edge to the right of all existing edges

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -29,12 +29,12 @@ class _DfBase(ParentBuilder, Generic[DP]):
         self._init_io_nodes(root_op)
 
     def _init_io_nodes(self, root_op: DP):
-        input_types = root_op.input_types()
-        output_types = root_op.output_types()
+        inner_sig = root_op.inner_signature()
+
         self.input_node = self.hugr.add_node(
-            ops.Input(input_types), self.root, len(input_types)
+            ops.Input(inner_sig.input), self.root, len(inner_sig.input)
         )
-        self.output_node = self.hugr.add_node(ops.Output(output_types), self.root)
+        self.output_node = self.hugr.add_node(ops.Output(inner_sig.output), self.root)
 
     @classmethod
     def new_nested(cls, root_op: DP, hugr: Hugr, parent: ToNode | None = None) -> Self:
@@ -61,7 +61,9 @@ class _DfBase(ParentBuilder, Generic[DP]):
     def inputs(self) -> list[OutPort]:
         return [self.input_node.out(i) for i in range(len(self._input_op().types))]
 
-    def add_op(self, op: ops.Op, /, *args: Wire, num_outs: int | None = None) -> Node:
+    def add_op(
+        self, op: ops.DataflowOp, /, *args: Wire, num_outs: int | None = None
+    ) -> Node:
         new_n = self.hugr.add_node(op, self.root, num_outs=num_outs)
         self._wire_up(new_n, args)
         return new_n

--- a/hugr-py/src/hugr/_dfg.py
+++ b/hugr-py/src/hugr/_dfg.py
@@ -108,7 +108,7 @@ class _DfBase(ParentBuilder[DP]):
 
     def set_outputs(self, *args: Wire) -> None:
         self._wire_up(self.output_node, args)
-        self.parent_op()._set_out_types(self._output_op().types)
+        self.parent_op()._set_out_types(self._output_op()._types())
 
     def add_state_order(self, src: Node, dst: Node) -> None:
         # adds edge to the right of all existing edges
@@ -116,8 +116,8 @@ class _DfBase(ParentBuilder[DP]):
 
     def _wire_up(self, node: Node, ports: Iterable[Wire]):
         tys = [self._wire_up_port(node, i, p) for i, p in enumerate(ports)]
-        if isinstance(op := self.hugr[node].op, ops.DataflowOp):
-            op._set_in_types(tys)
+        if isinstance(op := self.hugr[node].op, ops.PartialOp):
+            op.set_in_types(tys)
 
     def _get_dataflow_type(self, wire: Wire) -> Type:
         port = wire.out_port()

--- a/hugr-py/src/hugr/_exceptions.py
+++ b/hugr-py/src/hugr/_exceptions.py
@@ -21,5 +21,16 @@ class NotInSameCfg(Exception):
         return f"Source {self.src} is not in the same CFG as target {self.tgt}, so cannot wire up."
 
 
+@dataclass
+class MismatchedExit(Exception):
+    src: int
+
+    @property
+    def msg(self):
+        return (
+            f"Exit branch from node {self.src} does not match existing exit block type."
+        )
+
+
 class ParentBeforeChild(Exception):
     msg: str = "Parent node must be added before child node."

--- a/hugr-py/src/hugr/_exceptions.py
+++ b/hugr-py/src/hugr/_exceptions.py
@@ -34,3 +34,8 @@ class MismatchedExit(Exception):
 
 class ParentBeforeChild(Exception):
     msg: str = "Parent node must be added before child node."
+
+
+@dataclass
+class IncompleteOp(Exception):
+    msg: str = "Operation is incomplete, may require set_in_types to be called."

--- a/hugr-py/src/hugr/_hugr.py
+++ b/hugr-py/src/hugr/_hugr.py
@@ -16,7 +16,8 @@ from typing import (
 
 from typing_extensions import Self
 
-from hugr._ops import Op
+from hugr._ops import Op, DataflowOp
+from hugr._tys import Type, Kind
 from hugr.serialization.ops import OpType as SerialOp
 from hugr.serialization.serial_hugr import SerialHugr
 from hugr.utils import BiMap
@@ -332,6 +333,15 @@ class Hugr(Mapping[Node, NodeData]):
         return sum(1 for _ in self.outgoing_links(node))
 
     # TODO: num_links and _linked_ports
+
+    def port_kind(self, port: InPort | OutPort) -> Kind:
+        return self[port.node].op.port_kind(port)
+
+    def port_type(self, port: InPort | OutPort) -> Type | None:
+        op = self[port.node].op
+        if isinstance(op, DataflowOp):
+            return op.port_type(port)
+        return None
 
     def insert_hugr(self, hugr: Hugr, parent: ToNode | None = None) -> dict[Node, Node]:
         mapping: dict[Node, Node] = {}

--- a/hugr-py/src/hugr/_hugr.py
+++ b/hugr-py/src/hugr/_hugr.py
@@ -155,6 +155,7 @@ class ParentBuilder(ToNode, Protocol[OpVar]):
     def to_node(self) -> Node:
         return self.parent_node
 
+    @property
     def parent_op(self) -> OpVar:
         return cast(OpVar, self.hugr[self.parent_node].op)
 

--- a/hugr-py/src/hugr/_hugr.py
+++ b/hugr-py/src/hugr/_hugr.py
@@ -148,22 +148,25 @@ _SO = _SubPort[OutPort]
 _SI = _SubPort[InPort]
 
 
-class ParentBuilder(ToNode, Protocol):
-    hugr: Hugr
-    root: Node
+class ParentBuilder(ToNode, Protocol[OpVar]):
+    hugr: Hugr[OpVar]
+    parent_node: Node
 
     def to_node(self) -> Node:
-        return self.root
+        return self.parent_node
+
+    def parent_op(self) -> OpVar:
+        return cast(OpVar, self.hugr[self.parent_node].op)
 
 
 @dataclass()
-class Hugr(Mapping[Node, NodeData]):
+class Hugr(Mapping[Node, NodeData], Generic[OpVar]):
     root: Node
     _nodes: list[NodeData | None]
     _links: BiMap[_SO, _SI]
     _free_nodes: list[Node]
 
-    def __init__(self, root_op: Op) -> None:
+    def __init__(self, root_op: OpVar) -> None:
         self._free_nodes = []
         self._links = BiMap()
         self._nodes = []
@@ -268,6 +271,9 @@ class Hugr(Mapping[Node, NodeData]):
         except StopIteration:
             return
         # TODO make sure sub-offset is handled correctly
+
+    def root_op(self) -> OpVar:
+        return cast(OpVar, self[self.root].op)
 
     def num_nodes(self) -> int:
         return len(self._nodes) - len(self._free_nodes)

--- a/hugr-py/src/hugr/_hugr.py
+++ b/hugr-py/src/hugr/_hugr.py
@@ -12,6 +12,7 @@ from typing import (
     TypeVar,
     cast,
     overload,
+    Type as PyType,
 )
 
 from typing_extensions import Self
@@ -131,6 +132,7 @@ class NodeData:
 
 P = TypeVar("P", InPort, OutPort)
 K = TypeVar("K", InPort, OutPort)
+OpVar = TypeVar("OpVar", bound=Op)
 
 
 @dataclass(frozen=True, eq=True, order=True)
@@ -182,6 +184,11 @@ class Hugr(Mapping[Node, NodeData]):
 
     def __len__(self) -> int:
         return self.num_nodes()
+
+    def _get_typed_op(self, node: ToNode, cl: PyType[OpVar]) -> OpVar:
+        op = self[node].op
+        assert isinstance(op, cl)
+        return op
 
     def children(self, node: ToNode | None = None) -> list[Node]:
         node = node or self.root

--- a/hugr-py/src/hugr/_hugr.py
+++ b/hugr-py/src/hugr/_hugr.py
@@ -133,6 +133,7 @@ class NodeData:
 P = TypeVar("P", InPort, OutPort)
 K = TypeVar("K", InPort, OutPort)
 OpVar = TypeVar("OpVar", bound=Op)
+OpVar2 = TypeVar("OpVar2", bound=Op)
 
 
 @dataclass(frozen=True, eq=True, order=True)
@@ -189,7 +190,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVar]):
     def __len__(self) -> int:
         return self.num_nodes()
 
-    def _get_typed_op(self, node: ToNode, cl: PyType[OpVar]) -> OpVar:
+    def _get_typed_op(self, node: ToNode, cl: PyType[OpVar2]) -> OpVar2:
         op = self[node].op
         assert isinstance(op, cl)
         return op

--- a/hugr-py/src/hugr/_ops.py
+++ b/hugr-py/src/hugr/_ops.py
@@ -220,6 +220,9 @@ class Tag(DataflowOp):
             input=self.variants[self.tag], output=[tys.Sum(self.variants)]
         )
 
+    def __call__(self, value: Wire) -> Command:
+        return super().__call__(value)
+
 
 class DfParentOp(Op, Protocol):
     def inner_signature(self) -> tys.FunctionType: ...

--- a/hugr-py/src/hugr/_ops.py
+++ b/hugr-py/src/hugr/_ops.py
@@ -168,7 +168,7 @@ MakeTuple = MakeTupleDef()
 
 @dataclass()
 class UnpackTupleDef(DataflowOp, PartialOp):
-    _types: tys.TypeRow = field(default_factory=list)
+    _types: tys.TypeRow | None = None
 
     @property
     def types(self) -> tys.TypeRow:

--- a/hugr-py/src/hugr/_ops.py
+++ b/hugr-py/src/hugr/_ops.py
@@ -337,6 +337,9 @@ class DataflowBlock(DfParentOp):
     def _inputs(self) -> tys.TypeRow:
         return self.inputs
 
+    def nth_outputs(self, n: int) -> tys.TypeRow:
+        return [*self.sum_rows[n], *self.other_outputs]
+
 
 @dataclass
 class ExitBlock(Op):

--- a/hugr-py/src/hugr/_ops.py
+++ b/hugr-py/src/hugr/_ops.py
@@ -45,7 +45,7 @@ class DataflowOp(Op, Protocol):
 
 
 @runtime_checkable
-class PartialOp(DataflowOp, Protocol):
+class PartialOp(Protocol):
     def set_in_types(self, types: tys.TypeRow) -> None: ...
 
 
@@ -91,7 +91,7 @@ class Input(DataflowOp):
 
 
 @dataclass()
-class Output(PartialOp):
+class Output(DataflowOp, PartialOp):
     _types: tys.TypeRow | None = None
 
     @property
@@ -137,7 +137,7 @@ class Custom(DataflowOp):
 
 
 @dataclass()
-class MakeTupleDef(PartialOp):
+class MakeTupleDef(DataflowOp, PartialOp):
     _types: tys.TypeRow | None = None
     num_out: int | None = 1
 
@@ -167,7 +167,7 @@ MakeTuple = MakeTupleDef()
 
 
 @dataclass()
-class UnpackTupleDef(PartialOp):
+class UnpackTupleDef(DataflowOp, PartialOp):
     _types: tys.TypeRow = field(default_factory=list)
 
     @property

--- a/hugr-py/src/hugr/_tys.py
+++ b/hugr-py/src/hugr/_tys.py
@@ -226,8 +226,8 @@ class Alias(Type):
 
 @dataclass(frozen=True)
 class FunctionType(Type):
-    input: list[Type]
-    output: list[Type]
+    input: TypeRow
+    output: TypeRow
     extension_reqs: ExtensionSet = field(default_factory=ExtensionSet)
 
     def to_serial(self) -> stys.FunctionType:

--- a/hugr-py/src/hugr/_tys.py
+++ b/hugr-py/src/hugr/_tys.py
@@ -238,7 +238,7 @@ class FunctionType(Type):
         return cls(input=[], output=[])
 
     def flip(self) -> FunctionType:
-        return FunctionType(input=self.output, output=self.input)
+        return FunctionType(input=list(self.output), output=list(self.input))
 
 
 @dataclass(frozen=True)

--- a/hugr-py/src/hugr/_tys.py
+++ b/hugr-py/src/hugr/_tys.py
@@ -233,6 +233,9 @@ class FunctionType(Type):
     def empty(cls) -> FunctionType:
         return cls(input=[], output=[])
 
+    def flip(self) -> FunctionType:
+        return FunctionType(input=self.output, output=self.input)
+
 
 @dataclass(frozen=True)
 class PolyFuncType(Type):
@@ -270,3 +273,29 @@ class QubitDef(Type):
 Qubit = QubitDef()
 Bool = UnitSum(size=2)
 Unit = UnitSum(size=1)
+
+
+@dataclass(frozen=True)
+class ValueKind:
+    ty: Type
+
+
+@dataclass(frozen=True)
+class ConstKind:
+    ty: Type
+
+
+@dataclass(frozen=True)
+class FunctionKind:
+    ty: PolyFuncType
+
+
+@dataclass(frozen=True)
+class CFKind: ...
+
+
+@dataclass(frozen=True)
+class OrderKind: ...
+
+
+Kind = ValueKind | ConstKind | FunctionKind | CFKind | OrderKind

--- a/hugr-py/src/hugr/_tys.py
+++ b/hugr-py/src/hugr/_tys.py
@@ -159,14 +159,6 @@ class Array(Type):
         return stys.Array(ty=self.ty.to_serial_root(), len=self.size)
 
 
-@dataclass(frozen=True)
-class UnitSum(Type):
-    size: int
-
-    def to_serial(self) -> stys.UnitSum:
-        return stys.UnitSum(size=self.size)
-
-
 @dataclass()
 class Sum(Type):
     variant_rows: list[TypeRow]
@@ -179,6 +171,18 @@ class Sum(Type):
             len(self.variant_rows) == 1
         ), "Sum type must have exactly one row to be converted to a Tuple"
         return Tuple(*self.variant_rows[0])
+
+
+@dataclass()
+class UnitSum(Sum):
+    size: int
+
+    def __init__(self, size: int):
+        self.size = size
+        super().__init__(variant_rows=[[]] * size)
+
+    def to_serial(self) -> stys.UnitSum:  # type: ignore[override]
+        return stys.UnitSum(size=self.size)
 
 
 @dataclass()

--- a/hugr-py/src/hugr/serialization/ops.py
+++ b/hugr-py/src/hugr/serialization/ops.py
@@ -447,8 +447,8 @@ class MakeTuple(DataflowOp):
             in_types = []
         self.tys = list(in_types)
 
-    def deserialize(self) -> _ops.MakeTuple:
-        return _ops.MakeTuple(deser_it(self.tys))
+    def deserialize(self) -> _ops.MakeTupleDef:
+        return _ops.MakeTupleDef(deser_it(self.tys))
 
 
 class UnpackTuple(DataflowOp):
@@ -460,8 +460,8 @@ class UnpackTuple(DataflowOp):
     def insert_port_types(self, in_types: TypeRow, out_types: TypeRow) -> None:
         self.tys = list(out_types)
 
-    def deserialize(self) -> _ops.UnpackTuple:
-        return _ops.UnpackTuple(deser_it(self.tys))
+    def deserialize(self) -> _ops.UnpackTupleDef:
+        return _ops.UnpackTupleDef(deser_it(self.tys))
 
 
 class Tag(DataflowOp):

--- a/hugr-py/src/hugr/serialization/ops.py
+++ b/hugr-py/src/hugr/serialization/ops.py
@@ -229,7 +229,7 @@ class Output(DataflowOp):
         self.types = list(in_types)
 
     def deserialize(self) -> _ops.Output:
-        return _ops.Output(types=deser_it(self.types))
+        return _ops.Output(deser_it(self.types))
 
 
 class Call(DataflowOp):

--- a/hugr-py/tests/test_cfg.py
+++ b/hugr-py/tests/test_cfg.py
@@ -23,18 +23,15 @@ def test_branch() -> None:
     entry = cfg.add_entry()
     entry.set_block_outputs(*entry.inputs())
 
-    middle_1 = cfg.add_block([tys.Unit, INT_T])
+    middle_1 = cfg.add_successor(entry[0])
     middle_1.set_block_outputs(*middle_1.inputs())
-    middle_2 = cfg.add_block([tys.Unit, INT_T])
+    middle_2 = cfg.add_successor(entry[1])
     u, i = middle_2.inputs()
     n = middle_2.add(DivMod(i, i))
     middle_2.set_block_outputs(u, n[0])
 
-    cfg.branch(entry[0], middle_1)
-    cfg.branch(entry[1], middle_2)
-
-    cfg.branch(middle_1[0], cfg.exit)
-    cfg.branch(middle_2[0], cfg.exit)
+    cfg.branch_exit(middle_1[0])
+    cfg.branch_exit(middle_2[0])
 
     _validate(cfg.hugr)
 
@@ -58,16 +55,13 @@ def test_dom_edge() -> None:
 
     # entry dominates both middles so Unit type can be used as inter-graph
     # value between basic blocks
-    middle_1 = cfg.add_block([INT_T])
+    middle_1 = cfg.add_successor(entry[0])
     middle_1.set_block_outputs(u, *middle_1.inputs())
-    middle_2 = cfg.add_block([INT_T])
+    middle_2 = cfg.add_successor(entry[1])
     middle_2.set_block_outputs(u, *middle_2.inputs())
 
-    cfg.branch(entry[0], middle_1)
-    cfg.branch(entry[1], middle_2)
-
-    cfg.branch(middle_1[0], cfg.exit)
-    cfg.branch(middle_2[0], cfg.exit)
+    cfg.branch_exit(middle_1[0])
+    cfg.branch_exit(middle_2[0])
 
     _validate(cfg.hugr)
 
@@ -81,13 +75,15 @@ def test_asymm_types() -> None:
     tagged_int = entry.add(ops.Tag(0, [[INT_T], [tys.Bool]])(i))
     entry.set_block_outputs(tagged_int)
 
-    middle = cfg.add_block([INT_T])
+    middle = cfg.add_successor(entry[0])
     # discard the int and return the bool from entry
     middle.set_block_outputs(u, b)
 
     # middle expects an int and exit expects a bool
-    cfg.branch(entry[0], middle)
-    cfg.branch(entry[1], cfg.exit)
-    cfg.branch(middle[0], cfg.exit)
+    cfg.branch_exit(entry[1])
+    cfg.branch_exit(middle[0])
 
     _validate(cfg.hugr)
+
+
+# TODO loop

--- a/hugr-py/tests/test_cfg.py
+++ b/hugr-py/tests/test_cfg.py
@@ -42,7 +42,7 @@ def test_branch() -> None:
 def test_nested_cfg() -> None:
     dfg = Dfg(tys.Unit, tys.Bool)
 
-    cfg = dfg.add_cfg([tys.Unit, tys.Bool], [tys.Bool], *dfg.inputs())
+    cfg = dfg.add_cfg([tys.Unit, tys.Bool], *dfg.inputs())
 
     build_basic_cfg(cfg)
     dfg.set_outputs(cfg)

--- a/hugr-py/tests/test_cfg.py
+++ b/hugr-py/tests/test_cfg.py
@@ -39,7 +39,7 @@ def test_branch() -> None:
 
 
 def test_nested_cfg() -> None:
-    dfg = Dfg([tys.Unit, tys.Bool], [tys.Bool])
+    dfg = Dfg(tys.Unit, tys.Bool)
 
     cfg = dfg.add_cfg([tys.Unit, tys.Bool], [tys.Bool], *dfg.inputs())
 

--- a/hugr-py/tests/test_cfg.py
+++ b/hugr-py/tests/test_cfg.py
@@ -1,30 +1,31 @@
 from hugr._cfg import Cfg
 import hugr._tys as tys
 from hugr._dfg import Dfg
+import hugr._ops as ops
 from .test_hugr_build import _validate, INT_T, DivMod
 
 
 def build_basic_cfg(cfg: Cfg) -> None:
-    entry = cfg.simple_entry(1, [tys.Bool])
+    entry = cfg.add_entry()
 
     entry.set_block_outputs(*entry.inputs())
     cfg.branch(entry[0], cfg.exit)
 
 
 def test_basic_cfg() -> None:
-    cfg = Cfg([tys.Unit, tys.Bool], [tys.Bool])
+    cfg = Cfg([tys.Unit, tys.Bool])
     build_basic_cfg(cfg)
     _validate(cfg.hugr)
 
 
 def test_branch() -> None:
-    cfg = Cfg([tys.Bool, tys.Unit, INT_T], [INT_T])
-    entry = cfg.simple_entry(2, [tys.Unit, INT_T])
+    cfg = Cfg([tys.Bool, tys.Unit, INT_T])
+    entry = cfg.add_entry()
     entry.set_block_outputs(*entry.inputs())
 
-    middle_1 = cfg.simple_block([tys.Unit, INT_T], 1, [INT_T])
+    middle_1 = cfg.add_block([tys.Unit, INT_T])
     middle_1.set_block_outputs(*middle_1.inputs())
-    middle_2 = cfg.simple_block([tys.Unit, INT_T], 1, [INT_T])
+    middle_2 = cfg.add_block([tys.Unit, INT_T])
     u, i = middle_2.inputs()
     n = middle_2.add(DivMod(i, i))
     middle_2.set_block_outputs(u, n[0])
@@ -50,16 +51,16 @@ def test_nested_cfg() -> None:
 
 
 def test_dom_edge() -> None:
-    cfg = Cfg([tys.Bool, tys.Unit, INT_T], [INT_T])
-    entry = cfg.simple_entry(2, [INT_T])
+    cfg = Cfg([tys.Bool, tys.Unit, INT_T])
+    entry = cfg.add_entry()
     b, u, i = entry.inputs()
     entry.set_block_outputs(b, i)
 
     # entry dominates both middles so Unit type can be used as inter-graph
     # value between basic blocks
-    middle_1 = cfg.simple_block([INT_T], 1, [INT_T])
+    middle_1 = cfg.add_block([INT_T])
     middle_1.set_block_outputs(u, *middle_1.inputs())
-    middle_2 = cfg.simple_block([INT_T], 1, [INT_T])
+    middle_2 = cfg.add_block([INT_T])
     middle_2.set_block_outputs(u, *middle_2.inputs())
 
     cfg.branch(entry[0], middle_1)
@@ -67,5 +68,26 @@ def test_dom_edge() -> None:
 
     cfg.branch(middle_1[0], cfg.exit)
     cfg.branch(middle_2[0], cfg.exit)
+
+    _validate(cfg.hugr)
+
+
+def test_asymm_types() -> None:
+    # test different types going to entry block's susccessors
+    cfg = Cfg([tys.Bool, tys.Unit, INT_T])
+    entry = cfg.add_entry()
+    b, u, i = entry.inputs()
+
+    tagged_int = entry.add(ops.Tag(0, [[INT_T], [tys.Bool]])(i))
+    entry.set_block_outputs(tagged_int)
+
+    middle = cfg.add_block([INT_T])
+    # discard the int and return the bool from entry
+    middle.set_block_outputs(u, b)
+
+    # middle expects an int and exit expects a bool
+    cfg.branch(entry[0], middle)
+    cfg.branch(entry[1], cfg.exit)
+    cfg.branch(middle[0], cfg.exit)
 
     _validate(cfg.hugr)

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -120,7 +120,7 @@ def test_stable_indices():
 
 
 def test_simple_id():
-    h = Dfg.endo([tys.Qubit] * 2)
+    h = Dfg(tys.Qubit, tys.Qubit)
     a, b = h.inputs()
     h.set_outputs(a, b)
 
@@ -128,7 +128,7 @@ def test_simple_id():
 
 
 def test_multiport():
-    h = Dfg([tys.Bool], [tys.Bool] * 2)
+    h = Dfg(tys.Bool)
     (a,) = h.inputs()
     h.set_outputs(a, a)
     in_n, ou_n = h.input_node, h.output_node
@@ -151,7 +151,7 @@ def test_multiport():
 
 
 def test_add_op():
-    h = Dfg.endo([tys.Bool])
+    h = Dfg(tys.Bool)
     (a,) = h.inputs()
     nt = h.add_op(Not, a)
     h.set_outputs(nt)
@@ -161,25 +161,25 @@ def test_add_op():
 
 def test_tuple():
     row = [tys.Bool, tys.Qubit]
-    h = Dfg.endo(row)
+    h = Dfg(*row)
     a, b = h.inputs()
-    t = h.add(ops.MakeTuple(row)(a, b))
-    a, b = h.add(ops.UnpackTuple(row)(t))
+    t = h.add(ops.MakeTuple(a, b))
+    a, b = h.add(ops.UnpackTuple(t))
     h.set_outputs(a, b)
 
     _validate(h.hugr)
 
-    h1 = Dfg.endo(row)
+    h1 = Dfg(*row)
     a, b = h1.inputs()
-    mt = h1.add_op(ops.MakeTuple(row), a, b)
-    a, b = h1.add_op(ops.UnpackTuple(row), mt)[0, 1]
+    mt = h1.add_op(ops.MakeTuple, a, b)
+    a, b = h1.add_op(ops.UnpackTuple, mt)[0, 1]
     h1.set_outputs(a, b)
 
     assert h.hugr.to_serial() == h1.hugr.to_serial()
 
 
 def test_multi_out():
-    h = Dfg([INT_T] * 2, [INT_T] * 2)
+    h = Dfg(INT_T, INT_T)
     a, b = h.inputs()
     a, b = h.add(DivMod(a, b))
     h.set_outputs(a, b)
@@ -187,7 +187,7 @@ def test_multi_out():
 
 
 def test_insert():
-    h1 = Dfg.endo([tys.Bool])
+    h1 = Dfg(tys.Bool)
     (a1,) = h1.inputs()
     nt = h1.add(Not(a1))
     h1.set_outputs(nt)
@@ -200,12 +200,12 @@ def test_insert():
 
 
 def test_insert_nested():
-    h1 = Dfg.endo([tys.Bool])
+    h1 = Dfg(tys.Bool)
     (a1,) = h1.inputs()
     nt = h1.add(Not(a1))
     h1.set_outputs(nt)
 
-    h = Dfg.endo([tys.Bool])
+    h = Dfg(tys.Bool)
     (a,) = h.inputs()
     nested = h.insert_nested(h1, a)
     h.set_outputs(nested)
@@ -219,9 +219,9 @@ def test_build_nested():
         nt = dfg.add(Not(a1))
         dfg.set_outputs(nt)
 
-    h = Dfg.endo([tys.Bool])
+    h = Dfg(tys.Bool)
     (a,) = h.inputs()
-    nested = h.add_nested([tys.Bool], [tys.Bool], a)
+    nested = h.add_nested(a)
 
     _nested_nop(nested)
     assert len(h.hugr.children(nested)) == 3
@@ -231,9 +231,9 @@ def test_build_nested():
 
 
 def test_build_inter_graph():
-    h = Dfg.endo([tys.Bool, tys.Bool])
+    h = Dfg(tys.Bool, tys.Bool)
     (a, b) = h.inputs()
-    nested = h.add_nested([], [tys.Bool])
+    nested = h.add_nested()
 
     nt = nested.add(Not(a))
     nested.set_outputs(nt)
@@ -250,9 +250,9 @@ def test_build_inter_graph():
 
 
 def test_ancestral_sibling():
-    h = Dfg.endo([tys.Bool])
+    h = Dfg(tys.Bool)
     (a,) = h.inputs()
-    nested = h.add_nested([], [tys.Bool])
+    nested = h.add_nested()
 
     nt = nested.add(Not(a))
 

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -256,4 +256,4 @@ def test_ancestral_sibling():
 
     nt = nested.add(Not(a))
 
-    assert _ancestral_sibling(h.hugr, h.input_node, nt) == nested.root
+    assert _ancestral_sibling(h.hugr, h.input_node, nt) == nested.parent_node

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -85,7 +85,7 @@ def _validate(h: Hugr, mermaid: bool = False, roundtrip: bool = True):
 
 
 def test_stable_indices():
-    h = Hugr(ops.DFG())
+    h = Hugr(ops.DFG([]))
 
     nodes = [h.add_node(Not) for _ in range(3)]
     assert len(h) == 4
@@ -194,7 +194,7 @@ def test_insert():
 
     assert len(h1.hugr) == 4
 
-    new_h = Hugr(ops.DFG())
+    new_h = Hugr(ops.DFG([]))
     mapping = h1.hugr.insert_hugr(new_h, h1.hugr.root)
     assert mapping == {new_h.root: Node(4)}
 


### PR DESCRIPTION
Closes #1198

- ops have to report their signature, but may be initialised incomplete
- dataflow ops have hooks to update themselves based on the types flowing in to them
- parent ops can update themselves based on the types flowing out of them
- Tag needs to know all possible variants, can't infer from input types
- calculate cfg outputs by looking at output types of blocks that connect to exit block

reviewing commit by commit might be easier