### PR TITLE
ci: Update deprecated `release-please` action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
     name: Create release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
             # Using a personal access token so releases created by this workflow can trigger the deployment workflow
             token: ${{ secrets.HUGRBOT_PAT }}


### PR DESCRIPTION
The repository changed names.

This should include the fix in [release-please#2241](https://www.github.com/googleapis/release-please/pull/2241), which was causing the release PRs to be open as non-draft.