### PR TITLE
feat: Add missing ops

### DIFF
--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -39,8 +39,10 @@ pub enum FloatOps {
     fabs,
     fmul,
     fdiv,
+    fpow,
     ffloor,
     fceil,
+    fround,
     ftostring,
 }
 
@@ -60,10 +62,10 @@ impl MakeOpDef for FloatOps {
             feq | fne | flt | fgt | fle | fge => {
                 Signature::new(type_row![FLOAT64_TYPE; 2], type_row![BOOL_T])
             }
-            fmax | fmin | fadd | fsub | fmul | fdiv => {
+            fmax | fmin | fadd | fsub | fmul | fdiv | fpow => {
                 Signature::new(type_row![FLOAT64_TYPE; 2], type_row![FLOAT64_TYPE])
             }
-            fneg | fabs | ffloor | fceil => Signature::new_endo(type_row![FLOAT64_TYPE]),
+            fneg | fabs | ffloor | fceil | fround => Signature::new_endo(type_row![FLOAT64_TYPE]),
             ftostring => Signature::new(type_row![FLOAT64_TYPE], STRING_TYPE),
         }
         .into()
@@ -86,8 +88,10 @@ impl MakeOpDef for FloatOps {
             fabs => "absolute value",
             fmul => "multiplication",
             fdiv => "division",
+            fpow => "exponentiation",
             ffloor => "floor",
             fceil => "ceiling",
+            fround => "round",
             ftostring => "string representation",
         }
         .to_string()

--- a/hugr-core/src/std_extensions/arithmetic/float_ops/const_fold.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops/const_fold.rs
@@ -12,9 +12,11 @@ pub(super) fn set_fold(op: &FloatOps, def: &mut OpDef) {
     use FloatOps::*;
 
     match op {
-        fmax | fmin | fadd | fsub | fmul | fdiv => def.set_constant_folder(BinaryFold::from_op(op)),
+        fmax | fmin | fadd | fsub | fmul | fdiv | fpow => {
+            def.set_constant_folder(BinaryFold::from_op(op))
+        }
         feq | fne | flt | fgt | fle | fge => def.set_constant_folder(CmpFold::from_op(*op)),
-        fneg | fabs | ffloor | fceil => def.set_constant_folder(UnaryFold::from_op(op)),
+        fneg | fabs | ffloor | fceil | fround => def.set_constant_folder(UnaryFold::from_op(op)),
         ftostring => def.set_constant_folder(ToStringFold::from_op(op)),
     }
 }
@@ -43,6 +45,7 @@ impl BinaryFold {
             fsub => std::ops::Sub::sub,
             fmul => std::ops::Mul::mul,
             fdiv => std::ops::Div::div,
+            fpow => f64::powf,
             _ => panic!("not binary op"),
         }))
     }
@@ -106,6 +109,7 @@ impl UnaryFold {
             fabs => f64::abs,
             ffloor => f64::floor,
             fceil => f64::ceil,
+            fround => f64::round,
             _ => panic!("not unary op."),
         }))
     }

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -119,12 +119,12 @@ impl MakeOpDef for IntOpDef {
         let tv0 = int_tv(0);
         match self {
             iwiden_s | iwiden_u => CustomValidator::new(
-                int_polytype(2, vec![tv0.clone()], vec![int_tv(1)]),
+                int_polytype(2, vec![tv0], vec![int_tv(1)]),
                 IOValidator { f_ge_s: false },
             )
             .into(),
             inarrow_s | inarrow_u => CustomValidator::new(
-                int_polytype(2, tv0.clone(), sum_ty_with_err(int_tv(1))),
+                int_polytype(2, tv0, sum_ty_with_err(int_tv(1))),
                 IOValidator { f_ge_s: true },
             )
             .into(),
@@ -176,8 +176,8 @@ impl MakeOpDef for IntOpDef {
             iwiden_s => "widen a signed integer to a wider one with the same value",
             inarrow_u => "narrow an unsigned integer to a narrower one with the same value if possible",
             inarrow_s => "narrow a signed integer to a narrower one with the same value if possible",
-            itobool => "convert to bool (1 is true, 0 is false)",
-            ifrombool => "convert from bool (1 is true, 0 is false)",
+            itobool => "convert a 1-bit integer to bool (1 is true, 0 is false)",
+            ifrombool => "convert from bool into a 1-bit integer (1 is true, 0 is false)",
             ieq => "equality test",
             ine => "inequality test",
             ilt_u => "\"less than\" as unsigned integers",
@@ -226,8 +226,8 @@ impl MakeOpDef for IntOpDef {
             (leftmost bits replace rightmost bits)",
             irotr => "rotate first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits replace leftmost bits)",
-            is_to_u => "convert signed to unsigned by taking absolute value. Panics if the input is negative",
-            iu_to_s => "convert unsigned to signed by taking absolute value. Panics if the input is too large",
+            is_to_u => "convert signed to unsigned by taking absolute value",
+            iu_to_s => "convert unsigned to signed by taking absolute value",
             itostring_s => "convert a signed integer to its string representation",
             itostring_u => "convert an unsigned integer to its string representation",
         }.into()

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -89,6 +89,7 @@ pub enum IntOpDef {
     idiv_s,
     imod_checked_s,
     imod_s,
+    ipow,
     iabs,
     iand,
     ior,
@@ -98,6 +99,8 @@ pub enum IntOpDef {
     ishr,
     irotl,
     irotr,
+    iu_to_s,
+    is_to_u,
     itostring_u,
     itostring_s,
 }
@@ -130,10 +133,10 @@ impl MakeOpDef for IntOpDef {
             ieq | ine | ilt_u | ilt_s | igt_u | igt_s | ile_u | ile_s | ige_u | ige_s => {
                 int_polytype(1, vec![tv0; 2], type_row![BOOL_T]).into()
             }
-            imax_u | imax_s | imin_u | imin_s | iadd | isub | imul | iand | ior | ixor => {
+            imax_u | imax_s | imin_u | imin_s | iadd | isub | imul | iand | ior | ixor | ipow => {
                 ibinop_sig().into()
             }
-            ineg | iabs | inot => iunop_sig().into(),
+            ineg | iabs | inot | iu_to_s | is_to_u => iunop_sig().into(),
             idivmod_checked_u | idivmod_checked_s => {
                 let intpair: TypeRowRV = vec![tv0; 2].into();
                 int_polytype(
@@ -209,6 +212,7 @@ impl MakeOpDef for IntOpDef {
             idiv_s => "as idivmod_s but discarding the second output",
             imod_checked_s => "as idivmod_checked_s but discarding the first output",
             imod_s => "as idivmod_s but discarding the first output",
+            ipow => "raise first input to the power of second input",
             iabs => "convert signed to unsigned by taking absolute value",
             iand => "bitwise AND",
             ior => "bitwise OR",
@@ -222,6 +226,8 @@ impl MakeOpDef for IntOpDef {
             (leftmost bits replace rightmost bits)",
             irotr => "rotate first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits replace leftmost bits)",
+            is_to_u => "convert signed to unsigned by taking absolute value. Panics if the input is negative",
+            iu_to_s => "convert unsigned to signed by taking absolute value. Panics if the input is too large",
             itostring_s => "convert a signed integer to its string representation",
             itostring_u => "convert an unsigned integer to its string representation",
         }.into()
@@ -378,7 +384,7 @@ mod test {
     fn test_int_ops_extension() {
         assert_eq!(EXTENSION.name() as &str, "arithmetic.int");
         assert_eq!(EXTENSION.types().count(), 0);
-        assert_eq!(EXTENSION.operations().count(), 47);
+        assert_eq!(EXTENSION.operations().count(), 50);
         for (name, _) in EXTENSION.operations() {
             assert!(name.starts_with('i'));
         }

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -468,6 +468,10 @@ mod test {
     #[case::ipow(IntOpDef::ipow.with_log_width(5), &[2, 8], &[256], 5)]
     #[case::iu_to_s(IntOpDef::iu_to_s.with_log_width(5), &[42], &[42], 5)]
     #[case::is_to_u(IntOpDef::is_to_u.with_log_width(5), &[42], &[42], 5)]
+    #[should_panic(expected = "too large to be converted to signed")]
+    #[case::iu_to_s_panic(IntOpDef::iu_to_s.with_log_width(5), &[u32::MAX as u64], &[], 5)]
+    #[should_panic(expected = "Cannot convert negative integer")]
+    #[case::is_to_u_panic(IntOpDef::is_to_u.with_log_width(5), &[(0u32.wrapping_sub(42)) as u64], &[], 5)]
     fn int_fold(
         #[case] op: ConcreteIntOp,
         #[case] inputs: &[u64],

--- a/hugr-py/src/hugr/std/_json_defs/arithmetic/float.json
+++ b/hugr-py/src/hugr/std/_json_defs/arithmetic/float.json
@@ -522,6 +522,73 @@
       },
       "binary": false
     },
+    "fpow": {
+      "extension": "arithmetic.float",
+      "name": "fpow",
+      "description": "exponentiation",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            },
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "fround": {
+      "extension": "arithmetic.float",
+      "name": "fround",
+      "description": "round",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
     "fsub": {
       "extension": "arithmetic.float",
       "name": "fsub",

--- a/hugr-py/src/hugr/std/_json_defs/arithmetic/int.json
+++ b/hugr-py/src/hugr/std/_json_defs/arithmetic/int.json
@@ -959,7 +959,7 @@
     "ifrombool": {
       "extension": "arithmetic.int",
       "name": "ifrombool",
-      "description": "convert from bool (1 is true, 0 is false)",
+      "description": "convert from bool into a 1-bit integer (1 is true, 0 is false)",
       "signature": {
         "params": [],
         "body": {
@@ -2489,6 +2489,75 @@
       },
       "binary": false
     },
+    "ipow": {
+      "extension": "arithmetic.int",
+      "name": "ipow",
+      "description": "raise first input to the power of second input",
+      "signature": {
+        "params": [
+          {
+            "tp": "BoundedNat",
+            "bound": 7
+          }
+        ],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            },
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
     "irotl": {
       "extension": "arithmetic.int",
       "name": "irotl",
@@ -2587,6 +2656,59 @@
               ],
               "bound": "C"
             },
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "is_to_u": {
+      "extension": "arithmetic.int",
+      "name": "is_to_u",
+      "description": "convert signed to unsigned by taking absolute value",
+      "signature": {
+        "params": [
+          {
+            "tp": "BoundedNat",
+            "bound": 7
+          }
+        ],
+        "body": {
+          "input": [
             {
               "t": "Opaque",
               "extension": "arithmetic.int.types",
@@ -2837,7 +2959,7 @@
     "itobool": {
       "extension": "arithmetic.int",
       "name": "itobool",
-      "description": "convert to bool (1 is true, 0 is false)",
+      "description": "convert a 1-bit integer to bool (1 is true, 0 is false)",
       "signature": {
         "params": [],
         "body": {
@@ -2947,6 +3069,59 @@
               "extension": "prelude",
               "id": "string",
               "args": [],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "iu_to_s": {
+      "extension": "arithmetic.int",
+      "name": "iu_to_s",
+      "description": "convert unsigned to signed by taking absolute value",
+      "signature": {
+        "params": [
+          {
+            "tp": "BoundedNat",
+            "bound": 7
+          }
+        ],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
               "bound": "C"
             }
           ],

--- a/specification/std_extensions/arithmetic/float.json
+++ b/specification/std_extensions/arithmetic/float.json
@@ -522,6 +522,73 @@
       },
       "binary": false
     },
+    "fpow": {
+      "extension": "arithmetic.float",
+      "name": "fpow",
+      "description": "exponentiation",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            },
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "fround": {
+      "extension": "arithmetic.float",
+      "name": "fround",
+      "description": "round",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
     "fsub": {
       "extension": "arithmetic.float",
       "name": "fsub",

--- a/specification/std_extensions/arithmetic/int.json
+++ b/specification/std_extensions/arithmetic/int.json
@@ -959,7 +959,7 @@
     "ifrombool": {
       "extension": "arithmetic.int",
       "name": "ifrombool",
-      "description": "convert from bool (1 is true, 0 is false)",
+      "description": "convert from bool into a 1-bit integer (1 is true, 0 is false)",
       "signature": {
         "params": [],
         "body": {
@@ -2489,6 +2489,75 @@
       },
       "binary": false
     },
+    "ipow": {
+      "extension": "arithmetic.int",
+      "name": "ipow",
+      "description": "raise first input to the power of second input",
+      "signature": {
+        "params": [
+          {
+            "tp": "BoundedNat",
+            "bound": 7
+          }
+        ],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            },
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
     "irotl": {
       "extension": "arithmetic.int",
       "name": "irotl",
@@ -2587,6 +2656,59 @@
               ],
               "bound": "C"
             },
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "is_to_u": {
+      "extension": "arithmetic.int",
+      "name": "is_to_u",
+      "description": "convert signed to unsigned by taking absolute value",
+      "signature": {
+        "params": [
+          {
+            "tp": "BoundedNat",
+            "bound": 7
+          }
+        ],
+        "body": {
+          "input": [
             {
               "t": "Opaque",
               "extension": "arithmetic.int.types",
@@ -2837,7 +2959,7 @@
     "itobool": {
       "extension": "arithmetic.int",
       "name": "itobool",
-      "description": "convert to bool (1 is true, 0 is false)",
+      "description": "convert a 1-bit integer to bool (1 is true, 0 is false)",
       "signature": {
         "params": [],
         "body": {
@@ -2947,6 +3069,59 @@
               "extension": "prelude",
               "id": "string",
               "args": [],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "iu_to_s": {
+      "extension": "arithmetic.int",
+      "name": "iu_to_s",
+      "description": "convert unsigned to signed by taking absolute value",
+      "signature": {
+        "params": [
+          {
+            "tp": "BoundedNat",
+            "bound": 7
+          }
+        ],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "Variable",
+                  "idx": 0,
+                  "cached_decl": {
+                    "tp": "BoundedNat",
+                    "bound": 7
+                  }
+                }
+              ],
               "bound": "C"
             }
           ],


### PR DESCRIPTION
Adds some missing operations:

- `fpow`
- `fround`
- `ipow`
- `iu_to_s` / `is_to_u`. These are almost noops, but some runtimes may prefer to check and panic if the value is out-of-bounds.
- Mention that `ifrombool` / `itobool` only work with `i1` in their description. 