### PR TITLE
feat!: `Extension` requires a version

### DIFF
--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -45,6 +45,7 @@ delegate = { workspace = true }
 paste = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+semver = { version = "1.0.23", features = ["serde"] }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -330,10 +330,10 @@ impl Extension {
         }
     }
 
-    /// Creates a new extension with the given name and requirements.
+    /// Extend the requirements of this extension with another set of extensions.
     pub fn with_reqs(self, extension_reqs: impl Into<ExtensionSet>) -> Self {
         Self {
-            extension_reqs: extension_reqs.into(),
+            extension_reqs: self.extension_reqs.union(extension_reqs.into()),
             ..self
         }
     }

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -3,6 +3,7 @@
 //! TODO: YAML declaration and parsing. This should be similar to a plugin
 //! system (outside the `types` module), which also parses nested [`OpDef`]s.
 
+pub use semver::Version;
 use std::collections::btree_map;
 use std::collections::hash_map;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -264,6 +265,8 @@ pub type ExtensionId = IdentList;
 /// A extension is a set of capabilities required to execute a graph.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Extension {
+    /// Extension version, follows semver.
+    pub version: Version,
     /// Unique identifier for the extension.
     pub name: ExtensionId,
     /// Other extensions defining types used by this extension.
@@ -286,18 +289,22 @@ pub struct Extension {
 
 impl Extension {
     /// Creates a new extension with the given name.
-    pub fn new(name: ExtensionId) -> Self {
-        Self::new_with_reqs(name, ExtensionSet::default())
-    }
-
-    /// Creates a new extension with the given name and requirements.
-    pub fn new_with_reqs(name: ExtensionId, extension_reqs: impl Into<ExtensionSet>) -> Self {
+    pub fn new(name: ExtensionId, version: Version) -> Self {
         Self {
             name,
-            extension_reqs: extension_reqs.into(),
+            version,
+            extension_reqs: Default::default(),
             types: Default::default(),
             values: Default::default(),
             operations: Default::default(),
+        }
+    }
+
+    /// Creates a new extension with the given name and requirements.
+    pub fn with_reqs(self, extension_reqs: impl Into<ExtensionSet>) -> Self {
+        Self {
+            extension_reqs: extension_reqs.into(),
+            ..self
         }
     }
 

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -580,6 +580,14 @@ pub mod test {
     pub use super::op_def::test::SimpleOpDef;
 
     use super::*;
+
+    impl Extension {
+        /// Create a new extension for testing, with a 0 version.
+        pub(crate) fn new_test(name: ExtensionId) -> Self {
+            Self::new(name, Version::new(0, 0, 0))
+        }
+    }
+
     #[test]
     fn test_register_update() {
         let mut reg = ExtensionRegistry::try_new([]).unwrap();

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -129,6 +129,11 @@ impl ExtensionRegistry {
     pub fn iter(&self) -> impl Iterator<Item = (&ExtensionId, &Extension)> {
         self.0.iter()
     }
+
+    /// Delete an extension from the registry and return it if it was present.
+    pub fn remove_extension(&mut self, name: &ExtensionId) -> Option<Extension> {
+        self.0.remove(name)
+    }
 }
 
 impl IntoIterator for ExtensionRegistry {
@@ -599,7 +604,7 @@ pub mod test {
         assert_eq!(
             reg.register(ext1_1.clone()),
             Err(ExtensionRegistryError::AlreadyRegistered(
-                ext_1_id,
+                ext_1_id.clone(),
                 Version::new(1, 0, 0),
                 Version::new(1, 1, 0)
             ))
@@ -616,6 +621,9 @@ pub mod test {
         reg.register(ext2.clone()).unwrap();
         assert_eq!(reg.get("ext2").unwrap().version(), &Version::new(1, 0, 0));
         assert_eq!(reg.len(), 2);
+
+        assert!(reg.remove_extension(&ext_1_id).unwrap().version() == &Version::new(1, 1, 0));
+        assert_eq!(reg.len(), 1);
     }
     mod proptest {
 

--- a/hugr-core/src/extension/declarative.rs
+++ b/hugr-core/src/extension/declarative.rs
@@ -89,6 +89,7 @@ struct ExtensionSetDeclaration {
 /// A declarative extension definition.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct ExtensionDeclaration {
+    // TODO add version
     /// The name of the extension.
     name: ExtensionId,
     /// A list of types that this extension provides.
@@ -150,7 +151,8 @@ impl ExtensionDeclaration {
         imports: &ExtensionSet,
         ctx: DeclarationContext<'_>,
     ) -> Result<Extension, ExtensionDeclarationError> {
-        let mut ext = Extension::new_with_reqs(self.name.clone(), imports.clone());
+        let mut ext = Extension::new(self.name.clone(), semver::Version::new(0, 0, 0))
+            .with_reqs(imports.clone());
 
         for t in &self.types {
             t.register(&mut ext, ctx)?;

--- a/hugr-core/src/extension/declarative.rs
+++ b/hugr-core/src/extension/declarative.rs
@@ -151,7 +151,7 @@ impl ExtensionDeclaration {
         imports: &ExtensionSet,
         ctx: DeclarationContext<'_>,
     ) -> Result<Extension, ExtensionDeclarationError> {
-        let mut ext = Extension::new(self.name.clone(), semver::Version::new(0, 0, 0))
+        let mut ext = Extension::new(self.name.clone(), crate::extension::Version::new(0, 0, 0))
             .with_reqs(imports.clone());
 
         for t in &self.types {

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -591,7 +591,7 @@ pub(super) mod test {
     #[test]
     fn op_def_with_type_scheme() -> Result<(), Box<dyn std::error::Error>> {
         let list_def = EXTENSION.get_type(&LIST_TYPENAME).unwrap();
-        let mut e = Extension::new(EXT_ID);
+        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
         const TP: TypeParam = TypeParam::Type { b: TypeBound::Any };
         let list_of_var =
             Type::new_extension(list_def.instantiate(vec![TypeArg::new_var_use(0, TP)])?);
@@ -658,7 +658,7 @@ pub(super) mod test {
                 MAX_NAT
             }
         }
-        let mut e = Extension::new(EXT_ID);
+        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
         let def: &mut crate::extension::OpDef =
             e.add_op("MyOp".into(), "".to_string(), SigFun())?;
 
@@ -720,7 +720,7 @@ pub(super) mod test {
     fn type_scheme_instantiate_var() -> Result<(), Box<dyn std::error::Error>> {
         // Check that we can instantiate a PolyFuncTypeRV-scheme with an (external)
         // type variable
-        let mut e = Extension::new(EXT_ID);
+        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
         let def = e.add_op(
             "SimpleOp".into(),
             "".into(),
@@ -755,7 +755,7 @@ pub(super) mod test {
     fn instantiate_extension_delta() -> Result<(), Box<dyn std::error::Error>> {
         use crate::extension::prelude::{BOOL_T, PRELUDE_REGISTRY};
 
-        let mut e = Extension::new(EXT_ID);
+        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
 
         let params: Vec<TypeParam> = vec![TypeParam::Extensions];
         let db_set = ExtensionSet::type_var(0);

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -591,7 +591,7 @@ pub(super) mod test {
     #[test]
     fn op_def_with_type_scheme() -> Result<(), Box<dyn std::error::Error>> {
         let list_def = EXTENSION.get_type(&LIST_TYPENAME).unwrap();
-        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
+        let mut e = Extension::new_test(EXT_ID);
         const TP: TypeParam = TypeParam::Type { b: TypeBound::Any };
         let list_of_var =
             Type::new_extension(list_def.instantiate(vec![TypeArg::new_var_use(0, TP)])?);
@@ -658,7 +658,7 @@ pub(super) mod test {
                 MAX_NAT
             }
         }
-        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
+        let mut e = Extension::new_test(EXT_ID);
         let def: &mut crate::extension::OpDef =
             e.add_op("MyOp".into(), "".to_string(), SigFun())?;
 
@@ -720,7 +720,7 @@ pub(super) mod test {
     fn type_scheme_instantiate_var() -> Result<(), Box<dyn std::error::Error>> {
         // Check that we can instantiate a PolyFuncTypeRV-scheme with an (external)
         // type variable
-        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
+        let mut e = Extension::new_test(EXT_ID);
         let def = e.add_op(
             "SimpleOp".into(),
             "".into(),
@@ -755,7 +755,7 @@ pub(super) mod test {
     fn instantiate_extension_delta() -> Result<(), Box<dyn std::error::Error>> {
         use crate::extension::prelude::{BOOL_T, PRELUDE_REGISTRY};
 
-        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
+        let mut e = Extension::new_test(EXT_ID);
 
         let params: Vec<TypeParam> = vec![TypeParam::Extensions];
         let db_set = ExtensionSet::type_var(0);

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -85,9 +85,11 @@ impl SignatureFromArgs for GenericOpCustom {
 
 /// Name of prelude extension.
 pub const PRELUDE_ID: ExtensionId = ExtensionId::new_unchecked("prelude");
+/// Extension version.
+pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 lazy_static! {
     static ref PRELUDE_DEF: Extension = {
-        let mut prelude = Extension::new(PRELUDE_ID);
+        let mut prelude = Extension::new(PRELUDE_ID, VERSION);
         prelude
             .add_type(
                 TypeName::new_inline("usize"),

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -319,7 +319,7 @@ mod test {
 
     lazy_static! {
         static ref EXT: Extension = {
-            let mut e = Extension::new(EXT_ID.clone(), semver::Version::new(0, 1, 0));
+            let mut e = Extension::new_test(EXT_ID.clone());
             DummyEnum::Dumb.add_to_extension(&mut e).unwrap();
             e
         };

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -319,7 +319,7 @@ mod test {
 
     lazy_static! {
         static ref EXT: Extension = {
-            let mut e = Extension::new(EXT_ID.clone());
+            let mut e = Extension::new(EXT_ID.clone(), semver::Version::new(0, 1, 0));
             DummyEnum::Dumb.add_to_extension(&mut e).unwrap();
             e
         };

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -365,7 +365,7 @@ const_extension_ids! {
 }
 #[test]
 fn invalid_types() {
-    let mut e = Extension::new(EXT_ID);
+    let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
     e.add_type(
         "MyContainer".into(),
         vec![TypeBound::Copyable.into()],
@@ -570,7 +570,7 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
 
 pub(crate) fn extension_with_eval_parallel() -> Extension {
     let rowp = TypeParam::new_list(TypeBound::Any);
-    let mut e = Extension::new(EXT_ID);
+    let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
 
     let inputs = TypeRV::new_row_var_use(0, TypeBound::Any);
     let outputs = TypeRV::new_row_var_use(1, TypeBound::Any);
@@ -671,7 +671,7 @@ fn row_variables() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut e = Extension::new(EXT_ID);
+    let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
 
     let params: Vec<TypeParam> = vec![
         TypeBound::Any.into(),

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -365,7 +365,7 @@ const_extension_ids! {
 }
 #[test]
 fn invalid_types() {
-    let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
+    let mut e = Extension::new_test(EXT_ID);
     e.add_type(
         "MyContainer".into(),
         vec![TypeBound::Copyable.into()],
@@ -570,7 +570,7 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
 
 pub(crate) fn extension_with_eval_parallel() -> Extension {
     let rowp = TypeParam::new_list(TypeBound::Any);
-    let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
+    let mut e = Extension::new_test(EXT_ID);
 
     let inputs = TypeRV::new_row_var_use(0, TypeBound::Any);
     let outputs = TypeRV::new_row_var_use(1, TypeBound::Any);
@@ -671,7 +671,7 @@ fn row_variables() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
+    let mut e = Extension::new_test(EXT_ID);
 
     let params: Vec<TypeParam> = vec![
         TypeBound::Any.into(),

--- a/hugr-core/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions.rs
@@ -22,6 +22,8 @@ use lazy_static::lazy_static;
 mod const_fold;
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.conversions");
+/// Extension version.
+pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 
 /// Extension for conversions between floats and integers.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
@@ -121,8 +123,9 @@ impl MakeExtensionOp for ConvertOpType {
 lazy_static! {
     /// Extension for conversions between integers and floats.
     pub static ref EXTENSION: Extension = {
-        let mut extension = Extension::new_with_reqs(
+        let mut extension = Extension::new(
             EXTENSION_ID,
+            VERSION).with_reqs(
             ExtensionSet::from_iter(vec![
                 super::int_types::EXTENSION_ID,
                 super::float_types::EXTENSION_ID,

--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -17,6 +17,8 @@ use lazy_static::lazy_static;
 mod const_fold;
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.float");
+/// Extension version.
+pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 
 /// Integer extension operation definitions.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EnumIter, IntoStaticStr, EnumString)]
@@ -99,8 +101,9 @@ impl MakeOpDef for FloatOps {
 lazy_static! {
     /// Extension for basic float operations.
     pub static ref EXTENSION: Extension = {
-        let mut extension = Extension::new_with_reqs(
+        let mut extension = Extension::new(
             EXTENSION_ID,
+            VERSION).with_reqs(
             ExtensionSet::singleton(&super::int_types::EXTENSION_ID),
         );
 

--- a/hugr-core/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_types.rs
@@ -12,6 +12,8 @@ use lazy_static::lazy_static;
 
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.float.types");
+/// Extension version.
+pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 
 /// Identifier for the 64-bit IEEE 754-2019 floating-point type.
 const FLOAT_TYPE_ID: TypeName = TypeName::new_inline("float64");
@@ -76,7 +78,7 @@ impl CustomConst for ConstF64 {
 lazy_static! {
     /// Extension defining the float type.
     pub static ref EXTENSION: Extension = {
-        let mut extension = Extension::new(EXTENSION_ID);
+        let mut extension = Extension::new(EXTENSION_ID, VERSION);
 
         extension
             .add_type(

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -28,6 +28,8 @@ mod const_fold;
 
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.int");
+/// Extension version.
+pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 
 struct IOValidator {
     // whether the first type argument should be greater than or equal to the second
@@ -261,9 +263,10 @@ fn iunop_sig() -> PolyFuncTypeRV {
 lazy_static! {
     /// Extension for basic integer operations.
     pub static ref EXTENSION: Extension = {
-        let mut extension = Extension::new_with_reqs(
+        let mut extension = Extension::new(
             EXTENSION_ID,
-            ExtensionSet::singleton(&super::int_types::EXTENSION_ID),
+            VERSION).with_reqs(
+            ExtensionSet::singleton(&super::int_types::EXTENSION_ID)
         );
 
         IntOpDef::load_all_ops(&mut extension).unwrap();

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -16,6 +16,8 @@ use crate::{
 use lazy_static::lazy_static;
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("arithmetic.int.types");
+/// Extension version.
+pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 
 /// Identifier for the integer type.
 pub const INT_TYPE_ID: TypeName = TypeName::new_inline("int");
@@ -185,7 +187,7 @@ impl CustomConst for ConstInt {
 
 /// Extension for basic integer types.
 pub fn extension() -> Extension {
-    let mut extension = Extension::new(EXTENSION_ID);
+    let mut extension = Extension::new(EXTENSION_ID, VERSION);
 
     extension
         .add_type(

--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -31,6 +31,8 @@ pub const POP_NAME: OpName = OpName::new_inline("pop");
 pub const PUSH_NAME: OpName = OpName::new_inline("push");
 /// Reported unique name of the extension
 pub const EXTENSION_NAME: ExtensionId = ExtensionId::new_unchecked("Collections");
+/// Extension version.
+pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// Dynamically sized list of values, all of the same type.
@@ -138,7 +140,7 @@ impl ConstFold for PushFold {
 const TP: TypeParam = TypeParam::Type { b: TypeBound::Any };
 
 fn extension() -> Extension {
-    let mut extension = Extension::new(EXTENSION_NAME);
+    let mut extension = Extension::new(EXTENSION_NAME, VERSION);
 
     extension
         .add_type(

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -168,6 +168,8 @@ impl MakeOpDef for NotOp {
 }
 /// The extension identifier.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("logic");
+/// Extension version.
+pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 
 fn logic_op_sig() -> impl SignatureFromArgs {
     struct LogicOpCustom;
@@ -194,7 +196,7 @@ fn logic_op_sig() -> impl SignatureFromArgs {
 }
 /// Extension for basic logical operations.
 fn extension() -> Extension {
-    let mut extension = Extension::new(EXTENSION_ID);
+    let mut extension = Extension::new(EXTENSION_ID, VERSION);
     NaryLogic::load_all_ops(&mut extension).unwrap();
     NotOp.add_to_extension(&mut extension).unwrap();
 

--- a/hugr-core/src/std_extensions/ptr.rs
+++ b/hugr-core/src/std_extensions/ptr.rs
@@ -80,9 +80,12 @@ pub const PTR_TYPE_ID: TypeName = TypeName::new_inline("ptr");
 const TYPE_PARAMS: [TypeParam; 1] = [TypeParam::Type {
     b: TypeBound::Copyable,
 }];
+/// Extension version.
+pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
+
 /// Extension for pointer operations.
 fn extension() -> Extension {
-    let mut extension = Extension::new(EXTENSION_ID);
+    let mut extension = Extension::new(EXTENSION_ID, VERSION);
     extension
         .add_type(
             PTR_TYPE_ID,

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -313,7 +313,7 @@ pub(crate) mod test {
         const EXT_ID: ExtensionId = ExtensionId::new_unchecked("my_ext");
         const TYPE_NAME: TypeName = TypeName::new_inline("MyType");
 
-        let mut e = Extension::new(EXT_ID);
+        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
         e.add_type(
             TYPE_NAME,
             vec![bound.clone()],

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -313,7 +313,7 @@ pub(crate) mod test {
         const EXT_ID: ExtensionId = ExtensionId::new_unchecked("my_ext");
         const TYPE_NAME: TypeName = TypeName::new_inline("MyType");
 
-        let mut e = Extension::new(EXT_ID, semver::Version::new(0, 1, 0));
+        let mut e = Extension::new_test(EXT_ID);
         e.add_type(
             TYPE_NAME,
             vec![bound.clone()],

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -129,7 +129,7 @@ pub(crate) mod test_quantum_extension {
     /// The extension identifier.
     pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("test.quantum");
     fn extension() -> Extension {
-        let mut extension = Extension::new(EXTENSION_ID, semver::Version::parse("0.1.0").unwrap());
+        let mut extension = Extension::new_test(EXTENSION_ID);
 
         extension
             .add_op(OpName::new_inline("H"), "Hadamard".into(), one_qb_func())

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -129,7 +129,7 @@ pub(crate) mod test_quantum_extension {
     /// The extension identifier.
     pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("test.quantum");
     fn extension() -> Extension {
-        let mut extension = Extension::new(EXTENSION_ID);
+        let mut extension = Extension::new(EXTENSION_ID, semver::Version::parse("0.1.0").unwrap());
 
         extension
             .add_op(OpName::new_inline("H"), "Hadamard".into(), one_qb_func())

--- a/hugr-passes/src/merge_bbs.rs
+++ b/hugr-passes/src/merge_bbs.rs
@@ -178,7 +178,7 @@ mod test {
     }
 
     fn extension() -> Extension {
-        let mut e = Extension::new(EXT_ID);
+        let mut e = Extension::new(EXT_ID, hugr_core::extension::Version::new(0, 1, 0));
         e.add_op(
             "Test".into(),
             String::new(),

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -39,7 +39,7 @@
 //!     use hugr::{
 //!         extension::{
 //!             prelude::{BOOL_T, QB_T},
-//!             ExtensionId, ExtensionRegistry, PRELUDE,
+//!             ExtensionId, ExtensionRegistry, PRELUDE, Version,
 //!         },
 //!         ops::{CustomOp, OpName},
 //!         type_row,
@@ -58,8 +58,9 @@
 //!     }
 //!     /// The extension identifier.
 //!     pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("mini.quantum");
+//!     pub const VERSION: Version = Version::new(0, 1, 0);
 //!     fn extension() -> Extension {
-//!         let mut extension = Extension::new(EXTENSION_ID);
+//!         let mut extension = Extension::new(EXTENSION_ID, VERSION);
 //!
 //!         extension
 //!             .add_op(OpName::new_inline("H"), "Hadamard".into(), one_qb_func())


### PR DESCRIPTION
Closes #1357 

BREAKING CHANGE: `Extension::new` now requires a `Version` argument. `Extension::new_with_reqs` replaced with `with_reqs` which takes `self` (chain with `new`).