### PR TITLE
docs(hugr-py): build and publish docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,9 @@ jobs:
   build:
     name: Build docs.
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./hugr-py
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry
@@ -43,7 +46,7 @@ jobs:
       - name: Upload artifact.
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./docs/build/main
+          path: ./hugr-py/docs/build
 
   publish:
     name: Publish docs.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Build and publish docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    # only run if there are changes in the hugr-py directory
+    paths:
+      - 'hugr-py/**'
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued.
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build docs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python '3.10'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: "poetry"
+      - name: Install HUGR
+        run: poetry install --with docs
+      - name: Build docs
+        run: |
+          cd docs
+          ./build.sh
+      - name: Upload artifact.
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/build/main
+
+  publish:
+    name: Publish docs.
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Deploy to GitHub Pages.
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/hugr-py/docs/_static/_redirect.html
+++ b/hugr-py/docs/_static/_redirect.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to main branch</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./main/index.html">
+    <link rel="canonical" href="https://cqcl.github.io/hugr/main/index.html">
+  </head>
+</html>

--- a/hugr-py/docs/api-docs/_templates/versioning.html
+++ b/hugr-py/docs/api-docs/_templates/versioning.html
@@ -1,0 +1,8 @@
+{% if versions %}
+<h3>{{ _('Versions') }}</h3>
+<ul>
+  {%- for item in versions %}
+  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {%- endfor %}
+</ul>
+{% endif %}

--- a/hugr-py/docs/api-docs/conf.py
+++ b/hugr-py/docs/api-docs/conf.py
@@ -13,6 +13,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
+    "sphinx_multiversion",
 ]
 
 html_theme = "sphinx_book_theme"
@@ -36,6 +37,18 @@ autosummary_generate = True
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "conftest.py"]
+html_sidebars = {
+    "**": [
+        "navbar-logo.html",
+        "icon-links.html",
+        "search-button-field.html",
+        "sbt-sidebar-nav.html",
+        "versioning.html",
+    ],
+}
+
+smv_branch_whitelist = "main"
+smv_tag_whitelist = r"^hugr-py-.*$"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),

--- a/hugr-py/docs/build.sh
+++ b/hugr-py/docs/build.sh
@@ -4,4 +4,4 @@ mkdir build
 
 touch build/.nojekyll  # Disable jekyll to keep files starting with underscores
 
-sphinx-build -b html ./api-docs ./build/api-docs
+sphinx-multiversion ./api-docs ./build

--- a/hugr-py/docs/build.sh
+++ b/hugr-py/docs/build.sh
@@ -3,5 +3,6 @@
 mkdir build
 
 touch build/.nojekyll  # Disable jekyll to keep files starting with underscores
-
+# copy redirect file
+cp ./_static/_redirect.html ./build/index.html
 sphinx-multiversion ./api-docs ./build

--- a/hugr-py/poetry.lock
+++ b/hugr-py/poetry.lock
@@ -577,6 +577,20 @@ doc = ["ablog", "folium", "ipywidgets", "matplotlib", "myst-nb", "nbclient", "nu
 test = ["beautifulsoup4", "coverage", "defusedxml", "myst-nb", "pytest", "pytest-cov", "pytest-regressions", "sphinx_thebe"]
 
 [[package]]
+name = "sphinx-multiversion"
+version = "0.2.4"
+description = "Add support for multiple versions to sphinx"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sphinx-multiversion-0.2.4.tar.gz", hash = "sha256:5cd1ca9ecb5eed63cb8d6ce5e9c438ca13af4fa98e7eb6f376be541dd4990bcb"},
+    {file = "sphinx_multiversion-0.2.4-py3-none-any.whl", hash = "sha256:dec29f2a5890ad68157a790112edc0eb63140e70f9df0a363743c6258fbeb478"},
+]
+
+[package.dependencies]
+sphinx = ">=2.1"
+
+[[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.8"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
@@ -712,4 +726,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "0e927e63660da3f23f2e241a006c7255a780303326e967baec4f0436f16bbd84"
+content-hash = "c0e0f4ebdc6d0b9e2b6e71841109ee1a47f42d850aa5621c5723006a9dd9d99a"

--- a/hugr-py/pyproject.toml
+++ b/hugr-py/pyproject.toml
@@ -33,6 +33,7 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 sphinx = "^7.2.6"
 sphinx-book-theme = "^1.1.2"
+sphinx-multiversion = "^0.2.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Closes #1215

Will build and publish for main branch + every tagged version with docs (currently none), using [sphinx-multiversion](https://holzhaus.github.io/sphinx-multiversion/master/index.html)

With multiple versions looks like:

![image](https://github.com/CQCL/hugr/assets/12997250/f54738cf-d38f-4be7-a370-e34ab986482b)


Will follow-up with a PR adding links to readme etc. once I've seen the workflow succeeds.