### PR TITLE
fix(py): Set output cont for Conditionals

### DIFF
--- a/hugr-py/src/hugr/cond_loop.py
+++ b/hugr-py/src/hugr/cond_loop.py
@@ -158,6 +158,9 @@ class Conditional(ParentBuilder[ops.Conditional], AbstractContextManager):
     def _update_outputs(self, outputs: TypeRow) -> None:
         if self.parent_op._outputs is None:
             self.parent_op._outputs = outputs
+            self.parent_node = self.hugr._update_node_outs(
+                self.parent_node, len(outputs)
+            )
         else:
             if outputs != self.parent_op._outputs:
                 msg = "Mismatched case outputs."

--- a/hugr-py/src/hugr/node_port.py
+++ b/hugr-py/src/hugr/node_port.py
@@ -164,7 +164,10 @@ class Node(ToNode):
                 start = index.start or 0
                 stop = index.stop or self._num_out_ports
                 if stop is None:
-                    msg = "Stop must be specified when number of outputs unknown"
+                    msg = (
+                        f"{self} does not have a fixed number of output ports. "
+                        "Iterating over all output ports is not supported."
+                    )
                     raise ValueError(msg)
                 step = index.step or 1
                 return (self[i] for i in range(start, stop, step))


### PR DESCRIPTION
Missed this in #1400

drive-by: Improve the error message when a node does not have the output count set.