### PR TITLE
chore: docs fetch all tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,9 @@ jobs:
         working-directory: ./hugr-py
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python '3.10'


### PR DESCRIPTION
Need full history to build docs for old versions

If this becomes too heavy in the future we can optimise