### PR TITLE
test: Print `hugr-cli`'s errors on python tests

### DIFF
--- a/hugr-py/tests/conftest.py
+++ b/hugr-py/tests/conftest.py
@@ -136,7 +136,11 @@ def validate(h: Hugr, mermaid: bool = False, roundtrip: bool = True):
     if mermaid:
         cmd.append("--mermaid")
     serial = h.to_serial().to_json()
-    subprocess.run(cmd, check=True, input=serial.encode())  # noqa: S603
+    try:
+        subprocess.run(cmd, check=True, input=serial.encode(), capture_output=True)  # noqa: S603
+    except subprocess.CalledProcessError as e:
+        error = e.stderr.decode()
+        raise RuntimeError(error) from e
 
     if roundtrip:
         h2 = Hugr.from_serial(SerialHugr.load_json(json.loads(serial)))


### PR DESCRIPTION
Prints the error returned by `hugr-cli` when something fails, so we get better feedback.

Before:
```
subprocess.CalledProcessError: Command '['/Users/agustinborgna/src/hugr/target/debug/hugr', '-']' returned non-zero exit status 1.
```

After:
```
RuntimeError: Error validating HUGR: Parent node Node(0) has extensions [] that are too restrictive for child node Node(5), they must include child extensions [IdentList("quantum.tket2")]
```