### PR TITLE
feat: `FunctionBuilder::add_{in,out}put`

### DIFF
--- a/hugr-core/src/hugr/internal.rs
+++ b/hugr-core/src/hugr/internal.rs
@@ -74,6 +74,8 @@ pub trait HugrMutInternals: RootTagged {
     /// The `direction` parameter specifies whether to add ports to the incoming
     /// or outgoing list.
     ///
+    /// Returns the range of newly created ports.
+    ///
     /// # Panics
     ///
     /// If the node is not in the graph.
@@ -129,6 +131,9 @@ pub trait HugrMutInternals: RootTagged {
     /// Replace the OpType at node and return the old OpType.
     /// In general this invalidates the ports, which may need to be resized to
     /// match the OpType signature.
+    ///
+    /// Returns the old OpType.
+    ///
     /// TODO: Add a version which ignores input extensions
     ///
     /// # Errors


### PR DESCRIPTION
Closes #1562.

It's a chunk of code fiddling with the hugr internals, but it is something specific to function definitions so I think it should be ok to have it under `FunctionBuilder`.