### PR TITLE
style: Change "serialise" etc to "serialize" etc.

### DIFF
--- a/hugr-cli/README.md
+++ b/hugr-cli/README.md
@@ -8,7 +8,7 @@ hugr-cli
 [![msrv][]](https://github.com/CQCL/hugr)
 [![codecov][]](https://codecov.io/gh/CQCL/hugr)
 
-`hugr` CLI tool for common tasks on serialised HUGR (e.g. validation,
+`hugr` CLI tool for common tasks on serialized HUGR (e.g. validation,
 visualisation).
 
 Refer to the [main HUGR crate](http://crates.io/crates/hugr) for more information.

--- a/hugr-core/CHANGELOG.md
+++ b/hugr-core/CHANGELOG.md
@@ -41,7 +41,7 @@
 
 ### Testing
 
-- Serialisation round trip testing for `OpDef` ([#999](https://github.com/CQCL/hugr/pull/999))
+- Serialization round trip testing for `OpDef` ([#999](https://github.com/CQCL/hugr/pull/999))
 
 
 ## 0.1.0 (2024-05-29)

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -787,7 +787,7 @@ pub(super) mod test {
             type Strategy = BoxedStrategy<Self>;
             fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
                 // TODO there is also  SignatureFunc::CustomFunc, but for now
-                // this is not serialised. When it is, we should generate
+                // this is not serialized. When it is, we should generate
                 // examples here .
                 any::<PolyFuncType>()
                     .prop_map(|x| SignatureFunc::TypeScheme(CustomValidator::from_polyfunc(x)))
@@ -800,7 +800,7 @@ pub(super) mod test {
             type Strategy = BoxedStrategy<Self>;
             fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
                 // TODO There is also LowerFunc::CustomFunc, but for now this is
-                // not serialised. When it is, we should generate examples here.
+                // not serialized. When it is, we should generate examples here.
                 any::<ExtensionSet>()
                     .prop_map(|extensions| LowerFunc::FixedHugr {
                         extensions,
@@ -834,7 +834,7 @@ pub(super) mod test {
                                 misc,
                                 signature_func,
                                 lower_funcs,
-                                // TODO ``constant_folder` is not serialised, we should
+                                // TODO ``constant_folder` is not serialized, we should
                                 // generate examples once it is.
                                 constant_folder: None,
                             })

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -328,7 +328,7 @@ mod test {
 
     #[test]
     #[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
-    #[ignore = "issue 1225: In serialisation we do not distinguish between unknown CustomConst serialised value invalid but known CustomConst serialised values"]
+    #[ignore = "issue 1225: In serialization we do not distinguish between unknown CustomConst serialized value invalid but known CustomConst serialized values"]
     fn hugr_validation_0() {
         // https://github.com/CQCL/hugr/issues/1091 bad case
         let mut hugr: Hugr = serde_json::from_reader(BufReader::new(

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -28,7 +28,7 @@ use rstest::rstest;
 const NAT: Type = crate::extension::prelude::USIZE_T;
 const QB: Type = crate::extension::prelude::QB_T;
 
-/// Version 1 of the Testing HUGR serialisation format, see `testing_hugr.py`.
+/// Version 1 of the Testing HUGR serialization format, see `testing_hugr.py`.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
 struct SerTestingV1 {
     typ: Option<crate::types::Type>,

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -126,9 +126,9 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
         self.validate_subtree(self.hugr.root(), &[])?;
 
         // In tests we take the opportunity to verify that the hugr
-        // serialization round-trips. We verify the schema of the serialisation
+        // serialization round-trips. We verify the schema of the serialization
         // format only when an environment variable is set. This allows
-        // a developer to modify the definition of serialised types locally
+        // a developer to modify the definition of serialized types locally
         // without having to change the schema.
         #[cfg(all(test, not(miri)))]
         {

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -142,7 +142,7 @@ pub enum Value {
 /// An opaque newtype around a [`Box<dyn CustomConst>`](CustomConst).
 ///
 /// This type has special serialization behaviour in order to support
-/// serialisation and deserialisation of unknown impls of [CustomConst].
+/// serialization and deserialization of unknown impls of [CustomConst].
 ///
 /// During serialization we first serialize the internal [`dyn` CustomConst](CustomConst)
 /// into a [serde_yaml::Value]. We then create a [CustomSerialized] wrapping
@@ -156,7 +156,7 @@ pub enum Value {
 /// [CustomSerialized] into a [`Box<dyn CustomConst>`](CustomConst). The [OpaqueValue] is
 /// then produced from the [`Box<dyn [CustomConst]>`](CustomConst).
 ///
-/// In the case where the internal serialised value of a `CustomSerialized`
+/// In the case where the internal serialized value of a `CustomSerialized`
 /// is another `CustomSerialized` we do not attempt to recurse. This behaviour
 /// may change in future.
 ///
@@ -675,7 +675,7 @@ mod test {
             type Strategy = BoxedStrategy<Self>;
             fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
                 // We intentionally do not include `ConstF64` because it does not
-                // roundtrip serialise
+                // roundtrip serialize
                 prop_oneof![
                     any::<ConstInt>().prop_map_into(),
                     any::<CustomSerialized>().prop_map_into()

--- a/hugr-core/src/ops/constant/custom.rs
+++ b/hugr-core/src/ops/constant/custom.rs
@@ -141,7 +141,7 @@ pub struct CustomSerialized {
 }
 
 #[derive(Debug, Error)]
-#[error("Error serializing value into CustomSerialised: err: {err}, value: {payload:?}")]
+#[error("Error serializing value into CustomSerialized: err: {err}, value: {payload:?}")]
 pub struct SerializeError {
     #[source]
     err: serde_yaml::Error,
@@ -149,7 +149,7 @@ pub struct SerializeError {
 }
 
 #[derive(Debug, Error)]
-#[error("Error deserialising value from CustomSerialised: err: {err}, value: {payload:?}")]
+#[error("Error deserializing value from CustomSerialized: err: {err}, value: {payload:?}")]
 pub struct DeserializeError {
     #[source]
     err: serde_yaml::Error,
@@ -176,13 +176,13 @@ impl CustomSerialized {
     }
 
     /// If `cc` is a [Self], returns a clone of `cc` coerced to [Self].
-    /// Otherwise, returns a [Self] with `cc` serialised in it's value.
+    /// Otherwise, returns a [Self] with `cc` serialized in it's value.
     pub fn try_from_custom_const_ref(cc: &impl CustomConst) -> Result<Self, SerializeError> {
         Self::try_from_dyn_custom_const(cc)
     }
 
     /// If `cc` is a [Self], returns a clone of `cc` coerced to [Self].
-    /// Otherwise, returns a [Self] with `cc` serialised in it's value.
+    /// Otherwise, returns a [Self] with `cc` serialized in it's value.
     pub fn try_from_dyn_custom_const(cc: &dyn CustomConst) -> Result<Self, SerializeError> {
         Ok(match cc.as_any().downcast_ref::<Self>() {
             Some(cs) => cs.clone(),
@@ -222,7 +222,7 @@ impl CustomSerialized {
     /// Attempts to deserialize the value in self into a `Box<dyn CustomConst>`.
     /// This can fail, in particular when the `impl CustomConst` for the trait
     /// is not linked into the running executable.
-    /// If deserialisation fails, returns self in a box.
+    /// If deserialization fails, returns self in a box.
     ///
     /// Note that if the inner value is a [Self] we do not recursively
     /// deserialize it.
@@ -277,7 +277,7 @@ pub(super) mod serde_extension_value {
         use serde::Deserialize;
         // We deserialize a CustomSerialized, i.e. not a dyn CustomConst.
         let cs = CustomSerialized::deserialize(deserializer)?;
-        // We return the inner serialised CustomConst if we can, otherwise the
+        // We return the inner serialized CustomConst if we can, otherwise the
         // CustomSerialized itself.
         Ok(cs.into_custom_const_box())
     }
@@ -470,7 +470,7 @@ mod test {
         assert_eq!(&inner, &cs.clone().try_into_custom_const().unwrap());
 
         let ev: OpaqueValue = cs.clone().into();
-        // A serialisation round-trip results in an OpaqueValue with the value of inner
+        // A serialization round-trip results in an OpaqueValue with the value of inner
         assert_eq!(
             OpaqueValue::new(inner),
             serde_yaml::from_value(serde_yaml::to_value(&ev).unwrap()).unwrap()

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -709,7 +709,7 @@ mod test {
                         .boxed(),
                     // TODO this is a bit dodgy, TypeArgVariables are supposed
                     // to be constructed from TypeArg::new_var_use. We are only
-                    // using this instance for serialisation now, but if we want
+                    // using this instance for serialization now, but if we want
                     // to generate valid TypeArgs this will need to change.
                     any_with::<TypeArgVariable>(depth)
                         .prop_map(|v| Self::Variable { v })

--- a/hugr-py/CHANGELOG.md
+++ b/hugr-py/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ⚠ BREAKING CHANGES
 
-* New serialisation schema
+* New serialization schema
 * rename `Const::const_type` and `Value::const_type` to `Const::get_type` and `Value::get_type`. These now match several other `get_type` functions ([#1005](https://github.com/CQCL/hugr/issues/1005))
 * Many uses of `Const` now use `Value`.
 
@@ -23,7 +23,7 @@
 * `OpDef` serialization ([#1013](https://github.com/CQCL/hugr/issues/1013)) ([3d8f6f6](https://github.com/CQCL/hugr/commit/3d8f6f6a655f8af7f8fc2929f9bd7d3031b403f5))
 * input_port_types and other helper functions on pydantic schema ([#958](https://github.com/CQCL/hugr/issues/958)) ([8651839](https://github.com/CQCL/hugr/commit/86518390296bd93ca2fc65eccf158e21625b9073))
 * Remove insert_port_types for LoadFunction ([#993](https://github.com/CQCL/hugr/issues/993)) ([acca7bf](https://github.com/CQCL/hugr/commit/acca7bfb4a074c7feb3b4b5758f589941632bc5a))
-* Serialisation for `Type`, `PolyFuncType`, and `Value` ([#968](https://github.com/CQCL/hugr/issues/968)) ([d913f40](https://github.com/CQCL/hugr/commit/d913f406478a9f884bffef2002a02d423796b4e9))
+* Serialization for `Type`, `PolyFuncType`, and `Value` ([#968](https://github.com/CQCL/hugr/issues/968)) ([d913f40](https://github.com/CQCL/hugr/commit/d913f406478a9f884bffef2002a02d423796b4e9))
 * Serialization for `Op`s ([#997](https://github.com/CQCL/hugr/issues/997)) ([9ce6e49](https://github.com/CQCL/hugr/commit/9ce6e49d1d0c8c200b9b78ebe35a0a3257009ca1))
 * set `[build-system]` in `hugr-py/pyproject.toml` ([#1022](https://github.com/CQCL/hugr/issues/1022)) ([b9c3ee4](https://github.com/CQCL/hugr/commit/b9c3ee46abbc166fb82155c62c8583e575284578))
 

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -31,7 +31,7 @@ class InvalidPort(Exception):
 @runtime_checkable
 class Op(Protocol):
     """An abstract HUGR operation. Must be convertible
-    to a serialisable :class:`BaseOp`.
+    to a serializable :class:`BaseOp`.
     """
 
     @property
@@ -46,7 +46,7 @@ class Op(Protocol):
         ...  # pragma: no cover
 
     def to_serial(self, parent: Node) -> BaseOp:
-        """Convert this operation to a serialisable form."""
+        """Convert this operation to a serializable form."""
         ...  # pragma: no cover
 
     def port_kind(self, port: InPort | OutPort) -> tys.Kind:

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -17,7 +17,7 @@ class TypeParam(Protocol):
     """A HUGR type parameter."""
 
     def to_serial(self) -> stys.BaseTypeParam:
-        """Convert to serialisable model."""
+        """Convert to serializable model."""
         ...  # pragma: no cover
 
     def to_serial_root(self) -> stys.TypeParam:
@@ -28,7 +28,7 @@ class TypeArg(Protocol):
     """A HUGR type argument, which can be bound to a :class:TypeParam."""
 
     def to_serial(self) -> stys.BaseTypeArg:
-        """Convert to serialisable model."""
+        """Convert to serializable model."""
         ...  # pragma: no cover
 
     def to_serial_root(self) -> stys.TypeArg:
@@ -40,7 +40,7 @@ class Type(Protocol):
     """A HUGR type."""
 
     def to_serial(self) -> stys.BaseType:
-        """Convert to serialisable model."""
+        """Convert to serializable model."""
         ...  # pragma: no cover
 
     def to_serial_root(self) -> stys.Type:

--- a/hugr-py/src/hugr/utils.py
+++ b/hugr-py/src/hugr/utils.py
@@ -179,15 +179,15 @@ S = TypeVar("S", covariant=True)
 
 
 class SerCollection(Protocol[S]):
-    """Protocol for serialisable objects."""
+    """Protocol for serializable objects."""
 
     def to_serial_root(self) -> S:
-        """Convert to serialisable root model."""
+        """Convert to serializable root model."""
         ...  # pragma: no cover
 
 
 class DeserCollection(Protocol[S]):
-    """Protocol for deserialisable objects."""
+    """Protocol for deserializable objects."""
 
     def deserialize(self) -> S:
         """Deserialize from model."""

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -16,10 +16,10 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class Value(Protocol):
-    """Abstract value definition. Must be serialisable into a HUGR value."""
+    """Abstract value definition. Must be serializable into a HUGR value."""
 
     def to_serial(self) -> sops.BaseValue:
-        """Convert to serialisable model."""
+        """Convert to serializable model."""
         ...  # pragma: no cover
 
     def to_serial_root(self) -> sops.Value:

--- a/hugr/CHANGELOG.md
+++ b/hugr/CHANGELOG.md
@@ -41,7 +41,7 @@
 
 ### Testing
 
-- Serialisation round trip testing for `OpDef` ([#999](https://github.com/CQCL/hugr/pull/999))
+- Serialization round trip testing for `OpDef` ([#999](https://github.com/CQCL/hugr/pull/999))
 
 ### Refactor
 
@@ -79,11 +79,11 @@
 - Disallow non-finite values for `ConstF64` ([#1075](https://github.com/CQCL/hugr/pull/1075))
 - Serialization round-trips ([#948](https://github.com/CQCL/hugr/pull/948))
 - [**breaking**] Combine `ConstIntU` and `ConstIntS` ([#974](https://github.com/CQCL/hugr/pull/974))
-- Disable serialisation tests when miri is active ([#977](https://github.com/CQCL/hugr/pull/977))
-- [**breaking**] Serialisation schema ([#968](https://github.com/CQCL/hugr/pull/968))
+- Disable serialization tests when miri is active ([#977](https://github.com/CQCL/hugr/pull/977))
+- [**breaking**] Serialization schema ([#968](https://github.com/CQCL/hugr/pull/968))
 - Correct constant fold for `fne`. ([#995](https://github.com/CQCL/hugr/pull/995))
-- [**breaking**] Serialisation fixes ([#997](https://github.com/CQCL/hugr/pull/997))
-- [**breaking**] OpDef serialisation ([#1013](https://github.com/CQCL/hugr/pull/1013))
+- [**breaking**] Serialization fixes ([#997](https://github.com/CQCL/hugr/pull/997))
+- [**breaking**] OpDef serialization ([#1013](https://github.com/CQCL/hugr/pull/1013))
 - NaryLogicOp constant folding ([#1026](https://github.com/CQCL/hugr/pull/1026))
 
 ### Features
@@ -101,7 +101,7 @@
 - Add LoadFunction node ([#947](https://github.com/CQCL/hugr/pull/947))
 - Add From impls for TypeArg ([#1002](https://github.com/CQCL/hugr/pull/1002))
 - Constant-folding of integer and logic operations ([#1009](https://github.com/CQCL/hugr/pull/1009))
-- [**breaking**] Update serialisation schema, implement `CustomConst` serialisation ([#1005](https://github.com/CQCL/hugr/pull/1005))
+- [**breaking**] Update serialization schema, implement `CustomConst` serialization ([#1005](https://github.com/CQCL/hugr/pull/1005))
 - Merge basic blocks algorithm ([#956](https://github.com/CQCL/hugr/pull/956))
 - [**breaking**] Allow panic operation to have any input and output wires ([#1024](https://github.com/CQCL/hugr/pull/1024))
 
@@ -118,10 +118,10 @@
 - Reorg OutlineCfg/nest_cfgs tests so hugr doesn't depend on algorithm ([#1007](https://github.com/CQCL/hugr/pull/1007))
 - Ignore tests which depend on typetag when cfg(miri) ([#1051](https://github.com/CQCL/hugr/pull/1051))
 - Really ignore tests which depend on typetag when cfg(miri) ([#1058](https://github.com/CQCL/hugr/pull/1058))
-- Proptests for round trip serialisation of `Type`s and `Op`s. ([#981](https://github.com/CQCL/hugr/pull/981))
+- Proptests for round trip serialization of `Type`s and `Op`s. ([#981](https://github.com/CQCL/hugr/pull/981))
 - Add a test of instantiating an extension set ([#939](https://github.com/CQCL/hugr/pull/939))
-- Ignore serialisation tests when using miri ([#975](https://github.com/CQCL/hugr/pull/975))
-- [**breaking**] Test roundtrip serialisation against strict + lax schema ([#982](https://github.com/CQCL/hugr/pull/982))
+- Ignore serialization tests when using miri ([#975](https://github.com/CQCL/hugr/pull/975))
+- [**breaking**] Test roundtrip serialization against strict + lax schema ([#982](https://github.com/CQCL/hugr/pull/982))
 - Fix some bad assert_matches ([#1006](https://github.com/CQCL/hugr/pull/1006))
 - Expand test of instantiating extension sets ([#1003](https://github.com/CQCL/hugr/pull/1003))
 - Fix unconnected ports in extension test ([#1010](https://github.com/CQCL/hugr/pull/1010))

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1566,7 +1566,7 @@ Unfortunately this then requires a grammar and parsing/codegen, which is
 maintenance and design overhead. We believe that for most cases,
 inspecting and modifying the in-memory structure will be enough. If not,
 in future we can add a human language and a standalone module for
-conversion to/from the binary serialised form.
+conversion to/from the binary serialized form.
 
 ### Schema
 


### PR DESCRIPTION
Did: `git grep -l -i 'serialis' | xargs sed -i 's/erialis/erializ/g'`

The "-ize" spelling is already used much more often, so let's be consistent.