### PR TITLE
refactor!: Rename builder helpers: ft1->endo_ft, ft2->inout_ft

### DIFF
--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -129,7 +129,7 @@ pub fn endo_ft(types: impl Into<TypeRow>) -> FunctionType {
 
 /// Return a FunctionType with the specified input and output types
 /// whose extension delta, when used in a non-FuncDefn container, will be inferred.
-pub fn ft2(inputs: impl Into<TypeRow>, outputs: impl Into<TypeRow>) -> FunctionType {
+pub fn inout_ft(inputs: impl Into<TypeRow>, outputs: impl Into<TypeRow>) -> FunctionType {
     FunctionType::new(inputs, outputs).with_extension_delta(TO_BE_INFERRED)
 }
 

--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -123,7 +123,7 @@ pub use circuit::{CircuitBuildError, CircuitBuilder};
 
 /// Return a FunctionType with the same input and output types (specified)
 /// whose extension delta, when used in a non-FuncDefn container, will be inferred.
-pub fn ft1(types: impl Into<TypeRow>) -> FunctionType {
+pub fn endo_ft(types: impl Into<TypeRow>) -> FunctionType {
     FunctionType::new_endo(types).with_extension_delta(TO_BE_INFERRED)
 }
 

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -203,7 +203,7 @@ pub(crate) mod test {
     use serde_json::json;
 
     use crate::builder::build_traits::DataflowHugr;
-    use crate::builder::{ft1, BuilderWiringError, DataflowSubContainer, ModuleBuilder};
+    use crate::builder::{endo_ft, BuilderWiringError, DataflowSubContainer, ModuleBuilder};
     use crate::extension::prelude::{BOOL_T, USIZE_T};
     use crate::extension::{ExtensionId, SignatureError, EMPTY_REG, PRELUDE_REGISTRY};
     use crate::hugr::validate::InterGraphEdgeError;
@@ -420,12 +420,12 @@ pub(crate) mod test {
         let xb: ExtensionId = "B".try_into().unwrap();
         let xc: ExtensionId = "C".try_into().unwrap();
 
-        let mut parent = DFGBuilder::new(ft1(BIT))?;
+        let mut parent = DFGBuilder::new(endo_ft(BIT))?;
 
         let [w] = parent.input_wires_arr();
 
         // A box which adds extensions A and B, via child Lift nodes
-        let mut add_ab = parent.dfg_builder(ft1(BIT), [w])?;
+        let mut add_ab = parent.dfg_builder(endo_ft(BIT), [w])?;
         let [w] = add_ab.input_wires_arr();
 
         let lift_a = add_ab.add_dataflow_op(
@@ -451,7 +451,7 @@ pub(crate) mod test {
 
         // Add another node (a sibling to add_ab) which adds extension C
         // via a child lift node
-        let mut add_c = parent.dfg_builder(ft1(BIT), [w])?;
+        let mut add_c = parent.dfg_builder(endo_ft(BIT), [w])?;
         let [w] = add_c.input_wires_arr();
         let lift_c = add_c.add_dataflow_op(
             Lift {

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -402,7 +402,7 @@ impl CustomConst for ConstExternalSymbol {
 #[cfg(test)]
 mod test {
     use crate::{
-        builder::{ft1, DFGBuilder, Dataflow, DataflowHugr},
+        builder::{endo_ft, DFGBuilder, Dataflow, DataflowHugr},
         utils::test_quantum_extension::cx_gate,
         Hugr, Wire,
     };
@@ -452,7 +452,7 @@ mod test {
         assert!(error_val.equal_consts(&ConstError::new(2, "my message")));
         assert!(!error_val.equal_consts(&ConstError::new(3, "my message")));
 
-        let mut b = DFGBuilder::new(ft1(type_row![])).unwrap();
+        let mut b = DFGBuilder::new(endo_ft(type_row![])).unwrap();
 
         let err = b.add_load_value(error_val);
 
@@ -486,7 +486,7 @@ mod test {
             )
             .unwrap();
 
-        let mut b = DFGBuilder::new(ft1(type_row![QB_T, QB_T])).unwrap();
+        let mut b = DFGBuilder::new(endo_ft(type_row![QB_T, QB_T])).unwrap();
         let [q0, q1] = b.input_wires_arr();
         let [q0, q1] = b
             .add_dataflow_op(cx_gate(), [q0, q1])
@@ -524,7 +524,7 @@ mod test {
     #[test]
     /// Test print operation
     fn test_print() {
-        let mut b: DFGBuilder<Hugr> = DFGBuilder::new(ft1(vec![])).unwrap();
+        let mut b: DFGBuilder<Hugr> = DFGBuilder::new(endo_ft(vec![])).unwrap();
         let greeting: ConstString = ConstString::new("Hello, world!".into());
         let greeting_out: Wire = b.add_load_value(greeting);
         let print_op = PRELUDE

--- a/hugr-core/src/hugr/rewrite/inline_dfg.rs
+++ b/hugr-core/src/hugr/rewrite/inline_dfg.rs
@@ -133,7 +133,8 @@ mod test {
     use rstest::rstest;
 
     use crate::builder::{
-        ft1, ft2, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer, SubContainer,
+        endo_ft, ft2, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
+        SubContainer,
     };
     use crate::extension::prelude::QB_T;
     use crate::extension::{ExtensionRegistry, ExtensionSet, PRELUDE};
@@ -244,7 +245,7 @@ mod test {
 
     #[test]
     fn permutation() -> Result<(), Box<dyn std::error::Error>> {
-        let mut h = DFGBuilder::new(ft1(type_row![QB_T, QB_T]))?;
+        let mut h = DFGBuilder::new(endo_ft(type_row![QB_T, QB_T]))?;
         let [p, q] = h.input_wires_arr();
         let [p_h] = h
             .add_dataflow_op(test_quantum_extension::h_gate(), [p])?
@@ -339,11 +340,11 @@ mod test {
             PRELUDE.to_owned(),
         ])
         .unwrap();
-        let mut outer = DFGBuilder::new(ft1(type_row![QB_T, QB_T]))?;
+        let mut outer = DFGBuilder::new(endo_ft(type_row![QB_T, QB_T]))?;
         let [a, b] = outer.input_wires_arr();
         let h_a = outer.add_dataflow_op(test_quantum_extension::h_gate(), [a])?;
         let h_b = outer.add_dataflow_op(test_quantum_extension::h_gate(), [b])?;
-        let mut inner = outer.dfg_builder(ft1(QB_T), h_b.outputs())?;
+        let mut inner = outer.dfg_builder(endo_ft(QB_T), h_b.outputs())?;
         let [i] = inner.input_wires_arr();
         let f = inner.add_load_value(float_types::ConstF64::new(1.0));
         inner.add_other_wire(inner.input().node(), f.node());

--- a/hugr-core/src/hugr/rewrite/inline_dfg.rs
+++ b/hugr-core/src/hugr/rewrite/inline_dfg.rs
@@ -133,7 +133,7 @@ mod test {
     use rstest::rstest;
 
     use crate::builder::{
-        endo_ft, ft2, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
+        endo_ft, inout_ft, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
         SubContainer,
     };
     use crate::extension::prelude::QB_T;
@@ -175,7 +175,7 @@ mod test {
         .unwrap();
         let int_ty = &int_types::INT_TYPES[6];
 
-        let mut outer = DFGBuilder::new(ft2(vec![int_ty.clone(); 2], vec![int_ty.clone()]))?;
+        let mut outer = DFGBuilder::new(inout_ft(vec![int_ty.clone(); 2], vec![int_ty.clone()]))?;
         let [a, b] = outer.input_wires_arr();
         fn make_const<T: AsMut<Hugr> + AsRef<Hugr>>(
             d: &mut DFGBuilder<T>,

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::builder::{
-    ft2, test::closed_dfg_root_hugr, Container, DFGBuilder, Dataflow, DataflowHugr,
+    inout_ft, test::closed_dfg_root_hugr, Container, DFGBuilder, Dataflow, DataflowHugr,
     DataflowSubContainer, HugrBuilder, ModuleBuilder,
 };
 use crate::extension::prelude::{BOOL_T, PRELUDE_ID, QB_T, USIZE_T};
@@ -351,7 +351,7 @@ fn hierarchy_order() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn constants_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
-    let mut builder = DFGBuilder::new(ft2(vec![], vec![INT_TYPES[4].clone()])).unwrap();
+    let mut builder = DFGBuilder::new(inout_ft(vec![], INT_TYPES[4].clone())).unwrap();
     let w = builder.add_load_value(ConstInt::new_s(4, -2).unwrap());
     let hugr = builder.finish_hugr_with_outputs([w], &INT_OPS_REGISTRY)?;
 

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -7,7 +7,7 @@ use rstest::rstest;
 use super::*;
 use crate::builder::test::closed_dfg_root_hugr;
 use crate::builder::{
-    ft2, BuildError, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
+    inout_ft, BuildError, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
     FunctionBuilder, HugrBuilder, ModuleBuilder, SubContainer,
 };
 use crate::extension::prelude::{BOOL_T, PRELUDE, PRELUDE_ID, QB_T, USIZE_T};
@@ -769,7 +769,7 @@ fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
 
     let int_pair = Type::new_tuple(type_row![USIZE_T; 2]);
     // Root DFG: applies a function int--PRELUDE-->int to each element of a pair of two ints
-    let mut d = DFGBuilder::new(ft2(
+    let mut d = DFGBuilder::new(inout_ft(
         vec![utou(PRELUDE_ID), int_pair.clone()],
         vec![int_pair.clone()],
     ))?;

--- a/hugr-core/src/hugr/views/tests.rs
+++ b/hugr-core/src/hugr/views/tests.rs
@@ -2,7 +2,7 @@ use portgraph::PortOffset;
 use rstest::{fixture, rstest};
 
 use crate::{
-    builder::{ft2, BuildError, BuildHandle, Container, DFGBuilder, Dataflow, DataflowHugr},
+    builder::{inout_ft, BuildError, BuildHandle, Container, DFGBuilder, Dataflow, DataflowHugr},
     extension::prelude::QB_T,
     ops::{
         handle::{DataflowOpID, NodeHandle},
@@ -152,7 +152,7 @@ fn value_types() {
 fn static_targets() {
     use crate::extension::prelude::{ConstUsize, USIZE_T};
     use itertools::Itertools;
-    let mut dfg = DFGBuilder::new(ft2(type_row![], type_row![USIZE_T])).unwrap();
+    let mut dfg = DFGBuilder::new(inout_ft(type_row![], type_row![USIZE_T])).unwrap();
 
     let c = dfg.add_constant(Value::extension(ConstUsize::new(1)));
 

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -526,7 +526,7 @@ pub type ValueNameRef = str;
 #[cfg(test)]
 mod test {
     use super::Value;
-    use crate::builder::ft2;
+    use crate::builder::inout_ft;
     use crate::builder::test::simple_dfg_hugr;
     use crate::std_extensions::arithmetic::int_types::ConstInt;
     use crate::{
@@ -587,7 +587,7 @@ mod test {
         let pred_rows = vec![type_row![USIZE_T, FLOAT64_TYPE], Type::EMPTY_TYPEROW];
         let pred_ty = SumType::new(pred_rows.clone());
 
-        let mut b = DFGBuilder::new(ft2(
+        let mut b = DFGBuilder::new(inout_ft(
             type_row![],
             TypeRow::from(vec![pred_ty.clone().into()]),
         ))?;

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use hugr_core::builder::ft2;
+use hugr_core::builder::inout_ft;
 use itertools::Itertools;
 use thiserror::Error;
 
@@ -136,7 +136,7 @@ pub fn fold_leaf_op(op: &OpType, consts: &[(IncomingPort, Value)]) -> ConstFoldR
 /// against `reg`.
 fn const_graph(consts: Vec<Value>, reg: &ExtensionRegistry) -> Hugr {
     let const_types = consts.iter().map(Value::get_type).collect_vec();
-    let mut b = DFGBuilder::new(ft2(type_row![], const_types)).unwrap();
+    let mut b = DFGBuilder::new(inout_ft(type_row![], const_types)).unwrap();
 
     let outputs = consts
         .into_iter()


### PR DESCRIPTION
In response to [this comment](https://github.com/CQCL/hugr/pull/1226#pullrequestreview-2158309800) that "the builder...helpers are quite confusing", this offers a better compromise between brevity and readability, i.e. slightly more of the latter.

BREAKING CHANGE: builder::ft1 is now `builder::endo_ft`, similarly `ft2` is new `inout_ft`