### PR TITLE
refactor(hugr-core)!: declarative module behind optional feature flag

### DIFF
--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [features]
 extension_inference = []
+declarative = ["serde_yaml"]
 
 [dependencies]
 portgraph = { workspace = true, features = ["serde", "petgraph"] }
@@ -28,7 +29,7 @@ num-rational = { workspace = true, features = ["serde"] }
 downcast-rs = { workspace = true }
 # Rc used here for Extension, but unfortunately we must turn the feature on globally
 serde = { workspace = true, features = ["derive", "rc"] }
-serde_yaml = { workspace = true }
+serde_yaml = { workspace = true, optional = true }
 typetag = { workspace = true }
 smol_str = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true }

--- a/hugr-core/README.md
+++ b/hugr-core/README.md
@@ -19,6 +19,8 @@ Please read the [API documentation here][].
   Experimental feature which allows automatic inference of extension usages and
   requirements in a HUGR and validation that extensions are correctly specified.
   Not enabled by default.
+- `declarative`:
+  Experimental support for declaring extensions in YAML files, support is limited.
 
 ## Recent Changes
 

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -33,6 +33,7 @@ pub mod simple_op;
 pub use const_fold::{ConstFold, ConstFoldResult, Folder};
 pub use prelude::{PRELUDE, PRELUDE_REGISTRY};
 
+#[cfg(feature = "declarative")]
 pub mod declarative;
 
 /// Extension Registries store extensions to be looked up e.g. during validation.

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -96,6 +96,7 @@ pub fn try_collect_array<const N: usize, T>(
 /// ```
 ///
 /// From https://github.com/serde-rs/serde/issues/818.
+#[allow(dead_code)]
 pub(crate) fn is_default<T: Default + PartialEq>(t: &T) -> bool {
     *t == Default::default()
 }

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -22,7 +22,8 @@ bench = false
 path = "src/lib.rs"
 
 [features]
-extension_inference = []
+extension_inference = ["hugr-core/extension_inference"]
+declarative = ["hugr-core/declarative"]
 
 [dependencies]
 hugr-core = { path = "../hugr-core", version = "0.6.0" }

--- a/hugr/README.md
+++ b/hugr/README.md
@@ -33,6 +33,8 @@ Please read the [API documentation here][].
   Experimental feature which allows automatic inference of extension usages and
   requirements in a HUGR and validation that extensions are correctly specified.
   Not enabled by default.
+- `declarative`:
+  Experimental support for declaring extensions in YAML files, support is limited.
 
 ## Recent Changes
 


### PR DESCRIPTION
Closes #1340 

BREAKING CHANGE: `hugr::extension::declarative` now only available with "declarative" feature