### PR TITLE
feat!: `MakeOpDef` has new `extension` method.

### DIFF
--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -26,6 +26,8 @@ pub enum OpLoadError {
     NotMember(String),
     #[error("Type args invalid: {0}.")]
     InvalidArgs(#[from] SignatureError),
+    #[error("OpDef belongs to extension {0}, expected {1}.")]
+    WrongExtension(ExtensionId, ExtensionId),
 }
 
 impl<T> NamedOp for T
@@ -50,6 +52,9 @@ pub trait MakeOpDef: NamedOp {
 
     /// Return the signature (polymorphic function type) of the operation.
     fn signature(&self) -> SignatureFunc;
+
+    /// The ID of the extension this operation is defined in.
+    fn extension_id() -> ExtensionId;
 
     /// Description of the operation. By default, the same as `self.name()`.
     fn description(&self) -> String {
@@ -138,10 +143,19 @@ impl<T: MakeOpDef> MakeExtensionOp for T {
 
 /// Load an [MakeOpDef] from its name.
 /// See [strum_macros::EnumString].
-pub fn try_from_name<T>(name: &OpNameRef) -> Result<T, OpLoadError>
+pub fn try_from_name<T>(def: &OpDef) -> Result<T, OpLoadError>
 where
     T: std::str::FromStr + MakeOpDef,
 {
+    let expected_extension = T::extension_id();
+    if def.extension() != &expected_extension {
+        return Err(OpLoadError::WrongExtension(
+            def.extension().clone(),
+            expected_extension,
+        ));
+    }
+    let name: &OpNameRef = def.name();
+
     T::from_str(name).map_err(|_| OpLoadError::NotMember(name.to_string()))
 }
 
@@ -244,6 +258,10 @@ mod test {
 
         fn from_def(_op_def: &OpDef) -> Result<Self, OpLoadError> {
             Ok(Self::Dumb)
+        }
+
+        fn extension_id() -> ExtensionId {
+            EXT_ID.to_owned()
         }
     }
     const_extension_ids! {

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -54,7 +54,7 @@ pub trait MakeOpDef: NamedOp {
     fn signature(&self) -> SignatureFunc;
 
     /// The ID of the extension this operation is defined in.
-    fn expected_extension(&self) -> ExtensionId;
+    fn extension(&self) -> ExtensionId;
 
     /// Description of the operation. By default, the same as `self.name()`.
     fn description(&self) -> String {
@@ -148,7 +148,7 @@ where
     T: std::str::FromStr + MakeOpDef,
 {
     let op = T::from_str(name).map_err(|_| OpLoadError::NotMember(name.to_string()))?;
-    let expected_extension = op.expected_extension();
+    let expected_extension = op.extension();
     if def_extension != &expected_extension {
         return Err(OpLoadError::WrongExtension(
             def_extension.clone(),
@@ -260,7 +260,7 @@ mod test {
             Ok(Self::Dumb)
         }
 
-        fn expected_extension(&self) -> ExtensionId {
+        fn extension(&self) -> ExtensionId {
             EXT_ID.to_owned()
         }
     }

--- a/hugr-core/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions.rs
@@ -36,7 +36,11 @@ pub enum ConvertOpDef {
 
 impl MakeOpDef for ConvertOpDef {
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def.name())
+        crate::extension::simple_op::try_from_name(op_def)
+    }
+
+    fn extension_id() -> ExtensionId {
+        EXTENSION_ID.to_owned()
     }
 
     fn signature(&self) -> SignatureFunc {

--- a/hugr-core/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions.rs
@@ -39,7 +39,7 @@ impl MakeOpDef for ConvertOpDef {
         crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
     }
 
-    fn expected_extension(&self) -> ExtensionId {
+    fn extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 

--- a/hugr-core/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions.rs
@@ -36,10 +36,10 @@ pub enum ConvertOpDef {
 
 impl MakeOpDef for ConvertOpDef {
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def)
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
     }
 
-    fn extension_id() -> ExtensionId {
+    fn expected_extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 

--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -47,7 +47,7 @@ impl MakeOpDef for FloatOps {
         crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
     }
 
-    fn expected_extension(&self) -> ExtensionId {
+    fn extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 

--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -44,7 +44,11 @@ pub enum FloatOps {
 
 impl MakeOpDef for FloatOps {
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def.name())
+        crate::extension::simple_op::try_from_name(op_def)
+    }
+
+    fn extension_id() -> ExtensionId {
+        EXTENSION_ID.to_owned()
     }
 
     fn signature(&self) -> SignatureFunc {

--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -44,10 +44,10 @@ pub enum FloatOps {
 
 impl MakeOpDef for FloatOps {
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def)
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
     }
 
-    fn extension_id() -> ExtensionId {
+    fn expected_extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -100,10 +100,10 @@ pub enum IntOpDef {
 
 impl MakeOpDef for IntOpDef {
     fn from_def(op_def: &OpDef) -> Result<Self, crate::extension::simple_op::OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def)
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
     }
 
-    fn extension_id() -> ExtensionId {
+    fn expected_extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -100,7 +100,11 @@ pub enum IntOpDef {
 
 impl MakeOpDef for IntOpDef {
     fn from_def(op_def: &OpDef) -> Result<Self, crate::extension::simple_op::OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def.name())
+        crate::extension::simple_op::try_from_name(op_def)
+    }
+
+    fn extension_id() -> ExtensionId {
+        EXTENSION_ID.to_owned()
     }
 
     fn signature(&self) -> SignatureFunc {

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -103,7 +103,7 @@ impl MakeOpDef for IntOpDef {
         crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
     }
 
-    fn expected_extension(&self) -> ExtensionId {
+    fn extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -75,7 +75,7 @@ impl MakeOpDef for NaryLogic {
         try_from_name(op_def.name(), op_def.extension())
     }
 
-    fn expected_extension(&self) -> ExtensionId {
+    fn extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 
@@ -131,7 +131,7 @@ impl MakeOpDef for NotOp {
         }
     }
 
-    fn expected_extension(&self) -> ExtensionId {
+    fn extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -72,10 +72,10 @@ impl MakeOpDef for NaryLogic {
     }
 
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
-        try_from_name(op_def)
+        try_from_name(op_def.name(), op_def.extension())
     }
 
-    fn extension_id() -> ExtensionId {
+    fn expected_extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 
@@ -131,7 +131,7 @@ impl MakeOpDef for NotOp {
         }
     }
 
-    fn extension_id() -> ExtensionId {
+    fn expected_extension(&self) -> ExtensionId {
         EXTENSION_ID.to_owned()
     }
 

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -72,7 +72,11 @@ impl MakeOpDef for NaryLogic {
     }
 
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
-        try_from_name(op_def.name())
+        try_from_name(op_def)
+    }
+
+    fn extension_id() -> ExtensionId {
+        EXTENSION_ID.to_owned()
     }
 
     fn post_opdef(&self, def: &mut OpDef) {
@@ -125,6 +129,10 @@ impl MakeOpDef for NotOp {
         } else {
             Err(OpLoadError::NotMember(op_def.name().to_string()))
         }
+    }
+
+    fn extension_id() -> ExtensionId {
+        EXTENSION_ID.to_owned()
     }
 
     fn signature(&self) -> SignatureFunc {


### PR DESCRIPTION
Closes #1241 

Used to ensure `try_from_name` only succeeds when the extension is correct

BREAKING CHANGE:
- `MakeOpDef` trait has new required `extension` method.
- `try_from_name` takes the OpDef extension and checks it