### PR TITLE
ci: Fix pr-title not running

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,8 +14,6 @@ on:
 
 jobs:
     check-title:
-        name: Validate Conventional Commit PR title
-        if: github.event_name == 'pull_request_target'
         uses: CQCL/hugrverse-actions/.github/workflows/pr-title.yml@main
         secrets:
             GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
     check-title:
+        name: check-title
         uses: CQCL/hugrverse-actions/.github/workflows/pr-title.yml@main
         secrets:
             GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}


### PR DESCRIPTION
It seems that skipping reusable workflow jobs causes inconsistent check names between `pull_request_target` and `merge_group`.
For the non-skipped PR runs we get a `local_job/remote_job` name,
but the skipped jobs in the merge queue are just called `local_job`.... (even if skipped in the called workflow instead of locally).

I updated the reusable workflow to skip individual steps instead of the whole job, so now we shouldn't have to deal with that inconsistency.

I will need to update the required check name to `local/remote`