### PR TITLE
feat(hugr-py): `AsCustomOp` protocol for user-defined custom op types.

### DIFF
--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -206,6 +206,12 @@ class AsCustomOp(DataflowOp, Protocol):
     to behave as a custom dataflow operation.
     """
 
+    @dataclass(frozen=True)
+    class InvalidCustomOp(Exception):
+        """Custom operation does not match the expected type."""
+
+        msg: str
+
     @cached_property
     def custom_op(self) -> Custom:
         """:class:`Custom` operation that this type represents.
@@ -233,6 +239,10 @@ class AsCustomOp(DataflowOp, Protocol):
         If successful, returns the singleton, else None.
 
         Non-singleton types should override this method.
+
+        Raises:
+            InvalidCustomOp: If the given `custom` does not match the expected one for a
+            given extension/operation name.
         """
         default = cls()
         if default.custom_op == custom:
@@ -287,6 +297,10 @@ class Custom(AsCustomOp):
     @classmethod
     def from_custom(cls, custom: Custom) -> Custom:
         return custom
+
+    def check_id(self, extension: tys.ExtensionId, op_name: str) -> bool:
+        """Check if the operation matches the given extension and operation name."""
+        return self.extension == extension and self.op_name == op_name
 
 
 @dataclass()

--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -73,13 +73,14 @@ class _DivModDef(AsCustomOp):
 
     @classmethod
     def from_custom(cls, custom: Custom) -> Self | None:
-        if not (custom.extension == OPS_EXTENSION and custom.op_name == cls.op_name):
+        if not custom.check_id(OPS_EXTENSION, "idivmod_u"):
             return None
         match custom.args:
             case [tys.BoundedNatArg(n=a1), tys.BoundedNatArg(n=a2)]:
                 return cls(arg1=a1, arg2=a2)
             case _:
-                return None
+                msg = f"Invalid args: {custom.args}"
+                raise AsCustomOp.InvalidCustomOp(msg)
 
     def __call__(self, a: ComWire, b: ComWire) -> Command:
         return DataflowOp.__call__(self, a, b)

--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar
+
+from typing_extensions import Self
 
 from hugr import tys, val
-from hugr.ops import Custom
+from hugr.ops import AsCustomOp, Custom, DataflowOp
+
+if TYPE_CHECKING:
+    from hugr.ops import Command, ComWire
 
 
 def int_t(width: int) -> tys.Opaque:
@@ -44,27 +50,39 @@ class IntVal(val.ExtensionValue):
         return val.Extension("int", INT_T, self.v)
 
 
-@dataclass(frozen=True)
-class IntOps(Custom):
-    """Base class for integer operations."""
-
-    extension: tys.ExtensionId = "arithmetic.int"
-
-
-_ARG_I32 = tys.BoundedNatArg(n=5)
+OPS_EXTENSION: tys.ExtensionId = "arithmetic.int"
 
 
 @dataclass(frozen=True)
-class _DivModDef(IntOps):
+class _DivModDef(AsCustomOp):
     """DivMod operation, has two inputs and two outputs."""
 
-    num_out: int = 2
-    extension: tys.ExtensionId = "arithmetic.int"
-    op_name: str = "idivmod_u"
-    signature: tys.FunctionType = field(
-        default_factory=lambda: tys.FunctionType(input=[INT_T] * 2, output=[INT_T] * 2)
-    )
-    args: list[tys.TypeArg] = field(default_factory=lambda: [_ARG_I32, _ARG_I32])
+    op_name: ClassVar[str] = "idivmod_u"
+    arg1: int = 5
+    arg2: int = 5
+
+    def to_custom(self) -> Custom:
+        return Custom(
+            "idivmod_u",
+            tys.FunctionType(
+                input=[int_t(self.arg1)] * 2, output=[int_t(self.arg2)] * 2
+            ),
+            extension=OPS_EXTENSION,
+            args=[tys.BoundedNatArg(n=self.arg1), tys.BoundedNatArg(n=self.arg2)],
+        )
+
+    @classmethod
+    def from_custom(cls, custom: Custom) -> Self | None:
+        if not (custom.extension == OPS_EXTENSION and custom.op_name == cls.op_name):
+            return None
+        match custom.args:
+            case [tys.BoundedNatArg(n=a1), tys.BoundedNatArg(n=a2)]:
+                return cls(arg1=a1, arg2=a2)
+            case _:
+                return None
+
+    def __call__(self, a: ComWire, b: ComWire) -> Command:
+        return DataflowOp.__call__(self, a, b)
 
 
 #: DivMod operation.

--- a/hugr-py/src/hugr/std/logic.py
+++ b/hugr-py/src/hugr/std/logic.py
@@ -6,32 +6,24 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from hugr import tys
-from hugr.ops import Command, Custom
+from hugr.ops import AsCustomOp, Command, Custom, DataflowOp
 
 if TYPE_CHECKING:
     from hugr.ops import ComWire
 
 
-@dataclass(frozen=True)
-class LogicOps(Custom):
-    """Base class for logic operations."""
-
-    extension: tys.ExtensionId = "logic"
-
-
-_NotSig = tys.FunctionType.endo([tys.Bool])
+EXTENSION_ID: tys.ExtensionId = "logic"
 
 
 @dataclass(frozen=True)
-class _NotDef(LogicOps):
+class _NotDef(AsCustomOp):
     """Not operation."""
 
-    num_out: int = 1
-    op_name: str = "Not"
-    signature: tys.FunctionType = _NotSig
+    def to_custom(self) -> Custom:
+        return Custom("Not", tys.FunctionType.endo([tys.Bool]), extension=EXTENSION_ID)
 
     def __call__(self, a: ComWire) -> Command:
-        return super().__call__(a)
+        return DataflowOp.__call__(self, a)
 
 
 #: Not operation

--- a/hugr-py/tests/test_custom.py
+++ b/hugr-py/tests/test_custom.py
@@ -1,0 +1,42 @@
+import pytest
+
+from hugr import tys
+from hugr.node_port import Node
+from hugr.ops import AsCustomOp, Custom
+from hugr.std.int import DivMod
+from hugr.std.logic import EXTENSION_ID, Not
+
+from .conftest import CX, H, Measure, Rz
+
+
+@pytest.mark.parametrize(
+    "as_custom",
+    [Not, DivMod, H, CX, Measure, Rz],
+)
+def test_custom(as_custom: AsCustomOp):
+    custom = as_custom.to_custom()
+
+    assert custom.to_custom() == custom
+    assert Custom.from_custom(custom) == custom
+
+    assert type(as_custom).from_custom(custom) == as_custom
+    assert as_custom.to_serial(Node(0)).deserialize() == custom
+    assert custom == as_custom
+    assert as_custom == custom
+
+
+def test_custom_bad_eq():
+    assert Not != DivMod
+
+    bad_custom_sig = Custom("Not", extension=EXTENSION_ID)  # empty signature
+
+    assert Not != bad_custom_sig
+
+    bad_custom_args = Custom(
+        "Not",
+        extension=EXTENSION_ID,
+        signature=tys.FunctionType.endo([tys.Bool]),
+        args=[tys.Bool.type_arg()],
+    )
+
+    assert Not != bad_custom_args


### PR DESCRIPTION
Downstream users can implement this protocol to use their own convenience classes. Typically a use wants to implement:
- `to_custom`
- `__call__` to provide a useful calling signature.
- `from_custom` if different instances of the type correspond to different ops (non-singleton).

Replace existing custom operation types with this.

Follow ups:
- Similar thing for custom types.
- Optional: allow these types to register themselves with `serialization.ops.CustomOp` so they can be deserialized directly.