### PR TITLE
chore: Don't produce docs for `hugr-cli` binary target

### DIFF
--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -5,13 +5,12 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
 readme = "README.md"
-documentation = "https://docs.rs/hugr-passes/"
+documentation = "https://docs.rs/hugr-cli/"
 homepage = { workspace = true }
 repository = { workspace = true }
 description = "Compiler passes for Quantinuum's HUGR"
 keywords = ["Quantum", "Quantinuum"]
 categories = ["compilers"]
-
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
@@ -33,3 +32,4 @@ rstest.workspace = true
 [[bin]]
 name = "hugr"
 path = "src/main.rs"
+doc = false


### PR DESCRIPTION
This avoids the error due to duplicated target names, as the binary `hugr` has the same name as the main library `hugr`.

`cargo doc` showed this warning:
```
warning: output filename collision.
The bin target `hugr` in package `hugr-cli v0.1.4 (/home/runner/work/hugr/hugr/hugr-cli)` has the same output filename as the lib target `hugr` in package `hugr v0.8.0 (/home/runner/work/hugr/hugr/hugr)`.
Colliding filename is: /home/runner/work/hugr/hugr/target/doc/hugr/index.html
The targets should have unique names.
This is a known bug where multiple crates with the same name use
the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
``` 

This caused the resulting docs to produce non-deterministic output, with either target overriding the other.
See [cargo#6313](https://www.github.com/rust-lang/cargo/issues/6313).