### PR TITLE
docs: Clarify CustomConst::equal_consts

### DIFF
--- a/hugr-core/src/ops/constant/custom.rs
+++ b/hugr-core/src/ops/constant/custom.rs
@@ -75,6 +75,11 @@ pub trait CustomConst:
     /// Compare two constants for equality, using downcasting and comparing the definitions.
     ///
     /// If the type implements `PartialEq`, use [`downcast_equal_consts`] to compare the values.
+    ///
+    /// Note that this does not require any equivalent of [Eq]: it is permissible to return
+    /// `false` if in doubt, and in particular, there is no requirement for reflexivity.
+    /// However, we do expect symmetry (`x.equal_consts(y) == y.equal_consts(x)`).
+    /// TODO What about transitivity?
     fn equal_consts(&self, _other: &dyn CustomConst) -> bool {
         // false unless overloaded
         false

--- a/hugr-core/src/ops/constant/custom.rs
+++ b/hugr-core/src/ops/constant/custom.rs
@@ -81,7 +81,7 @@ pub trait CustomConst:
     /// However, we do expect symmetry (`x.equal_consts(y) == y.equal_consts(x)`).
     /// TODO What about transitivity?
     fn equal_consts(&self, _other: &dyn CustomConst) -> bool {
-        // false unless overloaded
+        // false unless overridden
         false
     }
 

--- a/hugr-core/src/ops/constant/custom.rs
+++ b/hugr-core/src/ops/constant/custom.rs
@@ -77,9 +77,10 @@ pub trait CustomConst:
     /// If the type implements `PartialEq`, use [`downcast_equal_consts`] to compare the values.
     ///
     /// Note that this does not require any equivalent of [Eq]: it is permissible to return
-    /// `false` if in doubt, and in particular, there is no requirement for reflexivity.
-    /// However, we do expect symmetry (`x.equal_consts(y) == y.equal_consts(x)`).
-    /// TODO What about transitivity?
+    /// `false` if in doubt, and in particular, there is no requirement for reflexivity
+    /// (i.e. `x.equal_consts(x)` can be `false`). However, we do expect both
+    /// symmetry (`x.equal_consts(y) == y.equal_consts(x)`) and transitivity
+    /// (if `x.equal_consts(y) && y.equal_consts(z)` then `x.equal_consts(z)`).
     fn equal_consts(&self, _other: &dyn CustomConst) -> bool {
         // false unless overridden
         false


### PR DESCRIPTION
This is just explaining existing behaviour, but I think it's important to explain that we are not expecting the equivalent of `Eq` on a structure that could be just an `f64`....

This does constrain impls to be symmetric and transitive, but all current ones are, and I couldn't think of any... (indeed, "either Eq or always return false" would describe all current impls, and this is still significantly more permissive than that.)