### PR TITLE
docs(hugr-py): expand toctree

### DIFF
--- a/hugr-py/docs/api-docs/conf.py
+++ b/hugr-py/docs/api-docs/conf.py
@@ -27,6 +27,7 @@ html_theme_options = {
         "image_light": "_static/Quantinuum_logo_black.png",
         "image_dark": "_static/Quantinuum_logo_white.png",
     },
+    "show_navbar_depth": 2,
 }
 
 html_static_path = ["../_static"]


### PR DESCRIPTION
now looks like: 
<img width="304" alt="image" src="https://github.com/user-attachments/assets/ed030671-e933-48b0-bdf9-1ace4b601f75">
