### PR TITLE
fix!: `ops::Module` now empty struct rather than unit struct

### DIFF
--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -49,9 +49,6 @@ struct NodeSer {
     parent: Node,
     #[serde(flatten)]
     op: OpType,
-
-    #[serde(skip_serializing, default)]
-    input_extensions: Option<crate::extension::ExtensionSet>,
 }
 
 /// Version 1 of the HUGR serialization format.
@@ -149,7 +146,6 @@ impl TryFrom<&Hugr> for SerHugrV1 {
             nodes[new_node] = Some(NodeSer {
                 parent,
                 op: opt.clone(),
-                input_extensions: None,
             });
             metadata[new_node].clone_from(hugr.metadata.get(n.pg_index()));
         }

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -466,7 +466,6 @@ fn roundtrip_optype(#[case] optype: impl Into<OpType> + std::fmt::Debug) {
     check_testing_roundtrip(NodeSer {
         parent: portgraph::NodeIndex::new(0).into(),
         op: optype.into(),
-        input_extensions: None,
     });
 }
 
@@ -495,11 +494,7 @@ mod proptest {
                 (0..i32::MAX as usize).prop_map(|x| portgraph::NodeIndex::new(x).into()),
                 any::<OpType>(),
             )
-                .prop_map(|(parent, op)| NodeSer {
-                    parent,
-                    op,
-                    input_extensions: None,
-                })
+                .prop_map(|(parent, op)| NodeSer { parent, op })
                 .boxed()
         }
     }

--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -17,11 +17,15 @@ use super::{impl_op_name, OpTag, OpTrait};
 /// The root of a module, parent of all other `OpType`s.
 #[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(Arbitrary))]
-pub struct Module;
+pub struct Module {
+    // can't be simple unit struct due to flattened serialization issues
+    // see https://github.com/CQCL/hugr/issues/1270
+}
+
 impl Module {
     /// Construct a new Module.
     pub const fn new() -> Self {
-        Self
+        Self {}
     }
 }
 


### PR DESCRIPTION
Fixes #1270 without keeping the unused `input_extensions` field. 

BREAKING CHANGE: `ops::Module` no longer unit struct, must be constructed with `new()` or `default()`