### PR TITLE
fix(py): Invalid serialization of float and int constants

### DIFF
--- a/hugr-py/src/hugr/serialization/ops.py
+++ b/hugr-py/src/hugr/serialization/ops.py
@@ -112,7 +112,12 @@ class ExtensionValue(BaseValue):
     value: CustomConst
 
     def deserialize(self) -> val.Value:
-        return val.Extension(self.value.c, self.typ.deserialize(), self.value.v)
+        return val.Extension(
+            name=self.value.c,
+            typ=self.typ.deserialize(),
+            val=self.value.v,
+            extensions=self.extensions,
+        )
 
 
 class FunctionValue(BaseValue):

--- a/hugr-py/src/hugr/std/float.py
+++ b/hugr-py/src/hugr/std/float.py
@@ -27,4 +27,8 @@ class FloatVal(val.ExtensionValue):
     v: float
 
     def to_value(self) -> val.Extension:
-        return val.Extension("float", FLOAT_T, self.v)
+        name = "ConstF64"
+        payload = {"value": self.v}
+        return val.Extension(
+            name, typ=FLOAT_T, val=payload, extensions=[EXTENSION.name]
+        )

--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -62,7 +62,14 @@ class IntVal(val.ExtensionValue):
     width: int = field(default=5)
 
     def to_value(self) -> val.Extension:
-        return val.Extension("int", int_t(self.width), self.v)
+        name = "ConstInt"
+        payload = {"log_width": self.width, "value": self.v}
+        return val.Extension(
+            name,
+            typ=int_t(self.width),
+            val=payload,
+            extensions=[INT_TYPES_EXTENSION.name],
+        )
 
 
 INT_OPS_EXTENSION = ext.Extension("arithmetic.int", ext.Version(0, 1, 0))

--- a/hugr-py/tests/conftest.py
+++ b/hugr-py/tests/conftest.py
@@ -136,8 +136,10 @@ def validate(h: Hugr, roundtrip: bool = True):
     _run_hugr_cmd(serial, cmd)
 
     if roundtrip:
-        h2 = Hugr.from_serial(SerialHugr.load_json(json.loads(serial)))
-        assert serial == h2.to_serial().to_json()
+        starting_json = json.loads(serial)
+        h2 = Hugr.from_serial(SerialHugr.load_json(starting_json))
+        roundtrip_json = json.loads(h2.to_serial().to_json())
+        assert roundtrip_json == starting_json
 
 
 def _run_hugr_cmd(serial: str, cmd: list[str]):

--- a/hugr-py/tests/test_cfg.py
+++ b/hugr-py/tests/test_cfg.py
@@ -68,7 +68,7 @@ def test_dom_edge() -> None:
 
 
 def test_asymm_types() -> None:
-    # test different types going to entry block's susccessors
+    # test different types going to entry block's successors
     with Cfg() as cfg:
         with cfg.add_entry() as entry:
             int_load = entry.load(IntVal(34))


### PR DESCRIPTION
Fixes #1424 

I updated the roundtrip validation to compare decoded jsons rather than strings.

The values were manually compared against a rust serialization output. We cannot do better without python-side extension loading.