### PR TITLE
feat(py): Set node output# for dfgs and cfgs

### DIFF
--- a/hugr-py/src/hugr/cfg.py
+++ b/hugr-py/src/hugr/cfg.py
@@ -22,17 +22,21 @@ if TYPE_CHECKING:
 class Block(_DfBase[ops.DataflowBlock]):
     """Builder class for a basic block in a HUGR control flow graph."""
 
-    def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
-        self.set_outputs(branching, *other_outputs)
+    def set_outputs(self, *outputs: Wire) -> None:
+        super().set_outputs(*outputs)
 
+        assert len(outputs) > 0
+        branching = outputs[0]
         branch_type = self.hugr.port_type(branching.out_port())
         assert isinstance(branch_type, tys.Sum)
-        self.set_parent_output_count(len(branch_type.variant_rows))
+        self._set_parent_output_count(len(branch_type.variant_rows))
+
+    def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
+        self.set_outputs(branching, *other_outputs)
 
     def set_single_succ_outputs(self, *outputs: Wire) -> None:
         u = self.load(val.Unit)
         self.set_outputs(u, *outputs)
-        self.set_parent_output_count(1)
 
     def _wire_up_port(self, node: Node, offset: PortOffset, p: Wire) -> Type:
         src = p.out_port()

--- a/hugr-py/src/hugr/cond_loop.py
+++ b/hugr-py/src/hugr/cond_loop.py
@@ -224,7 +224,7 @@ class TailLoop(_DfBase[ops.TailLoop]):
         sum_type = self.hugr.port_type(sum_wire.out_port())
         assert isinstance(sum_type, Sum)
         assert len(sum_type.variant_rows) == 2
-        self._set_parent_output_count(len(sum_type.variant_rows[1]) + len(outputs[1:]))
+        self._set_parent_output_count(len(sum_type.variant_rows[1]) + len(outputs) - 1)
 
     def set_loop_outputs(self, sum_wire: Wire, *rest: Wire) -> None:
         """Set the outputs of the loop body. The first wire must be the sum type

--- a/hugr-py/src/hugr/cond_loop.py
+++ b/hugr-py/src/hugr/cond_loop.py
@@ -216,6 +216,16 @@ class TailLoop(_DfBase[ops.TailLoop]):
         root_op = ops.TailLoop(just_inputs, rest)
         super().__init__(root_op)
 
+    def set_outputs(self, *outputs: Wire) -> None:
+        super().set_outputs(*outputs)
+
+        assert len(outputs) > 0
+        sum_wire = outputs[0]
+        sum_type = self.hugr.port_type(sum_wire.out_port())
+        assert isinstance(sum_type, Sum)
+        assert len(sum_type.variant_rows) == 2
+        self._set_parent_output_count(len(sum_type.variant_rows[1]) + len(outputs[1:]))
+
     def set_loop_outputs(self, sum_wire: Wire, *rest: Wire) -> None:
         """Set the outputs of the loop body. The first wire must be the sum type
         that controls loop termination.
@@ -225,8 +235,3 @@ class TailLoop(_DfBase[ops.TailLoop]):
             rest: The remaining output wires (corresponding to the 'rest' types).
         """
         self.set_outputs(sum_wire, *rest)
-
-        sum_type = self.hugr.port_type(sum_wire.out_port())
-        assert isinstance(sum_type, Sum)
-        assert len(sum_type.variant_rows) == 2
-        self.set_parent_output_count(len(sum_type.variant_rows[1]) + len(rest))

--- a/hugr-py/src/hugr/cond_loop.py
+++ b/hugr-py/src/hugr/cond_loop.py
@@ -11,13 +11,14 @@ from typing import TYPE_CHECKING
 from typing_extensions import Self
 
 from hugr import ops
+from hugr.tys import Sum
 
 from .dfg import _DfBase
 from .hugr import Hugr, ParentBuilder
 
 if TYPE_CHECKING:
     from .node_port import Node, ToNode, Wire
-    from .tys import Sum, TypeRow
+    from .tys import TypeRow
 
 
 class Case(_DfBase[ops.Case]):
@@ -224,3 +225,8 @@ class TailLoop(_DfBase[ops.TailLoop]):
             rest: The remaining output wires (corresponding to the 'rest' types).
         """
         self.set_outputs(sum_wire, *rest)
+
+        sum_type = self.hugr.port_type(sum_wire.out_port())
+        assert isinstance(sum_type, Sum)
+        assert len(sum_type.variant_rows) == 2
+        self.set_parent_output_count(len(sum_type.variant_rows[1]) + len(rest))

--- a/hugr-py/src/hugr/dfg.py
+++ b/hugr-py/src/hugr/dfg.py
@@ -466,7 +466,7 @@ class _DfBase(ParentBuilder[DP], _DefinitionBuilder, AbstractContextManager):
         self._wire_up(self.output_node, args)
         self.parent_op._set_out_types(self._output_op().types)
 
-    def set_parent_output_count(self, count: int) -> None:
+    def _set_parent_output_count(self, count: int) -> None:
         """Set the final number of output ports on the parent operation.
 
         Args:
@@ -474,7 +474,7 @@ class _DfBase(ParentBuilder[DP], _DefinitionBuilder, AbstractContextManager):
 
         Example:
             >>> dfg = Dfg(tys.Bool)
-            >>> dfg.set_parent_output_count(2)
+            >>> dfg._set_parent_output_count(2)
         """
         self.parent_node = self.hugr._update_node_outs(self.parent_node, count)
 
@@ -634,7 +634,7 @@ class Dfg(_DfBase[ops.DFG]):
 
     def set_outputs(self, *outputs: Wire) -> None:
         super().set_outputs(*outputs)
-        self.set_parent_output_count(len(outputs))
+        self._set_parent_output_count(len(outputs))
 
 
 def _ancestral_sibling(h: Hugr, src: Node, tgt: Node) -> Node | None:

--- a/hugr-py/src/hugr/dfg.py
+++ b/hugr-py/src/hugr/dfg.py
@@ -466,6 +466,18 @@ class _DfBase(ParentBuilder[DP], _DefinitionBuilder, AbstractContextManager):
         self._wire_up(self.output_node, args)
         self.parent_op._set_out_types(self._output_op().types)
 
+    def set_parent_output_count(self, count: int) -> None:
+        """Set the final number of output ports on the parent operation.
+
+        Args:
+            count: The number of output ports.
+
+        Example:
+            >>> dfg = Dfg(tys.Bool)
+            >>> dfg.set_parent_output_count(2)
+        """
+        self.parent_node = self.hugr._update_node_outs(self.parent_node, count)
+
     def add_state_order(self, src: Node, dst: Node) -> None:
         """Add a state order link between two nodes.
 
@@ -619,6 +631,10 @@ class Dfg(_DfBase[ops.DFG]):
     def __init__(self, *input_types: tys.Type) -> None:
         parent_op = ops.DFG(list(input_types), None)
         super().__init__(parent_op)
+
+    def set_outputs(self, *outputs: Wire) -> None:
+        super().set_outputs(*outputs)
+        self.set_parent_output_count(len(outputs))
 
 
 def _ancestral_sibling(h: Hugr, src: Node, tgt: Node) -> Node | None:

--- a/hugr-py/src/hugr/hugr.py
+++ b/hugr-py/src/hugr/hugr.py
@@ -176,10 +176,10 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVar]):
             The updated node.
         """
         self[node]._num_outs = num_outs or 0
+        node = replace(node, _num_out_ports=num_outs)
         parent = self[node].parent
         if parent is not None:
             pos = self[parent].children.index(node)
-            node = replace(node, _num_out_ports=num_outs)
             self[parent].children[pos] = node
         return node
 

--- a/hugr-py/src/hugr/hugr.py
+++ b/hugr-py/src/hugr/hugr.py
@@ -175,6 +175,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVar]):
         Returns:
             The updated node.
         """
+        self[node]._num_outs = num_outs or 0
         parent = self[node].parent
         if parent is not None:
             pos = self[parent].children.index(node)

--- a/hugr-py/src/hugr/hugr.py
+++ b/hugr-py/src/hugr/hugr.py
@@ -169,6 +169,19 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVar]):
             self[parent].children.append(node)
         return node
 
+    def _update_node_outs(self, node: Node, num_outs: int | None) -> Node:
+        """Update the number of outgoing ports for a node.
+
+        Returns:
+            The updated node.
+        """
+        parent = self[node].parent
+        if parent is not None:
+            pos = self[parent].children.index(node)
+            node = replace(node, _num_out_ports=num_outs)
+            self[parent].children[pos] = node
+        return node
+
     def add_node(
         self,
         op: Op,


### PR DESCRIPTION
Updates the parent node with the output port count as soon as a builder knows its output.

This lets us do things like
```python
dfg = Dfg(tys.Bool)
dfg.set_outputs(*dfg.inputs())
wires: list[Wire] = list(dfg)
```