### PR TITLE
feat: Improve error message on failed custom op validation

### DIFF
--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -742,8 +742,12 @@ pub enum ValidationError {
     #[error("Node {node:?} needs a concrete ExtensionSet - inference will provide this for Case/CFG/Conditional/DataflowBlock/DFG/TailLoop only")]
     ExtensionsNotInferred { node: Node },
     /// Error in a node signature
-    #[error("Error in signature of node {node:?}: {cause}")]
-    SignatureError { node: Node, cause: SignatureError },
+    #[error("Error in signature of node {node}: {cause}")]
+    SignatureError {
+        node: Node,
+        #[source]
+        cause: SignatureError,
+    },
     /// Error in a [CustomOp] serialized as an [Opaque].
     ///
     /// [CustomOp]: crate::ops::CustomOp


### PR DESCRIPTION
Prints the node and operation in the error message.

Before:
```console
$ hugr validate test.hugr
Error validating HUGR: Type arguments of node did not match params declared by definition: Wrong number of type arguments: 1 vs expected 0 declared type parameters
```

After:
```console
$ hugr validate test.hugr
Error validating HUGR: Error in signature of operation 'Not' in Node(27): Type arguments of node did not match params declared by definition: Wrong number of type arguments: 1 vs expected 0 declared type parameters
```