### PR TITLE
chore(rs): hugr 0.9.1 patch release

### DIFF
--- a/hugr-cli/CHANGELOG.md
+++ b/hugr-cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1 (2024-07-25)
+
+- Updated `hugr` dependencies.
+
+
 ## 0.2.0 (2024-07-19)
 
 ### Refactor

--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -16,7 +16,7 @@ categories = ["compilers"]
 clap = { workspace = true, features = ["derive"] }
 clap-stdin.workspace = true
 clap-verbosity-flag.workspace = true
-hugr-core = { path = "../hugr-core", version = "0.6.0" }
+hugr-core = { path = "../hugr-core", version = "0.6.1" }
 serde_json.workspace = true
 thiserror.workspace = true
 

--- a/hugr-core/CHANGELOG.md
+++ b/hugr-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.1 (2024-07-25)
+
+### Bug Fixes
+
+- Dfg wrapper build handles incorrect output wire numbers ([#1332](https://github.com/CQCL/hugr/pull/1332))
+- Sibling extension panics while computing signature with non-dataflow nodes ([#1350](https://github.com/CQCL/hugr/pull/1350))
+
+
 ## 0.6.0 (2024-07-19)
 
 ### Bug Fixes

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 

--- a/hugr-core/src/builder/handle.rs
+++ b/hugr-core/src/builder/handle.rs
@@ -1,5 +1,5 @@
 //! Handles to nodes in HUGR used during the building phase.
-use crate::ops::handle::{BasicBlockID, CaseID, DfgID, FuncID, NodeHandle, TailLoopID};
+use crate::ops::handle::{BasicBlockID, CaseID, DfgID, FuncID, NodeHandle};
 use crate::ops::OpTag;
 use crate::utils::collect_array;
 use crate::{Node, OutgoingPort, Wire};
@@ -70,7 +70,7 @@ impl From<BuildHandle<DfgID>> for BuildHandle<FuncID<true>> {
     fn from(value: BuildHandle<DfgID>) -> Self {
         Self {
             node_handle: value.node().into(),
-            num_value_outputs: value.num_value_outputs,
+            num_value_outputs: 0,
         }
     }
 }
@@ -87,17 +87,7 @@ impl From<BuildHandle<DfgID>> for BuildHandle<CaseID> {
     fn from(value: BuildHandle<DfgID>) -> Self {
         Self {
             node_handle: value.node().into(),
-            num_value_outputs: value.num_value_outputs,
-        }
-    }
-}
-
-impl From<BuildHandle<DfgID>> for BuildHandle<TailLoopID> {
-    #[inline]
-    fn from(value: BuildHandle<DfgID>) -> Self {
-        Self {
-            node_handle: value.node().into(),
-            num_value_outputs: value.num_value_outputs,
+            num_value_outputs: 0,
         }
     }
 }

--- a/hugr-passes/CHANGELOG.md
+++ b/hugr-passes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 (2024-07-25)
+
+- Updated `hugr` dependencies.
+
+
 ## 0.6.0 (2024-07-19)
 
 ### Refactor

--- a/hugr-passes/Cargo.toml
+++ b/hugr-passes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-passes"
-version = "0.6.0"
+version = "0.6.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -13,7 +13,7 @@ keywords = ["Quantum", "Quantinuum"]
 categories = ["compilers"]
 
 [dependencies]
-hugr-core = { path = "../hugr-core", version = "0.6.0" }
+hugr-core = { path = "../hugr-core", version = "0.6.1" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 paste = { workspace = true }

--- a/hugr/CHANGELOG.md
+++ b/hugr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.1 (2024-07-25)
+
+### Bug Fixes
+
+- Dfg wrapper build handles incorrect output wire numbers ([#1332](https://github.com/CQCL/hugr/pull/1332))
+- Sibling extension panics while computing signature with non-dataflow nodes ([#1350](https://github.com/CQCL/hugr/pull/1350))
+
+
 ## 0.9.0 (2024-07-19)
 
 ### Bug Fixes

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr"
-version = "0.9.0"
+version = "0.9.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 extension_inference = []
 
 [dependencies]
-hugr-core = { path = "../hugr-core", version = "0.6.0" }
-hugr-passes = { path = "../hugr-passes", version = "0.6.0" }
+hugr-core = { path = "../hugr-core", version = "0.6.1" }
+hugr-passes = { path = "../hugr-passes", version = "0.6.1" }
 
 [dev-dependencies]
 rstest = { workspace = true }


### PR DESCRIPTION
This is a patch release including only some non-breaking changes since 0.9.0.

## New release
* `hugr`: 0.9.0 -> 0.9.1
* `hugr-core`: 0.6.0 -> 0.6.1
* `hugr-passes`: 0.6.0 -> 0.6.1
* `hugr-cli`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `hugr`
<blockquote>

## 0.9.1 (2024-07-25)

### Bug Fixes

- Dfg wrapper build handles incorrect output wire numbers ([#1332](https://github.com/CQCL/hugr/pull/1332))
- Sibling extension panics while computing signature with non-dataflow nodes ([#1350](https://github.com/CQCL/hugr/pull/1350))
</blockquote>

## `hugr-core`
<blockquote>

## 0.6.1 (2024-07-25)

### Bug Fixes

- Dfg wrapper build handles incorrect output wire numbers ([#1332](https://github.com/CQCL/hugr/pull/1332))
- Sibling extension panics while computing signature with non-dataflow nodes ([#1350](https://github.com/CQCL/hugr/pull/1350))
</blockquote>

## `hugr-passes`
<blockquote>

## 0.6.1 (2024-07-25)

Nothing here.
</blockquote>

## `hugr-cli`
<blockquote>

## 0.2.1 (2024-07-25)

Nothing here.
</blockquote>


</p></details>

---
This PR was generated by a human.