### PR TITLE
feat!: Update remaining builder methods to "infer by default"

### DIFF
--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -305,6 +305,7 @@ pub trait Dataflow: Container {
     /// The `inputs` must be an iterable over pairs of the type of the input and
     /// the corresponding wire.
     /// The `output_types` are the types of the outputs.
+    /// The Extension delta will be inferred.
     ///
     /// # Errors
     ///
@@ -314,7 +315,27 @@ pub trait Dataflow: Container {
         &mut self,
         inputs: impl IntoIterator<Item = (Type, Wire)>,
         output_types: TypeRow,
-        extension_delta: ExtensionSet,
+    ) -> Result<CFGBuilder<&mut Hugr>, BuildError> {
+        self.cfg_builder_exts(inputs, output_types, TO_BE_INFERRED)
+    }
+
+    /// Return a builder for a [`crate::ops::CFG`] node,
+    /// i.e. a nested controlflow subgraph.
+    /// The `inputs` must be an iterable over pairs of the type of the input and
+    /// the corresponding wire.
+    /// The `output_types` are the types of the outputs.
+    /// `extension_delta` is explicitly specified. Alternatively
+    /// [cfg_builder](Self::cfg_builder) may be used to infer it.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if there is an error when building
+    /// the CFG node.
+    fn cfg_builder_exts(
+        &mut self,
+        inputs: impl IntoIterator<Item = (Type, Wire)>,
+        output_types: TypeRow,
+        extension_delta: impl Into<ExtensionSet>,
     ) -> Result<CFGBuilder<&mut Hugr>, BuildError> {
         let (input_types, input_wires): (Vec<Type>, Vec<Wire>) = inputs.into_iter().unzip();
 

--- a/hugr-core/src/builder/cfg.rs
+++ b/hugr-core/src/builder/cfg.rs
@@ -468,11 +468,8 @@ pub(crate) mod test {
                 let [int] = func_builder.input_wires_arr();
 
                 let cfg_id = {
-                    let mut cfg_builder = func_builder.cfg_builder(
-                        vec![(NAT, int)],
-                        type_row![NAT],
-                        ExtensionSet::new(),
-                    )?;
+                    let mut cfg_builder =
+                        func_builder.cfg_builder(vec![(NAT, int)], type_row![NAT])?;
                     build_basic_cfg(&mut cfg_builder)?;
 
                     cfg_builder.finish_sub_container()?

--- a/hugr-core/src/builder/tail_loop.rs
+++ b/hugr-core/src/builder/tail_loop.rs
@@ -1,4 +1,4 @@
-use crate::extension::ExtensionSet;
+use crate::extension::{ExtensionSet, TO_BE_INFERRED};
 use crate::ops::{self, DataflowOpTrait};
 
 use crate::hugr::views::HugrView;
@@ -71,18 +71,30 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
 }
 
 impl TailLoopBuilder<Hugr> {
-    /// Initialize new builder for a [`ops::TailLoop`] rooted HUGR
+    /// Initialize new builder for a [`ops::TailLoop`] rooted HUGR.
+    /// Extension delta will be inferred.
     pub fn new(
         just_inputs: impl Into<TypeRow>,
         inputs_outputs: impl Into<TypeRow>,
         just_outputs: impl Into<TypeRow>,
-        extension_delta: ExtensionSet,
+    ) -> Result<Self, BuildError> {
+        Self::new_exts(just_inputs, inputs_outputs, just_outputs, TO_BE_INFERRED)
+    }
+
+    /// Initialize new builder for a [`ops::TailLoop`] rooted HUGR.
+    /// `extension_delta` is explicitly specified; alternatively, [new](Self::new)
+    /// may be used to infer it.
+    pub fn new_exts(
+        just_inputs: impl Into<TypeRow>,
+        inputs_outputs: impl Into<TypeRow>,
+        just_outputs: impl Into<TypeRow>,
+        extension_delta: impl Into<ExtensionSet>,
     ) -> Result<Self, BuildError> {
         let tail_loop = ops::TailLoop {
             just_inputs: just_inputs.into(),
             just_outputs: just_outputs.into(),
             rest: inputs_outputs.into(),
-            extension_delta,
+            extension_delta: extension_delta.into(),
         };
         let base = Hugr::new(tail_loop.clone());
         let root = base.root();
@@ -111,7 +123,7 @@ mod test {
     fn basic_loop() -> Result<(), BuildError> {
         let build_result: Result<Hugr, ValidationError> = {
             let mut loop_b =
-                TailLoopBuilder::new(vec![], vec![BIT], vec![USIZE_T], PRELUDE_ID.into())?;
+                TailLoopBuilder::new_exts(vec![], vec![BIT], vec![USIZE_T], PRELUDE_ID)?;
             let [i1] = loop_b.input_wires_arr();
             let const_wire = loop_b.add_load_value(ConstUsize::new(1));
 
@@ -195,9 +207,7 @@ mod test {
     #[test]
     // fixed: issue 1257: When building a TailLoop, calling outputs_arr, you are given an OrderEdge "output wire"
     fn tailloop_output_arr() {
-        let mut builder =
-            TailLoopBuilder::new(type_row![], type_row![], type_row![], ExtensionSet::new())
-                .unwrap();
+        let mut builder = TailLoopBuilder::new(type_row![], type_row![], type_row![]).unwrap();
         let control = builder.add_load_value(Value::false_val());
         let tailloop = builder.finish_with_outputs(control, []).unwrap();
         let [] = tailloop.outputs_arr();

--- a/hugr-core/src/builder/tail_loop.rs
+++ b/hugr-core/src/builder/tail_loop.rs
@@ -143,12 +143,8 @@ mod test {
                     )?
                     .outputs_arr();
                 let loop_id = {
-                    let mut loop_b = fbuild.tail_loop_builder(
-                        vec![(BIT, b1)],
-                        vec![],
-                        type_row![NAT],
-                        PRELUDE_ID.into(),
-                    )?;
+                    let mut loop_b =
+                        fbuild.tail_loop_builder(vec![(BIT, b1)], vec![], type_row![NAT])?;
                     let signature = loop_b.loop_signature()?.clone();
                     let const_val = Value::true_val();
                     let const_wire = loop_b.add_load_const(Value::true_val());

--- a/hugr-core/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr-core/src/hugr/rewrite/outline_cfg.rs
@@ -134,7 +134,7 @@ impl Rewrite for OutlineCfg {
             .unwrap();
             let wires_in = inputs.iter().cloned().zip(new_block_bldr.input_wires());
             let cfg = new_block_bldr
-                .cfg_builder(wires_in, outputs, extension_delta)
+                .cfg_builder_exts(wires_in, outputs, extension_delta)
                 .unwrap();
             let cfg = cfg.finish_sub_container().unwrap();
             let unit_sum = new_block_bldr.add_constant(ops::Value::unary_unit_sum());


### PR DESCRIPTION
closes #1318...unless there are any others I've missed (but those taking FunctionType don't need update)

BREAKING CHANGE: `cfg_builder`, `tail_loop_builder`, `ConditionalBuilder::new` and `TailLoopBuilder::new` no longer take an ExtensionSet parameter; either remove the argument (to use extension inference) or use the `_exts` variant