### PR TITLE
refactor!: rename `HugrView` function type methods + simplify behaviour

### DIFF
--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -332,11 +332,10 @@ pub trait HugrView: HugrInternals {
     /// signature corresponding to the input and output node of its sibling
     /// graph. Otherwise, returns `None`.
     ///
-    /// In contrast to [`get_function_type`][HugrView::get_function_type], this
+    /// In contrast to [`poly_func_type`][HugrView::poly_func_type], this
     /// method always return a concrete [`FunctionType`].
-    fn get_df_function_type(&self) -> Option<FunctionType> {
-        let op = self.get_optype(self.root());
-        op.inner_function_type()
+    fn inner_function_type(&self) -> Option<FunctionType> {
+        self.root_type().inner_function_type()
     }
 
     /// Returns the function type defined by this HUGR.
@@ -349,12 +348,11 @@ pub trait HugrView: HugrInternals {
     /// of the function.
     ///
     /// Otherwise, returns `None`.
-    fn get_function_type(&self) -> Option<PolyFuncType> {
-        let op = self.get_optype(self.root());
-        match op {
+    fn poly_func_type(&self) -> Option<PolyFuncType> {
+        match self.root_type() {
             OpType::FuncDecl(decl) => Some(decl.signature.clone()),
             OpType::FuncDefn(defn) => Some(defn.signature.clone()),
-            _ => op.inner_function_type().map(PolyFuncType::from),
+            _ => None,
         }
     }
 

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -261,13 +261,13 @@ pub(super) mod test {
         assert_eq!(region.children(inner).count(), 2);
 
         assert_eq!(
-            region.get_function_type(),
+            region.poly_func_type(),
             Some(FunctionType::new_endo(type_row![NAT, QB]).into())
         );
         let inner_region: DescendantsGraph = DescendantsGraph::try_new(&hugr, inner)?;
         assert_eq!(
-            inner_region.get_function_type(),
-            Some(FunctionType::new(type_row![NAT], type_row![NAT]).into())
+            inner_region.inner_function_type(),
+            Some(FunctionType::new(type_row![NAT], type_row![NAT]))
         );
 
         Ok(())

--- a/hugr-core/src/hugr/views/sibling.rs
+++ b/hugr-core/src/hugr/views/sibling.rs
@@ -443,7 +443,7 @@ mod test {
     fn flat_mut(mut simple_dfg_hugr: Hugr) {
         simple_dfg_hugr.update_validate(&PRELUDE_REGISTRY).unwrap();
         let root = simple_dfg_hugr.root();
-        let signature = simple_dfg_hugr.get_df_function_type().unwrap().clone();
+        let signature = simple_dfg_hugr.inner_function_type().unwrap().clone();
 
         let sib_mut = SiblingMut::<CfgID>::try_new(&mut simple_dfg_hugr, root);
         assert_eq!(


### PR DESCRIPTION
Closes #957

- `mono_fn_type` now enforces function value monomorphism
- get_df_function_type -> inner_function_type so it matches the actual op function being called more obviously.
- The culprit `get_function_type` changed to `poly_func_type` which _only_ reports polymorphic type from func defn/decl

BREAKING CHANGE: 
 - rename `get_df_function_type` to `inner_function_type`
- `get_function_type` replaced with `poly_func_type` which only reports polymorphic function type for Func(Defn/Decl) rooted HUGRs