### PR TITLE
feat(py): Parametric int type helper, and arbitrary width int constants

### DIFF
--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar
 
 from typing_extensions import Self
@@ -73,9 +73,10 @@ class IntVal(val.ExtensionValue):
     """Custom value for an integer."""
 
     v: int
+    width: int = field(default=5)
 
     def to_value(self) -> val.Extension:
-        return val.Extension("int", INT_T, self.v)
+        return val.Extension("int", int_t(self.width), self.v)
 
 
 OPS_EXTENSION: tys.ExtensionId = "arithmetic.int"

--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -36,34 +36,6 @@ def int_t(width: int) -> tys.Opaque:
     )
 
 
-# The exclusive bound for the integer type width.
-# Integer widths are in the closed range [0, LOG_WIDTH_BOUND-1].
-LOG_WIDTH_BOUND = 7
-
-
-def int_tv(var_id: int) -> tys.Opaque:
-    """Create an integer type with a parametric log bit width.
-
-
-    Args:
-        var_id: The id of the type argument. It must correspond to a `BoundedNatArg`.
-
-    Returns:
-        The integer type.
-
-    Examples:
-        >>> int_tv(0).id
-        'int'
-    """
-    return tys.Opaque(
-        extension="arithmetic.int.types",
-        id="int",
-        # param is a `TypeParam`
-        args=[tys.VariableArg(idx=var_id, param=tys.BoundedNatParam(LOG_WIDTH_BOUND))],
-        bound=tys.TypeBound.Copyable,
-    )
-
-
 #: HUGR 32-bit integer type.
 INT_T = int_t(5)
 

--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 def int_t(width: int) -> tys.Opaque:
-    """Create an integer type with a given log bit width.
+    """Create an integer type with a fixed log bit width.
 
 
     Args:
@@ -32,6 +32,34 @@ def int_t(width: int) -> tys.Opaque:
         extension="arithmetic.int.types",
         id="int",
         args=[tys.BoundedNatArg(n=width)],
+        bound=tys.TypeBound.Copyable,
+    )
+
+
+# The exclusive bound for the integer type width.
+# Integer widths are in the closed range [0, LOG_WIDTH_BOUND-1].
+LOG_WIDTH_BOUND = 7
+
+
+def int_tv(var_id: int) -> tys.Opaque:
+    """Create an integer type with a parametric log bit width.
+
+
+    Args:
+        var_id: The id of the type argument. It must correspond to a `BoundedNatArg`.
+
+    Returns:
+        The integer type.
+
+    Examples:
+        >>> int_tv(0).id
+        'int'
+    """
+    return tys.Opaque(
+        extension="arithmetic.int.types",
+        id="int",
+        # param is a `TypeParam`
+        args=[tys.VariableArg(idx=var_id, param=tys.BoundedNatParam(LOG_WIDTH_BOUND))],
         bound=tys.TypeBound.Copyable,
     )
 


### PR DESCRIPTION
- Adds an `int_tv` method to create parametric integer types
- Adds a `width` member to `IntVal`, so we can define constants for other integer widths