### PR TITLE
feat(py): Add node metadata

### DIFF
--- a/hugr-py/src/hugr/function.py
+++ b/hugr-py/src/hugr/function.py
@@ -57,3 +57,8 @@ class Module(_DefinitionBuilder[ops.Module]):
     def add_alias_decl(self, name: str, bound: TypeBound) -> Node:
         """Add a type alias declaration."""
         return self.hugr.add_node(ops.AliasDecl(name, bound), self.hugr.root)
+
+    @property
+    def metadata(self) -> dict[str, object]:
+        """Metadata associated with this module."""
+        return self.hugr.root.metadata

--- a/hugr-py/src/hugr/node_port.py
+++ b/hugr-py/src/hugr/node_port.py
@@ -141,6 +141,11 @@ class ToNode(Wire, Protocol):
         else:
             return self.out(offset)
 
+    @property
+    def metadata(self) -> dict[str, object]:
+        """Metadata associated with this node."""
+        return self.to_node()._metadata
+
 
 @dataclass(frozen=True, eq=True, order=True)
 class Node(ToNode):
@@ -149,7 +154,10 @@ class Node(ToNode):
     """
 
     idx: NodeIdx
-    _num_out_ports: int | None = field(default=None, compare=False)
+    _metadata: dict[str, object] = field(
+        repr=False, compare=False, default_factory=dict
+    )
+    _num_out_ports: int | None = field(default=None, compare=False, repr=False)
 
     def _index(
         self, index: PortOffset | slice | tuple[PortOffset, ...]

--- a/hugr-py/src/hugr/tracked_dfg.py
+++ b/hugr-py/src/hugr/tracked_dfg.py
@@ -1,6 +1,7 @@
 """Dfg builder that allows tracking a set of wires and appending operations by index."""
 
 from collections.abc import Iterable
+from typing import Any
 
 from hugr import tys
 from hugr.dfg import Dfg
@@ -123,7 +124,7 @@ class TrackedDfg(Dfg):
             raise IndexError(msg)
         return tracked
 
-    def add(self, com: Command) -> Node:
+    def add(self, com: Command, *, metadata: dict[str, Any] | None = None) -> Node:
         """Add a command to the DFG.
 
         Overrides :meth:`Dfg.add <hugr.dfg.Dfg.add>` to allow Command inputs
@@ -138,6 +139,7 @@ class TrackedDfg(Dfg):
 
         Args:
             com: Command to append.
+            metadata: Metadata to attach to the function definition. Defaults to None.
 
         Returns:
             The new node.

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -69,14 +69,15 @@ def test_simple_id():
     validate(simple_id().hugr)
 
 
-def test_json_roundtrip():
-    hugr = simple_id().hugr
-    json = hugr.to_json()
+def test_metadata():
+    h = Dfg(tys.Bool)
+    h.metadata["name"] = "simple_id"
 
-    hugr2 = Hugr.load_json(json)
-    json2 = hugr2.to_json()
+    (b,) = h.inputs()
+    b = h.add_op(Not, b, metadata={"name": "not"})
 
-    assert json2 == json
+    h.set_outputs(b)
+    validate(h.hugr)
 
 
 def test_multiport():


### PR DESCRIPTION
Adds a dictionary with metadata to the nodes.
`ToNode` now has a `metadata` property, so we can use
```python
d = Dfg(...)
d.metadata["key"] = 42

n = d.hugr.add_node(..., metadata={"something": "value"})
assert n.metadata["something"] == "value"
```

I chosed not to add a `metadata` argument to all the `add_{container}` methods in DfgBase to avoid cluttering the API.

Closes #1319 