### PR TITLE
chore: Replace `build.rs` with lint config in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ license = "Apache-2.0"
 # authors
 
 [workspace.lints.rust]
-missing_docs = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci_run)'] }
 
+missing_docs = "warn"
 [workspace.lints.clippy]
 # Unstable check, may cause false positives.
 # https://github.com/rust-lang/rust-clippy/issues/5112

--- a/hugr-core/build.rs
+++ b/hugr-core/build.rs
@@ -1,7 +1,0 @@
-//! Build script for the `hugr` crate.
-
-fn main() {
-    // We use a `ci_run` RUSTFLAG to indicate that we are running a CI check,
-    // so we can reject debug code using some tools defined in `utils.rs`.
-    println!("cargo:rustc-check-cfg=cfg(ci_run)");
-}


### PR DESCRIPTION
Rust 1.80 [just dropped](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html), adding a lint option that allows us to avoid the `build.rs` definition we had to add for https://github.com/CQCL/hugr/issues/1067.
(The nightly lint got updated before hitting beta, so there shouldn't be compatibility problems there).

~~Depends on #1355~~