### PR TITLE
refactor!: flatten `CustomOp` in to `OpType`

### DIFF
--- a/hugr-core/src/builder/circuit.rs
+++ b/hugr-core/src/builder/circuit.rs
@@ -253,7 +253,7 @@ mod test {
             DataflowSubContainer,
         },
         extension::prelude::BOOL_T,
-        ops::{custom::OpaqueOp, CustomOp},
+        ops::custom::OpaqueOp,
         type_row,
         types::Signature,
     };
@@ -297,13 +297,13 @@ mod test {
     #[test]
     fn with_nonlinear_and_outputs() {
         let missing_ext: ExtensionId = "MissingExt".try_into().unwrap();
-        let my_custom_op = CustomOp::new_opaque(OpaqueOp::new(
+        let my_custom_op = OpaqueOp::new(
             missing_ext.clone(),
             "MyOp",
             "unknown op".to_string(),
             vec![],
             Signature::new(vec![QB, NAT], vec![QB]),
-        ));
+        );
         let build_res = build_main(
             Signature::new(type_row![QB, QB, NAT], type_row![QB, QB, BOOL_T])
                 .with_extension_delta(ExtensionSet::from_iter([

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -234,7 +234,7 @@ impl CustomConcrete for OpaqueOp {
     type Identifier = OpName;
 
     fn def_name(&self) -> &OpName {
-        self.name()
+        self.op_name()
     }
 
     fn type_args(&self) -> &[TypeArg] {

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -276,10 +276,10 @@ pub enum LowerFunc {
     FixedHugr {
         /// The extensions required by the [`Hugr`]
         extensions: ExtensionSet,
-        /// The [`Hugr`] to be used to replace [CustomOp]s matching the parent
+        /// The [`Hugr`] to be used to replace [ExtensionOp]s matching the parent
         /// [OpDef]
         ///
-        /// [CustomOp]: crate::ops::CustomOp
+        /// [ExtensionOp]: crate::ops::ExtensionOp
         hugr: Hugr,
     },
     /// Custom binary function that can (fallibly) compute a Hugr

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -495,7 +495,7 @@ pub(super) mod test {
     use crate::extension::prelude::USIZE_T;
     use crate::extension::{ExtensionRegistry, ExtensionSet, PRELUDE};
     use crate::extension::{SignatureError, EMPTY_REG, PRELUDE_REGISTRY};
-    use crate::ops::{CustomOp, OpName};
+    use crate::ops::OpName;
     use crate::std_extensions::collections::{EXTENSION, LIST_TYPENAME};
     use crate::types::type_param::{TypeArgError, TypeParam};
     use crate::types::{PolyFuncTypeRV, Signature, Type, TypeArg, TypeBound, TypeRV};
@@ -615,10 +615,8 @@ pub(super) mod test {
             Type::new_extension(list_def.instantiate(vec![TypeArg::Type { ty: USIZE_T }])?);
         let mut dfg = DFGBuilder::new(endo_sig(vec![list_usize]))?;
         let rev = dfg.add_dataflow_op(
-            CustomOp::new_extension(
-                e.instantiate_extension_op(&OP_NAME, vec![TypeArg::Type { ty: USIZE_T }], &reg)
-                    .unwrap(),
-            ),
+            e.instantiate_extension_op(&OP_NAME, vec![TypeArg::Type { ty: USIZE_T }], &reg)
+                .unwrap(),
             dfg.input_wires(),
         )?;
         dfg.finish_hugr_with_outputs(rev.outputs(), &reg)?;

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -211,7 +211,6 @@ pub fn new_array_op(element_ty: Type, size: u64) -> CustomOp {
             &PRELUDE_REGISTRY,
         )
         .unwrap()
-        .into()
 }
 
 /// Name of the string type.

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -3,7 +3,7 @@
 use lazy_static::lazy_static;
 
 use crate::ops::constant::{CustomCheckFailure, ValueName};
-use crate::ops::{CustomOp, OpName};
+use crate::ops::{ExtensionOp, OpName};
 use crate::types::{FuncValueType, SumType, TypeName};
 use crate::{
     extension::{ExtensionId, TypeDefBound},
@@ -200,7 +200,7 @@ pub const NEW_ARRAY_OP_ID: OpName = OpName::new_inline("new_array");
 pub const PANIC_OP_ID: OpName = OpName::new_inline("panic");
 
 /// Initialize a new array op of element type `element_ty` of length `size`
-pub fn new_array_op(element_ty: Type, size: u64) -> CustomOp {
+pub fn new_array_op(element_ty: Type, size: u64) -> ExtensionOp {
     PRELUDE
         .instantiate_extension_op(
             &NEW_ARRAY_OP_ID,

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -91,10 +91,7 @@ pub trait MakeOpDef: NamedOp {
     where
         Self: Sized + std::str::FromStr,
     {
-        match custom_op {
-            CustomOp::Extension(ext) => Self::from_extension_op(ext),
-            CustomOp::Opaque(opaque) => try_from_name(opaque.name(), opaque.extension()),
-        }
+        Self::from_extension_op(custom_op)
     }
 }
 
@@ -117,10 +114,7 @@ pub trait HasDef: MakeExtensionOp {
     where
         Self: Sized,
     {
-        match custom_op {
-            CustomOp::Extension(ext) => Self::from_extension_op(ext),
-            CustomOp::Opaque(opaque) => Self::Def::from_op(custom_op)?.instantiate(opaque.args()),
-        }
+        Self::from_extension_op(custom_op)
     }
 }
 
@@ -137,7 +131,7 @@ pub trait MakeExtensionOp: NamedOp {
     where
         Self: Sized,
     {
-        let ext: &ExtensionOp = op.as_custom_op()?.as_extension_op()?;
+        let ext: &ExtensionOp = op.as_custom_op()?;
         Self::from_extension_op(ext).ok()
     }
 

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -2,9 +2,9 @@
 
 use strum::IntoEnumIterator;
 
-use crate::ops::{CustomOp, OpName, OpNameRef};
+use crate::ops::{ExtensionOp, OpName, OpNameRef};
 use crate::{
-    ops::{custom::ExtensionOp, NamedOp, OpType},
+    ops::{NamedOp, OpType},
     types::TypeArg,
     Extension,
 };
@@ -87,11 +87,11 @@ pub trait MakeOpDef: NamedOp {
     }
 
     /// If the definition can be loaded from a string, load from an [ExtensionOp].
-    fn from_op(custom_op: &CustomOp) -> Result<Self, OpLoadError>
+    fn from_op(ext_op: &ExtensionOp) -> Result<Self, OpLoadError>
     where
         Self: Sized + std::str::FromStr,
     {
-        Self::from_extension_op(custom_op)
+        Self::from_extension_op(ext_op)
     }
 }
 
@@ -109,12 +109,12 @@ pub trait HasDef: MakeExtensionOp {
     /// Associated [HasConcrete] type.
     type Def: HasConcrete<Concrete = Self> + std::str::FromStr;
 
-    /// Load the operation from a [CustomOp].
-    fn from_op(custom_op: &CustomOp) -> Result<Self, OpLoadError>
+    /// Load the operation from a [ExtensionOp].
+    fn from_op(ext_op: &ExtensionOp) -> Result<Self, OpLoadError>
     where
         Self: Sized,
     {
-        Self::from_extension_op(custom_op)
+        Self::from_extension_op(ext_op)
     }
 }
 
@@ -131,7 +131,7 @@ pub trait MakeExtensionOp: NamedOp {
     where
         Self: Sized,
     {
-        let ext: &ExtensionOp = op.as_custom_op()?;
+        let ext: &ExtensionOp = op.as_extension_op()?;
         Self::from_extension_op(ext).ok()
     }
 

--- a/hugr-core/src/hugr/rewrite/inline_dfg.rs
+++ b/hugr-core/src/hugr/rewrite/inline_dfg.rs
@@ -159,7 +159,7 @@ mod test {
     }
     fn extension_ops(h: &impl HugrView) -> Vec<Node> {
         h.nodes()
-            .filter(|n| matches!(h.get_optype(*n), OpType::CustomOp(_)))
+            .filter(|n| matches!(h.get_optype(*n), OpType::ExtensionOp(_)))
             .collect()
     }
 

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -479,12 +479,10 @@ mod test {
         );
         let pop: CustomOp = collections::EXTENSION
             .instantiate_extension_op("pop", [TypeArg::Type { ty: USIZE_T }], &reg)
-            .unwrap()
-            .into();
+            .unwrap();
         let push: CustomOp = collections::EXTENSION
             .instantiate_extension_op("push", [TypeArg::Type { ty: USIZE_T }], &reg)
-            .unwrap()
-            .into();
+            .unwrap();
         let just_list = TypeRow::from(vec![listy.clone()]);
         let intermed = TypeRow::from(vec![listy.clone(), USIZE_T]);
 
@@ -643,15 +641,7 @@ mod test {
     fn test_invalid() {
         let unknown_ext: ExtensionId = "unknown_ext".try_into().unwrap();
         let utou = Signature::new_endo(vec![USIZE_T]);
-        let mk_op = |s| {
-            CustomOp::new_opaque(OpaqueOp::new(
-                unknown_ext.clone(),
-                s,
-                String::new(),
-                vec![],
-                utou.clone(),
-            ))
-        };
+        let mk_op = |s| OpaqueOp::new(unknown_ext.clone(), s, String::new(), vec![], utou.clone());
         let mut h = DFGBuilder::new(
             Signature::new(type_row![USIZE_T, BOOL_T], type_row![USIZE_T])
                 .with_extension_delta(unknown_ext.clone()),

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -454,7 +454,7 @@ mod test {
     use crate::hugr::internal::HugrMutInternals;
     use crate::hugr::rewrite::replace::WhichHugr;
     use crate::hugr::{HugrMut, Rewrite};
-    use crate::ops::custom::{CustomOp, OpaqueOp};
+    use crate::ops::custom::{ExtensionOp, OpaqueOp};
     use crate::ops::dataflow::DataflowOpTrait;
     use crate::ops::handle::{BasicBlockID, ConstID, NodeHandle};
     use crate::ops::{self, Case, DataflowBlock, OpTag, OpType, DFG};
@@ -477,10 +477,10 @@ mod test {
                 .instantiate([TypeArg::Type { ty: USIZE_T }])
                 .unwrap(),
         );
-        let pop: CustomOp = collections::EXTENSION
+        let pop: ExtensionOp = collections::EXTENSION
             .instantiate_extension_op("pop", [TypeArg::Type { ty: USIZE_T }], &reg)
             .unwrap();
-        let push: CustomOp = collections::EXTENSION
+        let push: ExtensionOp = collections::EXTENSION
             .instantiate_extension_op("push", [TypeArg::Type { ty: USIZE_T }], &reg)
             .unwrap();
         let just_list = TypeRow::from(vec![listy.clone()]);

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -203,8 +203,8 @@ pub fn check_hugr(lhs: &Hugr, rhs: &Hugr) {
         let old_op = h_canon.get_optype(node);
         if !new_op.is_const() {
             match (new_op, old_op) {
-                (OpType::CustomOp(ext), OpType::OpaqueOp(opaque))
-                | (OpType::OpaqueOp(opaque), OpType::CustomOp(ext)) => {
+                (OpType::ExtensionOp(ext), OpType::OpaqueOp(opaque))
+                | (OpType::OpaqueOp(opaque), OpType::ExtensionOp(ext)) => {
                     let ext_opaque: OpaqueOp = ext.clone().into();
                     assert_eq!(ext_opaque, opaque.clone());
                 }
@@ -553,7 +553,7 @@ mod proptest {
                 any::<OpType>(),
             )
                 .prop_map(|(parent, op)| {
-                    if let OpType::CustomOp(ext_op) = op {
+                    if let OpType::ExtensionOp(ext_op) = op {
                         let opaque: OpaqueOp = ext_op.into();
                         NodeSer {
                             parent,

--- a/hugr-core/src/hugr/serialize/upgrade/testcases/hugr_with_named_op.json
+++ b/hugr-core/src/hugr/serialize/upgrade/testcases/hugr_with_named_op.json
@@ -56,7 +56,7 @@
     },
     {
       "parent": 0,
-      "op": "OpaqueOp",
+      "op": "Extension",
       "extension": "logic",
       "name": "And",
       "description": "logical 'and'",

--- a/hugr-core/src/hugr/serialize/upgrade/testcases/hugr_with_named_op.json
+++ b/hugr-core/src/hugr/serialize/upgrade/testcases/hugr_with_named_op.json
@@ -56,7 +56,7 @@
     },
     {
       "parent": 0,
-      "op": "CustomOp",
+      "op": "OpaqueOp",
       "extension": "logic",
       "name": "And",
       "description": "logical 'and'",

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -578,7 +578,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
         match op_type {
             OpType::ExtensionOp(ext_op) => validate_ext(ext_op)?,
             OpType::OpaqueOp(opaque) => {
-                // ry to resolve serialized names to actual OpDefs in Extensions.
+                // Try to resolve serialized names to actual OpDefs in Extensions.
                 if let Some(ext_op) = resolve_opaque_op(node, opaque, self.extension_registry)? {
                     validate_ext(&ext_op)?;
                 } else {

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use crate::extension::{ExtensionRegistry, SignatureError, TO_BE_INFERRED};
 
 use crate::ops::constant::ConstTypeError;
-use crate::ops::custom::{resolve_opaque_op, CustomOp, CustomOpError};
+use crate::ops::custom::{resolve_opaque_op, CustomOpError, ExtensionOp};
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::{FuncDefn, OpParent, OpTag, OpTrait, OpType, ValidateOp};
 use crate::types::type_param::TypeParam;
@@ -567,36 +567,26 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
         let op_type = self.hugr.get_optype(node);
         // The op_type must be defined only in terms of type variables defined outside the node
         // TODO consider turning this match into a trait method?
+
+        let validate_ext = |ext_op: &ExtensionOp| -> Result<(), ValidationError> {
+            // Check TypeArgs are valid, and if we can, fit the declared TypeParams
+            ext_op
+                .def()
+                .validate_args(ext_op.args(), self.extension_registry, var_decls)
+                .map_err(|cause| ValidationError::SignatureError { node, cause })
+        };
         match op_type {
-            OpType::CustomOp(op) => {
-                // Try to resolve serialized names to actual OpDefs in Extensions.
-                let temp: CustomOp;
-                let resolved = match op {
-                    CustomOp::Opaque(opaque) => {
-                        // If resolve_extension_ops has been called first, this would always return Ok(None)
-                        match resolve_opaque_op(node, opaque, self.extension_registry)? {
-                            Some(exten) => {
-                                temp = CustomOp::new_extension(exten);
-                                &temp
-                            }
-                            None => op,
-                        }
-                    }
-                    CustomOp::Extension(_) => op,
-                };
-                // Check TypeArgs are valid, and if we can, fit the declared TypeParams
-                match resolved {
-                    CustomOp::Extension(exten) => exten
-                        .def()
-                        .validate_args(exten.args(), self.extension_registry, var_decls)
-                        .map_err(|cause| ValidationError::SignatureError { node, cause })?,
-                    CustomOp::Opaque(opaque) => {
-                        // Best effort. Just check TypeArgs are valid in themselves, allowing any of them
-                        // to contain type vars (we don't know how many are binary params, so accept if in doubt)
-                        for arg in opaque.args() {
-                            arg.validate(self.extension_registry, var_decls)
-                                .map_err(|cause| ValidationError::SignatureError { node, cause })?;
-                        }
+            OpType::CustomOp(ext_op) => validate_ext(ext_op)?,
+            OpType::OpaqueOp(opaque) => {
+                // ry to resolve serialized names to actual OpDefs in Extensions.
+                if let Some(ext_op) = resolve_opaque_op(node, opaque, self.extension_registry)? {
+                    validate_ext(&ext_op)?;
+                } else {
+                    // Best effort. Just check TypeArgs are valid in themselves, allowing any of them
+                    // to contain type vars (we don't know how many are binary params, so accept if in doubt)
+                    for arg in opaque.args() {
+                        arg.validate(self.extension_registry, var_decls)
+                            .map_err(|cause| ValidationError::SignatureError { node, cause })?;
                     }
                 }
             }
@@ -751,7 +741,7 @@ pub enum ValidationError {
     /// Error in a [CustomOp] serialized as an [Opaque].
     ///
     /// [CustomOp]: crate::ops::CustomOp
-    /// [Opaque]: crate::ops::CustomOp::Opaque
+    /// [Opaque]: crate::ops::OpaqueOp
     #[error(transparent)]
     CustomOpError(#[from] CustomOpError),
     /// A [Const] contained a [Value] of unexpected [Type].

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use crate::extension::{ExtensionRegistry, SignatureError, TO_BE_INFERRED};
 
 use crate::ops::constant::ConstTypeError;
-use crate::ops::custom::{resolve_opaque_op, CustomOpError, ExtensionOp};
+use crate::ops::custom::{resolve_opaque_op, ExtensionOp, OpaqueOpError};
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::{FuncDefn, OpParent, OpTag, OpTrait, OpType, ValidateOp};
 use crate::types::type_param::TypeParam;
@@ -576,7 +576,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
                 .map_err(|cause| ValidationError::SignatureError { node, cause })
         };
         match op_type {
-            OpType::CustomOp(ext_op) => validate_ext(ext_op)?,
+            OpType::ExtensionOp(ext_op) => validate_ext(ext_op)?,
             OpType::OpaqueOp(opaque) => {
                 // ry to resolve serialized names to actual OpDefs in Extensions.
                 if let Some(ext_op) = resolve_opaque_op(node, opaque, self.extension_registry)? {
@@ -738,12 +738,12 @@ pub enum ValidationError {
         #[source]
         cause: SignatureError,
     },
-    /// Error in a [CustomOp] serialized as an [Opaque].
+    /// Error in a [ExtensionOp] serialized as an [Opaque].
     ///
-    /// [CustomOp]: crate::ops::CustomOp
+    /// [ExtensionOp]: crate::ops::ExtensionOp
     /// [Opaque]: crate::ops::OpaqueOp
     #[error(transparent)]
-    CustomOpError(#[from] CustomOpError),
+    OpaqueOpError(#[from] OpaqueOpError),
     /// A [Const] contained a [Value] of unexpected [Type].
     ///
     /// [Const]: crate::ops::Const

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -566,7 +566,6 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
     ) -> Result<(), ValidationError> {
         let op_type = self.hugr.get_optype(node);
         // The op_type must be defined only in terms of type variables defined outside the node
-        // TODO consider turning this match into a trait method?
 
         let validate_ext = |ext_op: &ExtensionOp| -> Result<(), ValidationError> {
             // Check TypeArgs are valid, and if we can, fit the declared TypeParams

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -21,7 +21,7 @@ use enum_dispatch::enum_dispatch;
 
 pub use constant::{Const, Value};
 pub use controlflow::{BasicBlock, Case, Conditional, DataflowBlock, ExitBlock, TailLoop, CFG};
-pub use custom::{CustomOp, OpaqueOp};
+pub use custom::{ExtensionOp, OpaqueOp};
 pub use dataflow::{
     Call, CallIndirect, DataflowOpTrait, DataflowParent, Input, LoadConstant, LoadFunction, Output,
     DFG,
@@ -53,8 +53,9 @@ pub enum OpType {
     LoadConstant,
     LoadFunction,
     DFG,
-    #[serde(skip_deserializing, rename = "OpaqueOp")]
-    CustomOp,
+    #[serde(skip_deserializing, rename = "Extension")]
+    ExtensionOp,
+    #[serde(rename = "Extension")]
     OpaqueOp,
     Noop,
     MakeTuple,
@@ -114,7 +115,7 @@ impl_op_ref_try_into!(CallIndirect);
 impl_op_ref_try_into!(LoadConstant);
 impl_op_ref_try_into!(LoadFunction);
 impl_op_ref_try_into!(DFG, dfg);
-impl_op_ref_try_into!(CustomOp);
+impl_op_ref_try_into!(ExtensionOp);
 impl_op_ref_try_into!(Noop);
 impl_op_ref_try_into!(MakeTuple);
 impl_op_ref_try_into!(UnpackTuple);
@@ -429,7 +430,7 @@ impl OpParent for Call {}
 impl OpParent for CallIndirect {}
 impl OpParent for LoadConstant {}
 impl OpParent for LoadFunction {}
-impl OpParent for CustomOp {}
+impl OpParent for ExtensionOp {}
 impl OpParent for OpaqueOp {}
 impl OpParent for Noop {}
 impl OpParent for MakeTuple {}

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -21,7 +21,7 @@ use enum_dispatch::enum_dispatch;
 
 pub use constant::{Const, Value};
 pub use controlflow::{BasicBlock, Case, Conditional, DataflowBlock, ExitBlock, TailLoop, CFG};
-pub use custom::CustomOp;
+pub use custom::{CustomOp, OpaqueOp};
 pub use dataflow::{
     Call, CallIndirect, DataflowOpTrait, DataflowParent, Input, LoadConstant, LoadFunction, Output,
     DFG,
@@ -53,7 +53,9 @@ pub enum OpType {
     LoadConstant,
     LoadFunction,
     DFG,
+    #[serde(skip_deserializing, rename = "OpaqueOp")]
     CustomOp,
+    OpaqueOp,
     Noop,
     MakeTuple,
     UnpackTuple,
@@ -428,6 +430,7 @@ impl OpParent for CallIndirect {}
 impl OpParent for LoadConstant {}
 impl OpParent for LoadFunction {}
 impl OpParent for CustomOp {}
+impl OpParent for OpaqueOp {}
 impl OpParent for Noop {}
 impl OpParent for MakeTuple {}
 impl OpParent for UnpackTuple {}

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -13,7 +13,6 @@ use {
 use crate::extension::{ConstFoldResult, ExtensionId, ExtensionRegistry, OpDef, SignatureError};
 use crate::hugr::internal::HugrMutInternals;
 use crate::hugr::HugrView;
-use crate::types::EdgeKind;
 use crate::types::{type_param::TypeArg, Signature};
 use crate::{ops, Hugr, IncomingPort, Node};
 
@@ -21,150 +20,8 @@ use super::dataflow::DataflowOpTrait;
 use super::tag::OpTag;
 use super::{NamedOp, OpName, OpNameRef, OpTrait, OpType};
 
-/// A user-defined operation defined in an extension.
-///
-/// Any custom operation can be encoded as a serializable [`OpaqueOp`]. If the
-/// operation's extension is loaded in the current context, the operation can be
-/// resolved into an [`ExtensionOp`] containing a reference to its definition.
-///
-///   [`OpaqueOp`]: crate::ops::custom::OpaqueOp
-///   [`ExtensionOp`]: crate::ops::custom::ExtensionOp
-#[derive(Clone, Debug, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(test, derive(Arbitrary))]
-#[serde(into = "OpaqueOp", from = "OpaqueOp")]
-pub enum CustomOp {
-    /// When we've found (loaded) the [Extension] definition and identified the [OpDef]
-    ///
-    /// [Extension]: crate::Extension
-    Extension(Box<ExtensionOp>),
-    /// When we either haven't tried to identify the [Extension] or failed to find it.
-    ///
-    /// [Extension]: crate::Extension
-    Opaque(Box<OpaqueOp>),
-}
-
-impl PartialEq for CustomOp {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Extension(l0), Self::Extension(r0)) => l0 == r0,
-            (Self::Opaque(l0), Self::Opaque(r0)) => l0 == r0,
-            (Self::Extension(l0), Self::Opaque(r0)) => &l0.make_opaque() == r0.as_ref(),
-            (Self::Opaque(l0), Self::Extension(r0)) => l0.as_ref() == &r0.make_opaque(),
-        }
-    }
-}
-
-impl CustomOp {
-    /// Create a new CustomOp from an [ExtensionOp].
-    pub fn new_extension(op: ExtensionOp) -> Self {
-        Self::Extension(Box::new(op))
-    }
-
-    /// Create a new CustomOp from an [OpaqueOp].
-    pub fn new_opaque(op: OpaqueOp) -> Self {
-        Self::Opaque(Box::new(op))
-    }
-
-    /// Return the argument values for this operation.
-    pub fn args(&self) -> &[TypeArg] {
-        match self {
-            Self::Opaque(op) => op.args(),
-            Self::Extension(op) => op.args(),
-        }
-    }
-
-    /// Returns the extension ID of this operation.
-    pub fn extension(&self) -> &ExtensionId {
-        match self {
-            Self::Opaque(op) => op.extension(),
-            Self::Extension(op) => op.def.extension(),
-        }
-    }
-
-    /// If the operation is an instance of [ExtensionOp], return a reference to it.
-    /// If the operation is opaque, return None.
-    pub fn as_extension_op(&self) -> Option<&ExtensionOp> {
-        match self {
-            Self::Extension(e) => Some(e),
-            Self::Opaque(_) => None,
-        }
-    }
-
-    /// Downgrades this opaque operation into an [`OpaqueOp`].
-    pub fn into_opaque(self) -> OpaqueOp {
-        match self {
-            Self::Opaque(op) => *op,
-            Self::Extension(op) => (*op).into(),
-        }
-    }
-
-    /// Returns `true` if this operation is an instance of [`ExtensionOp`].
-    pub fn is_extension_op(&self) -> bool {
-        matches!(self, Self::Extension(_))
-    }
-
-    /// Returns `true` if this operation is an instance of [`OpaqueOp`].
-    pub fn is_opaque(&self) -> bool {
-        matches!(self, Self::Opaque(_))
-    }
-}
-
-impl NamedOp for CustomOp {
-    /// The name of the operation.
-    fn name(&self) -> OpName {
-        let (res_id, name) = match self {
-            Self::Opaque(op) => (&op.extension, &op.name),
-            Self::Extension(ext) => (ext.def.extension(), ext.def.name()),
-        };
-        qualify_name(res_id, name)
-    }
-}
-
-impl DataflowOpTrait for CustomOp {
-    const TAG: OpTag = OpTag::Leaf;
-
-    /// A human-readable description of the operation.
-    fn description(&self) -> &str {
-        match self {
-            Self::Opaque(op) => DataflowOpTrait::description(op.as_ref()),
-            Self::Extension(ext_op) => DataflowOpTrait::description(ext_op.as_ref()),
-        }
-    }
-
-    /// The signature of the operation.
-    fn signature(&self) -> Signature {
-        match self {
-            Self::Opaque(op) => op.signature(),
-            Self::Extension(ext_op) => ext_op.signature(),
-        }
-    }
-
-    fn other_input(&self) -> Option<EdgeKind> {
-        Some(EdgeKind::StateOrder)
-    }
-
-    fn other_output(&self) -> Option<EdgeKind> {
-        Some(EdgeKind::StateOrder)
-    }
-}
-
-impl From<OpaqueOp> for CustomOp {
-    fn from(op: OpaqueOp) -> Self {
-        Self::new_opaque(op)
-    }
-}
-
-impl From<CustomOp> for OpaqueOp {
-    fn from(value: CustomOp) -> Self {
-        value.into_opaque()
-    }
-}
-
-impl From<ExtensionOp> for CustomOp {
-    fn from(op: ExtensionOp) -> Self {
-        Self::new_extension(op)
-    }
-}
+/// Alias for [ExtensionOp].
+pub type CustomOp = ExtensionOp;
 
 /// An operation defined by an [OpDef] from a loaded [Extension].
 ///
@@ -172,7 +29,8 @@ impl From<ExtensionOp> for CustomOp {
 /// See [ExtensionOp::make_opaque].
 ///
 /// [Extension]: crate::Extension
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(into = "OpaqueOp")]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct ExtensionOp {
     #[cfg_attr(
@@ -250,12 +108,6 @@ impl From<ExtensionOp> for OpaqueOp {
     }
 }
 
-impl From<ExtensionOp> for OpType {
-    fn from(value: ExtensionOp) -> Self {
-        OpType::CustomOp(value.into())
-    }
-}
-
 impl PartialEq for ExtensionOp {
     fn eq(&self, other: &Self) -> bool {
         Arc::<OpDef>::ptr_eq(&self.def, &other.def) && self.args == other.args
@@ -263,6 +115,13 @@ impl PartialEq for ExtensionOp {
 }
 
 impl Eq for ExtensionOp {}
+
+impl NamedOp for ExtensionOp {
+    /// The name of the operation.
+    fn name(&self) -> OpName {
+        qualify_name(self.def.extension(), self.def.name())
+    }
+}
 
 impl DataflowOpTrait for ExtensionOp {
     const TAG: OpTag = OpTag::Leaf;
@@ -323,9 +182,15 @@ impl OpaqueOp {
     }
 }
 
+impl NamedOp for OpaqueOp {
+    /// The name of the operation.
+    fn name(&self) -> OpName {
+        qualify_name(&self.extension, &self.name)
+    }
+}
 impl OpaqueOp {
     /// Unique name of the operation.
-    pub fn name(&self) -> &OpName {
+    pub fn op_name(&self) -> &OpName {
         &self.name
     }
 
@@ -337,12 +202,6 @@ impl OpaqueOp {
     /// Parent extension.
     pub fn extension(&self) -> &ExtensionId {
         &self.extension
-    }
-}
-
-impl From<OpaqueOp> for OpType {
-    fn from(value: OpaqueOp) -> Self {
-        OpType::CustomOp(value.into())
     }
 }
 
@@ -367,7 +226,7 @@ pub fn resolve_extension_ops(
 ) -> Result<(), CustomOpError> {
     let mut replacements = Vec::new();
     for n in h.nodes() {
-        if let OpType::CustomOp(CustomOp::Opaque(opaque)) = h.get_optype(n) {
+        if let OpType::OpaqueOp(opaque) = h.get_optype(n) {
             if let Some(resolved) = resolve_opaque_op(n, opaque, extension_registry)? {
                 replacements.push((n, resolved))
             }
@@ -472,14 +331,13 @@ mod test {
     #[test]
     fn new_opaque_op() {
         let sig = Signature::new_endo(vec![QB_T]);
-        let op: CustomOp = OpaqueOp::new(
+        let op = OpaqueOp::new(
             "res".try_into().unwrap(),
             "op",
             "desc".into(),
             vec![TypeArg::Type { ty: USIZE_T }],
             sig.clone(),
-        )
-        .into();
+        );
         assert_eq!(op.name(), "res.op");
         assert_eq!(DataflowOpTrait::description(&op), "desc");
         assert_eq!(op.args(), &[TypeArg::Type { ty: USIZE_T }]);
@@ -487,8 +345,6 @@ mod test {
             op.signature(),
             sig.with_extension_delta(op.extension().clone())
         );
-        assert!(op.is_opaque());
-        assert!(!op.is_extension_op());
     }
 
     #[test]

--- a/hugr-core/src/ops/validate.rs
+++ b/hugr-core/src/ops/validate.rs
@@ -410,7 +410,7 @@ mod test {
 
 use super::{
     AliasDecl, AliasDefn, Call, CallIndirect, Const, CustomOp, FuncDecl, Input, Lift, LoadConstant,
-    LoadFunction, MakeTuple, Noop, Output, Tag, UnpackTuple,
+    LoadFunction, MakeTuple, Noop, OpaqueOp, Output, Tag, UnpackTuple,
 };
 impl_validate_op!(FuncDecl);
 impl_validate_op!(AliasDecl);
@@ -423,6 +423,7 @@ impl_validate_op!(LoadConstant);
 impl_validate_op!(LoadFunction);
 impl_validate_op!(CallIndirect);
 impl_validate_op!(CustomOp);
+impl_validate_op!(OpaqueOp);
 impl_validate_op!(Noop);
 impl_validate_op!(MakeTuple);
 impl_validate_op!(UnpackTuple);

--- a/hugr-core/src/ops/validate.rs
+++ b/hugr-core/src/ops/validate.rs
@@ -409,8 +409,8 @@ mod test {
 }
 
 use super::{
-    AliasDecl, AliasDefn, Call, CallIndirect, Const, CustomOp, FuncDecl, Input, Lift, LoadConstant,
-    LoadFunction, MakeTuple, Noop, OpaqueOp, Output, Tag, UnpackTuple,
+    AliasDecl, AliasDefn, Call, CallIndirect, Const, ExtensionOp, FuncDecl, Input, Lift,
+    LoadConstant, LoadFunction, MakeTuple, Noop, OpaqueOp, Output, Tag, UnpackTuple,
 };
 impl_validate_op!(FuncDecl);
 impl_validate_op!(AliasDecl);
@@ -422,7 +422,7 @@ impl_validate_op!(Call);
 impl_validate_op!(LoadConstant);
 impl_validate_op!(LoadFunction);
 impl_validate_op!(CallIndirect);
-impl_validate_op!(CustomOp);
+impl_validate_op!(ExtensionOp);
 impl_validate_op!(OpaqueOp);
 impl_validate_op!(Noop);
 impl_validate_op!(MakeTuple);

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -374,7 +374,7 @@ fn sum_ty_with_err(t: Type) -> Type {
 #[cfg(test)]
 mod test {
     use crate::{
-        ops::{dataflow::DataflowOpTrait, CustomOp},
+        ops::{dataflow::DataflowOpTrait, ExtensionOp},
         std_extensions::arithmetic::int_types::int_type,
         types::Signature,
     };
@@ -452,9 +452,9 @@ mod test {
                 .is_none(),
             "type arguments invalid"
         );
-        let custom_op: CustomOp = o.clone().to_extension_op().unwrap();
+        let ext_op: ExtensionOp = o.clone().to_extension_op().unwrap();
 
-        assert_eq!(ConcreteIntOp::from_op(&custom_op).unwrap(), o);
-        assert_eq!(IntOpDef::from_op(&custom_op).unwrap(), IntOpDef::itobool);
+        assert_eq!(ConcreteIntOp::from_op(&ext_op).unwrap(), o);
+        assert_eq!(IntOpDef::from_op(&ext_op).unwrap(), IntOpDef::itobool);
     }
 }

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -452,13 +452,9 @@ mod test {
                 .is_none(),
             "type arguments invalid"
         );
-        let custom_op: CustomOp = o.clone().to_extension_op().unwrap().into();
+        let custom_op: CustomOp = o.clone().to_extension_op().unwrap();
 
         assert_eq!(ConcreteIntOp::from_op(&custom_op).unwrap(), o);
         assert_eq!(IntOpDef::from_op(&custom_op).unwrap(), IntOpDef::itobool);
-        assert_eq!(
-            IntOpDef::from_op(&custom_op.into_opaque().into()).unwrap(),
-            IntOpDef::itobool
-        );
     }
 }

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -299,13 +299,9 @@ pub(crate) mod test {
         for def in [NaryLogic::And, NaryLogic::Or, NaryLogic::Eq] {
             let o = def.with_n_inputs(3);
             let ext_op = o.clone().to_extension_op().unwrap();
-            let custom_op: CustomOp = ext_op.into();
+            let custom_op: CustomOp = ext_op;
             assert_eq!(NaryLogic::from_op(&custom_op).unwrap(), def);
             assert_eq!(ConcreteLogicOp::from_op(&custom_op).unwrap(), o);
-            assert_eq!(
-                ConcreteLogicOp::from_op(&custom_op.into_opaque().into()).unwrap(),
-                o
-            );
         }
 
         NotOp::from_extension_op(&NotOp.to_extension_op().unwrap()).unwrap();

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -273,7 +273,7 @@ pub(crate) mod test {
             prelude::BOOL_T,
             simple_op::{HasDef, MakeExtensionOp, MakeOpDef, MakeRegisteredOp},
         },
-        ops::{CustomOp, NamedOp, Value},
+        ops::{NamedOp, Value},
         Extension,
     };
 
@@ -299,9 +299,8 @@ pub(crate) mod test {
         for def in [NaryLogic::And, NaryLogic::Or, NaryLogic::Eq] {
             let o = def.with_n_inputs(3);
             let ext_op = o.clone().to_extension_op().unwrap();
-            let custom_op: CustomOp = ext_op;
-            assert_eq!(NaryLogic::from_op(&custom_op).unwrap(), def);
-            assert_eq!(ConcreteLogicOp::from_op(&custom_op).unwrap(), o);
+            assert_eq!(NaryLogic::from_op(&ext_op).unwrap(), def);
+            assert_eq!(ConcreteLogicOp::from_op(&ext_op).unwrap(), o);
         }
 
         NotOp::from_extension_op(&NotOp.to_extension_op().unwrap()).unwrap();

--- a/hugr-core/src/std_extensions/ptr.rs
+++ b/hugr-core/src/std_extensions/ptr.rs
@@ -248,7 +248,7 @@ pub(crate) mod test {
             PtrOp::new(PtrOpDef::Write, INT_TYPES[5].clone()),
         ];
         for op in ops {
-            let op_t: CustomOp = op.clone().to_extension_op().unwrap().into();
+            let op_t: CustomOp = op.clone().to_extension_op().unwrap();
             let def_op = PtrOpDef::from_op(&op_t).unwrap();
             assert_eq!(op.def, def_op);
             let new_op = PtrOp::from_op(&op_t).unwrap();

--- a/hugr-core/src/std_extensions/ptr.rs
+++ b/hugr-core/src/std_extensions/ptr.rs
@@ -213,7 +213,7 @@ impl HasDef for PtrOp {
 pub(crate) mod test {
     use crate::builder::DFGBuilder;
     use crate::extension::prelude::BOOL_T;
-    use crate::ops::CustomOp;
+    use crate::ops::ExtensionOp;
     use crate::{
         builder::{Dataflow, DataflowHugr},
         ops::NamedOp,
@@ -248,7 +248,7 @@ pub(crate) mod test {
             PtrOp::new(PtrOpDef::Write, INT_TYPES[5].clone()),
         ];
         for op in ops {
-            let op_t: CustomOp = op.clone().to_extension_op().unwrap();
+            let op_t: ExtensionOp = op.clone().to_extension_op().unwrap();
             let def_op = PtrOpDef::from_op(&op_t).unwrap();
             assert_eq!(op.def, def_op);
             let new_op = PtrOp::from_op(&op_t).unwrap();

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -110,7 +110,7 @@ pub(crate) mod test_quantum_extension {
             prelude::{BOOL_T, QB_T},
             ExtensionId, ExtensionRegistry, PRELUDE,
         },
-        ops::CustomOp,
+        ops::ExtensionOp,
         std_extensions::arithmetic::float_types,
         type_row,
         types::{PolyFuncTypeRV, Signature},
@@ -180,32 +180,32 @@ pub(crate) mod test_quantum_extension {
 
     }
 
-    fn get_gate(gate_name: &OpNameRef) -> CustomOp {
+    fn get_gate(gate_name: &OpNameRef) -> ExtensionOp {
         EXTENSION
             .instantiate_extension_op(gate_name, [], &REG)
             .unwrap()
     }
-    pub(crate) fn h_gate() -> CustomOp {
+    pub(crate) fn h_gate() -> ExtensionOp {
         get_gate("H")
     }
 
-    pub(crate) fn cx_gate() -> CustomOp {
+    pub(crate) fn cx_gate() -> ExtensionOp {
         get_gate("CX")
     }
 
-    pub(crate) fn measure() -> CustomOp {
+    pub(crate) fn measure() -> ExtensionOp {
         get_gate("Measure")
     }
 
-    pub(crate) fn rz_f64() -> CustomOp {
+    pub(crate) fn rz_f64() -> ExtensionOp {
         get_gate("RzF64")
     }
 
-    pub(crate) fn q_alloc() -> CustomOp {
+    pub(crate) fn q_alloc() -> ExtensionOp {
         get_gate("QAlloc")
     }
 
-    pub(crate) fn q_discard() -> CustomOp {
+    pub(crate) fn q_discard() -> ExtensionOp {
         get_gate("QDiscard")
     }
 }

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -184,7 +184,6 @@ pub(crate) mod test_quantum_extension {
         EXTENSION
             .instantiate_extension_op(gate_name, [], &REG)
             .unwrap()
-            .into()
     }
     pub(crate) fn h_gate() -> CustomOp {
         get_gate("H")

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -121,7 +121,7 @@ pub fn fold_leaf_op(op: &OpType, consts: &[(IncomingPort, Value)]) -> ConstFoldR
             SumType::new(t.variants.clone()),
         )
         .unwrap()]),
-        OpType::CustomOp(ext_op) => ext_op.constant_fold(consts),
+        OpType::ExtensionOp(ext_op) => ext_op.constant_fold(consts),
         _ => None,
     };
     debug_assert!(fold_result.as_ref().map_or(true, |x| x.len()

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -121,10 +121,7 @@ pub fn fold_leaf_op(op: &OpType, consts: &[(IncomingPort, Value)]) -> ConstFoldR
             SumType::new(t.variants.clone()),
         )
         .unwrap()]),
-        OpType::CustomOp(op) => {
-            let ext_op = op.as_extension_op()?;
-            ext_op.constant_fold(consts)
-        }
+        OpType::CustomOp(ext_op) => ext_op.constant_fold(consts),
         _ => None,
     };
     debug_assert!(fold_result.as_ref().map_or(true, |x| x.len()

--- a/hugr-passes/src/merge_bbs.rs
+++ b/hugr-passes/src/merge_bbs.rs
@@ -295,7 +295,7 @@ mod test {
         );
         // And the Noop in the entry block is consumed by the custom Test op
         let tst = find_unique(h.nodes(), |n| {
-            matches!(h.get_optype(*n), OpType::CustomOp(_))
+            matches!(h.get_optype(*n), OpType::ExtensionOp(_))
         });
         assert_eq!(h.get_parent(tst), Some(entry));
         assert_eq!(
@@ -360,7 +360,7 @@ mod test {
         // Should only be one BB left
         let [bb, _exit] = h.children(h.root()).collect::<Vec<_>>().try_into().unwrap();
         let tst = find_unique(h.nodes(), |n| {
-            matches!(h.get_optype(*n), OpType::CustomOp(_))
+            matches!(h.get_optype(*n), OpType::ExtensionOp(_))
         });
         assert_eq!(h.get_parent(tst), Some(bb));
 

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -279,7 +279,7 @@ class AsExtOp(DataflowOp, Protocol):
     def outer_signature(self) -> tys.FunctionType:
         return self.ext_op.outer_signature()
 
-    def to_serial(self, parent: Node) -> sops.CustomOp:
+    def to_serial(self, parent: Node) -> sops.Extension:
         return self.ext_op.to_serial(parent)
 
     @property
@@ -297,8 +297,8 @@ class Custom(DataflowOp):
     extension: tys.ExtensionId = ""
     args: list[tys.TypeArg] = field(default_factory=list)
 
-    def to_serial(self, parent: Node) -> sops.CustomOp:
-        return sops.CustomOp(
+    def to_serial(self, parent: Node) -> sops.Extension:
+        return sops.Extension(
             parent=parent.idx,
             extension=self.extension,
             name=self.name,
@@ -366,7 +366,7 @@ class ExtOp(AsExtOp):
             args=self.args,
         )
 
-    def to_serial(self, parent: Node) -> sops.CustomOp:
+    def to_serial(self, parent: Node) -> sops.Extension:
         return self.to_custom_op().to_serial(parent)
 
     def op_def(self) -> ext.OpDef:

--- a/hugr-py/src/hugr/serialization/ops.py
+++ b/hugr-py/src/hugr/serialization/ops.py
@@ -506,7 +506,7 @@ class CustomOp(DataflowOp):
     it.
     """
 
-    op: Literal["CustomOp"] = "CustomOp"
+    op: Literal["OpaqueOp"] = "OpaqueOp"
     extension: ExtensionId
     name: str
     signature: stys.FunctionType = Field(default_factory=stys.FunctionType.empty)

--- a/hugr-py/src/hugr/serialization/ops.py
+++ b/hugr-py/src/hugr/serialization/ops.py
@@ -501,12 +501,12 @@ class CFG(DataflowOp):
 ControlFlowOp = Conditional | TailLoop | CFG
 
 
-class CustomOp(DataflowOp):
+class Extension(DataflowOp):
     """A user-defined operation that can be downcasted by the extensions that define
     it.
     """
 
-    op: Literal["OpaqueOp"] = "OpaqueOp"
+    op: Literal["Extension"] = "Extension"
     extension: ExtensionId
     name: str
     signature: stys.FunctionType = Field(default_factory=stys.FunctionType.empty)
@@ -649,7 +649,7 @@ class OpType(RootModel):
         | CallIndirect
         | LoadConstant
         | LoadFunction
-        | CustomOp
+        | Extension
         | Noop
         | MakeTuple
         | UnpackTuple

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -41,7 +41,7 @@
 //!             prelude::{BOOL_T, QB_T},
 //!             ExtensionId, ExtensionRegistry, PRELUDE, Version,
 //!         },
-//!         ops::{CustomOp, OpName},
+//!         ops::{ExtensionOp, OpName},
 //!         type_row,
 //!         types::{FuncValueType, PolyFuncTypeRV},
 //!         Extension,
@@ -88,21 +88,21 @@
 //!             ExtensionRegistry::try_new([EXTENSION.to_owned(), PRELUDE.to_owned()]).unwrap();
 //!
 //!     }
-//!     fn get_gate(gate_name: impl Into<OpName>) -> CustomOp {
+//!     fn get_gate(gate_name: impl Into<OpName>) -> ExtensionOp {
 //!         EXTENSION
 //!             .instantiate_extension_op(&gate_name.into(), [], &REG)
 //!             .unwrap()
 //!             .into()
 //!     }
-//!     pub fn h_gate() -> CustomOp {
+//!     pub fn h_gate() -> ExtensionOp {
 //!         get_gate("H")
 //!     }
 //!
-//!     pub fn cx_gate() -> CustomOp {
+//!     pub fn cx_gate() -> ExtensionOp {
 //!         get_gate("CX")
 //!     }
 //!
-//!     pub fn measure() -> CustomOp {
+//!     pub fn measure() -> ExtensionOp {
 //!         get_gate("Measure")
 //!     }
 //! }

--- a/poetry.lock
+++ b/poetry.lock
@@ -163,7 +163,7 @@ typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
 name = "hugr"
-version = "0.5.0"
+version = "0.6.0"
 description = "Quantinuum's common representation for quantum programs"
 optional = false
 python-versions = ">=3.10"

--- a/specification/schema/hugr_schema_live.json
+++ b/specification/schema/hugr_schema_live.json
@@ -396,55 +396,6 @@
             "title": "CustomConst",
             "type": "object"
         },
-        "CustomOp": {
-            "additionalProperties": true,
-            "description": "A user-defined operation that can be downcasted by the extensions that define it.",
-            "properties": {
-                "parent": {
-                    "title": "Parent",
-                    "type": "integer"
-                },
-                "op": {
-                    "const": "CustomOp",
-                    "default": "CustomOp",
-                    "enum": [
-                        "CustomOp"
-                    ],
-                    "title": "Op",
-                    "type": "string"
-                },
-                "extension": {
-                    "title": "Extension",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "signature": {
-                    "$ref": "#/$defs/FunctionType"
-                },
-                "description": {
-                    "default": "",
-                    "title": "Description",
-                    "type": "string"
-                },
-                "args": {
-                    "items": {
-                        "$ref": "#/$defs/TypeArg"
-                    },
-                    "title": "Args",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "parent",
-                "extension",
-                "name"
-            ],
-            "title": "CustomOp",
-            "type": "object"
-        },
         "DFG": {
             "additionalProperties": true,
             "description": "A simply nested dataflow graph.",
@@ -579,57 +530,6 @@
                 "bound"
             ],
             "title": "ExplicitBound",
-            "type": "object"
-        },
-        "Extension": {
-            "properties": {
-                "version": {
-                    "title": "Version",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "extension_reqs": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Extension Reqs",
-                    "type": "array",
-                    "uniqueItems": true
-                },
-                "types": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/TypeDef"
-                    },
-                    "title": "Types",
-                    "type": "object"
-                },
-                "values": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/hugr__serialization__extension__ExtensionValue"
-                    },
-                    "title": "Values",
-                    "type": "object"
-                },
-                "operations": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/OpDef"
-                    },
-                    "title": "Operations",
-                    "type": "object"
-                }
-            },
-            "required": [
-                "version",
-                "name",
-                "extension_reqs",
-                "types",
-                "values",
-                "operations"
-            ],
-            "title": "Extension",
             "type": "object"
         },
         "ExtensionsArg": {
@@ -1202,10 +1102,10 @@
                     "Case": "#/$defs/Case",
                     "Conditional": "#/$defs/Conditional",
                     "Const": "#/$defs/Const",
-                    "CustomOp": "#/$defs/CustomOp",
                     "DFG": "#/$defs/DFG",
                     "DataflowBlock": "#/$defs/DataflowBlock",
                     "ExitBlock": "#/$defs/ExitBlock",
+                    "Extension": "#/$defs/hugr__serialization__ops__Extension",
                     "FuncDecl": "#/$defs/FuncDecl",
                     "FuncDefn": "#/$defs/FuncDefn",
                     "Input": "#/$defs/Input",
@@ -1272,7 +1172,7 @@
                     "$ref": "#/$defs/LoadFunction"
                 },
                 {
-                    "$ref": "#/$defs/CustomOp"
+                    "$ref": "#/$defs/hugr__serialization__ops__Extension"
                 },
                 {
                     "$ref": "#/$defs/Noop"
@@ -1388,7 +1288,7 @@
                 },
                 "extensions": {
                     "items": {
-                        "$ref": "#/$defs/Extension"
+                        "$ref": "#/$defs/hugr__serialization__extension__Extension"
                     },
                     "title": "Extensions",
                     "type": "array"
@@ -2242,6 +2142,57 @@
             "title": "VariableArg",
             "type": "object"
         },
+        "hugr__serialization__extension__Extension": {
+            "properties": {
+                "version": {
+                    "title": "Version",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "extension_reqs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Extension Reqs",
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "types": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/TypeDef"
+                    },
+                    "title": "Types",
+                    "type": "object"
+                },
+                "values": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/hugr__serialization__extension__ExtensionValue"
+                    },
+                    "title": "Values",
+                    "type": "object"
+                },
+                "operations": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/OpDef"
+                    },
+                    "title": "Operations",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "version",
+                "name",
+                "extension_reqs",
+                "types",
+                "values",
+                "operations"
+            ],
+            "title": "Extension",
+            "type": "object"
+        },
         "hugr__serialization__extension__ExtensionValue": {
             "properties": {
                 "extension": {
@@ -2262,6 +2213,55 @@
                 "typed_value"
             ],
             "title": "ExtensionValue",
+            "type": "object"
+        },
+        "hugr__serialization__ops__Extension": {
+            "additionalProperties": true,
+            "description": "A user-defined operation that can be downcasted by the extensions that define it.",
+            "properties": {
+                "parent": {
+                    "title": "Parent",
+                    "type": "integer"
+                },
+                "op": {
+                    "const": "Extension",
+                    "default": "Extension",
+                    "enum": [
+                        "Extension"
+                    ],
+                    "title": "Op",
+                    "type": "string"
+                },
+                "extension": {
+                    "title": "Extension",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "signature": {
+                    "$ref": "#/$defs/FunctionType"
+                },
+                "description": {
+                    "default": "",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "args": {
+                    "items": {
+                        "$ref": "#/$defs/TypeArg"
+                    },
+                    "title": "Args",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "parent",
+                "extension",
+                "name"
+            ],
+            "title": "Extension",
             "type": "object"
         },
         "hugr__serialization__ops__ExtensionValue": {

--- a/specification/schema/hugr_schema_strict_live.json
+++ b/specification/schema/hugr_schema_strict_live.json
@@ -396,55 +396,6 @@
             "title": "CustomConst",
             "type": "object"
         },
-        "CustomOp": {
-            "additionalProperties": false,
-            "description": "A user-defined operation that can be downcasted by the extensions that define it.",
-            "properties": {
-                "parent": {
-                    "title": "Parent",
-                    "type": "integer"
-                },
-                "op": {
-                    "const": "CustomOp",
-                    "default": "CustomOp",
-                    "enum": [
-                        "CustomOp"
-                    ],
-                    "title": "Op",
-                    "type": "string"
-                },
-                "extension": {
-                    "title": "Extension",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "signature": {
-                    "$ref": "#/$defs/FunctionType"
-                },
-                "description": {
-                    "default": "",
-                    "title": "Description",
-                    "type": "string"
-                },
-                "args": {
-                    "items": {
-                        "$ref": "#/$defs/TypeArg"
-                    },
-                    "title": "Args",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "parent",
-                "extension",
-                "name"
-            ],
-            "title": "CustomOp",
-            "type": "object"
-        },
         "DFG": {
             "additionalProperties": false,
             "description": "A simply nested dataflow graph.",
@@ -579,57 +530,6 @@
                 "bound"
             ],
             "title": "ExplicitBound",
-            "type": "object"
-        },
-        "Extension": {
-            "properties": {
-                "version": {
-                    "title": "Version",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "extension_reqs": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Extension Reqs",
-                    "type": "array",
-                    "uniqueItems": true
-                },
-                "types": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/TypeDef"
-                    },
-                    "title": "Types",
-                    "type": "object"
-                },
-                "values": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/hugr__serialization__extension__ExtensionValue"
-                    },
-                    "title": "Values",
-                    "type": "object"
-                },
-                "operations": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/OpDef"
-                    },
-                    "title": "Operations",
-                    "type": "object"
-                }
-            },
-            "required": [
-                "version",
-                "name",
-                "extension_reqs",
-                "types",
-                "values",
-                "operations"
-            ],
-            "title": "Extension",
             "type": "object"
         },
         "ExtensionsArg": {
@@ -1202,10 +1102,10 @@
                     "Case": "#/$defs/Case",
                     "Conditional": "#/$defs/Conditional",
                     "Const": "#/$defs/Const",
-                    "CustomOp": "#/$defs/CustomOp",
                     "DFG": "#/$defs/DFG",
                     "DataflowBlock": "#/$defs/DataflowBlock",
                     "ExitBlock": "#/$defs/ExitBlock",
+                    "Extension": "#/$defs/hugr__serialization__ops__Extension",
                     "FuncDecl": "#/$defs/FuncDecl",
                     "FuncDefn": "#/$defs/FuncDefn",
                     "Input": "#/$defs/Input",
@@ -1272,7 +1172,7 @@
                     "$ref": "#/$defs/LoadFunction"
                 },
                 {
-                    "$ref": "#/$defs/CustomOp"
+                    "$ref": "#/$defs/hugr__serialization__ops__Extension"
                 },
                 {
                     "$ref": "#/$defs/Noop"
@@ -1388,7 +1288,7 @@
                 },
                 "extensions": {
                     "items": {
-                        "$ref": "#/$defs/Extension"
+                        "$ref": "#/$defs/hugr__serialization__extension__Extension"
                     },
                     "title": "Extensions",
                     "type": "array"
@@ -2242,6 +2142,57 @@
             "title": "VariableArg",
             "type": "object"
         },
+        "hugr__serialization__extension__Extension": {
+            "properties": {
+                "version": {
+                    "title": "Version",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "extension_reqs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Extension Reqs",
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "types": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/TypeDef"
+                    },
+                    "title": "Types",
+                    "type": "object"
+                },
+                "values": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/hugr__serialization__extension__ExtensionValue"
+                    },
+                    "title": "Values",
+                    "type": "object"
+                },
+                "operations": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/OpDef"
+                    },
+                    "title": "Operations",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "version",
+                "name",
+                "extension_reqs",
+                "types",
+                "values",
+                "operations"
+            ],
+            "title": "Extension",
+            "type": "object"
+        },
         "hugr__serialization__extension__ExtensionValue": {
             "properties": {
                 "extension": {
@@ -2262,6 +2213,55 @@
                 "typed_value"
             ],
             "title": "ExtensionValue",
+            "type": "object"
+        },
+        "hugr__serialization__ops__Extension": {
+            "additionalProperties": false,
+            "description": "A user-defined operation that can be downcasted by the extensions that define it.",
+            "properties": {
+                "parent": {
+                    "title": "Parent",
+                    "type": "integer"
+                },
+                "op": {
+                    "const": "Extension",
+                    "default": "Extension",
+                    "enum": [
+                        "Extension"
+                    ],
+                    "title": "Op",
+                    "type": "string"
+                },
+                "extension": {
+                    "title": "Extension",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "signature": {
+                    "$ref": "#/$defs/FunctionType"
+                },
+                "description": {
+                    "default": "",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "args": {
+                    "items": {
+                        "$ref": "#/$defs/TypeArg"
+                    },
+                    "title": "Args",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "parent",
+                "extension",
+                "name"
+            ],
+            "title": "Extension",
             "type": "object"
         },
         "hugr__serialization__ops__ExtensionValue": {

--- a/specification/schema/testing_hugr_schema_live.json
+++ b/specification/schema/testing_hugr_schema_live.json
@@ -396,55 +396,6 @@
             "title": "CustomConst",
             "type": "object"
         },
-        "CustomOp": {
-            "additionalProperties": true,
-            "description": "A user-defined operation that can be downcasted by the extensions that define it.",
-            "properties": {
-                "parent": {
-                    "title": "Parent",
-                    "type": "integer"
-                },
-                "op": {
-                    "const": "CustomOp",
-                    "default": "CustomOp",
-                    "enum": [
-                        "CustomOp"
-                    ],
-                    "title": "Op",
-                    "type": "string"
-                },
-                "extension": {
-                    "title": "Extension",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "signature": {
-                    "$ref": "#/$defs/FunctionType"
-                },
-                "description": {
-                    "default": "",
-                    "title": "Description",
-                    "type": "string"
-                },
-                "args": {
-                    "items": {
-                        "$ref": "#/$defs/TypeArg"
-                    },
-                    "title": "Args",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "parent",
-                "extension",
-                "name"
-            ],
-            "title": "CustomOp",
-            "type": "object"
-        },
         "DFG": {
             "additionalProperties": true,
             "description": "A simply nested dataflow graph.",
@@ -579,57 +530,6 @@
                 "bound"
             ],
             "title": "ExplicitBound",
-            "type": "object"
-        },
-        "Extension": {
-            "properties": {
-                "version": {
-                    "title": "Version",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "extension_reqs": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Extension Reqs",
-                    "type": "array",
-                    "uniqueItems": true
-                },
-                "types": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/TypeDef"
-                    },
-                    "title": "Types",
-                    "type": "object"
-                },
-                "values": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/hugr__serialization__extension__ExtensionValue"
-                    },
-                    "title": "Values",
-                    "type": "object"
-                },
-                "operations": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/OpDef"
-                    },
-                    "title": "Operations",
-                    "type": "object"
-                }
-            },
-            "required": [
-                "version",
-                "name",
-                "extension_reqs",
-                "types",
-                "values",
-                "operations"
-            ],
-            "title": "Extension",
             "type": "object"
         },
         "ExtensionsArg": {
@@ -1202,10 +1102,10 @@
                     "Case": "#/$defs/Case",
                     "Conditional": "#/$defs/Conditional",
                     "Const": "#/$defs/Const",
-                    "CustomOp": "#/$defs/CustomOp",
                     "DFG": "#/$defs/DFG",
                     "DataflowBlock": "#/$defs/DataflowBlock",
                     "ExitBlock": "#/$defs/ExitBlock",
+                    "Extension": "#/$defs/hugr__serialization__ops__Extension",
                     "FuncDecl": "#/$defs/FuncDecl",
                     "FuncDefn": "#/$defs/FuncDefn",
                     "Input": "#/$defs/Input",
@@ -1272,7 +1172,7 @@
                     "$ref": "#/$defs/LoadFunction"
                 },
                 {
-                    "$ref": "#/$defs/CustomOp"
+                    "$ref": "#/$defs/hugr__serialization__ops__Extension"
                 },
                 {
                     "$ref": "#/$defs/Noop"
@@ -1388,7 +1288,7 @@
                 },
                 "extensions": {
                     "items": {
-                        "$ref": "#/$defs/Extension"
+                        "$ref": "#/$defs/hugr__serialization__extension__Extension"
                     },
                     "title": "Extensions",
                     "type": "array"
@@ -2320,6 +2220,57 @@
             "title": "VariableArg",
             "type": "object"
         },
+        "hugr__serialization__extension__Extension": {
+            "properties": {
+                "version": {
+                    "title": "Version",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "extension_reqs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Extension Reqs",
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "types": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/TypeDef"
+                    },
+                    "title": "Types",
+                    "type": "object"
+                },
+                "values": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/hugr__serialization__extension__ExtensionValue"
+                    },
+                    "title": "Values",
+                    "type": "object"
+                },
+                "operations": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/OpDef"
+                    },
+                    "title": "Operations",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "version",
+                "name",
+                "extension_reqs",
+                "types",
+                "values",
+                "operations"
+            ],
+            "title": "Extension",
+            "type": "object"
+        },
         "hugr__serialization__extension__ExtensionValue": {
             "properties": {
                 "extension": {
@@ -2340,6 +2291,55 @@
                 "typed_value"
             ],
             "title": "ExtensionValue",
+            "type": "object"
+        },
+        "hugr__serialization__ops__Extension": {
+            "additionalProperties": true,
+            "description": "A user-defined operation that can be downcasted by the extensions that define it.",
+            "properties": {
+                "parent": {
+                    "title": "Parent",
+                    "type": "integer"
+                },
+                "op": {
+                    "const": "Extension",
+                    "default": "Extension",
+                    "enum": [
+                        "Extension"
+                    ],
+                    "title": "Op",
+                    "type": "string"
+                },
+                "extension": {
+                    "title": "Extension",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "signature": {
+                    "$ref": "#/$defs/FunctionType"
+                },
+                "description": {
+                    "default": "",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "args": {
+                    "items": {
+                        "$ref": "#/$defs/TypeArg"
+                    },
+                    "title": "Args",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "parent",
+                "extension",
+                "name"
+            ],
+            "title": "Extension",
             "type": "object"
         },
         "hugr__serialization__ops__ExtensionValue": {

--- a/specification/schema/testing_hugr_schema_strict_live.json
+++ b/specification/schema/testing_hugr_schema_strict_live.json
@@ -396,55 +396,6 @@
             "title": "CustomConst",
             "type": "object"
         },
-        "CustomOp": {
-            "additionalProperties": false,
-            "description": "A user-defined operation that can be downcasted by the extensions that define it.",
-            "properties": {
-                "parent": {
-                    "title": "Parent",
-                    "type": "integer"
-                },
-                "op": {
-                    "const": "CustomOp",
-                    "default": "CustomOp",
-                    "enum": [
-                        "CustomOp"
-                    ],
-                    "title": "Op",
-                    "type": "string"
-                },
-                "extension": {
-                    "title": "Extension",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "signature": {
-                    "$ref": "#/$defs/FunctionType"
-                },
-                "description": {
-                    "default": "",
-                    "title": "Description",
-                    "type": "string"
-                },
-                "args": {
-                    "items": {
-                        "$ref": "#/$defs/TypeArg"
-                    },
-                    "title": "Args",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "parent",
-                "extension",
-                "name"
-            ],
-            "title": "CustomOp",
-            "type": "object"
-        },
         "DFG": {
             "additionalProperties": false,
             "description": "A simply nested dataflow graph.",
@@ -579,57 +530,6 @@
                 "bound"
             ],
             "title": "ExplicitBound",
-            "type": "object"
-        },
-        "Extension": {
-            "properties": {
-                "version": {
-                    "title": "Version",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "extension_reqs": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Extension Reqs",
-                    "type": "array",
-                    "uniqueItems": true
-                },
-                "types": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/TypeDef"
-                    },
-                    "title": "Types",
-                    "type": "object"
-                },
-                "values": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/hugr__serialization__extension__ExtensionValue"
-                    },
-                    "title": "Values",
-                    "type": "object"
-                },
-                "operations": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/OpDef"
-                    },
-                    "title": "Operations",
-                    "type": "object"
-                }
-            },
-            "required": [
-                "version",
-                "name",
-                "extension_reqs",
-                "types",
-                "values",
-                "operations"
-            ],
-            "title": "Extension",
             "type": "object"
         },
         "ExtensionsArg": {
@@ -1202,10 +1102,10 @@
                     "Case": "#/$defs/Case",
                     "Conditional": "#/$defs/Conditional",
                     "Const": "#/$defs/Const",
-                    "CustomOp": "#/$defs/CustomOp",
                     "DFG": "#/$defs/DFG",
                     "DataflowBlock": "#/$defs/DataflowBlock",
                     "ExitBlock": "#/$defs/ExitBlock",
+                    "Extension": "#/$defs/hugr__serialization__ops__Extension",
                     "FuncDecl": "#/$defs/FuncDecl",
                     "FuncDefn": "#/$defs/FuncDefn",
                     "Input": "#/$defs/Input",
@@ -1272,7 +1172,7 @@
                     "$ref": "#/$defs/LoadFunction"
                 },
                 {
-                    "$ref": "#/$defs/CustomOp"
+                    "$ref": "#/$defs/hugr__serialization__ops__Extension"
                 },
                 {
                     "$ref": "#/$defs/Noop"
@@ -1388,7 +1288,7 @@
                 },
                 "extensions": {
                     "items": {
-                        "$ref": "#/$defs/Extension"
+                        "$ref": "#/$defs/hugr__serialization__extension__Extension"
                     },
                     "title": "Extensions",
                     "type": "array"
@@ -2320,6 +2220,57 @@
             "title": "VariableArg",
             "type": "object"
         },
+        "hugr__serialization__extension__Extension": {
+            "properties": {
+                "version": {
+                    "title": "Version",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "extension_reqs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Extension Reqs",
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "types": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/TypeDef"
+                    },
+                    "title": "Types",
+                    "type": "object"
+                },
+                "values": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/hugr__serialization__extension__ExtensionValue"
+                    },
+                    "title": "Values",
+                    "type": "object"
+                },
+                "operations": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/OpDef"
+                    },
+                    "title": "Operations",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "version",
+                "name",
+                "extension_reqs",
+                "types",
+                "values",
+                "operations"
+            ],
+            "title": "Extension",
+            "type": "object"
+        },
         "hugr__serialization__extension__ExtensionValue": {
             "properties": {
                 "extension": {
@@ -2340,6 +2291,55 @@
                 "typed_value"
             ],
             "title": "ExtensionValue",
+            "type": "object"
+        },
+        "hugr__serialization__ops__Extension": {
+            "additionalProperties": false,
+            "description": "A user-defined operation that can be downcasted by the extensions that define it.",
+            "properties": {
+                "parent": {
+                    "title": "Parent",
+                    "type": "integer"
+                },
+                "op": {
+                    "const": "Extension",
+                    "default": "Extension",
+                    "enum": [
+                        "Extension"
+                    ],
+                    "title": "Op",
+                    "type": "string"
+                },
+                "extension": {
+                    "title": "Extension",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "signature": {
+                    "$ref": "#/$defs/FunctionType"
+                },
+                "description": {
+                    "default": "",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "args": {
+                    "items": {
+                        "$ref": "#/$defs/TypeArg"
+                    },
+                    "title": "Args",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "parent",
+                "extension",
+                "name"
+            ],
+            "title": "Extension",
             "type": "object"
         },
         "hugr__serialization__ops__ExtensionValue": {


### PR DESCRIPTION
In new workflow most of the time we just want to work with extension ops, and opaque are just used for serialisation. To that end flatten `CustomOp` out.  If there are `OpaqueOp`s in the HUGR it means the extension was not available to resolve in to. Will be disallowed in follow up PR.

Relates to #1362 


BREAKING CHANGE: `CustomOp` removed, `OpType` now contains `ExtensionOp` and `OpaqueOp` directly. `CustomOpError` renamed to`OpaqueOpError`.