### PR TITLE
Enable `release-plz` for `hugr-model`

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -38,3 +38,7 @@ release = true
 [[package]]
 name = "hugr-cli"
 release = true
+
+[[package]]
+name = "hugr-model"
+release = true


### PR DESCRIPTION
The crate is published now, so we can configure automatic updates.
https://crates.io/crates/hugr-model