### PR TITLE
chore: Fix lints from clippy 1.82

### DIFF
--- a/hugr-core/src/builder/circuit.rs
+++ b/hugr-core/src/builder/circuit.rs
@@ -11,6 +11,7 @@ use crate::{CircuitUnit, Wire};
 
 /// Builder to build regions of dataflow graphs that look like Circuits,
 /// where some inputs of operations directly correspond to some outputs.
+///
 /// Allows appending operations by indexing a vector of input wires.
 #[derive(Debug, PartialEq)]
 pub struct CircuitBuilder<'a, T: ?Sized> {

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -452,8 +452,9 @@ pub enum ExtensionBuildError {
 pub struct ExtensionSet(BTreeSet<ExtensionId>);
 
 /// A special ExtensionId which indicates that the delta of a non-Function
-/// container node should be computed by extension inference. See [`infer_extensions`]
-/// which lists the container nodes to which this can be applied.
+/// container node should be computed by extension inference.
+///
+/// See [`infer_extensions`] which lists the container nodes to which this can be applied.
 ///
 /// [`infer_extensions`]: crate::hugr::Hugr::infer_extensions
 pub const TO_BE_INFERRED: ExtensionId = ExtensionId::new_unchecked(".TO_BE_INFERRED");

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -42,6 +42,7 @@ where
 
 /// Traits implemented by types which can add themselves to [`Extension`]s as
 /// [`OpDef`]s or load themselves from an [`OpDef`].
+///
 /// Particularly useful with C-style enums that implement [strum::IntoEnumIterator],
 /// as then all definitions can be added to an extension at once.
 pub trait MakeOpDef: NamedOp {

--- a/hugr-core/src/ops/constant/custom.rs
+++ b/hugr-core/src/ops/constant/custom.rs
@@ -88,6 +88,8 @@ pub trait CustomConst:
     fn get_type(&self) -> Type;
 }
 
+/// Fallible hash function.
+///
 /// Prerequisite for `CustomConst`. Allows to declare a custom hash function,
 /// but the easiest options are either to `impl TryHash for ... {}` to indicate
 /// "not hashable", or else to implement/derive [Hash].

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -262,6 +262,7 @@ impl<RV: MaybeRV> TypeEnum<RV> {
     try_from = "serialize::SerSimpleType"
 )]
 /// A HUGR type - the valid types of [EdgeKind::Value] and [EdgeKind::Const] edges.
+///
 /// Such an edge is valid if the ports on either end agree on the [Type].
 /// Types have an optional [TypeBound] which places limits on the valid
 /// operations on a type.

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -120,8 +120,9 @@ fn const_graph(consts: Vec<Value>, reg: &ExtensionRegistry) -> Hugr {
 }
 
 /// Given some `candidate_nodes` to search for LoadConstant operations in `hugr`,
-/// return an iterator of possible constant folding rewrites. The
-/// [`SimpleReplacement`] replaces an operation with constants that result from
+/// return an iterator of possible constant folding rewrites.
+///
+/// The [`SimpleReplacement`] replaces an operation with constants that result from
 /// evaluating it, the extension registry `reg` is used to validate the
 /// replacement HUGR. The vector of [`RemoveLoadConstant`] refer to the
 /// LoadConstant nodes that could be removed - they are not automatically

--- a/hugr-passes/src/nest_cfgs.rs
+++ b/hugr-passes/src/nest_cfgs.rs
@@ -55,6 +55,7 @@ use hugr_core::{Direction, Hugr, Node};
 
 /// A "view" of a CFG in a Hugr which allows basic blocks in the underlying CFG to be split into
 /// multiple blocks in the view (or merged together).
+///
 /// `T` is the type of basic block; this can just be a BasicBlock (e.g. [`Node`]) in the Hugr,
 /// or an [IdentityCfgMap] if the extra level of indirection is not required. However, since
 /// SESE regions are bounded by edges between pairs of such `T`, such splitting may allow the
@@ -153,6 +154,7 @@ pub fn transform_cfg_to_nested<T: Copy + Eq + Hash + std::fmt::Debug>(
 
 /// Search the entire Hugr looking for CFGs, and transform each
 /// into as deeply-nested form as possible (as per [transform_cfg_to_nested]).
+///
 /// This search may be expensive, although if it finds much/many CFGs,
 /// the analysis/transformation on them is likely to be more expensive still!
 pub fn transform_all_cfgs(h: &mut Hugr) {


### PR DESCRIPTION
Rust 1.82 comes out on 2024-10-17.
The matching version of clippy has a new lint for doc lines where the first paragraph is too long.
https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph

This PR preventively fixes the issues before they cause lint errors on CI.