### PR TITLE
refactor!: use JSON rather than YAML in opaque fields.

### DIFF
--- a/hugr-core/src/extension/declarative/ops.rs
+++ b/hugr-core/src/extension/declarative/ops.rs
@@ -44,7 +44,7 @@ pub(super) struct OperationDeclaration {
     /// This data is kept in the Hugr, and may be accessed by the relevant runtime.
     #[serde(default)]
     #[serde(skip_serializing_if = "crate::utils::is_default")]
-    misc: HashMap<String, serde_yaml::Value>,
+    misc: HashMap<String, serde_json::Value>,
     /// A pre-compiled lowering routine.
     ///
     /// This is not yet supported, and will raise an error if present.

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -109,7 +109,7 @@ pub trait CustomLowerFunc: Send + Sync {
         &self,
         name: &OpNameRef,
         arg_values: &[TypeArg],
-        misc: &HashMap<String, serde_yaml::Value>,
+        misc: &HashMap<String, serde_json::Value>,
         available_extensions: &ExtensionSet,
     ) -> Option<Hugr>;
 }
@@ -319,7 +319,7 @@ pub struct OpDef {
     description: String,
     /// Miscellaneous data associated with the operation.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    misc: HashMap<String, serde_yaml::Value>,
+    misc: HashMap<String, serde_json::Value>,
 
     #[serde(flatten)]
     signature_func: SignatureFunc,
@@ -434,8 +434,8 @@ impl OpDef {
     pub fn add_misc(
         &mut self,
         k: impl ToString,
-        v: serde_yaml::Value,
-    ) -> Option<serde_yaml::Value> {
+        v: serde_json::Value,
+    ) -> Option<serde_json::Value> {
         self.misc.insert(k.to_string(), v)
     }
 
@@ -825,9 +825,9 @@ pub(super) mod test {
             type Parameters = ();
             type Strategy = BoxedStrategy<Self>;
             fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-                use crate::proptest::{any_serde_yaml_value, any_smolstr, any_string};
+                use crate::proptest::{any_serde_json_value, any_smolstr, any_string};
                 use proptest::collection::{hash_map, vec};
-                let misc = hash_map(any_string(), any_serde_yaml_value(), 0..3);
+                let misc = hash_map(any_string(), any_serde_json_value(), 0..3);
                 (
                     any::<ExtensionId>(),
                     any_smolstr(),

--- a/hugr-core/src/proptest.rs
+++ b/hugr-core/src/proptest.rs
@@ -104,13 +104,13 @@ lazy_static! {
         ].sboxed()
     };
 
-    /// A strategy for an arbitrary non-recursive [serde_yaml::Value].
+    /// A strategy for an arbitrary non-recursive [serde_json::Value].
     /// In particular, no `Mapping`, `Sequence`, or `Tagged`.
     ///
     /// This is used as the base strategy for the general
     /// [recursive](Strategy::prop_recursive) strategy.
-    static ref ANY_SERDE_YAML_VALUE_LEAF: SBoxedStrategy<serde_yaml::Value> = {
-        use serde_yaml::value::Value;
+    static ref ANY_SERDE_JSON_VALUE_LEAF: SBoxedStrategy<serde_json::Value> = {
+        use serde_json::value::Value;
         prop_oneof![
             Just(Value::Null),
             any::<bool>().prop_map_into(),
@@ -155,9 +155,9 @@ pub fn any_smolstr() -> SBoxedStrategy<SmolStr> {
     ANY_STRING.clone().prop_map_into().sboxed()
 }
 
-pub fn any_serde_yaml_value() -> impl Strategy<Value = serde_yaml::Value> {
-    // use serde_yaml::value::{Tag, TaggedValue, Value};
-    ANY_SERDE_YAML_VALUE_LEAF
+pub fn any_serde_json_value() -> impl Strategy<Value = serde_json::Value> {
+    // use serde_json::value::{Tag, TaggedValue, Value};
+    ANY_SERDE_JSON_VALUE_LEAF
         .clone()
         .prop_recursive(
             3,  // No more than 3 branch levels deep
@@ -168,8 +168,10 @@ pub fn any_serde_yaml_value() -> impl Strategy<Value = serde_yaml::Value> {
                     // TODO TaggedValue doesn't roundtrip through JSON
                     // (any_nonempty_string().prop_map(Tag::new), element.clone()).prop_map(|(tag, value)| Value::Tagged(Box::new(TaggedValue { tag, value }))),
                     proptest::collection::vec(element.clone(), 0..3).prop_map_into(),
-                    vec((any_string().prop_map_into(), element.clone()), 0..3)
-                        .prop_map(|x| x.into_iter().collect::<serde_yaml::Mapping>().into())
+                    vec((any_string().prop_map_into(), element.clone()), 0..3).prop_map(|x| x
+                        .into_iter()
+                        .collect::<serde_json::Map<String, serde_json::Value>>()
+                        .into())
                 ]
             },
         )

--- a/hugr-core/src/proptest.rs
+++ b/hugr-core/src/proptest.rs
@@ -105,7 +105,7 @@ lazy_static! {
     };
 
     /// A strategy for an arbitrary non-recursive [serde_json::Value].
-    /// In particular, no `Mapping`, `Sequence`, or `Tagged`.
+    /// In particular, no `Array` or `Object`
     ///
     /// This is used as the base strategy for the general
     /// [recursive](Strategy::prop_recursive) strategy.
@@ -156,7 +156,6 @@ pub fn any_smolstr() -> SBoxedStrategy<SmolStr> {
 }
 
 pub fn any_serde_json_value() -> impl Strategy<Value = serde_json::Value> {
-    // use serde_json::value::{Tag, TaggedValue, Value};
     ANY_SERDE_JSON_VALUE_LEAF
         .clone()
         .prop_recursive(
@@ -165,8 +164,6 @@ pub fn any_serde_json_value() -> impl Strategy<Value = serde_json::Value> {
             3,  // Each collection is up to 3 elements long
             |element| {
                 prop_oneof![
-                    // TODO TaggedValue doesn't roundtrip through JSON
-                    // (any_nonempty_string().prop_map(Tag::new), element.clone()).prop_map(|(tag, value)| Value::Tagged(Box::new(TaggedValue { tag, value }))),
                     proptest::collection::vec(element.clone(), 0..3).prop_map_into(),
                     vec((any_string().prop_map_into(), element.clone()), 0..3).prop_map(|x| x
                         .into_iter()


### PR DESCRIPTION
Closes #1048

BREAKING CHANGE: use `serde_json::Value` rather than `serde_yaml::Value` in `CustomSerialized`, `OpDef`, `OperationDeclaration`