### PR TITLE
docs: update spec for Row Variables and no-input-extensions

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -869,6 +869,25 @@ a valid type as long as the TypeArgs match the declared TypeParams, which can be
 (Note that within a polymorphic type scheme, type variables of kind `Sequence` or `Opaque` will only be usable
 as arguments to Opaque types---see [Extension System](#extension-system).)
 
+#### Row Variables
+
+Type variables of kind `TypeParam::List(TypeParam::Type(_))` are known as
+"row variables" and along with type parameters of the same kinds are given special
+treatment, as follows:
+* A `TypeParam` of such kind may be instantiated with not just a `TypeArg::List`
+  but also a single `TypeArg::Type`. (This is purely a notational convenience.)
+  For example, `Type::Function(usize, unit, <exts>)` is equivalent shorthand
+  for `Type::Function(#(usize), #(unit), <exts>)`.
+* When a `TypeArg::Sequence` is provided as argument for such a TypeParam, we allow
+  the elements of the Sequence to be not just types (including variables of kind
+  `TypeParam::Type(_)`), but also row variables. These are implicitly spliced in
+  (appending with other elements).
+
+For example, a polymorphic FuncDefn might declare a row variable X of kind
+`TypeParam::List(TypeParam::Type(Copyable))` and have as output a (tuple) type
+`Sum([#(X, usize)])`. A call that instantiates said type-parameter with
+`TypeArg::Sequence([usize, unit])` would then have output `Sum([#(usize, unit, usize)])`.
+
 ### Extension Tracking
 
 The type of `Function` includes a set of [extensions](#extension-system) which are required to execute the graph.

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -889,6 +889,8 @@ For example, a polymorphic FuncDefn might declare a row variable X of kind
 `Sum([#(X, usize)])`. A call that instantiates said type-parameter with
 `TypeArg::Sequence([usize, unit])` would then have output `Sum([#(usize, unit, usize)])`.
 
+See [Declarative Format](#declarative-format) for more examples.
+
 Note that since a row variable does not have kind Type, it cannot be used as the type of an edge.
 
 ### Extension Tracking
@@ -1170,6 +1172,14 @@ extensions:
     # outputs would be, in principle: Array<i+j>(t)
     # - but default type scheme interpreter does not support such addition
     # Hence, no signature block => will look up a compute_signature in registry.
+  - name: TupleConcat
+    description: "Concatenate two tuples"
+    params:
+      a: List[Type]
+      b: List[Type]
+    signature:
+      inputs: Sum([a]), Sum([b])
+      outputs: Sum([(a,b)]) # Syntax! Sum([a,b]) would be either-a-or-b, this has one variant
   - name: GraphOp
     description: "Involves running an argument Graph. E.g. run it some variable number of times."
     params:

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -976,7 +976,7 @@ tooling. These operations cover various flavours:
 
 - Instruction sets specific to a target.
 - Operations that are best expressed in some other format that can be
-  compiled in to a graph (e.g. ZX).
+  compiled into a graph (e.g. ZX).
 - Ephemeral operations used by specific compiler passes.
 
 A nice-to-have for this extensibility is a human-friendly format for

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -850,11 +850,11 @@ TypeArgs appropriate for the function's TypeParams:
 
 ```haskell
 TypeArg ::= Type(Type) -- could be a variable of kind Type, or contain variable(s)
-          | Extensions(Extensions) -- may contain TypeArg's of kind Extensions
-          | Variable -- refers to an enclosing TypeParam (binder) of any kind below
           | BoundedUSize(u64)
+          | Extensions(Extensions) -- may contain TypeArg's of kind Extensions
           | Sequence([TypeArg]) -- fits either a List or Tuple TypeParam
           | Opaque(Value)
+          | Variable -- refers to an enclosing TypeParam (binder) of any kind above
 ```
 
 For example, a Function node declaring a `TypeParam::Opaque("Array", [5, TypeArg::Type(Type::Opaque("usize"))])`

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -813,7 +813,7 @@ Extensions ::= (Extension)* -- a set, not a list
 Type ::= Sum([#]) -- disjoint union of rows of other types, tagged by unsigned int
        | Opaque(Name, [TypeArg]) -- a (instantiation of a) custom type defined by an extension
        | Function(#, #, Extensions) -- monomorphic function: arguments, results, and delta (see below)
-       | Variable -- refers to a TypeParam bound by the nearest enclosing FuncDefn node, or an enclosing Function Type
+       | Variable -- refers to a TypeParam bound by an the nearest enclosing FuncDefn node or polymorphic type scheme
 ```
 
 (We write `[Foo]` to indicate a list of Foo's.)

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -879,14 +879,17 @@ treatment, as follows:
   For example, `Type::Function(usize, unit, <exts>)` is equivalent shorthand
   for `Type::Function(#(usize), #(unit), <exts>)`.
 * When a `TypeArg::Sequence` is provided as argument for such a TypeParam, we allow
-  the elements of the Sequence to be not just types (including variables of kind
-  `TypeParam::Type(_)`), but also row variables. These are implicitly spliced in
-  (appending with other elements).
+  elements to be a mixture of both types (including variables of kind
+  `TypeParam::Type(_)`) and also row variables. When such variables are instantiated
+  (with other Sequences) the elements of the inner Sequence are spliced directly into
+  the outer (concatenating their elements), eliding the inner (Sequence) wrapper.
 
 For example, a polymorphic FuncDefn might declare a row variable X of kind
 `TypeParam::List(TypeParam::Type(Copyable))` and have as output a (tuple) type
 `Sum([#(X, usize)])`. A call that instantiates said type-parameter with
 `TypeArg::Sequence([usize, unit])` would then have output `Sum([#(usize, unit, usize)])`.
+
+Note that since a row variable does not have kind Type, it cannot be used as the type of an edge.
 
 ### Extension Tracking
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -791,15 +791,16 @@ There are two classes of type: `AnyType` $\supset$ `CopyableType`. Types in thes
 classes are distinguished by whether the runtime values of those types can be implicitly
 copied or discarded (multiple or 0 links from on output port respectively):
 
-- For the broadest class (`AnyType`), the only operation supported is the identity operation (aka no-op, or `lift` - see [Extension Tracking](#extension-tracking) below). Specifically, we do not require it to be possible to copy or discard all values, hence the requirement that outports of linear type must have exactly one edge. (That is, a type not known to be in the copyable subset). All incoming ports must have exactly one edge.
+- For the broadest class (`AnyType`), the only operation supported is the identity operation (aka no-op, or `lift` - see [Extension Tracking](#extension-tracking) below). Specifically, we do not require it to be possible to copy or discard all values, hence the requirement that outports of linear type must have exactly one edge. (That is, a type not known to be in the copyable subset).
 
     In fully qubit-counted contexts programs take in a number of qubits as input and return the same number, with no discarding.
 
 - The smaller class is `CopyableType`, i.e. types holding ordinary classical
   data, where values can be copied (and discarded, the 0-ary copy). This
   allows multiple (or 0) outgoing edges from an outport; also these types can
-  be sent down `Const` edges. Note: dataflow inputs (`Value`, `Const` and `Function`) always
-  require a single connection.
+  be sent down `Const` edges.
+
+Note that all dataflow inputs (`Value`, `Const` and `Function`) always require a single connection, regardless of whether the type is `AnyType` or `Copyable`.
 
 **Rows** The `#` is a *row* which is a sequence of zero or more types. Types in the row can optionally be given names in metadata i.e. this does not affect behaviour of the HUGR. When writing literal types, we use `#` to distinguish between tuples and rows, e.g. `(int<1>,int<2>)` is a tuple while `Sum(#(int<1>),#(int<2>))` contains two rows.
 


### PR DESCRIPTION
Also some driveby updates e.g. missed in #906.
Closes #1097, #745.