### PR TITLE
fix: `std.collections.insert` wrong output order

### DIFF
--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -164,7 +164,7 @@ impl ListOp {
             insert => self
                 .list_polytype(
                     vec![l.clone(), USIZE_T, e.clone()],
-                    vec![l, either_type(Type::UNIT, e).into()],
+                    vec![l, either_type(e, Type::UNIT).into()],
                 )
                 .into(),
             length => self.list_polytype(vec![l], vec![USIZE_T]).into(),


### PR DESCRIPTION
We changed the `Either` type to use the *right* variant to represent success.

The `insert` operations returns nothing on success, and the element on error. We had the incorrect order here. 