### PR TITLE
ci: Check python test result on required checks check

### DIFF
--- a/.github/change-filters.yml
+++ b/.github/change-filters.yml
@@ -8,9 +8,11 @@ rust:
   - "hugr-passes/**"
   - "Cargo.toml"
   - "specification/schema/**"
+  - ".github/workflows/ci-rs.yml"
 
 python:
   - "hugr-py/**"
   - "pyproject.toml"
   - "poetry.lock"
   - "specification/schema/**"
+  - ".github/workflows/ci-py.yml"

--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -171,6 +171,7 @@ jobs:
         if: |
           needs.changes.result == 'failure' || needs.changes.result == 'cancelled' ||
           needs.check.result == 'failure' || needs.check.result == 'cancelled' ||
+          needs.test.result == 'failure' || needs.test.result == 'cancelled' ||
           needs.serialization-schema.result == 'failure' || needs.serialization-schema.result == 'cancelled'
         run: |
           echo "Required checks failed"


### PR DESCRIPTION
A python test failure didn't cause the required checks to fail...

drive-by: Add workflow files to the CI change filters, so modifications trigger the checks.