### PR TITLE
fix(hugr-py): record node children correctly when deserializing

### DIFF
--- a/hugr-py/src/hugr/hugr.py
+++ b/hugr-py/src/hugr/hugr.py
@@ -669,9 +669,10 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
                 parent = None
 
             serial_node.root.parent = -1
-            hugr._nodes.append(
-                NodeData(serial_node.root.deserialize(), parent, metadata=node_meta)
+            n = hugr._add_node(
+                serial_node.root.deserialize(), parent, metadata=node_meta
             )
+            assert n.idx == idx, "Nodes should be added contiguously"
 
         for (src_node, src_offset), (dst_node, dst_offset) in serial.edges:
             if src_offset is None or dst_offset is None:

--- a/hugr-py/tests/serialization/test_basic.py
+++ b/hugr-py/tests/serialization/test_basic.py
@@ -1,4 +1,6 @@
+from hugr import Hugr, tys
 from hugr._serialization.serial_hugr import SerialHugr, serialization_version
+from hugr.function import Module
 
 
 def test_empty():
@@ -10,3 +12,15 @@ def test_empty():
         "metadata": None,
         "encoder": None,
     }
+
+
+def test_children():
+    mod = Module()
+    mod.declare_function("foo", tys.PolyFuncType([], tys.FunctionType.empty()))
+
+    h = mod.hugr
+    assert len(h.children(h.root)) == 1
+
+    h2 = Hugr.load_json(h.to_json())
+
+    assert len(h2.children(h2.root)) == 1


### PR DESCRIPTION
Closes #1479