### PR TITLE
feat: Make `BuildHandle::num_value_outputs` public

### DIFF
--- a/hugr-core/src/builder/handle.rs
+++ b/hugr-core/src/builder/handle.rs
@@ -33,7 +33,7 @@ impl<T: NodeHandle> NodeHandle for BuildHandle<T> {
 impl<T: NodeHandle> BuildHandle<T> {
     #[inline]
     /// Number of Value kind outputs from this node.
-    fn num_value_outputs(&self) -> usize {
+    pub fn num_value_outputs(&self) -> usize {
         self.num_value_outputs
     }
 


### PR DESCRIPTION
Mini API improvement.

The alternative required creating an output wires array and checking its length...