### PR TITLE
ci: install capnp in unsoundness check

### DIFF
--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -34,5 +34,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v0-miri
+      - name: Install CapnProto
+        run: sudo apt-get install -y capnproto
       - name: Test with Miri
         run: cargo miri test


### PR DESCRIPTION
miri check currently failing because of this

working run: https://github.com/CQCL/hugr/actions/runs/11295167361