### PR TITLE
refactor!: FunctionBuilder takes impl Into<PolyFuncType>

### DIFF
--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -42,7 +42,7 @@
 //!     let _dfg_handle = {
 //!         let mut dfg = module_builder.define_function(
 //!             "main",
-//!             FunctionType::new(vec![BOOL_T], vec![BOOL_T]).into(),
+//!             FunctionType::new(vec![BOOL_T], vec![BOOL_T]),
 //!         )?;
 //!
 //!         // Get the wires from the function inputs.
@@ -59,7 +59,7 @@
 //!     let _circuit_handle = {
 //!         let mut dfg = module_builder.define_function(
 //!             "circuit",
-//!             FunctionType::new(vec![BOOL_T, BOOL_T], vec![BOOL_T, BOOL_T]).into(),
+//!             FunctionType::new_endo(vec![BOOL_T, BOOL_T]),
 //!         )?;
 //!         let mut circuit = dfg.as_circuit(dfg.input_wires());
 //!

--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -78,8 +78,9 @@ pub trait Container {
     fn define_function(
         &mut self,
         name: impl Into<String>,
-        signature: PolyFuncType,
+        signature: impl Into<PolyFuncType>,
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
+        let signature = signature.into();
         let body = signature.body().clone();
         let f_node = self.add_child_node(ops::FuncDefn {
             name: name.into(),

--- a/hugr-core/src/builder/cfg.rs
+++ b/hugr-core/src/builder/cfg.rs
@@ -402,7 +402,7 @@ pub(crate) mod test {
         let build_result = {
             let mut module_builder = ModuleBuilder::new();
             let mut func_builder = module_builder
-                .define_function("main", FunctionType::new(vec![NAT], type_row![NAT]).into())?;
+                .define_function("main", FunctionType::new(vec![NAT], type_row![NAT]))?;
             let _f_id = {
                 let [int] = func_builder.input_wires_arr();
 

--- a/hugr-core/src/builder/conditional.rs
+++ b/hugr-core/src/builder/conditional.rs
@@ -232,10 +232,8 @@ mod test {
     fn basic_conditional_module() -> Result<(), BuildError> {
         let build_result: Result<Hugr, BuildError> = {
             let mut module_builder = ModuleBuilder::new();
-            let mut fbuild = module_builder.define_function(
-                "main",
-                FunctionType::new(type_row![NAT], type_row![NAT]).into(),
-            )?;
+            let mut fbuild = module_builder
+                .define_function("main", FunctionType::new(type_row![NAT], type_row![NAT]))?;
             let tru_const = fbuild.add_constant(Value::true_val());
             let _fdef = {
                 let const_wire = fbuild.load_const(&tru_const);

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -227,7 +227,7 @@ pub(crate) mod test {
             let _f_id = {
                 let mut func_builder = module_builder.define_function(
                     "main",
-                    FunctionType::new(type_row![NAT, QB], type_row![NAT, QB]).into(),
+                    FunctionType::new(type_row![NAT, QB], type_row![NAT, QB]),
                 )?;
 
                 let [int, qb] = func_builder.input_wires_arr();
@@ -258,7 +258,7 @@ pub(crate) mod test {
 
             let f_build = module_builder.define_function(
                 "main",
-                FunctionType::new(type_row![BOOL_T], type_row![BOOL_T, BOOL_T]).into(),
+                FunctionType::new(type_row![BOOL_T], type_row![BOOL_T, BOOL_T]),
             )?;
 
             f(f_build)?;
@@ -306,10 +306,8 @@ pub(crate) mod test {
         let builder = || {
             let mut module_builder = ModuleBuilder::new();
 
-            let f_build = module_builder.define_function(
-                "main",
-                FunctionType::new(type_row![QB], type_row![QB, QB]).into(),
-            )?;
+            let f_build = module_builder
+                .define_function("main", FunctionType::new(type_row![QB], type_row![QB, QB]))?;
 
             let [q1] = f_build.input_wires_arr();
             f_build.finish_with_outputs([q1, q1])?;
@@ -398,10 +396,8 @@ pub(crate) mod test {
         let mut module_builder = ModuleBuilder::new();
 
         let (dfg_node, f_node) = {
-            let mut f_build = module_builder.define_function(
-                "main",
-                FunctionType::new(type_row![BIT], type_row![BIT]).into(),
-            )?;
+            let mut f_build = module_builder
+                .define_function("main", FunctionType::new(type_row![BIT], type_row![BIT]))?;
 
             let [i1] = f_build.input_wires_arr();
             let dfg = f_build.add_hugr_with_wires(dfg_hugr, [i1])?;

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -138,7 +138,11 @@ impl FunctionBuilder<Hugr> {
     /// # Errors
     ///
     /// Error in adding DFG child nodes.
-    pub fn new(name: impl Into<String>, signature: PolyFuncType) -> Result<Self, BuildError> {
+    pub fn new(
+        name: impl Into<String>,
+        signature: impl Into<PolyFuncType>,
+    ) -> Result<Self, BuildError> {
+        let signature = signature.into();
         let body = signature.body().clone();
         let op = ops::FuncDefn {
             signature,
@@ -328,10 +332,8 @@ pub(crate) mod test {
     #[test]
     fn simple_inter_graph_edge() {
         let builder = || -> Result<Hugr, BuildError> {
-            let mut f_build = FunctionBuilder::new(
-                "main",
-                FunctionType::new(type_row![BIT], type_row![BIT]).into(),
-            )?;
+            let mut f_build =
+                FunctionBuilder::new("main", FunctionType::new(type_row![BIT], type_row![BIT]))?;
 
             let [i1] = f_build.input_wires_arr();
             let noop = f_build.add_dataflow_op(Noop { ty: BIT }, [i1])?;
@@ -352,10 +354,8 @@ pub(crate) mod test {
 
     #[test]
     fn error_on_linear_inter_graph_edge() -> Result<(), BuildError> {
-        let mut f_build = FunctionBuilder::new(
-            "main",
-            FunctionType::new(type_row![QB], type_row![QB]).into(),
-        )?;
+        let mut f_build =
+            FunctionBuilder::new("main", FunctionType::new(type_row![QB], type_row![QB]))?;
 
         let [i1] = f_build.input_wires_arr();
         let noop = f_build.add_dataflow_op(Noop { ty: QB }, [i1])?;

--- a/hugr-core/src/builder/module.rs
+++ b/hugr-core/src/builder/module.rs
@@ -203,8 +203,7 @@ mod test {
                 FunctionType::new(
                     vec![qubit_state_type.get_alias_type()],
                     vec![qubit_state_type.get_alias_type()],
-                )
-                .into(),
+                ),
             )?;
             n_identity(f_build)?;
             module_builder.finish_hugr(&EMPTY_REG)
@@ -220,11 +219,11 @@ mod test {
 
             let mut f_build = module_builder.define_function(
                 "main",
-                FunctionType::new(type_row![NAT], type_row![NAT, NAT]).into(),
+                FunctionType::new(type_row![NAT], type_row![NAT, NAT]),
             )?;
             let local_build = f_build.define_function(
                 "local",
-                FunctionType::new(type_row![NAT], type_row![NAT, NAT]).into(),
+                FunctionType::new(type_row![NAT], type_row![NAT, NAT]),
             )?;
             let [wire] = local_build.input_wires_arr();
             let f_id = local_build.finish_with_outputs([wire, wire])?;

--- a/hugr-core/src/builder/tail_loop.rs
+++ b/hugr-core/src/builder/tail_loop.rs
@@ -128,9 +128,7 @@ mod test {
             let mut module_builder = ModuleBuilder::new();
             let mut fbuild = module_builder.define_function(
                 "main",
-                FunctionType::new(type_row![BIT], type_row![NAT])
-                    .with_extension_delta(PRELUDE_ID)
-                    .into(),
+                FunctionType::new(type_row![BIT], type_row![NAT]).with_extension_delta(PRELUDE_ID),
             )?;
             let _fdef = {
                 let [b1] = fbuild

--- a/hugr-core/src/hugr/rewrite/consts.rs
+++ b/hugr-core/src/hugr/rewrite/consts.rs
@@ -128,8 +128,7 @@ mod test {
         let mut build = ModuleBuilder::new();
         let con_node = build.add_constant(Value::extension(ConstUsize::new(2)));
 
-        let mut dfg_build =
-            build.define_function("main", FunctionType::new_endo(type_row![]).into())?;
+        let mut dfg_build = build.define_function("main", FunctionType::new_endo(type_row![]))?;
         let load_1 = dfg_build.load_const(&con_node);
         let load_2 = dfg_build.load_const(&con_node);
         let tup = dfg_build.add_dataflow_op(

--- a/hugr-core/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr-core/src/hugr/rewrite/outline_cfg.rs
@@ -441,7 +441,7 @@ mod test {
         let mut fbuild = module_builder
             .define_function(
                 "main",
-                FunctionType::new(type_row![USIZE_T], type_row![USIZE_T]).into(),
+                FunctionType::new(type_row![USIZE_T], type_row![USIZE_T]),
             )
             .unwrap();
         let [i1] = fbuild.input_wires_arr();

--- a/hugr-core/src/hugr/rewrite/simple_replace.rs
+++ b/hugr-core/src/hugr/rewrite/simple_replace.rs
@@ -255,7 +255,7 @@ pub(in crate::hugr::rewrite) mod test {
         let _f_id = {
             let mut func_builder = module_builder.define_function(
                 "main",
-                FunctionType::new(type_row![QB, QB, QB], type_row![QB, QB, QB]).into(),
+                FunctionType::new(type_row![QB, QB, QB], type_row![QB, QB, QB]),
             )?;
 
             let [qb0, qb1, qb2] = func_builder.input_wires_arr();

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -252,7 +252,7 @@ fn weighted_hugr_ser() {
 
         let t_row = vec![Type::new_sum([type_row![NAT], type_row![QB]])];
         let mut f_build = module_builder
-            .define_function("main", FunctionType::new(t_row.clone(), t_row).into())
+            .define_function("main", FunctionType::new(t_row.clone(), t_row))
             .unwrap();
 
         let outputs = f_build

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -257,7 +257,7 @@ fn no_ext_edge_into_func() -> Result<(), Box<dyn std::error::Error>> {
         FunctionType::new(vec![], Type::new_function(b2b.clone())),
         [],
     )?;
-    let mut func = dfg.define_function("AndWithOuter", b2b.clone().into())?;
+    let mut func = dfg.define_function("AndWithOuter", b2b.clone())?;
     let [fn_input] = func.input_wires_arr();
     let and_op = func.add_dataflow_op(and_op(), [fn_input, input])?; // 'ext' edge
     let func = func.finish_with_outputs(and_op.outputs())?;
@@ -651,7 +651,7 @@ fn inner_row_variables() -> Result<(), Box<dyn std::error::Error>> {
     // All the wires here are carrying higher-order Function values
     let [func_arg] = fb.input_wires_arr();
     let [id_usz] = {
-        let bldr = fb.define_function("id_usz", FunctionType::new_endo(USIZE_T).into())?;
+        let bldr = fb.define_function("id_usz", FunctionType::new_endo(USIZE_T))?;
         let vals = bldr.input_wires();
         let [inner_def] = bldr.finish_with_outputs(vals)?.outputs_arr();
         let loadf = LoadFunction::try_new(
@@ -843,7 +843,7 @@ fn test_polymorphic_load() -> Result<(), Box<dyn std::error::Error>> {
         vec![],
         vec![Type::new_function(FunctionType::new_endo(vec![USIZE_T]))],
     );
-    let mut f = m.define_function("main", sig.into())?;
+    let mut f = m.define_function("main", sig)?;
     let l = f.load_func(&id, &[USIZE_T.into()], &PRELUDE_REGISTRY)?;
     f.finish_with_outputs([l])?;
     let _ = m.finish_prelude_hugr()?;

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -223,7 +223,7 @@ pub(super) mod test {
         let (f_id, inner_id) = {
             let mut func_builder = module_builder.define_function(
                 "main",
-                FunctionType::new(type_row![NAT, QB], type_row![NAT, QB]).into(),
+                FunctionType::new(type_row![NAT, QB], type_row![NAT, QB]),
             )?;
 
             let [int, qb] = func_builder.input_wires_arr();

--- a/hugr-core/src/hugr/views/sibling.rs
+++ b/hugr-core/src/hugr/views/sibling.rs
@@ -410,7 +410,7 @@ mod test {
     fn nested_flat() -> Result<(), Box<dyn std::error::Error>> {
         let mut module_builder = ModuleBuilder::new();
         let fty = FunctionType::new(type_row![NAT], type_row![NAT]);
-        let mut fbuild = module_builder.define_function("main", fty.clone().into())?;
+        let mut fbuild = module_builder.define_function("main", fty.clone())?;
         let dfg = fbuild.dfg_builder(fty, fbuild.input_wires())?;
         let ins = dfg.input_wires();
         let sub_dfg = dfg.finish_with_outputs(ins)?;

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -415,7 +415,7 @@ impl SiblingSubgraph {
     /// The new Hugr will contain a [FuncDefn][crate::ops::FuncDefn] root
     /// with the same signature as the subgraph and the specified `name`
     pub fn extract_subgraph(&self, hugr: &impl HugrView, name: impl Into<String>) -> Hugr {
-        let mut builder = FunctionBuilder::new(name, self.signature(hugr).into()).unwrap();
+        let mut builder = FunctionBuilder::new(name, self.signature(hugr)).unwrap();
         // Take the unfinished Hugr from the builder, to avoid unnecessary
         // validation checks that require connecting the inputs and outputs.
         let mut extracted = mem::take(builder.hugr_mut());

--- a/hugr-core/src/hugr/views/tests.rs
+++ b/hugr-core/src/hugr/views/tests.rs
@@ -184,7 +184,7 @@ fn test_dataflow_ports_only() {
         let local_and = dfg
             .define_function(
                 "and",
-                FunctionType::new(type_row![BOOL_T; 2], type_row![BOOL_T]).into(),
+                FunctionType::new(type_row![BOOL_T; 2], type_row![BOOL_T]),
             )
             .unwrap();
         let first_input = local_and.input().out_wire(0);


### PR DESCRIPTION
Currently FunctionBuilder::new and the `define_function` method both take a PolyFuncType; this PR changes that to a more-general `impl Into<PolyFuncType>`.

BREAKING CHANGE: clients calling these methods with a FunctionType's `.into()` will fail to compile with a "type annotations required" error, which can be fixed by deleting the `.into()`.