### PR TITLE
refactor!: Bring the collections ext in line with other extension defs

### DIFF
--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -524,21 +524,21 @@ mod test {
                 inputs: vec![listy.clone()].into(),
                 sum_rows: vec![type_row![]],
                 other_outputs: vec![listy.clone()].into(),
-                extension_delta: collections::EXTENSION_NAME.into(),
+                extension_delta: collections::EXTENSION_ID.into(),
             },
         );
         let r_df1 = replacement.add_node_with_parent(
             r_bb,
             DFG {
                 signature: Signature::new(vec![listy.clone()], simple_unary_plus(intermed.clone()))
-                    .with_extension_delta(collections::EXTENSION_NAME),
+                    .with_extension_delta(collections::EXTENSION_ID),
             },
         );
         let r_df2 = replacement.add_node_with_parent(
             r_bb,
             DFG {
                 signature: Signature::new(intermed, simple_unary_plus(just_list.clone()))
-                    .with_extension_delta(collections::EXTENSION_NAME),
+                    .with_extension_delta(collections::EXTENSION_ID),
             },
         );
         [0, 1]

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -547,7 +547,7 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
         PolyFuncType::new(
             [BOUND],
             Signature::new(vec![], vec![list_of_var.clone()])
-                .with_extension_delta(collections::EXTENSION_NAME),
+                .with_extension_delta(collections::EXTENSION_ID),
         ),
     )?;
     let empty_list = Value::extension(collections::ListValue::new_empty(Type::new_var_use(

--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -208,7 +208,7 @@ impl MakeOpDef for ListOp {
 }
 
 lazy_static! {
-    /// Extension for basic float operations.
+    /// Extension for list operations.
     pub static ref EXTENSION: Extension = {
         println!("creating collections extension");
         let mut extension = Extension::new(EXTENSION_ID, VERSION);
@@ -227,7 +227,7 @@ lazy_static! {
         extension
     };
 
-    /// Registry of extensions required to validate float operations.
+    /// Registry of extensions required to validate list operations.
     pub static ref COLLECTIONS_REGISTRY: ExtensionRegistry  = ExtensionRegistry::try_new([
         PRELUDE.to_owned(),
         EXTENSION.to_owned(),

--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -131,8 +131,8 @@ impl ListOp {
     /// Compute the signature of the operation, given the list type definition.
     fn compute_signature(self, list_type_def: &TypeDef) -> SignatureFunc {
         use ListOp::*;
-        let e = self.elem_type();
-        let l = self.list_type(list_type_def);
+        let e = Type::new_var_use(0, TypeBound::Any);
+        let l = self.list_type(list_type_def, 0);
         match self {
             pop => self
                 .list_polytype(vec![l.clone()], vec![l.clone(), e.clone()])
@@ -150,16 +150,11 @@ impl ListOp {
         PolyFuncTypeRV::new(vec![Self::TP], FuncValueType::new(input, output))
     }
 
-    /// Returns a generic unbounded type for a list element.
-    fn elem_type(self) -> Type {
-        Type::new_var_use(0, TypeBound::Any)
-    }
-
-    /// Returns the type of a generic list.
-    fn list_type(self, list_type_def: &TypeDef) -> Type {
+    /// Returns the type of a generic list, associated with the element type parameter at index `idx`.
+    fn list_type(self, list_type_def: &TypeDef, idx: usize) -> Type {
         Type::new_extension(
             list_type_def
-                .instantiate(vec![TypeArg::new_var_use(0, Self::TP)])
+                .instantiate(vec![TypeArg::new_var_use(idx, Self::TP)])
                 .unwrap(),
         )
     }

--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -337,7 +337,9 @@ mod test {
 
     #[test]
     fn test_extension() {
-        assert_eq!(EXTENSION.name(), &EXTENSION_ID);
+        assert_eq!(&ListOp::push.extension_id(), EXTENSION.name());
+        assert_eq!(&ListOp::push.extension(), EXTENSION.name());
+        assert!(ListOp::pop.registry().contains(EXTENSION.name()));
         for (_, op_def) in EXTENSION.operations() {
             assert_eq!(op_def.extension(), &EXTENSION_ID);
         }

--- a/hugr-core/src/std_extensions/collections/list_fold.rs
+++ b/hugr-core/src/std_extensions/collections/list_fold.rs
@@ -1,0 +1,49 @@
+//! Folding definitions for list operations.
+
+use crate::extension::{ConstFold, OpDef};
+use crate::ops;
+use crate::types::type_param::TypeArg;
+use crate::utils::sorted_consts;
+
+use super::{ListOp, ListValue};
+
+pub(super) fn set_fold(op: &ListOp, def: &mut OpDef) {
+    match op {
+        ListOp::pop => def.set_constant_folder(PopFold),
+        ListOp::push => def.set_constant_folder(PushFold),
+    }
+}
+
+pub struct PopFold;
+
+impl ConstFold for PopFold {
+    fn fold(
+        &self,
+        _type_args: &[TypeArg],
+        consts: &[(crate::IncomingPort, ops::Value)],
+    ) -> crate::extension::ConstFoldResult {
+        let [list]: [&ops::Value; 1] = sorted_consts(consts).try_into().ok()?;
+        let list: &ListValue = list.get_custom_value().expect("Should be list value.");
+        let mut list = list.clone();
+        let elem = list.0.pop()?; // empty list fails to evaluate "pop"
+
+        Some(vec![(0.into(), list.into()), (1.into(), elem)])
+    }
+}
+
+pub struct PushFold;
+
+impl ConstFold for PushFold {
+    fn fold(
+        &self,
+        _type_args: &[TypeArg],
+        consts: &[(crate::IncomingPort, ops::Value)],
+    ) -> crate::extension::ConstFoldResult {
+        let [list, elem]: [&ops::Value; 2] = sorted_consts(consts).try_into().ok()?;
+        let list: &ListValue = list.get_custom_value().expect("Should be list value.");
+        let mut list = list.clone();
+        list.0.push(elem.clone());
+
+        Some(vec![(0.into(), list.into())])
+    }
+}

--- a/hugr-passes/src/const_fold/test.rs
+++ b/hugr-passes/src/const_fold/test.rs
@@ -143,12 +143,12 @@ fn test_list_ops() -> Result<(), Box<dyn std::error::Error>> {
     let list_wire = build.add_load_const(list.clone());
 
     let pop = build.add_dataflow_op(
-        ListOp::Pop.with_type(BOOL_T).to_extension_op(&reg).unwrap(),
+        ListOp::pop.with_type(BOOL_T).to_extension_op(&reg).unwrap(),
         [list_wire],
     )?;
 
     let push = build.add_dataflow_op(
-        ListOp::Push
+        ListOp::push
             .with_type(BOOL_T)
             .to_extension_op(&reg)
             .unwrap(),


### PR DESCRIPTION
Refactors the list operations definition so it's easier to add new ones (#1467), and to bring it in line with the other extension definitions.

- Make the operation enum variants `camelCase`, to match their op names. This lets us us `strum` to auto-derive all the string conversions.
- Implemented `MakeOpDef`, `MakeRegisteredOp`,

BREAKING CHANGE: Renamed `ListOp` variants to camelCase. `collections::EXTENSION_NAME` is now called `EXTENSION_ID`.