### PR TITLE
chore: Only release-plz after release PRs

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -15,6 +15,13 @@ changelog_config = "cliff.toml"
 git_tag_name = "{{ package }}-v{{ version }}"
 git_release_name = "{{ package }}: v{{ version }}"
 
+# Only create releases / push to crates.io after merging a release-please PR.
+# This lets merge new crates to `main` without worrying about accidentally creating
+# github releases.
+#
+# To trigger a release manually, merge a PR from a branch starting with `release-plz-`.
+release_always = false
+
 [[package]]
 name = "hugr"
 changelog_include = ["hugr-core", "hugr-passes"]


### PR DESCRIPTION
Stops releases from being created by new packages pushed to `main`.

https://release-plz.ieni.dev/docs/config#the-release_always-field

This saves us from having to temporarily configure `git_tag_enable` and `git_release_enable` for each crate. https://github.com/CQCL/tket2/pull/519/commits/73d6e651c7cebc6758ac7957a6ff9c7aee1f9419


Copied from https://github.com/CQCL/tket2/pull/524