### PR TITLE
chore: release

### DIFF
--- a/hugr-cli/CHANGELOG.md
+++ b/hugr-cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## 0.6.0 (2024-09-04)
 
 ### Features

--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -15,7 +15,7 @@ categories = ["compilers"]
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 clap-verbosity-flag.workspace = true
-hugr-core = { path = "../hugr-core", version = "0.9.1" }
+hugr-core = { path = "../hugr-core", version = "0.10.0" }
 serde_json.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/hugr-core/CHANGELOG.md
+++ b/hugr-core/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.10.0 (2024-10-08)
+
+### Bug Fixes
+
+- [**breaking**] Make list length op give back the list ([#1547](https://github.com/CQCL/hugr/pull/1547))
+
+### Features
+
+- [**breaking**] Allow CustomConsts to (optionally) be hashable ([#1397](https://github.com/CQCL/hugr/pull/1397))
+- Add an `OpLoadError` variant of `BuildError`. ([#1537](https://github.com/CQCL/hugr/pull/1537))
+- [**breaking**] `HugrMut::remove_node` and `SimpleReplacement` return removed weights ([#1516](https://github.com/CQCL/hugr/pull/1516))
+- Draft for `hugr-model` with export, import, parsing and pretty printing ([#1542](https://github.com/CQCL/hugr/pull/1542))
+
+
 ## 0.9.1 (2024-09-04)
 
 ### Bug Fixes

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -51,7 +51,7 @@ paste = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 semver = { version = "1.0.23", features = ["serde"] }
-hugr-model = { path = "../hugr-model", optional = true }
+hugr-model = { version = "0.1.0", path = "../hugr-model", optional = true }
 indexmap.workspace = true
 fxhash.workspace = true
 bumpalo = { workspace = true, features = ["collections"] }

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-core"
-version = "0.9.1"
+version = "0.10.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 

--- a/hugr-passes/CHANGELOG.md
+++ b/hugr-passes/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 ## 0.8.1 (2024-09-04)
 
 ### Features

--- a/hugr-passes/Cargo.toml
+++ b/hugr-passes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-passes"
-version = "0.8.1"
+version = "0.8.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -13,7 +13,7 @@ keywords = ["Quantum", "Quantinuum"]
 categories = ["compilers"]
 
 [dependencies]
-hugr-core = { path = "../hugr-core", version = "0.9.1" }
+hugr-core = { path = "../hugr-core", version = "0.10.0" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 paste = { workspace = true }

--- a/hugr/CHANGELOG.md
+++ b/hugr/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.13.0 (2024-10-08)
+
+### Bug Fixes
+
+- [**breaking**] Make list length op give back the list ([#1547](https://github.com/CQCL/hugr/pull/1547))
+
+### Features
+
+- [**breaking**] Allow CustomConsts to (optionally) be hashable ([#1397](https://github.com/CQCL/hugr/pull/1397))
+- Add an `OpLoadError` variant of `BuildError`. ([#1537](https://github.com/CQCL/hugr/pull/1537))
+- [**breaking**] `HugrMut::remove_node` and `SimpleReplacement` return removed weights ([#1516](https://github.com/CQCL/hugr/pull/1516))
+- Draft for `hugr-model` with export, import, parsing and pretty printing ([#1542](https://github.com/CQCL/hugr/pull/1542))
+
+
 ## 0.12.1 (2024-09-04)
 
 ### Bug Fixes

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr"
-version = "0.12.1"
+version = "0.13.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 
@@ -26,8 +26,8 @@ extension_inference = ["hugr-core/extension_inference"]
 declarative = ["hugr-core/declarative"]
 
 [dependencies]
-hugr-core = { path = "../hugr-core", version = "0.9.1" }
-hugr-passes = { path = "../hugr-passes", version = "0.8.1" }
+hugr-core = { path = "../hugr-core", version = "0.10.0" }
+hugr-passes = { path = "../hugr-passes", version = "0.8.2" }
 
 [dev-dependencies]
 rstest = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `hugr`: 0.12.1 -> 0.13.0 (✓ API compatible changes)
* `hugr-core`: 0.9.1 -> 0.10.0 (✓ API compatible changes)
* `hugr-passes`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `hugr-cli`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `hugr`
<blockquote>

## 0.13.0 (2024-10-08)

### Bug Fixes

- [**breaking**] Make list length op give back the list ([#1547](https://github.com/CQCL/hugr/pull/1547))

### Features

- [**breaking**] Allow CustomConsts to (optionally) be hashable ([#1397](https://github.com/CQCL/hugr/pull/1397))
- Add an `OpLoadError` variant of `BuildError`. ([#1537](https://github.com/CQCL/hugr/pull/1537))
- [**breaking**] `HugrMut::remove_node` and `SimpleReplacement` return removed weights ([#1516](https://github.com/CQCL/hugr/pull/1516))
- Draft for `hugr-model` with export, import, parsing and pretty printing ([#1542](https://github.com/CQCL/hugr/pull/1542))
</blockquote>

## `hugr-core`
<blockquote>

## 0.10.0 (2024-10-08)

### Bug Fixes

- [**breaking**] Make list length op give back the list ([#1547](https://github.com/CQCL/hugr/pull/1547))

### Features

- [**breaking**] Allow CustomConsts to (optionally) be hashable ([#1397](https://github.com/CQCL/hugr/pull/1397))
- Add an `OpLoadError` variant of `BuildError`. ([#1537](https://github.com/CQCL/hugr/pull/1537))
- [**breaking**] `HugrMut::remove_node` and `SimpleReplacement` return removed weights ([#1516](https://github.com/CQCL/hugr/pull/1516))
- Draft for `hugr-model` with export, import, parsing and pretty printing ([#1542](https://github.com/CQCL/hugr/pull/1542))
</blockquote>

## `hugr-passes`
<blockquote>

## 0.8.1 (2024-09-04)

### Features

- Op replacement and lowering functions ([#1509](https://github.com/CQCL/hugr/pull/1509))
</blockquote>

## `hugr-cli`
<blockquote>

## 0.6.0 (2024-09-04)

### Features

- [**breaking**] Allow registry specification in `run_dump` ([#1501](https://github.com/CQCL/hugr/pull/1501))
- [**breaking**] Add `Package::validate` and return `ExtensionRegistry` in helpers. ([#1507](https://github.com/CQCL/hugr/pull/1507))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).