### PR TITLE
fix(py): `Hugr.__iter__` returning `NodeData | None` instead of `Node`s

### DIFF
--- a/hugr-py/src/hugr/hugr.py
+++ b/hugr-py/src/hugr/hugr.py
@@ -121,9 +121,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVar]):
         return n
 
     def __iter__(self) -> Iterator[Node]:
-        for idx, data in enumerate(self._nodes):
-            if data is not None:
-                yield Node(idx, data._num_outs)
+        return (Node(idx) for idx, data in enumerate(self._nodes) if data is not None)
 
     def __len__(self) -> int:
         return self.num_nodes()
@@ -133,11 +131,9 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVar]):
         assert isinstance(op, cl)
         return op
 
-    def nodes(self) -> Iterator[tuple[Node, NodeData]]:
+    def nodes(self) -> Iterable[tuple[Node, NodeData]]:
         """Iterator over nodes of the hugr and their data."""
-        for idx, data in enumerate(self._nodes):
-            if data is not None:
-                yield Node(idx, data._num_outs), data
+        return self.items()
 
     def children(self, node: ToNode | None = None) -> list[Node]:
         """The child nodes of a given `node`.

--- a/hugr-py/src/hugr/hugr.py
+++ b/hugr-py/src/hugr/hugr.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, field, replace
 from typing import (
     TYPE_CHECKING,
@@ -120,8 +120,10 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVar]):
             raise KeyError(key)
         return n
 
-    def __iter__(self):
-        return iter(self._nodes)
+    def __iter__(self) -> Iterator[Node]:
+        for idx, data in enumerate(self._nodes):
+            if data is not None:
+                yield Node(idx, data._num_outs)
 
     def __len__(self) -> int:
         return self.num_nodes()
@@ -130,6 +132,12 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVar]):
         op = self[node].op
         assert isinstance(op, cl)
         return op
+
+    def nodes(self) -> Iterator[tuple[Node, NodeData]]:
+        """Iterator over nodes of the hugr and their data."""
+        for idx, data in enumerate(self._nodes):
+            if data is not None:
+                yield Node(idx, data._num_outs), data
 
     def children(self, node: ToNode | None = None) -> list[Node]:
         """The child nodes of a given `node`.

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -19,6 +19,8 @@ def test_stable_indices():
 
     nodes = [h.add_node(Not) for _ in range(3)]
     assert len(h) == 4
+    assert list(iter(h)) == [Node(i) for i in range(4)]
+    assert all(data is not None for node, data in h.nodes())
 
     h.add_link(nodes[0].out(0), nodes[1].inp(0))
     assert h.children() == nodes
@@ -47,6 +49,8 @@ def test_stable_indices():
 
     assert len(h) == 4
     assert h._free_nodes == []
+    assert list(iter(h)) == [Node(i) for i in range(4)]
+    assert all(data is not None for node, data in h.nodes())
 
 
 def simple_id() -> Dfg:


### PR DESCRIPTION
`Hugr` is a `Mapping[Node, NodeData]`, so its `__iter__` should return a list of `Node`s, but it was returning a list of node data with `None` holes