### PR TITLE
ci: Reduce rust coverage report delay

### DIFF
--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -95,7 +95,7 @@ jobs:
   test:
     needs: [changes, build_binary]
     if: ${{ needs.changes.outputs.python == 'true' }}
-    name: check python ${{ matrix.python-version }}
+    name: test python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -147,7 +147,7 @@ jobs:
 
   tests-nightly-coverage:
     needs: changes
-    # Run only if there are changes in the relevant files and the check job passed or was skipped
+    # Run only if there are changes in the relevant files
     if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     name: tests (Rust nightly, coverage)

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -123,7 +123,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust: ['1.75', beta, 'nightly']
+        # Stable is covered by `tests-stable-no-features` and `tests-stable-all-features`
+        # Nightly is covered by `tests-nightly-coverage`
+        rust: ['1.75', beta]
     name: tests (Rust ${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v4
@@ -142,6 +144,37 @@ jobs:
         run: cargo test --verbose --workspace --all-features --no-run
       - name: Tests with all features
         run: cargo test --verbose --workspace --all-features
+
+  tests-nightly-coverage:
+    needs: changes
+    # Run only if there are changes in the relevant files and the check job passed or was skipped
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'merge_group' }}
+    runs-on: ubuntu-latest
+    name: tests (Rust nightly, coverage)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          # Nightly is required to count doctests coverage
+          toolchain: 'nightly'
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run tests with coverage instrumentation
+        run: |
+            cargo llvm-cov clean --workspace
+            cargo llvm-cov --no-report --workspace --no-default-features --doctests
+            cargo llvm-cov --no-report --workspace --all-features --doctests
+      - name: Generate coverage report
+        run: cargo llvm-cov --all-features report --codecov --output-path coverage.json
+      - name: Upload coverage to codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.json
+          name: rust
+          flags: rust
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # This is a meta job to mark successful completion of the required checks,
   # even if they are skipped due to no changes in the relevant files.
@@ -168,33 +201,3 @@ jobs:
       - name: Pass if required checks passed
         run: |
           echo "All required checks passed"
-
-  coverage:
-    needs: [changes, tests-stable-no-features, tests-stable-all-features, tests-other, check]
-    # Run only if there are changes in the relevant files and the check job passed or was skipped
-    if: always() && !failure() && !cancelled() && needs.changes.outputs.rust == 'true' && github.event_name != 'merge_group'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: mozilla-actions/sccache-action@v0.0.5
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          # Nightly is required to count doctests coverage
-          toolchain: 'nightly'
-          components: llvm-tools-preview
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Run tests with coverage instrumentation
-        run: |
-            cargo llvm-cov clean --workspace
-            cargo llvm-cov --no-report --workspace --no-default-features --doctests
-            cargo llvm-cov --no-report --workspace --all-features --doctests
-      - name: Generate coverage report
-        run: cargo llvm-cov --all-features report --codecov --output-path coverage.json
-      - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
-        with:
-          files: coverage.json
-          name: rust
-          flags: rust
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
CI was running tests on `{MSRV, beta, nightly}` first, and only then running tests with coverage instrumentation on nightly.

Since those tests are not on the critical path for the required checks, we can run the nightly tests directly with instrumentation on the first pass, shaving ~2mins from the commit-to-codecov report delay.

I'm only doing this for rust, as the python tests _are_ in the required checks sets and we don't want to slow down those.

drive-by: The python tests job had the same name as the linting job.