### PR TITLE
fix: Panic on `SimpleReplace` with multiports

### DIFF
--- a/hugr-core/src/hugr/rewrite/simple_replace.rs
+++ b/hugr-core/src/hugr/rewrite/simple_replace.rs
@@ -370,9 +370,9 @@ pub(in crate::hugr::rewrite) mod test {
     ///  └─────────┘   │
     ///                └─────────────────
     ///
-    /// This can be replaced with a single NOT gate, coping the input to the first output.
+    /// This can be replaced with a single NOT op, coping the input to the first output.
     ///
-    /// Returns the hugr and the nodes of the NOT gates, in order.
+    /// Returns the hugr and the nodes of the NOT ops, in order.
     #[fixture]
     pub(in crate::hugr::rewrite) fn dfg_hugr_half_not_bools() -> (Hugr, Vec<Node>) {
         fn build() -> Result<(Hugr, Vec<Node>), BuildError> {
@@ -717,7 +717,7 @@ pub(in crate::hugr::rewrite) mod test {
         Ok(())
     }
 
-    /// Remove one of the NOT gates in [`dfg_hugr_half_not_bools`] by connecting the input
+    /// Remove one of the NOT ops in [`dfg_hugr_half_not_bools`] by connecting the input
     /// directly to the output.
     ///
     /// https://github.com/CQCL/hugr/issues/1323

--- a/hugr-core/src/hugr/rewrite/simple_replace.rs
+++ b/hugr-core/src/hugr/rewrite/simple_replace.rs
@@ -660,6 +660,8 @@ pub(in crate::hugr::rewrite) mod test {
 
     /// Remove all the NOT gates in [`dfg_hugr_copy_bools`] by connecting the input
     /// directly to the outputs.
+    ///
+    /// https://github.com/CQCL/hugr/issues/1190
     #[rstest]
     fn test_copy_inputs(
         dfg_hugr_copy_bools: (Hugr, Vec<Node>),
@@ -717,6 +719,8 @@ pub(in crate::hugr::rewrite) mod test {
 
     /// Remove one of the NOT gates in [`dfg_hugr_half_not_bools`] by connecting the input
     /// directly to the output.
+    ///
+    /// https://github.com/CQCL/hugr/issues/1323
     #[rstest]
     fn test_half_nots(
         dfg_hugr_half_not_bools: (Hugr, Vec<Node>),


### PR DESCRIPTION
Fixes #1323

This fix generalises the one from #1191.
SimpleReplace was too eager in disconnecting/connecting edges to the replacement graph, and that caused issues when querying the neighbours of multiports.

This gets resolved by delaying all new connections to the replacement until after we have computed all of them.
We don't need to do explicit disconnections to the replaced subgraph, since the nodes get removed anyway.