### PR TITLE
feat!: disallow opaque ops during validation

### DIFF
--- a/hugr-core/src/builder/circuit.rs
+++ b/hugr-core/src/builder/circuit.rs
@@ -247,13 +247,13 @@ mod test {
     use crate::utils::test_quantum_extension::{
         self, cx_gate, h_gate, measure, q_alloc, q_discard, rz_f64,
     };
+    use crate::Extension;
     use crate::{
         builder::{
             test::{build_main, NAT, QB},
             DataflowSubContainer,
         },
         extension::prelude::BOOL_T,
-        ops::custom::OpaqueOp,
         type_row,
         types::Signature,
     };
@@ -296,19 +296,15 @@ mod test {
 
     #[test]
     fn with_nonlinear_and_outputs() {
-        let missing_ext: ExtensionId = "MissingExt".try_into().unwrap();
-        let my_custom_op = OpaqueOp::new(
-            missing_ext.clone(),
-            "MyOp",
-            "unknown op".to_string(),
-            vec![],
-            Signature::new(vec![QB, NAT], vec![QB]),
-        );
+        let my_ext_name: ExtensionId = "MyExt".try_into().unwrap();
+        let mut my_ext = Extension::new_test(my_ext_name.clone());
+        let my_custom_op = my_ext.simple_ext_op("MyOp", Signature::new(vec![QB, NAT], vec![QB]));
+
         let build_res = build_main(
             Signature::new(type_row![QB, QB, NAT], type_row![QB, QB, BOOL_T])
                 .with_extension_delta(ExtensionSet::from_iter([
                     test_quantum_extension::EXTENSION_ID,
-                    missing_ext,
+                    my_ext_name,
                 ]))
                 .into(),
             |mut f_build| {

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -596,7 +596,7 @@ pub mod test {
             Self::new(name, Version::new(0, 0, 0))
         }
 
-        /// Add a simple OpDef to the extension and return an extension op for it..
+        /// Add a simple OpDef to the extension and return an extension op for it.
         /// No description, no type parameters.
         pub(crate) fn simple_ext_op(
             &mut self,

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -595,6 +595,18 @@ pub mod test {
         pub(crate) fn new_test(name: ExtensionId) -> Self {
             Self::new(name, Version::new(0, 0, 0))
         }
+
+        /// Add a simple OpDef to the extension and return an extension op for it..
+        /// No description, no type parameters.
+        pub(crate) fn simple_ext_op(
+            &mut self,
+            name: &str,
+            signature: impl Into<SignatureFunc>,
+        ) -> ExtensionOp {
+            self.add_op(name.into(), "".to_string(), signature).unwrap();
+            self.instantiate_extension_op(name, [], &PRELUDE_REGISTRY)
+                .unwrap()
+        }
     }
 
     #[test]

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -241,9 +241,8 @@ impl SignatureFunc {
                 (&temp, other_args)
             }
             SignatureFunc::MissingComputeFunc => return Err(SignatureError::MissingComputeFunc),
-            SignatureFunc::MissingValidateFunc(_) => {
-                return Err(SignatureError::MissingValidateFunc)
-            }
+            // TODO raise warning: https://github.com/CQCL/hugr/issues/1432
+            SignatureFunc::MissingValidateFunc(ts) => (ts, args),
         };
 
         let mut res = pf.instantiate(args, exts)?;

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -641,7 +641,6 @@ mod test {
     fn test_invalid() {
         let mut new_ext = crate::Extension::new_test("new_ext".try_into().unwrap());
         let ext_name = new_ext.name().clone();
-        // let unknown_ext: ExtensionId = "unknown_ext".try_into().unwrap();
         let utou = Signature::new_endo(vec![USIZE_T]);
         let mut mk_op = |s| new_ext.simple_ext_op(s, utou.clone());
         let mut h = DFGBuilder::new(

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -450,11 +450,11 @@ mod test {
         DataflowSubContainer, HugrBuilder, SubContainer,
     };
     use crate::extension::prelude::{BOOL_T, USIZE_T};
-    use crate::extension::{ExtensionId, ExtensionRegistry, PRELUDE, PRELUDE_REGISTRY};
+    use crate::extension::{ExtensionRegistry, PRELUDE, PRELUDE_REGISTRY};
     use crate::hugr::internal::HugrMutInternals;
     use crate::hugr::rewrite::replace::WhichHugr;
     use crate::hugr::{HugrMut, Rewrite};
-    use crate::ops::custom::{ExtensionOp, OpaqueOp};
+    use crate::ops::custom::ExtensionOp;
     use crate::ops::dataflow::DataflowOpTrait;
     use crate::ops::handle::{BasicBlockID, ConstID, NodeHandle};
     use crate::ops::{self, Case, DataflowBlock, OpTag, OpType, DFG};
@@ -639,12 +639,14 @@ mod test {
 
     #[test]
     fn test_invalid() {
-        let unknown_ext: ExtensionId = "unknown_ext".try_into().unwrap();
+        let mut new_ext = crate::Extension::new_test("new_ext".try_into().unwrap());
+        let ext_name = new_ext.name().clone();
+        // let unknown_ext: ExtensionId = "unknown_ext".try_into().unwrap();
         let utou = Signature::new_endo(vec![USIZE_T]);
-        let mk_op = |s| OpaqueOp::new(unknown_ext.clone(), s, String::new(), vec![], utou.clone());
+        let mut mk_op = |s| new_ext.simple_ext_op(s, utou.clone());
         let mut h = DFGBuilder::new(
             Signature::new(type_row![USIZE_T, BOOL_T], type_row![USIZE_T])
-                .with_extension_delta(unknown_ext.clone()),
+                .with_extension_delta(ext_name.clone()),
         )
         .unwrap();
         let [i, b] = h.input_wires_arr();
@@ -653,7 +655,7 @@ mod test {
                 (vec![type_row![]; 2], b),
                 [(USIZE_T, i)],
                 type_row![USIZE_T],
-                unknown_ext.clone(),
+                ext_name.clone(),
             )
             .unwrap();
         let mut case1 = cond.case_builder(0).unwrap();
@@ -667,7 +669,7 @@ mod test {
             .unwrap();
         let mut baz_dfg = case2
             .dfg_builder(
-                utou.clone().with_extension_delta(unknown_ext.clone()),
+                utou.clone().with_extension_delta(ext_name.clone()),
                 bar.outputs(),
             )
             .unwrap();

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use crate::extension::{ExtensionRegistry, SignatureError, TO_BE_INFERRED};
 
 use crate::ops::constant::ConstTypeError;
-use crate::ops::custom::{resolve_opaque_op, ExtensionOp, OpaqueOpError};
+use crate::ops::custom::{ExtensionOp, OpaqueOpError};
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::{FuncDefn, OpParent, OpTag, OpTrait, OpType, ValidateOp};
 use crate::types::type_param::TypeParam;
@@ -584,17 +584,11 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
         match op_type {
             OpType::ExtensionOp(ext_op) => validate_ext(ext_op)?,
             OpType::OpaqueOp(opaque) => {
-                // Try to resolve serialized names to actual OpDefs in Extensions.
-                if let Some(ext_op) = resolve_opaque_op(node, opaque, self.extension_registry)? {
-                    validate_ext(&ext_op)?;
-                } else {
-                    // Best effort. Just check TypeArgs are valid in themselves, allowing any of them
-                    // to contain type vars (we don't know how many are binary params, so accept if in doubt)
-                    for arg in opaque.args() {
-                        arg.validate(self.extension_registry, var_decls)
-                            .map_err(|cause| ValidationError::SignatureError { node, cause })?;
-                    }
-                }
+                Err(OpaqueOpError::UnresolvedOp(
+                    node,
+                    opaque.op_name().clone(),
+                    opaque.extension().clone(),
+                ))?;
             }
             OpType::Call(c) => {
                 c.validate(self.extension_registry)

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -158,6 +158,13 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
     fn validate_node(&self, node: Node) -> Result<(), ValidationError> {
         let op_type = self.hugr.get_optype(node);
 
+        if let OpType::OpaqueOp(opaque) = op_type {
+            Err(OpaqueOpError::UnresolvedOp(
+                node,
+                opaque.op_name().clone(),
+                opaque.extension().clone(),
+            ))?;
+        }
         // The Hugr can have only one root node.
         if node == self.hugr.root() {
             // The root node has no edges.

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -310,6 +310,9 @@ pub enum OpaqueOpError {
         #[source]
         cause: SignatureError,
     },
+    /// Unresolved operation encountered during validation.
+    #[error("Unexpected unresolved opaque operation '{1}' in {0}, from Extension {2}.")]
+    UnresolvedOp(Node, OpName, ExtensionId),
 }
 
 #[cfg(test)]

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -470,3 +470,6 @@ class Package:
             modules=[m.to_serial() for m in self.modules],
             extensions=[e.to_serial() for e in self.extensions],
         )
+
+    def to_json(self) -> str:
+        return self.to_serial().model_dump_json()

--- a/hugr-py/tests/test_cond_loop.py
+++ b/hugr-py/tests/test_cond_loop.py
@@ -3,9 +3,10 @@ import pytest
 from hugr import ops, tys, val
 from hugr.cond_loop import Conditional, ConditionalError, TailLoop
 from hugr.dfg import Dfg
+from hugr.ext import Package
 from hugr.std.int import INT_T, IntVal
 
-from .conftest import H, Measure, validate
+from .conftest import QUANTUM_EXT, H, Measure, validate
 
 SUM_T = tys.Sum([[tys.Qubit], [tys.Qubit, INT_T]])
 
@@ -64,7 +65,7 @@ def test_if_else() -> None:
 
     h.set_outputs(else_.conditional_node)
 
-    validate(h.hugr)
+    validate(Package([h.hugr], [QUANTUM_EXT]))
 
 
 def test_incomplete() -> None:
@@ -93,7 +94,7 @@ def test_tail_loop() -> None:
         build_tl(tl)
     h.set_outputs(tl)
 
-    validate(h.hugr)
+    validate(Package([h.hugr], [QUANTUM_EXT]))
 
     # build then insert
     tl = TailLoop([], [tys.Qubit])
@@ -103,7 +104,7 @@ def test_tail_loop() -> None:
     (q,) = h.inputs()
     tl_n = h.insert_tail_loop(tl, [q], [])
     h.set_outputs(tl_n)
-    validate(h.hugr)
+    validate(Package([h.hugr], [QUANTUM_EXT]))
 
 
 def test_complex_tail_loop() -> None:
@@ -132,6 +133,4 @@ def test_complex_tail_loop() -> None:
     # loop returns [qubit, int, bool]
     h.set_outputs(*tl[:3])
 
-    validate(h.hugr, True)
-
-    # TODO rewrite with context managers
+    validate(h.hugr)

--- a/hugr-py/tests/test_custom.py
+++ b/hugr-py/tests/test_custom.py
@@ -13,8 +13,7 @@ from hugr.std.int import INT_OPS_EXTENSION, INT_TYPES_EXTENSION, DivMod, int_t
 from hugr.std.logic import EXTENSION as LOGIC_EXT
 from hugr.std.logic import Not
 
-from .conftest import CX, H, Measure, Rz, validate
-from .conftest import QUANTUM_EXT as QUANTUM_EXT
+from .conftest import CX, QUANTUM_EXT, H, Measure, Rz, validate
 
 STRINGLY_EXT = ext.Extension("my_extension", ext.Version(0, 0, 0))
 _STRINGLY_DEF = STRINGLY_EXT.add_op_def(

--- a/hugr-py/tests/test_custom.py
+++ b/hugr-py/tests/test_custom.py
@@ -14,7 +14,7 @@ from hugr.std.logic import EXTENSION as LOGIC_EXT
 from hugr.std.logic import Not
 
 from .conftest import CX, H, Measure, Rz, validate
-from .conftest import EXTENSION as QUANTUM_EXT
+from .conftest import QUANTUM_EXT as QUANTUM_EXT
 
 STRINGLY_EXT = ext.Extension("my_extension", ext.Version(0, 0, 0))
 _STRINGLY_DEF = STRINGLY_EXT.add_op_def(
@@ -58,7 +58,7 @@ def test_stringly_typed():
     n = dfg.add(StringlyOp("world")())
     dfg.set_outputs()
     assert dfg.hugr[n].op == StringlyOp("world")
-    validate(dfg.hugr)
+    validate(ext.Package([dfg.hugr], [STRINGLY_EXT]))
 
     new_h = Hugr.from_serial(dfg.hugr.to_serial())
 

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -253,7 +253,7 @@ def test_poly_function(direct_call: bool) -> None:
 
     f_main.set_outputs(call)
 
-    validate(mod.hugr, True)
+    validate(mod.hugr)
 
 
 @pytest.mark.parametrize("direct_call", [True, False])

--- a/hugr-py/tests/test_tracked_dfg.py
+++ b/hugr-py/tests/test_tracked_dfg.py
@@ -1,11 +1,12 @@
 import pytest
 
 from hugr import tys
+from hugr.ext import Package
 from hugr.std.float import FLOAT_T, FloatVal
 from hugr.std.logic import Not
 from hugr.tracked_dfg import TrackedDfg
 
-from .conftest import CX, H, Measure, Rz, validate
+from .conftest import CX, QUANTUM_EXT, H, Measure, Rz, validate
 
 
 def test_track_wire():
@@ -47,7 +48,7 @@ def test_simple_circuit():
         for out in outs
     }
     assert out_ins == {cx_n}
-    validate(circ.hugr)
+    validate(Package([circ.hugr], [QUANTUM_EXT]))
 
 
 def test_complex_circuit():
@@ -67,4 +68,4 @@ def test_complex_circuit():
 
     assert circ._output_op().types == [tys.Qubit, tys.Qubit, tys.Bool]
 
-    validate(circ.hugr)
+    validate(Package([circ.hugr], [QUANTUM_EXT]))

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -299,7 +299,7 @@ the following basic dataflow operations are available (in addition to the
   The signature of the operation comprises the output signature of the child
   Input node (as input) and the input signature of the child Output node (as
   output).
-- `OpaqueOp`: an operation defined by an [Extension](#extension-system).
+- `ExtensionOp`: an operation defined by an [Extension](#extension-system).
 
 The example below shows two DFGs, one nested within the other. Each has an Input
 and an Output node, whose outputs and inputs respectively match the inputs and
@@ -1015,7 +1015,7 @@ named **TypeDef**s and **OpDef**s---see [Declarative Format](#declarative-format
 These are (potentially polymorphic) definitions of types and operations, respectively---polymorphism arises because both may
 declare any number of TypeParams, as per [Polymorphism](#polymorphism). To use a TypeDef as a type,
 it must be instantiated with TypeArgs appropriate for its TypeParams, and similarly
-to use an OpDef as a node operation: each `OpaqueOp` node stores a static-constant list of TypeArgs.
+to use an OpDef as a node operation: each `ExtensionOp` node stores a static-constant list of TypeArgs.
 
 For TypeDef's, any set of TypeArgs conforming to its TypeParams, produces a valid type.
 However, for OpDef's, greater flexibility is allowed: each OpDef *either*


### PR DESCRIPTION
Update python to pass extensions as package when validating

Use cached signatures from opaque when resolving if missing binary compute.
Closes #1362


BREAKING CHANGE: HUGRs containing opaque operations that don't point to an extension in the registry will fail to validate. Use `Package` to pack extensions with HUGRs for serialisation.