### PR TITLE
chore: Update portgraph to `0.12.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ missing_docs = "warn"
 debug_assert_with_mut_call = "warn"
 
 [workspace.dependencies]
-portgraph = { version = "0.12.1" }
+portgraph = { version = "0.12.2" }
 insta = { version = "1.34.0" }
 bitvec = "1.0.1"
 cgmath = "0.18.0"

--- a/hugr-core/src/hugr/views/snapshots/hugr_core__hugr__views__tests__mmd_cfg.snap
+++ b/hugr-core/src/hugr/views/snapshots/hugr_core__hugr__views__tests__mmd_cfg.snap
@@ -8,24 +8,23 @@ graph LR
         subgraph 2 ["(2) DataflowBlock"]
             direction LR
             3["(3) Input"]
-            3--"0:0<br>usize"-->5
             4["(4) Output"]
             5["(5) Tag"]
+            3--"0:0<br>usize"-->5
             5--"0:0<br>[usize]+[usize]"-->4
         end
-        2-."0:0".->6
-        2-."1:0".->1
         1["(1) ExitBlock"]
         subgraph 6 ["(6) DataflowBlock"]
             direction LR
             7["(7) Input"]
-            7--"0:1<br>usize"-->8
             8["(8) Output"]
             9["(9) const:seq:{}"]
-            9--"0:0<br>[]"-->10
             10["(10) LoadConstant"]
+            7--"0:1<br>usize"-->8
+            9--"0:0<br>[]"-->10
             10--"0:0<br>[]"-->8
         end
+        2-."0:0".->6
+        2-."1:0".->1
         6-."0:0".->1
     end
-

--- a/hugr-core/src/hugr/views/snapshots/hugr_core__hugr__views__tests__mmd_dfg.snap
+++ b/hugr-core/src/hugr/views/snapshots/hugr_core__hugr__views__tests__mmd_dfg.snap
@@ -6,14 +6,14 @@ graph LR
     subgraph 0 ["(0) DFG"]
         direction LR
         1["(1) Input"]
-        1--"0:0<br>qubit"-->3
-        1--"1:1<br>qubit"-->3
         2["(2) Output"]
         3["(3) test.quantum.CX"]
+        4["(4) test.quantum.CX"]
+        1--"0:0<br>qubit"-->3
+        1--"1:1<br>qubit"-->3
         3--"0:1<br>qubit"-->4
         3--"1:0<br>qubit"-->4
         3-."2:2".->4
-        4["(4) test.quantum.CX"]
         4--"0:0<br>qubit"-->2
         4--"1:1<br>qubit"-->2
     end

--- a/hugr-core/src/hugr/views/snapshots/hugr_core__hugr__views__tests__mmd_empty_dfg.snap
+++ b/hugr-core/src/hugr/views/snapshots/hugr_core__hugr__views__tests__mmd_empty_dfg.snap
@@ -6,6 +6,6 @@ graph LR
     subgraph 0 ["(0) DFG"]
         direction LR
         1["(1) Input"]
-        1--"0:0<br>[]+[]"-->2
         2["(2) Output"]
+        1--"0:0<br>[]+[]"-->2
     end


### PR DESCRIPTION
Includes the fix in https://github.com/CQCL/portgraph/pull/139 that closes #1197