### PR TITLE
feat: `is_ext` utility for checking equality against extension ops

### DIFF
--- a/hugr-core/src/extension/prelude/array.rs
+++ b/hugr-core/src/extension/prelude/array.rs
@@ -335,8 +335,7 @@ mod tests {
             };
             let op = def.to_concrete(ty, size);
             let optype: OpType = op.clone().into();
-            let new_op: ArrayOp = optype.cast().unwrap();
-            assert_eq!(new_op, op);
+            assert!(optype.is_ext(op));
         }
     }
 

--- a/hugr-core/src/hugr/rewrite/insert_identity.rs
+++ b/hugr-core/src/hugr/rewrite/insert_identity.rs
@@ -125,9 +125,7 @@ mod tests {
 
         assert_eq!(h.node_count(), 7);
 
-        let noop: Noop = h.get_optype(noop_node).cast().unwrap();
-
-        assert_eq!(noop, Noop(QB_T));
+        assert_eq!(h.get_optype(noop_node).cast(), Some(Noop(QB_T)));
 
         h.update_validate(&PRELUDE_REGISTRY).unwrap();
     }

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -294,6 +294,14 @@ impl OpType {
         self.as_extension_op()
             .and_then(|o| T::from_extension_op(o).ok())
     }
+
+    /// Check if the operation is an extension operation by casting to it.
+    pub fn is_ext<T>(&self, op: T) -> bool
+    where
+        T: MakeExtensionOp + PartialEq,
+    {
+        self.cast::<T>() == Some(op)
+    }
 }
 
 /// Macro used by operations that want their


### PR DESCRIPTION
Open to bikeshedding on name of `is_ext`

left in an `assert_eq` that just uses cast directly as a comparison (this may not be worthwhile)