### PR TITLE
feat(hugr-py): context manager style nested building

### DIFF
--- a/hugr-py/src/hugr/dfg.py
+++ b/hugr-py/src/hugr/dfg.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
 from dataclasses import dataclass, field, replace
 from typing import (
     TYPE_CHECKING,
@@ -27,7 +28,7 @@ DP = TypeVar("DP", bound=ops.DfParentOp)
 
 
 @dataclass()
-class _DfBase(ParentBuilder[DP]):
+class _DfBase(ParentBuilder[DP], AbstractContextManager):
     """Base class for dataflow graph builders.
 
     Args:
@@ -55,6 +56,12 @@ class _DfBase(ParentBuilder[DP]):
             ops.Input(inputs), self.parent_node, len(inputs)
         )
         self.output_node = self.hugr.add_node(ops.Output(), self.parent_node)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args) -> None:
+        return None
 
     @classmethod
     def new_nested(
@@ -179,8 +186,8 @@ class _DfBase(ParentBuilder[DP]):
 
         Example:
             >>> dfg = Dfg(tys.Bool)
-            >>> dfg2 = dfg.add_nested(dfg.inputs()[0])
-            >>> dfg2.parent_node
+            >>> with dfg.add_nested(dfg.inputs()[0]) as dfg2:\
+                   dfg2.parent_node
             Node(3)
         """
         from .dfg import Dfg
@@ -207,8 +214,8 @@ class _DfBase(ParentBuilder[DP]):
 
         Example:
             >>> dfg = Dfg(tys.Bool)
-            >>> cfg = dfg.add_cfg(dfg.inputs()[0])
-            >>> cfg.parent_op
+            >>> with dfg.add_cfg(dfg.inputs()[0]) as cfg:\
+                    cfg.parent_op
             CFG(inputs=[Bool])
         """
         from .cfg import Cfg

--- a/hugr-py/tests/test_cfg.py
+++ b/hugr-py/tests/test_cfg.py
@@ -6,9 +6,8 @@ from .conftest import INT_T, DivMod, IntVal, validate
 
 
 def build_basic_cfg(cfg: Cfg) -> None:
-    entry = cfg.add_entry()
-
-    entry.set_single_succ_outputs(*entry.inputs())
+    with cfg.add_entry() as entry:
+        entry.set_single_succ_outputs(*entry.inputs())
     cfg.branch(entry[0], cfg.exit)
 
 
@@ -49,16 +48,17 @@ def test_nested_cfg() -> None:
 
 def test_dom_edge() -> None:
     cfg = Cfg(tys.Bool, tys.Unit, INT_T)
-    entry = cfg.add_entry()
-    b, u, i = entry.inputs()
-    entry.set_block_outputs(b, i)
+    with cfg.add_entry() as entry:
+        b, u, i = entry.inputs()
+        entry.set_block_outputs(b, i)
 
     # entry dominates both middles so Unit type can be used as inter-graph
     # value between basic blocks
-    middle_1 = cfg.add_successor(entry[0])
-    middle_1.set_block_outputs(u, *middle_1.inputs())
-    middle_2 = cfg.add_successor(entry[1])
-    middle_2.set_block_outputs(u, *middle_2.inputs())
+    with cfg.add_successor(entry[0]) as middle_1:
+        middle_1.set_block_outputs(u, *middle_1.inputs())
+
+    with cfg.add_successor(entry[1]) as middle_2:
+        middle_2.set_block_outputs(u, *middle_2.inputs())
 
     cfg.branch_exit(middle_1[0])
     cfg.branch_exit(middle_2[0])
@@ -68,22 +68,21 @@ def test_dom_edge() -> None:
 
 def test_asymm_types() -> None:
     # test different types going to entry block's susccessors
-    cfg = Cfg()
-    entry = cfg.add_entry()
+    with Cfg() as cfg:
+        with cfg.add_entry() as entry:
+            int_load = entry.load(IntVal(34))
 
-    int_load = entry.load(IntVal(34))
+            sum_ty = tys.Sum([[INT_T], [tys.Bool]])
+            tagged_int = entry.add(ops.Tag(0, sum_ty)(int_load))
+            entry.set_block_outputs(tagged_int)
 
-    sum_ty = tys.Sum([[INT_T], [tys.Bool]])
-    tagged_int = entry.add(ops.Tag(0, sum_ty)(int_load))
-    entry.set_block_outputs(tagged_int)
+        with cfg.add_successor(entry[0]) as middle:
+            # discard the int and return the bool from entry
+            middle.set_single_succ_outputs(middle.load(val.TRUE))
 
-    middle = cfg.add_successor(entry[0])
-    # discard the int and return the bool from entry
-    middle.set_single_succ_outputs(middle.load(val.TRUE))
-
-    # middle expects an int and exit expects a bool
-    cfg.branch_exit(entry[1])
-    cfg.branch_exit(middle[0])
+        # middle expects an int and exit expects a bool
+        cfg.branch_exit(entry[1])
+        cfg.branch_exit(middle[0])
 
     validate(cfg.hugr)
 

--- a/hugr-py/tests/test_cond_loop.py
+++ b/hugr-py/tests/test_cond_loop.py
@@ -13,13 +13,13 @@ def build_cond(h: Conditional) -> None:
     with pytest.raises(ConditionalError, match="Case 2 out of possible range."):
         h.add_case(2)
 
-    case0 = h.add_case(0)
-    q, b = case0.inputs()
-    case0.set_outputs(q, b)
+    with h.add_case(0) as case0:
+        q, b = case0.inputs()
+        case0.set_outputs(q, b)
 
-    case1 = h.add_case(1)
-    q, _i, b = case1.inputs()
-    case1.set_outputs(q, b)
+    with h.add_case(1) as case1:
+        q, _i, b = case1.inputs()
+        case1.set_outputs(q, b)
 
 
 def test_cond() -> None:
@@ -32,8 +32,10 @@ def test_nested_cond() -> None:
     h = Dfg(tys.Qubit)
     (q,) = h.inputs()
     tagged_q = h.add(ops.Tag(0, SUM_T)(q))
-    cond = h.add_conditional(tagged_q, h.load(val.TRUE))
-    build_cond(cond)
+
+    with h.add_conditional(tagged_q, h.load(val.TRUE)) as cond:
+        build_cond(cond)
+
     h.set_outputs(*cond[:2])
     validate(h.hugr)
 
@@ -53,17 +55,27 @@ def test_if_else() -> None:
     # apply an H if a bool is true.
     h = Dfg(tys.Qubit)
     (q,) = h.inputs()
-    if_ = h.add_if(h.load(val.TRUE), q)
+    with h.add_if(h.load(val.TRUE), q) as if_:
+        if_.set_outputs(if_.add(H(if_.input_node[0])))
 
-    if_.set_outputs(if_.add(H(if_.input_node[0])))
+    with if_.add_else() as else_:
+        else_.set_outputs(else_.input_node[0])
 
-    else_ = if_.add_else()
-    else_.set_outputs(else_.input_node[0])
-
-    cond = else_.finish()
-    h.set_outputs(cond)
+    h.set_outputs(else_.conditional_node)
 
     validate(h.hugr)
+
+
+def test_incomplete() -> None:
+    def _build_incomplete():
+        with Conditional(SUM_T, [tys.Bool]) as c, c.add_case(0) as case0:
+            q, b = case0.inputs()
+            case0.set_outputs(q, b)
+
+    with pytest.raises(
+        ConditionalError, match="All cases must be added before exiting context."
+    ):
+        _build_incomplete()
 
 
 def test_tail_loop() -> None:
@@ -76,8 +88,8 @@ def test_tail_loop() -> None:
     h = Dfg(tys.Qubit)
     (q,) = h.inputs()
 
-    tl = h.add_tail_loop([], [q])
-    build_tl(tl)
+    with h.add_tail_loop([], [q]) as tl:
+        build_tl(tl)
     h.set_outputs(tl)
 
     validate(h.hugr)
@@ -98,23 +110,23 @@ def test_complex_tail_loop() -> None:
     (q,) = h.inputs()
 
     # loop passes qubit to itself, and a bool as in-out
-    tl = h.add_tail_loop([q], [h.load(val.TRUE)])
-    q, b = tl.inputs()
+    with h.add_tail_loop([q], [h.load(val.TRUE)]) as tl:
+        q, b = tl.inputs()
 
-    # if b is true, return first variant (just qubit)
-    if_ = tl.add_if(b, q)
-    (q,) = if_.inputs()
-    tagged_q = if_.add(ops.Tag(0, SUM_T)(q))
-    if_.set_outputs(tagged_q)
+        # if b is true, return first variant (just qubit)
+        with tl.add_if(b, q) as if_:
+            (q,) = if_.inputs()
+            tagged_q = if_.add(ops.Tag(0, SUM_T)(q))
+            if_.set_outputs(tagged_q)
 
-    # else return second variant (qubit, int)
-    else_ = if_.add_else()
-    (q,) = else_.inputs()
-    tagged_q_i = else_.add(ops.Tag(1, SUM_T)(q, else_.load(IntVal(1))))
-    else_.set_outputs(tagged_q_i)
+        # else return second variant (qubit, int)
+        with if_.add_else() as else_:
+            (q,) = else_.inputs()
+            tagged_q_i = else_.add(ops.Tag(1, SUM_T)(q, else_.load(IntVal(1))))
+            else_.set_outputs(tagged_q_i)
 
-    # finish with Sum output from if-else, and bool from inputs
-    tl.set_loop_outputs(else_.finish(), b)
+        # finish with Sum output from if-else, and bool from inputs
+        tl.set_loop_outputs(else_.conditional_node, b)
 
     # loop returns [qubit, int, bool]
     h.set_outputs(*tl[:3])

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -145,16 +145,14 @@ def test_insert_nested():
 
 
 def test_build_nested():
-    def _nested_nop(dfg: Dfg):
-        (a1,) = dfg.inputs()
-        nt = dfg.add(Not(a1))
-        dfg.set_outputs(nt)
-
     h = Dfg(tys.Bool)
     (a,) = h.inputs()
-    nested = h.add_nested(a)
 
-    _nested_nop(nested)
+    with h.add_nested(a) as nested:
+        (a1,) = nested.inputs()
+        nt = nested.add(Not(a1))
+        nested.set_outputs(nt)
+
     assert len(h.hugr.children(nested)) == 3
     h.set_outputs(nested)
 
@@ -164,10 +162,9 @@ def test_build_nested():
 def test_build_inter_graph():
     h = Dfg(tys.Bool, tys.Bool)
     (a, b) = h.inputs()
-    nested = h.add_nested()
-
-    nt = nested.add(Not(a))
-    nested.set_outputs(nt)
+    with h.add_nested() as nested:
+        nt = nested.add(Not(a))
+        nested.set_outputs(nt)
 
     h.set_outputs(nested, b)
 
@@ -183,9 +180,8 @@ def test_build_inter_graph():
 def test_ancestral_sibling():
     h = Dfg(tys.Bool)
     (a,) = h.inputs()
-    nested = h.add_nested()
-
-    nt = nested.add(Not(a))
+    with h.add_nested() as nested:
+        nt = nested.add(Not(a))
 
     assert _ancestral_sibling(h.hugr, h.input_node, nt) == nested.parent_node
 


### PR DESCRIPTION
Currently the context doesn't do anything much, just offers syntactical nesting to make it easier to write HUGRs

The exception being Conditional, where we use the exit as an opportunity to check all cases have been built.
This can be extended to other cases (e.g. ensure expected  outputs have been set when exiting a dfg).

Closes #1243 