### PR TITLE
feat: Helper functions for requesting inference, use with builder in tests

### DIFF
--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -87,12 +87,12 @@
 //! ```
 use thiserror::Error;
 
-use crate::extension::SignatureError;
+use crate::extension::{SignatureError, TO_BE_INFERRED};
 use crate::hugr::ValidationError;
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
 use crate::ops::{NamedOp, OpType};
-use crate::types::ConstTypeError;
 use crate::types::Type;
+use crate::types::{ConstTypeError, FunctionType, TypeRow};
 use crate::{Node, Port, Wire};
 
 pub mod handle;
@@ -120,6 +120,18 @@ pub use conditional::{CaseBuilder, ConditionalBuilder};
 
 mod circuit;
 pub use circuit::{CircuitBuildError, CircuitBuilder};
+
+/// Return a FunctionType with the same input and output types (specified)
+/// whose extension delta, when used in a non-FuncDefn container, will be inferred.
+pub fn ft1(types: impl Into<TypeRow>) -> FunctionType {
+    FunctionType::new_endo(types).with_extension_delta(TO_BE_INFERRED)
+}
+
+/// Return a FunctionType with the specified input and output types
+/// whose extension delta, when used in a non-FuncDefn container, will be inferred.
+pub fn ft2(inputs: impl Into<TypeRow>, outputs: impl Into<TypeRow>) -> FunctionType {
+    FunctionType::new(inputs, outputs).with_extension_delta(TO_BE_INFERRED)
+}
 
 #[derive(Debug, Clone, PartialEq, Error)]
 #[non_exhaustive]

--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -263,10 +263,9 @@ pub trait Dataflow: Container {
         collect_array(self.input_wires())
     }
 
-    /// Return a builder for a [`crate::ops::DFG`] node, i.e. a nested dataflow subgraph.
-    /// The `inputs` must be an iterable over pairs of the type of the input and
-    /// the corresponding wire.
-    /// The `output_types` are the types of the outputs.
+    /// Return a builder for a [`crate::ops::DFG`] node, i.e. a nested dataflow subgraph,
+    /// given a signature describing its input and output types and extension delta,
+    /// and the input wires (which must match the input types)
     ///
     /// # Errors
     ///

--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -18,7 +18,9 @@ use crate::{
     types::EdgeKind,
 };
 
-use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError, PRELUDE_REGISTRY};
+use crate::extension::{
+    ExtensionRegistry, ExtensionSet, SignatureError, PRELUDE_REGISTRY, TO_BE_INFERRED,
+};
 use crate::types::{FunctionType, PolyFuncType, Type, TypeArg, TypeRow};
 
 use itertools::Itertools;
@@ -283,6 +285,21 @@ pub trait Dataflow: Container {
         let (dfg_n, _) = add_node_with_wires(self, op, input_wires)?;
 
         DFGBuilder::create_with_io(self.hugr_mut(), dfg_n, signature)
+    }
+
+    /// Return a builder for a [`crate::ops::DFG`] node, i.e. a nested dataflow subgraph,
+    /// that is endomorphic (the output types are the same as the input types).
+    /// The `inputs` must be an iterable over pairs of the type of the input and
+    /// the corresponding wire.
+    fn dfg_builder_endo(
+        &mut self,
+        inputs: impl IntoIterator<Item = (Type, Wire)>,
+    ) -> Result<DFGBuilder<&mut Hugr>, BuildError> {
+        let (types, input_wires): (Vec<Type>, Vec<Wire>) = inputs.into_iter().unzip();
+        self.dfg_builder(
+            FunctionType::new_endo(types).with_extension_delta(TO_BE_INFERRED),
+            input_wires,
+        )
     }
 
     /// Return a builder for a [`crate::ops::CFG`] node,

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -203,11 +203,9 @@ pub(crate) mod test {
     use serde_json::json;
 
     use crate::builder::build_traits::DataflowHugr;
-    use crate::builder::{BuilderWiringError, DataflowSubContainer, ModuleBuilder};
+    use crate::builder::{ft1, BuilderWiringError, DataflowSubContainer, ModuleBuilder};
     use crate::extension::prelude::{BOOL_T, USIZE_T};
-    use crate::extension::{
-        ExtensionId, ExtensionSet, SignatureError, EMPTY_REG, PRELUDE_REGISTRY,
-    };
+    use crate::extension::{ExtensionId, SignatureError, EMPTY_REG, PRELUDE_REGISTRY};
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::ops::OpTrait;
     use crate::ops::{handle::NodeHandle, Lift, Noop, OpTag};
@@ -421,23 +419,13 @@ pub(crate) mod test {
         let xa: ExtensionId = "A".try_into().unwrap();
         let xb: ExtensionId = "B".try_into().unwrap();
         let xc: ExtensionId = "C".try_into().unwrap();
-        let ab_extensions = ExtensionSet::from_iter([xa.clone(), xb.clone()]);
-        let abc_extensions = ab_extensions.clone().union(xc.clone().into());
 
-        let parent_sig =
-            FunctionType::new(type_row![BIT], type_row![BIT]).with_extension_delta(abc_extensions);
-        let mut parent = DFGBuilder::new(parent_sig)?;
-
-        let add_c_sig =
-            FunctionType::new(type_row![BIT], type_row![BIT]).with_extension_delta(xc.clone());
+        let mut parent = DFGBuilder::new(ft1(BIT))?;
 
         let [w] = parent.input_wires_arr();
 
-        let add_ab_sig = FunctionType::new(type_row![BIT], type_row![BIT])
-            .with_extension_delta(ab_extensions.clone());
-
         // A box which adds extensions A and B, via child Lift nodes
-        let mut add_ab = parent.dfg_builder(add_ab_sig, [w])?;
+        let mut add_ab = parent.dfg_builder(ft1(BIT), [w])?;
         let [w] = add_ab.input_wires_arr();
 
         let lift_a = add_ab.add_dataflow_op(
@@ -463,7 +451,7 @@ pub(crate) mod test {
 
         // Add another node (a sibling to add_ab) which adds extension C
         // via a child lift node
-        let mut add_c = parent.dfg_builder(add_c_sig, [w])?;
+        let mut add_c = parent.dfg_builder(ft1(BIT), [w])?;
         let [w] = add_c.input_wires_arr();
         let lift_c = add_c.add_dataflow_op(
             Lift {

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -61,8 +61,8 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> DFGBuilder<T> {
 }
 
 impl DFGBuilder<Hugr> {
-    /// Begin building a new DFG rooted HUGR.
-    /// Input extensions default to being an open variable
+    /// Begin building a new DFG-rooted HUGR given its inputs, outputs,
+    /// and extension delta.
     ///
     /// # Errors
     ///

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -402,7 +402,7 @@ impl CustomConst for ConstExternalSymbol {
 #[cfg(test)]
 mod test {
     use crate::{
-        builder::{DFGBuilder, Dataflow, DataflowHugr},
+        builder::{ft1, DFGBuilder, Dataflow, DataflowHugr},
         utils::test_quantum_extension::cx_gate,
         Hugr, Wire,
     };
@@ -452,9 +452,7 @@ mod test {
         assert!(error_val.equal_consts(&ConstError::new(2, "my message")));
         assert!(!error_val.equal_consts(&ConstError::new(3, "my message")));
 
-        let mut b =
-            DFGBuilder::new(FunctionType::new_endo(type_row![]).with_extension_delta(PRELUDE_ID))
-                .unwrap();
+        let mut b = DFGBuilder::new(ft1(type_row![])).unwrap();
 
         let err = b.add_load_value(error_val);
 
@@ -488,10 +486,7 @@ mod test {
             )
             .unwrap();
 
-        let mut b = DFGBuilder::new(
-            FunctionType::new_endo(type_row![QB_T, QB_T]).with_extension_delta(PRELUDE_ID),
-        )
-        .unwrap();
+        let mut b = DFGBuilder::new(ft1(type_row![QB_T, QB_T])).unwrap();
         let [q0, q1] = b.input_wires_arr();
         let [q0, q1] = b
             .add_dataflow_op(cx_gate(), [q0, q1])
@@ -529,9 +524,7 @@ mod test {
     #[test]
     /// Test print operation
     fn test_print() {
-        let mut b: DFGBuilder<Hugr> =
-            DFGBuilder::new(FunctionType::new_endo(vec![]).with_extension_delta(PRELUDE_ID))
-                .unwrap();
+        let mut b: DFGBuilder<Hugr> = DFGBuilder::new(ft1(vec![])).unwrap();
         let greeting: ConstString = ConstString::new("Hello, world!".into());
         let greeting_out: Wire = b.add_load_value(greeting);
         let print_op = PRELUDE

--- a/hugr-core/src/hugr/rewrite/inline_dfg.rs
+++ b/hugr-core/src/hugr/rewrite/inline_dfg.rs
@@ -195,7 +195,7 @@ mod test {
         }
         let c1 = nonlocal.then(|| make_const(&mut outer));
         let inner = {
-            let mut inner = outer.dfg_builder(ft1(int_ty.clone()), [a])?;
+            let mut inner = outer.dfg_builder_endo([(int_ty.clone(), a)])?;
             let [a] = inner.input_wires_arr();
             let c1 = c1.unwrap_or_else(|| make_const(&mut inner))?;
             let a1 = inner.add_dataflow_op(IntOpDef::iadd.with_log_width(6), [a, c1])?;

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::builder::{
-    test::closed_dfg_root_hugr, Container, DFGBuilder, Dataflow, DataflowHugr,
+    ft2, test::closed_dfg_root_hugr, Container, DFGBuilder, Dataflow, DataflowHugr,
     DataflowSubContainer, HugrBuilder, ModuleBuilder,
 };
 use crate::extension::prelude::{BOOL_T, PRELUDE_ID, QB_T, USIZE_T};
@@ -11,7 +11,7 @@ use crate::ops::custom::{ExtensionOp, OpaqueOp};
 use crate::ops::{self, dataflow::IOTrait, Input, Module, Noop, Output, Value, DFG};
 use crate::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
 use crate::std_extensions::arithmetic::int_ops::INT_OPS_REGISTRY;
-use crate::std_extensions::arithmetic::int_types::{self, int_custom_type, ConstInt, INT_TYPES};
+use crate::std_extensions::arithmetic::int_types::{int_custom_type, ConstInt, INT_TYPES};
 use crate::std_extensions::logic::NotOp;
 use crate::types::{
     type_param::TypeParam, FunctionType, PolyFuncType, SumType, Type, TypeArg, TypeBound,
@@ -351,11 +351,7 @@ fn hierarchy_order() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn constants_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
-    let mut builder = DFGBuilder::new(
-        FunctionType::new(vec![], vec![INT_TYPES[4].clone()])
-            .with_extension_delta(int_types::EXTENSION_ID),
-    )
-    .unwrap();
+    let mut builder = DFGBuilder::new(ft2(vec![], vec![INT_TYPES[4].clone()])).unwrap();
     let w = builder.add_load_value(ConstInt::new_s(4, -2).unwrap());
     let hugr = builder.finish_hugr_with_outputs([w], &INT_OPS_REGISTRY)?;
 

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -4,7 +4,7 @@ use rstest::rstest;
 use super::*;
 use crate::builder::test::closed_dfg_root_hugr;
 use crate::builder::{
-    BuildError, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
+    ft2, BuildError, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
     FunctionBuilder, HugrBuilder, ModuleBuilder, SubContainer,
 };
 use crate::extension::prelude::{BOOL_T, PRELUDE, PRELUDE_ID, QB_T, USIZE_T};
@@ -766,13 +766,10 @@ fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
 
     let int_pair = Type::new_tuple(type_row![USIZE_T; 2]);
     // Root DFG: applies a function int--PRELUDE-->int to each element of a pair of two ints
-    let mut d = DFGBuilder::new(
-        FunctionType::new(
-            vec![utou(PRELUDE_ID), int_pair.clone()],
-            vec![int_pair.clone()],
-        )
-        .with_extension_delta(PRELUDE_ID),
-    )?;
+    let mut d = DFGBuilder::new(ft2(
+        vec![utou(PRELUDE_ID), int_pair.clone()],
+        vec![int_pair.clone()],
+    ))?;
     // ....by calling a function parametrized<extensions E> (int--e-->int, int_pair) -> int_pair
     let f = {
         let es = ExtensionSet::type_var(0);

--- a/hugr-core/src/hugr/views/tests.rs
+++ b/hugr-core/src/hugr/views/tests.rs
@@ -2,7 +2,7 @@ use portgraph::PortOffset;
 use rstest::{fixture, rstest};
 
 use crate::{
-    builder::{BuildError, BuildHandle, Container, DFGBuilder, Dataflow, DataflowHugr},
+    builder::{ft2, BuildError, BuildHandle, Container, DFGBuilder, Dataflow, DataflowHugr},
     extension::prelude::QB_T,
     ops::{
         handle::{DataflowOpID, NodeHandle},
@@ -150,12 +150,9 @@ fn value_types() {
 
 #[test]
 fn static_targets() {
-    use crate::extension::prelude::{ConstUsize, PRELUDE_ID, USIZE_T};
+    use crate::extension::prelude::{ConstUsize, USIZE_T};
     use itertools::Itertools;
-    let mut dfg = DFGBuilder::new(
-        FunctionType::new(type_row![], type_row![USIZE_T]).with_extension_delta(PRELUDE_ID),
-    )
-    .unwrap();
+    let mut dfg = DFGBuilder::new(ft2(type_row![], type_row![USIZE_T])).unwrap();
 
     let c = dfg.add_constant(Value::extension(ConstUsize::new(1)));
 

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -460,8 +460,8 @@ pub type ValueNameRef = str;
 #[cfg(test)]
 mod test {
     use super::Value;
+    use crate::builder::ft2;
     use crate::builder::test::simple_dfg_hugr;
-    use crate::extension::prelude::PRELUDE_ID;
     use crate::std_extensions::arithmetic::int_types::ConstInt;
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
@@ -521,13 +521,10 @@ mod test {
         let pred_rows = vec![type_row![USIZE_T, FLOAT64_TYPE], Type::EMPTY_TYPEROW];
         let pred_ty = SumType::new(pred_rows.clone());
 
-        let mut b = DFGBuilder::new(
-            FunctionType::new(type_row![], TypeRow::from(vec![pred_ty.clone().into()]))
-                .with_extension_delta(ExtensionSet::from_iter([
-                    float_types::EXTENSION_ID,
-                    PRELUDE_ID,
-                ])),
-        )?;
+        let mut b = DFGBuilder::new(ft2(
+            type_row![],
+            TypeRow::from(vec![pred_ty.clone().into()]),
+        ))?;
         let c = b.add_constant(Value::sum(
             0,
             [

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use hugr_core::extension::ExtensionSet;
+use hugr_core::builder::ft2;
 use itertools::Itertools;
 use thiserror::Error;
 
@@ -19,7 +19,6 @@ use hugr_core::{
     },
     ops::{OpType, Value},
     type_row,
-    types::FunctionType,
     utils::sorted_consts,
     Hugr, HugrView, IncomingPort, Node, SimpleReplacement,
 };
@@ -137,10 +136,7 @@ pub fn fold_leaf_op(op: &OpType, consts: &[(IncomingPort, Value)]) -> ConstFoldR
 /// against `reg`.
 fn const_graph(consts: Vec<Value>, reg: &ExtensionRegistry) -> Hugr {
     let const_types = consts.iter().map(Value::get_type).collect_vec();
-    let exts = ExtensionSet::union_over(consts.iter().map(Value::extension_reqs));
-    let mut b =
-        DFGBuilder::new(FunctionType::new(type_row![], const_types).with_extension_delta(exts))
-            .unwrap();
+    let mut b = DFGBuilder::new(ft2(type_row![], const_types)).unwrap();
 
     let outputs = consts
         .into_iter()


### PR DESCRIPTION
* Add `builder::ft2` that takes 2 `Into<Typerow>`s, and builds a FunctionType with extension delta TO_BE_INFERRED
* And `builder::ft1` that takes a single `Into<TypeRow>` and makes an endomorphic FunctionType similarly
* Use these to update a bunch of tests made worse by earlier PRs (i.e. these now use inference rather than manually specifying deltas)
* Correct some doc comments....
* ....and add a `dfg_builder_endo` method that was hinted at by one of the incorrect doc comments, and that infers the delta.