### PR TITLE
ci: Fix docs build script error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-tags: true
 
       - name: Set up uv
-        run: .github/script/install-uv.sh
+        run: ../.github/script/install-uv.sh
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,6 +68,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     steps:
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Fixes #1478. Passing job: https://github.com/CQCL/hugr/actions/runs/10618695798

The job sets `./hugr-py` as working directory, so the script needed a different relative path.

drive-by: Don't try to publish on non-main workflow_dispatches. That caused the job to fail.