### PR TITLE
feat(hugr-py)!: pretty printing for ops and types

### DIFF
--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Setup dependencies
         run: uv sync
 
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
+
       - name: Run tests
         if: github.event_name == 'merge_group' || !matrix.python-version.coverage
         run: |

--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -143,7 +143,7 @@ jobs:
         if: github.event_name == 'merge_group' || !matrix.python-version.coverage
         run: |
           chmod +x $HUGR_BIN
-          uv run pytest
+          HUGR_RENDER_DOT=1 uv run pytest
 
       - name: Run python tests with coverage instrumentation
         if: github.event_name != 'merge_group' && matrix.python-version.coverage

--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -149,7 +149,7 @@ jobs:
         if: github.event_name != 'merge_group' && matrix.python-version.coverage
         run: |
           chmod +x $HUGR_BIN
-          uv run pytest --cov=./ --cov-report=xml
+          HUGR_RENDER_DOT=1 uv run pytest --cov=./ --cov-report=xml
 
       - name: Upload python coverage to codecov.io
         if: github.event_name != 'merge_group' && matrix.python-version.coverage

--- a/devenv.nix
+++ b/devenv.nix
@@ -20,6 +20,7 @@ in
       pkgs.llvmPackages_16.libllvm
       # cargo-llvm-cov is currently marked broken on nixpkgs unstable
       pkgs-stable.cargo-llvm-cov
+      pkgs.graphviz
     ] ++ lib.optionals
       pkgs.stdenv.isDarwin
       (with pkgs.darwin.apple_sdk; [

--- a/hugr-py/src/hugr/_serialization/ops.py
+++ b/hugr-py/src/hugr/_serialization/ops.py
@@ -522,7 +522,7 @@ class ExtensionOp(DataflowOp):
     def deserialize(self) -> ops.Custom:
         return ops.Custom(
             extension=self.extension,
-            name=self.name,
+            op_name=self.name,
             signature=self.signature.deserialize(),
             args=deser_it(self.args),
         )

--- a/hugr-py/src/hugr/_serialization/tys.py
+++ b/hugr-py/src/hugr/_serialization/tys.py
@@ -395,6 +395,13 @@ class TypeBound(Enum):
                 res = b
         return res
 
+    def __str__(self) -> str:
+        match self:
+            case TypeBound.Copyable:
+                return "Copyable"
+            case TypeBound.Any:
+                return "Any"
+
 
 class Opaque(BaseType):
     """An opaque Type that can be downcasted by the extensions that define it."""

--- a/hugr-py/src/hugr/build/dfg.py
+++ b/hugr-py/src/hugr/build/dfg.py
@@ -685,7 +685,7 @@ class Function(DfBase[ops.FuncDefn]):
     Examples:
         >>> f = Function("f", [tys.Bool])
         >>> f.parent_op
-        FuncDefn(name='f', inputs=[Bool], params=[])
+        FuncDefn(f_name='f', inputs=[Bool], params=[])
     """
 
     def __init__(

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -213,6 +213,12 @@ class OpDef(ExtensionObject):
             lower_funcs=[f._to_serial() for f in self.lower_funcs],
         )
 
+    def qualified_name(self) -> str:
+        ext_name = self._extension.name if self._extension else ""
+        if ext_name:
+            return f"{ext_name}.{self.name}"
+        return self.name
+
 
 @dataclass
 class ExtensionValue(ExtensionObject):

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -37,8 +37,9 @@ if TYPE_CHECKING:
     import graphviz as gv  # type: ignore[import-untyped]
 
     from hugr import ext
-    from hugr.render import RenderConfig
     from hugr.val import Value
+
+    from .render import RenderConfig
 
 
 @dataclass()

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     import graphviz as gv  # type: ignore[import-untyped]
 
     from hugr import ext
+    from hugr.render import RenderConfig
     from hugr.val import Value
 
 
@@ -677,22 +678,21 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         serial = SerialHugr.load_json(json_dict)
         return cls._from_serial(serial)
 
-    def render_dot(self, palette: str | None = None) -> gv.Digraph:
+    def render_dot(self, config: RenderConfig | None = None) -> gv.Digraph:
         """Render the HUGR to a graphviz Digraph.
 
         Args:
-            palette: The palette to use for rendering. See :obj:`PALETTE` for the
-                included options.
+            config: Render configuration.
 
         Returns:
             The graphviz Digraph.
         """
         from .render import DotRenderer
 
-        return DotRenderer(palette).render(self)
+        return DotRenderer(config).render(self)
 
     def store_dot(
-        self, filename: str, format: str = "svg", palette: str | None = None
+        self, filename: str, format: str = "svg", config: RenderConfig | None = None
     ) -> None:
         """Render the HUGR to a graphviz dot file.
 
@@ -700,9 +700,8 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             filename: The file to render to.
             format: The format used for rendering ('pdf', 'png', etc.).
                 Defaults to SVG.
-            palette: The palette to use for rendering. See :obj:`PALETTE` for the
-                included options.
+            config: Render configuration.
         """
         from .render import DotRenderer
 
-        DotRenderer(palette).store(self, filename=filename, format=format)
+        DotRenderer(config).store(self, filename=filename, format=format)

--- a/hugr-py/src/hugr/hugr/render.py
+++ b/hugr-py/src/hugr/hugr/render.py
@@ -1,13 +1,14 @@
 """Visualise HUGR using graphviz."""
 
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import graphviz as gv  # type: ignore[import-untyped]
 from graphviz import Digraph
 from typing_extensions import assert_never
 
 from hugr.hugr import Hugr
+from hugr.ops import AsExtOp
 from hugr.tys import CFKind, ConstKind, FunctionKind, Kind, OrderKind, ValueKind
 
 from .node_port import InPort, Node, OutPort
@@ -25,6 +26,10 @@ class Palette:
     discard: str
     node_border: str
     port_border: str
+
+    @classmethod
+    def named(cls, name: str) -> "Palette":
+        return PALETTE[name]
 
 
 PALETTE: dict[str, Palette] = {
@@ -61,22 +66,27 @@ PALETTE: dict[str, Palette] = {
 }
 
 
+@dataclass
+class RenderConfig:
+    """Configuration for rendering a HUGR to a graphviz dot file."""
+
+    #: The palette to use for rendering. See :obj:`PALETTE` for the included options.
+    palette: Palette = field(default_factory=lambda: PALETTE["default"])
+    #: If true prepend extension name to operation name.
+    qualify_op_name: bool = False
+
+
 class DotRenderer:
     """Render a HUGR to a graphviz dot file.
 
     Args:
-        palette: The palette to use for rendering. See :obj:`PALETTE` for the
-        included options.
+        config: Render config
     """
 
-    palette: Palette
+    config: RenderConfig
 
-    def __init__(self, palette: Palette | str | None = None) -> None:
-        if palette is None:
-            palette = "default"
-        if isinstance(palette, str):
-            palette = PALETTE[palette]
-        self.palette = palette
+    def __init__(self, config: RenderConfig | None = None) -> None:
+        self.config = config or RenderConfig()
 
     def render(self, hugr: Hugr) -> Digraph:
         """Render a HUGR to a graphviz dot object."""
@@ -85,7 +95,7 @@ class DotRenderer:
             "ranksep": "0.1",
             "nodesep": "0.15",
             "margin": "0",
-            "bgcolor": self.palette.background,
+            "bgcolor": self.config.palette.background,
         }
         if not (name := hugr[hugr.root].metadata.get("name", None)):
             name = ""
@@ -155,11 +165,11 @@ class DotRenderer:
 
     def _format_html_label(self, **kwargs: str) -> str:
         _HTML_LABEL_DEFAULTS = {
-            "label_color": self.palette.dark,
-            "node_back_color": self.palette.node,
+            "label_color": self.config.palette.dark,
+            "node_back_color": self.config.palette.node,
             "inputs_row": "",
             "outputs_row": "",
-            "border_colour": self.palette.port_border,
+            "border_colour": self.config.palette.port_border,
             "border_width": "1",
             "fontface": self._FONTFACE,
             "fontsize": 11.0,
@@ -174,10 +184,10 @@ class DotRenderer:
                     # differentiate input and output node identifiers
                     # with a prefix
                     port_id=id_prefix + port,
-                    back_colour=self.palette.background,
-                    font_colour=self.palette.dark,
+                    back_colour=self.config.palette.background,
+                    font_colour=self.config.palette.dark,
                     border_width="1",
-                    border_colour=self.palette.port_border,
+                    border_colour=self.config.palette.port_border,
                     fontface=self._FONTFACE,
                 )
                 for port in ports
@@ -218,29 +228,32 @@ class DotRenderer:
         )
 
         op = hugr[node].op
-
+        if isinstance(op, AsExtOp) and not self.config.qualify_op_name:
+            op_name = op.op_def().name
+        else:
+            op_name = op.name()
         if hugr.children(node):
             with graph.subgraph(name=f"cluster{node.idx}") as sub:
                 for child in hugr.children(node):
                     self._viz_node(child, hugr, sub)
                 html_label = self._format_html_label(
-                    node_back_color=self.palette.edge,
-                    node_label=op.name(),
+                    node_back_color=self.config.palette.edge,
+                    node_label=op_name,
                     node_data=data,
-                    border_colour=self.palette.port_border,
+                    border_colour=self.config.palette.port_border,
                     inputs_row=inputs_row,
                     outputs_row=outputs_row,
                 )
                 sub.node(f"{node.idx}", shape="plain", label=f"<{html_label}>")
-                sub.attr(label="", margin="10", color=self.palette.edge)
+                sub.attr(label="", margin="10", color=self.config.palette.edge)
         else:
             html_label = self._format_html_label(
-                node_back_color=self.palette.node,
-                node_label=op.name(),
+                node_back_color=self.config.palette.node,
+                node_label=op_name,
                 node_data=data,
                 inputs_row=inputs_row,
                 outputs_row=outputs_row,
-                border_colour=self.palette.background,
+                border_colour=self.config.palette.background,
             )
             graph.node(f"{node.idx}", label=f"<{html_label}>", shape="plain")
 
@@ -260,13 +273,13 @@ class DotRenderer:
         match kind:
             case ValueKind(ty):
                 label = str(ty)
-                color = self.palette.edge
+                color = self.config.palette.edge
             case OrderKind():
-                color = self.palette.dark
+                color = self.config.palette.dark
             case ConstKind() | FunctionKind():
-                color = self.palette.const
+                color = self.config.palette.const
             case CFKind():
-                color = self.palette.dark
+                color = self.config.palette.dark
             case _:
                 assert_never(kind)
 

--- a/hugr-py/src/hugr/hugr/render.py
+++ b/hugr-py/src/hugr/hugr/render.py
@@ -225,7 +225,7 @@ class DotRenderer:
                     self._viz_node(child, hugr, sub)
                 html_label = self._format_html_label(
                     node_back_color=self.palette.edge,
-                    node_label=str(op),
+                    node_label=op.name(),
                     node_data=data,
                     border_colour=self.palette.port_border,
                     inputs_row=inputs_row,
@@ -236,7 +236,7 @@ class DotRenderer:
         else:
             html_label = self._format_html_label(
                 node_back_color=self.palette.node,
-                node_label=str(op),
+                node_label=op.name(),
                 node_data=data,
                 inputs_row=inputs_row,
                 outputs_row=outputs_row,

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -66,6 +66,10 @@ class Op(Protocol):
     def _invalid_port(self, port: InPort | OutPort) -> InvalidPort:
         return InvalidPort(port, self)
 
+    def name(self) -> str:
+        """Name of the operation."""
+        return str(self)
+
 
 def _sig_port_type(sig: tys.FunctionType, port: InPort | OutPort) -> tys.Type:
     if port.direction == Direction.INCOMING:
@@ -177,6 +181,9 @@ class Input(DataflowOp):
     def __call__(self) -> Command:
         return super().__call__()
 
+    def name(self) -> str:
+        return "Input"
+
 
 @dataclass()
 class Output(DataflowOp, _PartialOp):
@@ -199,6 +206,9 @@ class Output(DataflowOp, _PartialOp):
 
     def _set_in_types(self, types: tys.TypeRow) -> None:
         self._types = types
+
+    def name(self) -> str:
+        return "Output"
 
 
 @runtime_checkable
@@ -286,12 +296,15 @@ class AsExtOp(DataflowOp, Protocol):
     def num_out(self) -> int:
         return len(self.outer_signature().output)
 
+    def name(self) -> str:
+        return f"{self.ext_op._op_def.qualified_name()}"
+
 
 @dataclass(frozen=True, eq=False)
 class Custom(DataflowOp):
     """Serializable version of non-core dataflow operation defined in an extension."""
 
-    name: str
+    op_name: str
     signature: tys.FunctionType = field(default_factory=tys.FunctionType.empty)
     description: str = ""
     extension: tys.ExtensionId = ""
@@ -301,7 +314,7 @@ class Custom(DataflowOp):
         return sops.ExtensionOp(
             parent=parent.idx,
             extension=self.extension,
-            name=self.name,
+            name=self.op_name,
             signature=self.signature._to_serial(),
             description=self.description,
             args=ser_it(self.args),
@@ -316,7 +329,7 @@ class Custom(DataflowOp):
 
     def check_id(self, extension: tys.ExtensionId, name: str) -> bool:
         """Check if the operation matches the given extension and operation name."""
-        return self.extension == extension and self.name == name
+        return self.extension == extension and self.op_name == name
 
     def resolve(self, registry: ext.ExtensionRegistry) -> ExtOp | Custom:
         """Resolve the custom operation to an :class:`ExtOp`.
@@ -326,7 +339,7 @@ class Custom(DataflowOp):
         from hugr.ext import ExtensionRegistry, Extension  # noqa: I001 # no circular import
 
         try:
-            op_def = registry.get_extension(self.extension).get_op(self.name)
+            op_def = registry.get_extension(self.extension).get_op(self.op_name)
         except (
             Extension.OperationNotFound,
             ExtensionRegistry.ExtensionNotFound,
@@ -338,6 +351,9 @@ class Custom(DataflowOp):
         # TODO check signature matches op_def reported signature
         # if/once op_def can compute signature from type scheme + args
         return ExtOp(op_def, signature, args)
+
+    def name(self) -> str:
+        return f"Custom({self.op_name})"
 
 
 @dataclass(frozen=True, eq=False)
@@ -360,7 +376,7 @@ class ExtOp(AsExtOp):
             sig = self.signature
 
         return Custom(
-            name=self._op_def.name,
+            op_name=self._op_def.name,
             signature=sig,
             extension=ext.name if ext else "",
             args=self.args,
@@ -442,6 +458,9 @@ class MakeTuple(AsExtOp, _PartialOp):
     def __repr__(self) -> str:
         return "MakeTuple" + (f"({self._types})" if self._types is not None else "")
 
+    def name(self) -> str:
+        return "MakeTuple"
+
 
 @dataclass()
 class UnpackTuple(AsExtOp, _PartialOp):
@@ -485,6 +504,12 @@ class UnpackTuple(AsExtOp, _PartialOp):
         (row,) = t.variant_rows
         self._types = row
 
+    def __repr__(self) -> str:
+        return "UnpackTuple" + (f"({self._types})" if self._types is not None else "")
+
+    def name(self) -> str:
+        return "UnpackTuple"
+
 
 @dataclass()
 class Tag(DataflowOp):
@@ -509,6 +534,9 @@ class Tag(DataflowOp):
         return tys.FunctionType(
             input=self.sum_ty.variant_rows[self.tag], output=[self.sum_ty]
         )
+
+    def __repr__(self) -> str:
+        return f"Tag({self.tag})"
 
 
 class DfParentOp(Op, Protocol):
@@ -574,6 +602,9 @@ class DFG(DfParentOp, DataflowOp):
     def _inputs(self) -> tys.TypeRow:
         return self.inputs
 
+    def name(self) -> str:
+        return "DFG"
+
 
 @dataclass()
 class CFG(DataflowOp):
@@ -613,6 +644,9 @@ class CFG(DataflowOp):
 
     def outer_signature(self) -> tys.FunctionType:
         return self.signature
+
+    def name(self) -> str:
+        return "CFG"
 
 
 @dataclass
@@ -681,6 +715,9 @@ class DataflowBlock(DfParentOp):
         """
         return [*self.sum_ty.variant_rows[n], *self.other_outputs]
 
+    def name(self) -> str:
+        return "DataflowBlock"
+
 
 @dataclass
 class ExitBlock(Op):
@@ -706,6 +743,9 @@ class ExitBlock(Op):
 
     def port_kind(self, port: InPort | OutPort) -> tys.Kind:
         return tys.CFKind()
+
+    def name(self) -> str:
+        return "ExitBlock"
 
 
 @dataclass
@@ -771,6 +811,9 @@ class LoadConst(DataflowOp):
     def __repr__(self) -> str:
         return "LoadConst" + (f"({self._typ})" if self._typ is not None else "")
 
+    def name(self) -> str:
+        return "LoadConst"
+
 
 @dataclass()
 class Conditional(DataflowOp):
@@ -824,6 +867,9 @@ class Conditional(DataflowOp):
         """
         return [*self.sum_ty.variant_rows[n], *self.other_inputs]
 
+    def name(self) -> str:
+        return "Conditional"
+
 
 @dataclass
 class Case(DfParentOp):
@@ -859,6 +905,9 @@ class Case(DfParentOp):
 
     def _inputs(self) -> tys.TypeRow:
         return self.inputs
+
+    def name(self) -> str:
+        return "Case"
 
 
 @dataclass
@@ -915,6 +964,9 @@ class TailLoop(DfParentOp, DataflowOp):
     def _inputs(self) -> tys.TypeRow:
         return self.just_inputs + self.rest
 
+    def name(self) -> str:
+        return "TailLoop"
+
 
 @dataclass
 class FuncDefn(DfParentOp):
@@ -923,7 +975,7 @@ class FuncDefn(DfParentOp):
     """
 
     #: function name
-    name: str
+    f_name: str
     #: input types of the function
     inputs: tys.TypeRow
     # ? type parameters of the function if polymorphic
@@ -954,7 +1006,7 @@ class FuncDefn(DfParentOp):
     def _to_serial(self, parent: Node) -> sops.FuncDefn:
         return sops.FuncDefn(
             parent=parent.idx,
-            name=self.name,
+            name=self.f_name,
             signature=self.signature._to_serial(),
         )
 
@@ -974,13 +1026,16 @@ class FuncDefn(DfParentOp):
             case _:
                 raise self._invalid_port(port)
 
+    def name(self) -> str:
+        return f"FuncDefn({self.f_name})"
+
 
 @dataclass
 class FuncDecl(Op):
     """Function declaration operation, defines the signature of a function."""
 
     #: function name
-    name: str
+    f_name: str
     #: polymorphic function signature
     signature: tys.PolyFuncType
     num_out: int = field(default=1, repr=False)
@@ -988,7 +1043,7 @@ class FuncDecl(Op):
     def _to_serial(self, parent: Node) -> sops.FuncDecl:
         return sops.FuncDecl(
             parent=parent.idx,
-            name=self.name,
+            name=self.f_name,
             signature=self.signature._to_serial(),
         )
 
@@ -998,6 +1053,9 @@ class FuncDecl(Op):
                 return tys.FunctionKind(self.signature)
             case _:
                 raise self._invalid_port(port)
+
+    def name(self) -> str:
+        return f"FuncDecl({self.f_name})"
 
 
 @dataclass
@@ -1011,6 +1069,9 @@ class Module(Op):
 
     def port_kind(self, port: InPort | OutPort) -> tys.Kind:
         raise self._invalid_port(port)
+
+    def name(self) -> str:
+        return "Module"
 
 
 class NoConcreteFunc(Exception):
@@ -1088,6 +1149,9 @@ class Call(_CallOrLoad, Op):
             case _:
                 return tys.ValueKind(_sig_port_type(self.instantiation, port))
 
+    def name(self) -> str:
+        return "Call"
+
 
 @dataclass()
 class CallIndirect(DataflowOp, _PartialOp):
@@ -1131,6 +1195,9 @@ class CallIndirect(DataflowOp, _PartialOp):
         ), f"Expected function type, got {func_sig}"
         self._signature = func_sig
 
+    def name(self) -> str:
+        return "CallIndirect"
+
 
 class LoadFunc(_CallOrLoad, DataflowOp):
     """Load a statically defined function as a higher order value.
@@ -1168,6 +1235,9 @@ class LoadFunc(_CallOrLoad, DataflowOp):
             case _:
                 raise self._invalid_port(port)
 
+    def name(self) -> str:
+        return "LoadFunc"
+
 
 @dataclass
 class Noop(AsExtOp, _PartialOp):
@@ -1199,13 +1269,16 @@ class Noop(AsExtOp, _PartialOp):
     def __repr__(self) -> str:
         return "Noop" + (f"({self._type})" if self._type is not None else "")
 
+    def name(self) -> str:
+        return "Noop"
+
 
 @dataclass
 class AliasDecl(Op):
     """Declare an external type alias."""
 
     #: Alias name.
-    name: str
+    alias: str
     #: Type bound.
     bound: tys.TypeBound
     num_out: int = field(default=0, repr=False)
@@ -1213,12 +1286,15 @@ class AliasDecl(Op):
     def _to_serial(self, parent: Node) -> sops.AliasDecl:
         return sops.AliasDecl(
             parent=parent.idx,
-            name=self.name,
+            name=self.alias,
             bound=self.bound,
         )
 
     def port_kind(self, port: InPort | OutPort) -> tys.Kind:
         raise self._invalid_port(port)
+
+    def name(self) -> str:
+        return f"AliasDecl({self.alias})"
 
 
 @dataclass
@@ -1226,7 +1302,7 @@ class AliasDefn(Op):
     """Declare a type alias."""
 
     #: Alias name.
-    name: str
+    alias: str
     #: Type definition.
     definition: tys.Type
     num_out: int = field(default=0, repr=False)
@@ -1234,9 +1310,12 @@ class AliasDefn(Op):
     def _to_serial(self, parent: Node) -> sops.AliasDefn:
         return sops.AliasDefn(
             parent=parent.idx,
-            name=self.name,
+            name=self.alias,
             definition=self.definition._to_serial_root(),
         )
 
     def port_kind(self, port: InPort | OutPort) -> tys.Kind:
         raise self._invalid_port(port)
+
+    def name(self) -> str:
+        return f"AliasDefn({self.alias})"

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -297,7 +297,7 @@ class AsExtOp(DataflowOp, Protocol):
         return len(self.outer_signature().output)
 
     def name(self) -> str:
-        return f"{self.ext_op._op_def.qualified_name()}"
+        return self.ext_op._op_def.qualified_name()
 
 
 @dataclass(frozen=True, eq=False)

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -11,7 +11,7 @@ from typing_extensions import Self
 import hugr._serialization.ops as sops
 from hugr import tys, val
 from hugr.hugr.node_port import Direction, InPort, Node, OutPort, PortOffset, Wire
-from hugr.utils import ser_it
+from hugr.utils import comma_sep_str, ser_it
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -297,7 +297,11 @@ class AsExtOp(DataflowOp, Protocol):
         return len(self.outer_signature().output)
 
     def name(self) -> str:
-        return self.ext_op._op_def.qualified_name()
+        name = self.ext_op._op_def.qualified_name()
+        ta = self.type_args()
+        if len(ta) == 0:
+            return name
+        return f"{name}<{comma_sep_str(self.type_args())}>"
 
 
 @dataclass(frozen=True, eq=False)

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -162,6 +162,9 @@ class TypeTypeArg(TypeArg):
     def resolve(self, registry: ext.ExtensionRegistry) -> TypeArg:
         return TypeTypeArg(self.ty.resolve(registry))
 
+    def __str__(self) -> str:
+        return str(self.ty)
+
 
 @dataclass(frozen=True)
 class BoundedNatArg(TypeArg):
@@ -172,6 +175,9 @@ class BoundedNatArg(TypeArg):
     def _to_serial(self) -> stys.BoundedNatArg:
         return stys.BoundedNatArg(n=self.n)
 
+    def __str__(self) -> str:
+        return str(self.n)
+
 
 @dataclass(frozen=True)
 class StringArg(TypeArg):
@@ -181,6 +187,9 @@ class StringArg(TypeArg):
 
     def _to_serial(self) -> stys.StringArg:
         return stys.StringArg(arg=self.value)
+
+    def __str__(self) -> str:
+        return self.value
 
 
 @dataclass(frozen=True)
@@ -195,6 +204,9 @@ class SequenceArg(TypeArg):
     def resolve(self, registry: ext.ExtensionRegistry) -> TypeArg:
         return SequenceArg([arg.resolve(registry) for arg in self.elems])
 
+    def __str__(self) -> str:
+        return f"({', '.join(str(arg) for arg in self.elems)})"
+
 
 @dataclass(frozen=True)
 class ExtensionsArg(TypeArg):
@@ -204,6 +216,9 @@ class ExtensionsArg(TypeArg):
 
     def _to_serial(self) -> stys.ExtensionsArg:
         return stys.ExtensionsArg(es=self.extensions)
+
+    def __str__(self) -> str:
+        return str(self.extensions)
 
 
 @dataclass(frozen=True)
@@ -215,6 +230,9 @@ class VariableArg(TypeArg):
 
     def _to_serial(self) -> stys.VariableArg:
         return stys.VariableArg(idx=self.idx, cached_decl=self.param._to_serial_root())
+
+    def __str__(self) -> str:
+        return f"VariableArg({self.idx})"
 
 
 # ----------------------------------------------
@@ -234,6 +252,9 @@ class Array(Type):
 
     def type_bound(self) -> TypeBound:
         return self.ty.type_bound()
+
+    def __repr__(self) -> str:
+        return f"Array({self.ty}, {self.size})"
 
 
 @dataclass()
@@ -357,6 +378,9 @@ class Variable(Type):
     def type_bound(self) -> TypeBound:
         return self.bound
 
+    def __repr__(self) -> str:
+        return f"Variable({self.idx})"
+
 
 @dataclass(frozen=True)
 class RowVariable(Type):
@@ -371,6 +395,9 @@ class RowVariable(Type):
     def type_bound(self) -> TypeBound:
         return self.bound
 
+    def __repr__(self) -> str:
+        return f"RowVariable({self.idx})"
+
 
 @dataclass(frozen=True)
 class USize(Type):
@@ -381,6 +408,9 @@ class USize(Type):
 
     def type_bound(self) -> TypeBound:
         return TypeBound.Copyable
+
+    def __repr__(self) -> str:
+        return "USize"
 
 
 @dataclass(frozen=True)
@@ -395,6 +425,9 @@ class Alias(Type):
 
     def type_bound(self) -> TypeBound:
         return self.bound
+
+    def __repr__(self) -> str:
+        return f"Alias({self.name})"
 
 
 @dataclass(frozen=True)
@@ -461,6 +494,10 @@ class FunctionType(Type):
             extension_reqs=self.extension_reqs,
         )
 
+    def __str__(self) -> str:
+        # [Qubit] -> [Bool]
+        return f"{self.input} -> {self.output})"
+
 
 @dataclass(frozen=True)
 class PolyFuncType(Type):
@@ -486,6 +523,10 @@ class PolyFuncType(Type):
             params=self.params,
             body=self.body.resolve(registry),
         )
+
+    def __str__(self) -> str:
+        # ∀[a]. [list<a>] -> [Bool]
+        return f"∀{self.params}. {self.body!s})"
 
 
 @dataclass
@@ -518,6 +559,9 @@ class ExtType(Type):
             args=[arg._to_serial_root() for arg in self.args],
             bound=self.type_bound(),
         )
+
+    def __str__(self) -> str:
+        return f"{self.type_def.name}<{', '.join(str(arg) for arg in self.args)}>"
 
 
 @dataclass
@@ -553,6 +597,9 @@ class Opaque(Type):
             return self
 
         return ExtType(type_def, self.args)
+
+    def __str__(self) -> str:
+        return f"{self.id}<{', '.join(str(arg) for arg in self.args)}>"
 
 
 @dataclass

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -189,7 +189,7 @@ class StringArg(TypeArg):
         return stys.StringArg(arg=self.value)
 
     def __str__(self) -> str:
-        return self.value
+        return f'{"self.value"}'
 
 
 @dataclass(frozen=True)

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -546,6 +546,16 @@ class PolyFuncType(Type):
     def __str__(self) -> str:
         return f"∀ {comma_sep_str(self.params)}. {self.body!s}"
 
+    @classmethod
+    def empty(cls) -> PolyFuncType:
+        """Generate an empty polymorphic function type.
+
+        Example:
+            >>> PolyFuncType.empty()
+            PolyFuncType(params=[], body=FunctionType([], []))
+        """
+        return PolyFuncType(params=[], body=FunctionType.empty())
+
 
 @dataclass
 class ExtType(Type):

--- a/hugr-py/src/hugr/utils.py
+++ b/hugr-py/src/hugr/utils.py
@@ -202,3 +202,16 @@ def ser_it(it: Iterable[SerCollection[S]]) -> list[S]:
 def deser_it(it: Iterable[DeserCollection[S]]) -> list[S]:
     """Deserialize an iterable of deserializable objects."""
     return [v.deserialize() for v in it]
+
+
+T = TypeVar("T")
+
+
+def comma_sep_str(items: Iterable[T]) -> str:
+    """Join items with commas and str."""
+    return ", ".join(map(str, items))
+
+
+def comma_sep_repr(items: Iterable[T]) -> str:
+    """Join items with commas and repr."""
+    return ", ".join(map(repr, items))

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 import hugr._serialization.ops as sops
 import hugr._serialization.tys as stys
 from hugr import tys
-from hugr.utils import ser_it
+from hugr.utils import comma_sep_repr, comma_sep_str, ser_it
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -153,7 +153,7 @@ class Tuple(Sum):
         )
 
     def __repr__(self) -> str:
-        return f"Tuple({', '.join(map(repr, self.vals))})"
+        return f"Tuple({comma_sep_repr(self.vals)})"
 
 
 @dataclass(eq=False)
@@ -176,7 +176,7 @@ class Some(Sum):
         )
 
     def __repr__(self) -> str:
-        return f"Some({', '.join(map(repr, self.vals))})"
+        return f"Some({comma_sep_repr(self.vals)})"
 
 
 @dataclass(eq=False)
@@ -229,8 +229,7 @@ class Left(Sum):
         return f"Left(vals={self.vals}, right_typ={list(right_typ)})"
 
     def __str__(self) -> str:
-        vals_str = ", ".join(map(str, self.vals))
-        return f"Left({vals_str})"
+        return f"Left({comma_sep_str(self.vals)})"
 
 
 @dataclass(eq=False)
@@ -262,8 +261,7 @@ class Right(Sum):
         return f"Right(left_typ={list(left_typ)}, vals={self.vals})"
 
     def __str__(self) -> str:
-        vals_str = ", ".join(map(str, self.vals))
-        return f"Right({vals_str})"
+        return f"Right({comma_sep_str(self.vals)})"
 
 
 @dataclass

--- a/hugr-py/tests/__snapshots__/test_hugr_build.ambr
+++ b/hugr-py/tests/__snapshots__/test_hugr_build.ambr
@@ -12,7 +12,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -47,7 +47,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -72,7 +72,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>_NotOp()</B></FONT></TD></TR>
+                  COLOR="black"><B>logic.Not</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -97,7 +97,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -135,7 +135,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Bool, Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -170,7 +170,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -186,7 +186,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -211,7 +211,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -236,7 +236,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>_NotOp()</B></FONT></TD></TR>
+                  COLOR="black"><B>logic.Not</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -261,7 +261,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -288,7 +288,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Bool, Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -329,7 +329,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -364,7 +364,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -380,7 +380,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -415,7 +415,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -440,7 +440,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>_NotOp()</B></FONT></TD></TR>
+                  COLOR="black"><B>logic.Not</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -475,7 +475,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -502,7 +502,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -542,7 +542,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -577,7 +577,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -593,7 +593,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -628,7 +628,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -653,7 +653,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>_NotOp()</B></FONT></TD></TR>
+                  COLOR="black"><B>logic.Not</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -688,7 +688,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -715,7 +715,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -755,7 +755,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -790,7 +790,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -815,7 +815,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>_NotOp()</B><BR/><BR/>name: not</FONT></TD></TR>
+                  COLOR="black"><B>logic.Not</B><BR/><BR/>name: not</FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -840,7 +840,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Bool])</B><BR/><BR/>name: simple_id</FONT></TD></TR>
+                  COLOR="black"><B>DFG</B><BR/><BR/>name: simple_id</FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -878,7 +878,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[ExtType(type_def=TypeDef(name='int', description='integral value of a given bit width', params=[BoundedNatParam(upper_bound=7)], bound=ExplicitBound(bound=<TypeBound.Copyable: 'C'>)), args=[BoundedNatArg(n=5)]), ExtType(type_def=TypeDef(name='int', description='integral value of a given bit width', params=[BoundedNatParam(upper_bound=7)], bound=ExplicitBound(bound=<TypeBound.Copyable: 'C'>)), args=[BoundedNatArg(n=5)])])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -913,7 +913,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -938,7 +938,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>_DivModDef(width=5)</B></FONT></TD></TR>
+                  COLOR="black"><B>arithmetic.int.idivmod_u</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -963,7 +963,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[ExtType(type_def=TypeDef(name='int', description='integral value of a given bit width', params=[BoundedNatParam(upper_bound=7)], bound=ExplicitBound(bound=<TypeBound.Copyable: 'C'>)), args=[BoundedNatArg(n=5)]), ExtType(type_def=TypeDef(name='int', description='integral value of a given bit width', params=[BoundedNatParam(upper_bound=7)], bound=ExplicitBound(bound=<TypeBound.Copyable: 'C'>)), args=[BoundedNatArg(n=5)])])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -982,10 +982,10 @@
       > shape=plain]
   		color="#1CADE4" label="" margin=10
   	}
-  	1:"out.0" -> 3:"in.0" [label="ExtType(type_def=TypeDef(name='int', description='integral value of a given bit width', params=[BoundedNatParam(upper_bound=7)], bound=ExplicitBound(bound=<TypeBound.Copyable: 'C'>)), args=[BoundedNatArg(n=5)])" arrowhead=none arrowsize=1.0 color="#1CADE4" fontcolor=black fontname=monospace fontsize=9 penwidth=1.5]
-  	1:"out.1" -> 3:"in.1" [label="ExtType(type_def=TypeDef(name='int', description='integral value of a given bit width', params=[BoundedNatParam(upper_bound=7)], bound=ExplicitBound(bound=<TypeBound.Copyable: 'C'>)), args=[BoundedNatArg(n=5)])" arrowhead=none arrowsize=1.0 color="#1CADE4" fontcolor=black fontname=monospace fontsize=9 penwidth=1.5]
-  	3:"out.0" -> 2:"in.0" [label="ExtType(type_def=TypeDef(name='int', description='integral value of a given bit width', params=[BoundedNatParam(upper_bound=7)], bound=ExplicitBound(bound=<TypeBound.Copyable: 'C'>)), args=[BoundedNatArg(n=5)])" arrowhead=none arrowsize=1.0 color="#1CADE4" fontcolor=black fontname=monospace fontsize=9 penwidth=1.5]
-  	3:"out.1" -> 2:"in.1" [label="ExtType(type_def=TypeDef(name='int', description='integral value of a given bit width', params=[BoundedNatParam(upper_bound=7)], bound=ExplicitBound(bound=<TypeBound.Copyable: 'C'>)), args=[BoundedNatArg(n=5)])" arrowhead=none arrowsize=1.0 color="#1CADE4" fontcolor=black fontname=monospace fontsize=9 penwidth=1.5]
+  	1:"out.0" -> 3:"in.0" [label="int<5>" arrowhead=none arrowsize=1.0 color="#1CADE4" fontcolor=black fontname=monospace fontsize=9 penwidth=1.5]
+  	1:"out.1" -> 3:"in.1" [label="int<5>" arrowhead=none arrowsize=1.0 color="#1CADE4" fontcolor=black fontname=monospace fontsize=9 penwidth=1.5]
+  	3:"out.0" -> 2:"in.0" [label="int<5>" arrowhead=none arrowsize=1.0 color="#1CADE4" fontcolor=black fontname=monospace fontsize=9 penwidth=1.5]
+  	3:"out.1" -> 2:"in.1" [label="int<5>" arrowhead=none arrowsize=1.0 color="#1CADE4" fontcolor=black fontname=monospace fontsize=9 penwidth=1.5]
   }
   
   '''
@@ -1003,7 +1003,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1038,7 +1038,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1053,7 +1053,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Bool])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1092,7 +1092,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Qubit])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1127,7 +1127,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1152,7 +1152,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Call(signature=PolyFuncType(params=[], body=FunctionType([Qubit], [Qubit])), instantiation=FunctionType([Qubit], [Qubit]), type_args=[])</B></FONT></TD></TR>
+                  COLOR="black"><B>Call</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1177,7 +1177,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>FuncDefn(name='recurse', inputs=[Qubit], params=[])</B></FONT></TD></TR>
+                  COLOR="black"><B>FuncDefn(recurse)</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1204,7 +1204,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Module()</B></FONT></TD></TR>
+                  COLOR="black"><B>Module</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1233,7 +1233,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Qubit, Qubit])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1268,7 +1268,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1283,7 +1283,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Qubit, Qubit])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1321,7 +1321,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Input(types=[Bool, Qubit])</B></FONT></TD></TR>
+                  COLOR="black"><B>Input</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1356,7 +1356,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>Output()</B></FONT></TD></TR>
+                  COLOR="black"><B>Output</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1381,7 +1381,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>MakeTuple([Bool, Qubit])</B></FONT></TD></TR>
+                  COLOR="black"><B>MakeTuple</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1416,7 +1416,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>UnpackTuple()</B></FONT></TD></TR>
+                  COLOR="black"><B>UnpackTuple</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -1441,7 +1441,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>DFG(inputs=[Bool, Qubit])</B></FONT></TD></TR>
+                  COLOR="black"><B>DFG</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>

--- a/hugr-py/tests/__snapshots__/test_hugr_build.ambr
+++ b/hugr-py/tests/__snapshots__/test_hugr_build.ambr
@@ -72,7 +72,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>logic.Not</B></FONT></TD></TR>
+                  COLOR="black"><B>Not</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -236,7 +236,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>logic.Not</B></FONT></TD></TR>
+                  COLOR="black"><B>Not</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -440,7 +440,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>logic.Not</B></FONT></TD></TR>
+                  COLOR="black"><B>Not</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -653,7 +653,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>logic.Not</B></FONT></TD></TR>
+                  COLOR="black"><B>Not</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -815,7 +815,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>logic.Not</B><BR/><BR/>name: not</FONT></TD></TR>
+                  COLOR="black"><B>Not</B><BR/><BR/>name: not</FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>
@@ -938,7 +938,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B>arithmetic.int.idivmod_u</B></FONT></TD></TR>
+                  COLOR="black"><B>idivmod_u</B></FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>

--- a/hugr-py/tests/conftest.py
+++ b/hugr-py/tests/conftest.py
@@ -6,7 +6,6 @@ import pathlib
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
-from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, TypeVar
 
 from typing_extensions import Self
@@ -166,9 +165,7 @@ def validate(
         dot = h.render_dot()
         assert snap == dot.source
         if os.environ.get("HUGR_RENDER_DOT"):
-            with NamedTemporaryFile(mode="w", delete=True) as f:
-                # test rendering succeeds
-                dot.render(f.name)
+            dot.pipe("svg")
 
 
 def _run_hugr_cmd(serial: str, cmd: list[str]):

--- a/hugr-py/tests/conftest.py
+++ b/hugr-py/tests/conftest.py
@@ -6,6 +6,7 @@ import pathlib
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
+from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, TypeVar
 
 from typing_extensions import Self
@@ -164,6 +165,10 @@ def validate(
     if snap is not None and isinstance(h, Hugr):
         dot = h.render_dot()
         assert snap == dot.source
+        if os.environ.get("HUGR_RENDER_DOT"):
+            with NamedTemporaryFile(mode="w", delete=True) as f:
+                # test rendering succeeds
+                dot.render(f.name)
 
 
 def _run_hugr_cmd(serial: str, cmd: list[str]):

--- a/hugr-py/tests/test_ops.py
+++ b/hugr-py/tests/test_ops.py
@@ -1,0 +1,66 @@
+import pytest
+
+from hugr.ops import (
+    CFG,
+    DFG,
+    AliasDecl,
+    AliasDefn,
+    Call,
+    CallIndirect,
+    Case,
+    Conditional,
+    Const,
+    DataflowBlock,
+    ExitBlock,
+    FuncDecl,
+    FuncDefn,
+    Input,
+    LoadConst,
+    LoadFunc,
+    MakeTuple,
+    Module,
+    Noop,
+    Op,
+    Output,
+    Tag,
+    TailLoop,
+    UnpackTuple,
+)
+from hugr.std.int import DivMod
+from hugr.std.logic import Not
+from hugr.tys import Bool, PolyFuncType, TypeBound
+from hugr.val import TRUE
+
+
+@pytest.mark.parametrize(
+    ("op", "string"),
+    [
+        (Input([]), "Input"),
+        (Output([]), "Output"),
+        (Not, "logic.Not"),
+        (DivMod, "arithmetic.int.idivmod_u<5>"),
+        (MakeTuple(), "MakeTuple"),
+        (UnpackTuple(), "UnpackTuple"),
+        (Tag(0, Bool), "Tag(0)"),
+        (CFG([]), "CFG"),
+        (DFG([]), "DFG"),
+        (DataflowBlock([]), "DataflowBlock"),
+        (ExitBlock([]), "ExitBlock"),
+        (LoadConst(), "LoadConst"),
+        (Conditional(Bool, []), "Conditional"),
+        (TailLoop([], []), "TailLoop"),
+        (Case([]), "Case"),
+        (Module(), "Module"),
+        (Call(PolyFuncType.empty()), "Call"),
+        (CallIndirect(), "CallIndirect"),
+        (LoadFunc(PolyFuncType.empty()), "LoadFunc"),
+        (FuncDefn("foo", []), "FuncDefn(foo)"),
+        (FuncDecl("bar", PolyFuncType.empty()), "FuncDecl(bar)"),
+        (Const(TRUE), "Const(TRUE)"),
+        (Noop(), "Noop"),
+        (AliasDecl("baz", TypeBound.Any), "AliasDecl(baz)"),
+        (AliasDefn("baz", Bool), "AliasDefn(baz)"),
+    ],
+)
+def test_ops_str(op: Op, string: str):
+    assert op.name() == string

--- a/hugr-py/tests/test_tys.py
+++ b/hugr-py/tests/test_tys.py
@@ -2,7 +2,41 @@ from __future__ import annotations
 
 import pytest
 
-from hugr.tys import Bool, Either, Option, Qubit, Sum, Tuple, Type, UnitSum
+from hugr.std.float import FLOAT_T
+from hugr.std.int import INT_T, _int_tv
+from hugr.tys import (
+    Alias,
+    Array,
+    Bool,
+    BoundedNatArg,
+    BoundedNatParam,
+    Either,
+    ExtensionsArg,
+    ExtensionsParam,
+    ExtType,
+    FunctionType,
+    ListParam,
+    Option,
+    PolyFuncType,
+    Qubit,
+    RowVariable,
+    SequenceArg,
+    StringArg,
+    StringParam,
+    Sum,
+    Tuple,
+    TupleParam,
+    Type,
+    TypeArg,
+    TypeBound,
+    TypeParam,
+    TypeTypeArg,
+    TypeTypeParam,
+    UnitSum,
+    USize,
+    Variable,
+    VariableArg,
+)
 
 
 def test_sums():
@@ -44,3 +78,66 @@ def test_sums():
 def test_tys_sum_str(ty: Type, string: str, repr_str: str):
     assert str(ty) == string
     assert repr(ty) == repr_str
+
+
+@pytest.mark.parametrize(
+    ("param", "string"),
+    [
+        (TypeTypeParam(TypeBound.Any), "Any"),
+        (BoundedNatParam(3), "Nat(3)"),
+        (BoundedNatParam(None), "Nat"),
+        (StringParam(), "String"),
+        (
+            TupleParam([TypeTypeParam(TypeBound.Any), BoundedNatParam(3)]),
+            "(Any, Nat(3))",
+        ),
+        (ListParam(StringParam()), "[String]"),
+        (ExtensionsParam(), "Extensions"),
+    ],
+)
+def test_params_str(param: TypeParam, string: str):
+    assert str(param) == string
+
+
+@pytest.mark.parametrize(
+    ("arg", "string"),
+    [
+        (TypeTypeArg(Bool), "Type(Bool)"),
+        (BoundedNatArg(3), "3"),
+        (StringArg("hello"), '"hello"'),
+        (
+            SequenceArg([TypeTypeArg(Qubit), BoundedNatArg(3)]),
+            "(Type(Qubit), 3)",
+        ),
+        (VariableArg(2, StringParam()), "$2"),
+        (ExtensionsArg(["A", "B"]), "Extensions(A, B)"),
+    ],
+)
+def test_args_str(arg: TypeArg, string: str):
+    assert str(arg) == string
+
+
+@pytest.mark.parametrize(
+    ("ty", "string"),
+    [
+        (Array(Bool, 3), "Array<Bool, 3>"),
+        (Variable(2, TypeBound.Any), "$2"),
+        (RowVariable(4, TypeBound.Copyable), "$4"),
+        (USize(), "USize"),
+        (INT_T, "int<5>"),
+        (FLOAT_T, "float64"),
+        (Alias("Foo", TypeBound.Copyable), "Foo"),
+        (FunctionType([Bool, Qubit], [Qubit, Bool]), "Bool, Qubit -> Qubit, Bool"),
+        (
+            PolyFuncType(
+                [TypeTypeParam(TypeBound.Any), BoundedNatParam(7)],
+                FunctionType([_int_tv(1)], [Variable(0, TypeBound.Copyable)]),
+            ),
+            "∀ Any, Nat(7). int<$1> -> $0",
+        ),
+    ],
+)
+def test_tys_str(ty: Type, string: str):
+    assert str(ty) == string
+    if isinstance(ty, ExtType):
+        assert str(ty._to_opaque()) == string

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ check:
 # Run all the tests.
 test language="[rust|python]" : (_run_lang language \
         "HUGR_TEST_SCHEMA=1 cargo test --all-features" \
-        "cargo build -p hugr-cli && uv run pytest"
+        "cargo build -p hugr-cli && HUGR_RENDER_DOT=1 uv run pytest"
     )
 
 # Run all the benchmarks.


### PR DESCRIPTION
Closes #1468 
Closes #1470

Previous testing wasn't covering label formatting because it requires actually rendering the dot in to an image. Have enabled that, but put it behind an env var because it significantly slows down tests.

BREAKING CHANGE: rename `Custom.name` to `Custom.op_name` and `Func(Defn/Decl).name` to `f_name` to allow for new `name` method