### PR TITLE
feat!: `HugrMut::remove_node` and `SimpleReplacement` return removed weights

### DIFF
--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -105,13 +105,13 @@ pub trait HugrMut: HugrMutInternals {
         self.hugr_mut().add_node_after(sibling, op)
     }
 
-    /// Remove a node from the graph.
+    /// Remove a node from the graph and return the node weight.
     ///
     /// # Panics
     ///
     /// If the node is not in the graph, or if the node is the root node.
     #[inline]
-    fn remove_node(&mut self, node: Node) {
+    fn remove_node(&mut self, node: Node) -> OpType {
         panic_invalid_non_root(self, node);
         self.hugr_mut().remove_node(node)
     }
@@ -264,11 +264,11 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
         node
     }
 
-    fn remove_node(&mut self, node: Node) {
+    fn remove_node(&mut self, node: Node) -> OpType {
         panic_invalid_non_root(self, node);
         self.as_mut().hierarchy.remove(node.pg_index());
         self.as_mut().graph.remove_node(node.pg_index());
-        self.as_mut().op_types.remove(node.pg_index());
+        self.as_mut().op_types.take(node.pg_index())
     }
 
     fn connect(

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -324,7 +324,9 @@ impl Rewrite for Replacement {
         }
 
         // 7. Remove remaining nodes
-        to_remove.into_iter().for_each(|n| h.remove_node(n));
+        to_remove.into_iter().for_each(|n| {
+            h.remove_node(n);
+        });
         Ok(node_map)
     }
 


### PR DESCRIPTION
Closes #476 

BREAKING CHANGE: `remove_node` now returns an OpType, and the `ApplyResult` of `SimpleReplacement` holds replaced nodes and weights.