### PR TITLE
fix!: Make list length op give back the list

### DIFF
--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -178,7 +178,7 @@ impl ListOp {
                     vec![l, either_type(e, Type::UNIT).into()],
                 )
                 .into(),
-            length => self.list_polytype(vec![l], vec![USIZE_T]).into(),
+            length => self.list_polytype(vec![l.clone()], vec![l, USIZE_T]).into(),
         }
     }
 

--- a/hugr-py/src/hugr/std/_json_defs/collections.json
+++ b/hugr-py/src/hugr/std/_json_defs/collections.json
@@ -190,6 +190,22 @@
           ],
           "output": [
             {
+              "t": "Opaque",
+              "extension": "collections",
+              "id": "List",
+              "args": [
+                {
+                  "tya": "Type",
+                  "ty": {
+                    "t": "V",
+                    "i": 0,
+                    "b": "A"
+                  }
+                }
+              ],
+              "bound": "A"
+            },
+            {
               "t": "I"
             }
           ],

--- a/specification/std_extensions/collections.json
+++ b/specification/std_extensions/collections.json
@@ -190,6 +190,22 @@
           ],
           "output": [
             {
+              "t": "Opaque",
+              "extension": "collections",
+              "id": "List",
+              "args": [
+                {
+                  "tya": "Type",
+                  "ty": {
+                    "t": "V",
+                    "i": 0,
+                    "b": "A"
+                  }
+                }
+              ],
+              "bound": "A"
+            },
+            {
               "t": "I"
             }
           ],


### PR DESCRIPTION
Fixes #1543.

BREAKING CHANGE: The `length` op in the std `collections` extensions now also returns the list.