### PR TITLE
ci: Install capnproto in release-plz ci

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,6 +18,8 @@ jobs:
           token: ${{ secrets.HUGRBOT_PAT }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Install CapnProto
+        run: sudo apt-get install -y capnproto
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,6 +31,7 @@ To setup the environment manually you will need:
 - Just: https://just.systems/
 - Rust `>=1.75`: https://www.rust-lang.org/tools/install
 - uv `>=0.3`: docs.astral.sh/uv/getting-started/installation
+- capnproto `>=1.0`: https://capnproto.org/install.html
 
 Once you have these installed, you can install the required python dependencies and setup pre-commit hooks with:
 


### PR DESCRIPTION
The last release workflow run failed due to capnproto not being installed.
https://github.com/CQCL/hugr/actions/runs/11325304655/job/31491921923

drive-by: Add `capnproto` to the list of dev requirements in `DEVELOPMENT.md`