### PR TITLE
feat!: variadic logic ops now binary

### DIFF
--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -29,7 +29,7 @@
 //! # use hugr::Hugr;
 //! # use hugr::builder::{BuildError, BuildHandle, Container, DFGBuilder, Dataflow, DataflowHugr, ModuleBuilder, DataflowSubContainer, HugrBuilder};
 //! use hugr::extension::prelude::BOOL_T;
-//! use hugr::std_extensions::logic::{EXTENSION_ID, LOGIC_REG, NotOp};
+//! use hugr::std_extensions::logic::{EXTENSION_ID, LOGIC_REG, LogicOp};
 //! use hugr::types::Signature;
 //!
 //! # fn doctest() -> Result<(), BuildError> {
@@ -49,7 +49,7 @@
 //!         let [w] = dfg.input_wires_arr();
 //!
 //!         // Add an operation connected to the input wire, and get the new dangling wires.
-//!         let [w] = dfg.add_dataflow_op(NotOp, [w])?.outputs_arr();
+//!         let [w] = dfg.add_dataflow_op(LogicOp::Not, [w])?.outputs_arr();
 //!
 //!         // Finish the function, connecting some wires to the output.
 //!         dfg.finish_with_outputs([w])
@@ -65,7 +65,7 @@
 //!         let mut circuit = dfg.as_circuit(dfg.input_wires());
 //!
 //!         // Add multiple operations, indicating only the wire index.
-//!         circuit.append(NotOp, [0])?.append(NotOp, [1])?;
+//!         circuit.append(LogicOp::Not, [0])?.append(LogicOp::Not, [1])?;
 //!
 //!         // Finish the circuit, and return the dataflow graph after connecting its outputs.
 //!         let outputs = circuit.finish();

--- a/hugr-core/src/hugr/rewrite/simple_replace.rs
+++ b/hugr-core/src/hugr/rewrite/simple_replace.rs
@@ -232,7 +232,7 @@ pub(in crate::hugr::rewrite) mod test {
     use crate::ops::OpTag;
     use crate::ops::OpTrait;
     use crate::std_extensions::logic::test::and_op;
-    use crate::std_extensions::logic::NotOp;
+    use crate::std_extensions::logic::LogicOp;
     use crate::type_row;
     use crate::types::{Signature, Type};
     use crate::utils::test_quantum_extension::{cx_gate, h_gate, EXTENSION_ID};
@@ -344,12 +344,12 @@ pub(in crate::hugr::rewrite) mod test {
             DFGBuilder::new(inout_sig(type_row![BOOL_T], type_row![BOOL_T, BOOL_T])).unwrap();
         let [b] = dfg_builder.input_wires_arr();
 
-        let not_inp = dfg_builder.add_dataflow_op(NotOp, vec![b]).unwrap();
+        let not_inp = dfg_builder.add_dataflow_op(LogicOp::Not, vec![b]).unwrap();
         let [b] = not_inp.outputs_arr();
 
-        let not_0 = dfg_builder.add_dataflow_op(NotOp, vec![b]).unwrap();
+        let not_0 = dfg_builder.add_dataflow_op(LogicOp::Not, vec![b]).unwrap();
         let [b0] = not_0.outputs_arr();
-        let not_1 = dfg_builder.add_dataflow_op(NotOp, vec![b]).unwrap();
+        let not_1 = dfg_builder.add_dataflow_op(LogicOp::Not, vec![b]).unwrap();
         let [b1] = not_1.outputs_arr();
 
         (
@@ -377,10 +377,10 @@ pub(in crate::hugr::rewrite) mod test {
             DFGBuilder::new(inout_sig(type_row![BOOL_T], type_row![BOOL_T, BOOL_T])).unwrap();
         let [b] = dfg_builder.input_wires_arr();
 
-        let not_inp = dfg_builder.add_dataflow_op(NotOp, vec![b]).unwrap();
+        let not_inp = dfg_builder.add_dataflow_op(LogicOp::Not, vec![b]).unwrap();
         let [b] = not_inp.outputs_arr();
 
-        let not_0 = dfg_builder.add_dataflow_op(NotOp, vec![b]).unwrap();
+        let not_0 = dfg_builder.add_dataflow_op(LogicOp::Not, vec![b]).unwrap();
         let [b0] = not_0.outputs_arr();
         let b1 = b;
 
@@ -726,7 +726,7 @@ pub(in crate::hugr::rewrite) mod test {
             let mut b =
                 DFGBuilder::new(inout_sig(type_row![BOOL_T], type_row![BOOL_T, BOOL_T])).unwrap();
             let [w] = b.input_wires_arr();
-            let not = b.add_dataflow_op(NotOp, vec![w]).unwrap();
+            let not = b.add_dataflow_op(LogicOp::Not, vec![w]).unwrap();
             let [w_not] = not.outputs_arr();
             (
                 b.finish_prelude_hugr_with_outputs([w, w_not]).unwrap(),

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -13,7 +13,7 @@ use crate::ops::{self, dataflow::IOTrait, Input, Module, Noop, Output, Value, DF
 use crate::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
 use crate::std_extensions::arithmetic::int_ops::INT_OPS_REGISTRY;
 use crate::std_extensions::arithmetic::int_types::{ConstInt, INT_TYPES};
-use crate::std_extensions::logic::NotOp;
+use crate::std_extensions::logic::LogicOp;
 use crate::types::type_param::TypeParam;
 use crate::types::{
     FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature, SumType, Type, TypeArg, TypeBound,
@@ -346,7 +346,7 @@ fn extension_ops() -> Result<(), Box<dyn std::error::Error>> {
     let [wire] = dfg.input_wires_arr();
 
     // Add an extension operation
-    let extension_op: ExtensionOp = NotOp.to_extension_op().unwrap();
+    let extension_op: ExtensionOp = LogicOp::Not.to_extension_op().unwrap();
     let wire = dfg
         .add_dataflow_op(extension_op.clone(), [wire])
         .unwrap()
@@ -365,7 +365,7 @@ fn opaque_ops() -> Result<(), Box<dyn std::error::Error>> {
     let [wire] = dfg.input_wires_arr();
 
     // Add an extension operation
-    let extension_op: ExtensionOp = NotOp.to_extension_op().unwrap();
+    let extension_op: ExtensionOp = LogicOp::Not.to_extension_op().unwrap();
     let wire = dfg
         .add_dataflow_op(extension_op.clone(), [wire])
         .unwrap()

--- a/hugr-core/src/hugr/serialize/upgrade/test.rs
+++ b/hugr-core/src/hugr/serialize/upgrade/test.rs
@@ -2,7 +2,7 @@ use crate::{
     builder::{DFGBuilder, Dataflow, DataflowHugr},
     extension::prelude::BOOL_T,
     hugr::serialize::test::check_hugr_deserialize,
-    std_extensions::logic::NaryLogic,
+    std_extensions::logic::LogicOp,
     type_row,
     types::Signature,
 };
@@ -49,9 +49,7 @@ pub fn hugr_with_named_op() -> Hugr {
     let mut builder =
         DFGBuilder::new(Signature::new(type_row![BOOL_T, BOOL_T], type_row![BOOL_T])).unwrap();
     let [a, b] = builder.input_wires_arr();
-    let x = builder
-        .add_dataflow_op(NaryLogic::And.with_n_inputs(2), [a, b])
-        .unwrap();
+    let x = builder.add_dataflow_op(LogicOp::And, [a, b]).unwrap();
     builder
         .finish_prelude_hugr_with_outputs(x.outputs())
         .unwrap()

--- a/hugr-core/src/hugr/serialize/upgrade/testcases/hugr_with_named_op.json
+++ b/hugr-core/src/hugr/serialize/upgrade/testcases/hugr_with_named_op.json
@@ -60,12 +60,7 @@
       "extension": "logic",
       "name": "And",
       "description": "logical 'and'",
-      "args": [
-        {
-          "tya": "BoundedNat",
-          "n": 2
-        }
-      ],
+      "args": [],
       "signature": {
         "input": [
           {

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -18,7 +18,8 @@ use crate::ops::handle::NodeHandle;
 use crate::ops::leaf::MakeTuple;
 use crate::ops::{self, Noop, OpType, Value};
 use crate::std_extensions::logic::test::{and_op, or_op};
-use crate::std_extensions::logic::{self, NotOp};
+use crate::std_extensions::logic::LogicOp;
+use crate::std_extensions::logic::{self};
 use crate::types::type_param::{TypeArg, TypeArgError};
 use crate::types::{
     CustomType, FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature, Type, TypeBound, TypeRV,
@@ -319,8 +320,8 @@ fn dfg_with_cycles() {
     let mut h = closed_dfg_root_hugr(Signature::new(type_row![BOOL_T, BOOL_T], type_row![BOOL_T]));
     let [input, output] = h.get_io(h.root()).unwrap();
     let or = h.add_node_with_parent(h.root(), or_op());
-    let not1 = h.add_node_with_parent(h.root(), NotOp);
-    let not2 = h.add_node_with_parent(h.root(), NotOp);
+    let not1 = h.add_node_with_parent(h.root(), LogicOp::Not);
+    let not2 = h.add_node_with_parent(h.root(), LogicOp::Not);
     h.connect(input, 0, or, 0);
     h.connect(or, 0, not1, 0);
     h.connect(not1, 0, or, 1);

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -733,7 +733,7 @@ mod tests {
     use crate::extension::{prelude, ExtensionRegistry};
     use crate::ops::Const;
     use crate::std_extensions::arithmetic::float_types::{self, ConstF64};
-    use crate::std_extensions::logic;
+    use crate::std_extensions::logic::{self, LogicOp};
     use crate::utils::test_quantum_extension::{self, cx_gate, rz_f64};
     use crate::{
         builder::{
@@ -746,7 +746,7 @@ mod tests {
         },
         hugr::views::{HierarchyView, SiblingGraph},
         ops::handle::{DfgID, FuncID, NodeHandle},
-        std_extensions::logic::{test::and_op, NotOp},
+        std_extensions::logic::test::and_op,
         type_row,
     };
 
@@ -821,9 +821,9 @@ mod tests {
         )?;
         let func_id = {
             let mut dfg = mod_builder.define_declaration(&func)?;
-            let outs1 = dfg.add_dataflow_op(NotOp, dfg.input_wires())?;
-            let outs2 = dfg.add_dataflow_op(NotOp, outs1.outputs())?;
-            let outs3 = dfg.add_dataflow_op(NotOp, outs2.outputs())?;
+            let outs1 = dfg.add_dataflow_op(LogicOp::Not, dfg.input_wires())?;
+            let outs2 = dfg.add_dataflow_op(LogicOp::Not, outs1.outputs())?;
+            let outs3 = dfg.add_dataflow_op(LogicOp::Not, outs2.outputs())?;
             dfg.finish_with_outputs(outs3.outputs())?
         };
         let hugr = mod_builder
@@ -844,8 +844,8 @@ mod tests {
         let func_id = {
             let mut dfg = mod_builder.define_declaration(&func)?;
             let [b0] = dfg.input_wires_arr();
-            let [b1] = dfg.add_dataflow_op(NotOp, [b0])?.outputs_arr();
-            let [b2] = dfg.add_dataflow_op(NotOp, [b1])?.outputs_arr();
+            let [b1] = dfg.add_dataflow_op(LogicOp::Not, [b0])?.outputs_arr();
+            let [b2] = dfg.add_dataflow_op(LogicOp::Not, [b1])?.outputs_arr();
             dfg.finish_with_outputs([b1, b2])?
         };
         let hugr = mod_builder
@@ -1106,7 +1106,10 @@ mod tests {
 
         let mut builder = DFGBuilder::new(inout_sig(one_bit.clone(), two_bit.clone())).unwrap();
         let inw = builder.input_wires().exactly_one().unwrap();
-        let outw1 = builder.add_dataflow_op(NotOp, [inw]).unwrap().out_wire(0);
+        let outw1 = builder
+            .add_dataflow_op(LogicOp::Not, [inw])
+            .unwrap()
+            .out_wire(0);
         let outw2 = builder
             .add_dataflow_op(and_op(), [inw, outw1])
             .unwrap()

--- a/hugr-core/src/hugr/views/tests.rs
+++ b/hugr-core/src/hugr/views/tests.rs
@@ -10,6 +10,7 @@ use crate::{
         handle::{DataflowOpID, NodeHandle},
         Value,
     },
+    std_extensions::logic::LogicOp,
     type_row,
     types::Signature,
     utils::test_quantum_extension::cx_gate,
@@ -119,7 +120,7 @@ fn all_ports(sample_hugr: (Hugr, BuildHandle<DataflowOpID>, BuildHandle<Dataflow
 fn value_types() {
     use crate::builder::Container;
     use crate::extension::prelude::BOOL_T;
-    use crate::std_extensions::logic::NotOp;
+
     use crate::utils::test_quantum_extension::h_gate;
     use itertools::Itertools;
 
@@ -128,7 +129,7 @@ fn value_types() {
 
     let [q, b] = dfg.input_wires_arr();
     let n1 = dfg.add_dataflow_op(h_gate(), [q]).unwrap();
-    let n2 = dfg.add_dataflow_op(NotOp, [b]).unwrap();
+    let n2 = dfg.add_dataflow_op(LogicOp::Not, [b]).unwrap();
     dfg.add_other_wire(n1.node(), n2.node());
     let h = dfg
         .finish_prelude_hugr_with_outputs([n2.out_wire(0), n1.out_wire(0)])
@@ -168,7 +169,7 @@ fn test_dataflow_ports_only() {
     use crate::builder::DataflowSubContainer;
     use crate::extension::{prelude::BOOL_T, PRELUDE_REGISTRY};
     use crate::hugr::views::PortIterator;
-    use crate::std_extensions::logic::NotOp;
+
     use itertools::Itertools;
 
     let mut dfg = DFGBuilder::new(endo_sig(BOOL_T)).unwrap();
@@ -184,7 +185,7 @@ fn test_dataflow_ports_only() {
     };
     let [in_bool] = dfg.input_wires_arr();
 
-    let not = dfg.add_dataflow_op(NotOp, [in_bool]).unwrap();
+    let not = dfg.add_dataflow_op(LogicOp::Not, [in_bool]).unwrap();
     let call = dfg
         .call(
             local_and.handle(),

--- a/specification/std_extensions/logic.json
+++ b/specification/std_extensions/logic.json
@@ -36,15 +36,63 @@
       "extension": "logic",
       "name": "And",
       "description": "logical 'and'",
-      "signature": null,
-      "binary": true
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            },
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            }
+          ],
+          "output": [
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
     },
     "Eq": {
       "extension": "logic",
       "name": "Eq",
       "description": "test if bools are equal",
-      "signature": null,
-      "binary": true
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            },
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            }
+          ],
+          "output": [
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
     },
     "Not": {
       "extension": "logic",
@@ -76,8 +124,32 @@
       "extension": "logic",
       "name": "Or",
       "description": "logical 'or'",
-      "signature": null,
-      "binary": true
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            },
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            }
+          ],
+          "output": [
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
     }
   }
 }


### PR DESCRIPTION

BREAKING CHANGE: And, Or, Eq are all now just binary operations. `NaryLogic` renamed to `LogicOp` and `NotOp` has been merged in to it.