### PR TITLE
feat: `Option` / `Result` helpers

### DIFF
--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -333,8 +333,7 @@ class Result(Sum):
         self.variant_rows = [list(ok), list(err)]
 
     def __repr__(self) -> str:
-        ok = self.variant_rows[0]
-        err = self.variant_rows[1]
+        ok, err  = self.variant_rows
         ok_str = ok[0] if len(ok) == 1 else tuple(ok)
         err_str = err[0] if len(err) == 1 else tuple(err)
         return f"Result({ok_str}, {err_str})"

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -328,12 +328,23 @@ class Either(Sum):
 
     In fallible contexts, the Left variant is used to represent success, and the
     Right variant is used to represent failure.
+
+    Example:
+        >>> either = Either([Bool, Bool], [Bool])
+        >>> either
+        Either(left=[Bool, Bool], right=[Bool])
+        >>> str(either)
+        'Either((Bool, Bool), Bool)'
     """
 
     def __init__(self, left: Iterable[Type], right: Iterable[Type]):
         self.variant_rows = [list(left), list(right)]
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no cover
+        left, right = self.variant_rows
+        return f"Either(left={left}, right={right})"
+
+    def __str__(self) -> str:
         left, right = self.variant_rows
         left_str = left[0] if len(left) == 1 else tuple(left)
         right_str = right[0] if len(right) == 1 else tuple(right)

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -9,6 +9,8 @@ import hugr._serialization.tys as stys
 from hugr.utils import ser_it
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from hugr import ext
 
 
@@ -301,6 +303,41 @@ class Tuple(Sum):
 
     def __repr__(self) -> str:
         return f"Tuple{tuple(self.variant_rows[0])}"
+
+
+@dataclass(eq=False)
+class Option(Sum):
+    """Optional tuple of elements.
+
+    Instances of this type correspond to :class:`Sum` with two variants.
+    The first variant is the tuple of elements, the second is empty.
+    """
+
+    def __init__(self, *tys: Type):
+        self.variant_rows = [list(tys), []]
+
+    def __repr__(self) -> str:
+        return f"Option({', '.join(map(repr, self.variant_rows[0]))})"
+
+
+@dataclass(eq=False)
+class Result(Sum):
+    """Fallible tuple of elements.
+
+    Instances of this type correspond to :class:`Sum` with two variants. The
+    first variant is a tuple of elements representing the successful state, the
+    second is a tuple of elements representing failure.
+    """
+
+    def __init__(self, ok: Iterable[Type], err: Iterable[Type]):
+        self.variant_rows = [list(ok), list(err)]
+
+    def __repr__(self) -> str:
+        ok = self.variant_rows[0]
+        err = self.variant_rows[1]
+        ok_str = ok[0] if len(ok) == 1 else tuple(ok)
+        err_str = err[0] if len(err) == 1 else tuple(err)
+        return f"Result({ok_str}, {err_str})"
 
 
 @dataclass(frozen=True)

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -321,22 +321,23 @@ class Option(Sum):
 
 
 @dataclass(eq=False)
-class Result(Sum):
-    """Fallible tuple of elements.
+class Either(Sum):
+    """Two-variant tuple of elements.
 
-    Instances of this type correspond to :class:`Sum` with two variants. The
-    first variant is a tuple of elements representing the successful state, the
-    second is a tuple of elements representing failure.
+    Instances of this type correspond to :class:`Sum` with a Left and a Right variant.
+
+    In fallible contexts, the Left variant is used to represent success, and the
+    Right variant is used to represent failure.
     """
 
-    def __init__(self, ok: Iterable[Type], err: Iterable[Type]):
-        self.variant_rows = [list(ok), list(err)]
+    def __init__(self, left: Iterable[Type], right: Iterable[Type]):
+        self.variant_rows = [list(left), list(right)]
 
     def __repr__(self) -> str:
-        ok, err  = self.variant_rows
-        ok_str = ok[0] if len(ok) == 1 else tuple(ok)
-        err_str = err[0] if len(err) == 1 else tuple(err)
-        return f"Result({ok_str}, {err_str})"
+        left, right = self.variant_rows
+        left_str = left[0] if len(left) == 1 else tuple(left)
+        right_str = right[0] if len(right) == 1 else tuple(right)
+        return f"Either({left_str}, {right_str})"
 
 
 @dataclass(frozen=True)

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -154,7 +154,6 @@ class Tuple(Sum):
 @dataclass
 class Some(Sum):
     """Optional tuple of value, containing a list of values.
-    Internally a :class:`Sum` with two variant rows.
 
     Example:
         >>> some = Some(TRUE, FALSE)
@@ -181,7 +180,6 @@ class Some(Sum):
 @dataclass
 class None_(Sum):
     """Optional tuple of value, containing no values.
-    Internally a :class:`Sum` with two variant rows.
 
     Example:
         >>> none = None_(tys.Bool)
@@ -200,63 +198,69 @@ class None_(Sum):
 
 
 @dataclass
-class Ok(Sum):
-    """Success variant of a :class:`tys.Result` type, containing a list of values.
+class Left(Sum):
+    """Left variant of a :class:`tys.Either` type, containing a list of values.
 
-    Internally a :class:`Sum` with two variant rows.
+    In fallible contexts, this represents the success variant.
 
     Example:
-        >>> ok = Ok([TRUE, FALSE], [tys.Bool])
-        >>> ok
-        Ok((TRUE, FALSE), Bool)
-        >>> ok.type_()
-        Result((Bool, Bool), Bool)
+        >>> left = Left([TRUE, FALSE], [tys.Bool])
+        >>> left
+        Left((TRUE, FALSE), Bool)
+        >>> left.type_()
+        Either((Bool, Bool), Bool)
     """
 
     #: The values of this tuple.
     vals: list[Value]
 
-    def __init__(self, vals: Iterable[Value], err_typ: Iterable[tys.Type]):
+    def __init__(self, vals: Iterable[Value], left_typ: Iterable[tys.Type]):
         val_list = list(vals)
         super().__init__(
-            tag=0, typ=tys.Result([v.type_() for v in val_list], err_typ), vals=val_list
+            tag=0,
+            typ=tys.Either([v.type_() for v in val_list], left_typ),
+            vals=val_list,
         )
 
     def __repr__(self) -> str:
         vals_str = self.vals[0] if len(self.vals) == 1 else tuple(self.vals)
-        _, err = self.typ.variant_rows
-        err_str = err[0] if len(err) == 1 else tuple(err)
-        return f"Ok({vals_str}, {err_str})"
+        _, right = self.typ.variant_rows
+        right_str = right[0] if len(right) == 1 else tuple(right)
+        return f"Left({vals_str}, {right_str})"
 
 
 @dataclass
-class Err(Sum):
-    """Error variant of a :class:`tys.Result` type, containing a list of values.
+class Right(Sum):
+    """Right variant of a :class:`tys.Either` type, containing a list of values.
+
+    In fallible contexts, this represents the failure variant.
 
     Internally a :class:`Sum` with two variant rows.
 
     Example:
-        >>> err = Err([tys.Bool, tys.Bool], [TRUE, FALSE])
-        >>> err
-        Err((Bool, Bool), (TRUE, FALSE))
-        >>> err.type_()
-        Result((Bool, Bool), (Bool, Bool))
+        >>> right = Right([tys.Bool, tys.Bool, tys.Bool], [TRUE, FALSE])
+        >>> right
+        Right((Bool, Bool, Bool), (TRUE, FALSE))
+        >>> right.type_()
+        Either((Bool, Bool, Bool), (Bool, Bool))
     """
 
     #: The values of this tuple.
     vals: list[Value]
 
-    def __init__(self, ok_typ: Iterable[tys.Type], vals: Iterable[Value]):
+    def __init__(self, left_typ: Iterable[tys.Type], vals: Iterable[Value]):
         val_list = list(vals)
         super().__init__(
-            tag=1, typ=tys.Result(ok_typ, [v.type_() for v in val_list]), vals=val_list
+            tag=1,
+            typ=tys.Either(left_typ, [v.type_() for v in val_list]),
+            vals=val_list,
         )
 
     def __repr__(self) -> str:
-        ok, _ = self.typ.variant_rows
-        ok_str = ok[0] if len(ok) == 1 else tuple(ok)
+        left, _ = self.typ.variant_rows
+        left_str = left[0] if len(left) == 1 else tuple(left)
         vals_str = self.vals[0] if len(self.vals) == 1 else tuple(self.vals)
-        return f"Err({ok_str}, {vals_str})"
+        return f"Right({left_str}, {vals_str})"
 
 
 @dataclass

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -159,6 +159,8 @@ class Some(Sum):
         >>> some = Some(TRUE, FALSE)
         >>> some
         Some(TRUE, FALSE)
+        >>> str(some)
+        'Some(TRUE, FALSE)'
         >>> some.type_()
         Option(Bool, Bool)
 
@@ -185,6 +187,8 @@ class None_(Sum):
         >>> none = None_(tys.Bool)
         >>> none
         None(Bool)
+        >>> str(none)
+        'None'
         >>> none.type_()
         Option(Bool)
 
@@ -196,6 +200,9 @@ class None_(Sum):
     def __repr__(self) -> str:
         return f"None({', '.join(map(repr, self.typ.variant_rows[0]))})"
 
+    def __str__(self) -> str:
+        return "None"
+
 
 @dataclass
 class Left(Sum):
@@ -206,27 +213,31 @@ class Left(Sum):
     Example:
         >>> left = Left([TRUE, FALSE], [tys.Bool])
         >>> left
-        Left((TRUE, FALSE), Bool)
-        >>> left.type_()
-        Either((Bool, Bool), Bool)
+        Left(vals=[TRUE, FALSE], right_typ=[Bool])
+        >>> str(left)
+        'Left(TRUE, FALSE)'
+        >>> str(left.type_())
+        'Either((Bool, Bool), Bool)'
     """
 
     #: The values of this tuple.
     vals: list[Value]
 
-    def __init__(self, vals: Iterable[Value], left_typ: Iterable[tys.Type]):
+    def __init__(self, vals: Iterable[Value], right_typ: Iterable[tys.Type]):
         val_list = list(vals)
         super().__init__(
             tag=0,
-            typ=tys.Either([v.type_() for v in val_list], left_typ),
+            typ=tys.Either([v.type_() for v in val_list], right_typ),
             vals=val_list,
         )
 
     def __repr__(self) -> str:
-        vals_str = self.vals[0] if len(self.vals) == 1 else tuple(self.vals)
-        _, right = self.typ.variant_rows
-        right_str = right[0] if len(right) == 1 else tuple(right)
-        return f"Left({vals_str}, {right_str})"
+        _, right_typ = self.typ.variant_rows
+        return f"Left(vals={self.vals}, right_typ={list(right_typ)})"
+
+    def __str__(self) -> str:
+        vals_str = ", ".join(map(str, self.vals))
+        return f"Left({vals_str})"
 
 
 @dataclass
@@ -240,9 +251,11 @@ class Right(Sum):
     Example:
         >>> right = Right([tys.Bool, tys.Bool, tys.Bool], [TRUE, FALSE])
         >>> right
-        Right((Bool, Bool, Bool), (TRUE, FALSE))
-        >>> right.type_()
-        Either((Bool, Bool, Bool), (Bool, Bool))
+        Right(left_typ=[Bool, Bool, Bool], vals=[TRUE, FALSE])
+        >>> str(right)
+        'Right(TRUE, FALSE)'
+        >>> str(right.type_())
+        'Either((Bool, Bool, Bool), (Bool, Bool))'
     """
 
     #: The values of this tuple.
@@ -257,10 +270,12 @@ class Right(Sum):
         )
 
     def __repr__(self) -> str:
-        left, _ = self.typ.variant_rows
-        left_str = left[0] if len(left) == 1 else tuple(left)
-        vals_str = self.vals[0] if len(self.vals) == 1 else tuple(self.vals)
-        return f"Right({left_str}, {vals_str})"
+        left_typ, _ = self.typ.variant_rows
+        return f"Right(left_typ={list(left_typ)}, vals={self.vals})"
+
+    def __str__(self) -> str:
+        vals_str = ", ".join(map(str, self.vals))
+        return f"Right({vals_str})"
 
 
 @dataclass

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -224,7 +224,7 @@ class Ok(Sum):
 
     def __repr__(self) -> str:
         vals_str = self.vals[0] if len(self.vals) == 1 else tuple(self.vals)
-        err = self.typ.variant_rows[1]
+        _, err = self.typ.variant_rows
         err_str = err[0] if len(err) == 1 else tuple(err)
         return f"Ok({vals_str}, {err_str})"
 
@@ -253,7 +253,7 @@ class Err(Sum):
         )
 
     def __repr__(self) -> str:
-        ok = self.typ.variant_rows[1]
+        ok, _ = self.typ.variant_rows
         ok_str = ok[0] if len(ok) == 1 else tuple(ok)
         vals_str = self.vals[0] if len(self.vals) == 1 else tuple(self.vals)
         return f"Err({ok_str}, {vals_str})"


### PR DESCRIPTION
Adds helpers for defining fallible types, so we ensure we always use the same definition. This change does _not_ modify the serialisation format, it's only helpers on top of `Sum`.

On the rust side:

- Adds prelude definitions for `option` and `result` types (special cases of `Sum`s),
including constant values for `some`/`none`, `ok`/`err`.

On the python side:

- Adds an `Option` and `None_` subtype of `tys.Sum`, and `Some`/`None`/`Ok`/`Err` value definitions (also subtypes of `val.Sum`).
  These implement nicer `__repr__`, but the classes get lost on a serialisation roundtrip. I'm not sure if we want to auto-detect the special cases during deserialisation?
  
The names used are rusticisms. Feel free to bikeshed them.

Closes #1473