### PR TITLE
feat: Add `Package` definition on `hugr-core`

### DIFF
--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -15,7 +15,8 @@ categories = ["compilers"]
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 clap-verbosity-flag.workspace = true
-hugr-core = { path = "../hugr-core", version = "0.13.1" }
+derive_more = { workspace = true, features = ["display", "error", "from"] }
+hugr = { path = "../hugr", version = "0.13.1" }
 serde_json.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/hugr-cli/src/extensions.rs
+++ b/hugr-cli/src/extensions.rs
@@ -1,6 +1,6 @@
 //! Dump standard extensions in serialized form.
 use clap::Parser;
-use hugr_core::extension::ExtensionRegistry;
+use hugr::extension::ExtensionRegistry;
 use std::{io::Write, path::PathBuf};
 
 /// Dump the standard extensions.

--- a/hugr-cli/src/main.rs
+++ b/hugr-cli/src/main.rs
@@ -9,7 +9,7 @@ use clap_verbosity_flag::Level;
 fn main() {
     match CliArgs::parse() {
         CliArgs::Validate(args) => run_validate(args),
-        CliArgs::GenExtensions(args) => args.run_dump(&hugr_core::std_extensions::STD_REG),
+        CliArgs::GenExtensions(args) => args.run_dump(&hugr::std_extensions::STD_REG),
         CliArgs::Mermaid(mut args) => args.run_print().unwrap(),
         CliArgs::External(_) => {
             // TODO: Implement support for external commands.

--- a/hugr-cli/src/mermaid.rs
+++ b/hugr-cli/src/mermaid.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use clap::Parser;
 use clio::Output;
-use hugr_core::HugrView;
+use hugr::HugrView;
 
 /// Dump the standard extensions.
 #[derive(Parser, Debug)]

--- a/hugr-cli/src/validate.rs
+++ b/hugr-cli/src/validate.rs
@@ -2,10 +2,10 @@
 
 use clap::Parser;
 use clap_verbosity_flag::Level;
-use hugr_core::{extension::ExtensionRegistry, Extension, Hugr};
-use thiserror::Error;
+use hugr::package::PackageValidationError;
+use hugr::{extension::ExtensionRegistry, Extension, Hugr};
 
-use crate::{CliError, HugrArgs, Package};
+use crate::{CliError, HugrArgs};
 
 /// Validate and visualise a HUGR file.
 #[derive(Parser, Debug)]
@@ -17,18 +17,6 @@ pub struct ValArgs {
     #[command(flatten)]
     /// common arguments
     pub hugr_args: HugrArgs,
-}
-
-/// Error type for the CLI.
-#[derive(Error, Debug)]
-#[non_exhaustive]
-pub enum ValError {
-    /// Error validating HUGR.
-    #[error("Error validating HUGR: {0}")]
-    Validate(#[from] hugr_core::hugr::ValidationError),
-    /// Error registering extension.
-    #[error("Error registering extension: {0}")]
-    ExtReg(#[from] hugr_core::extension::ExtensionRegistryError),
 }
 
 /// String to print when validation is successful.
@@ -50,49 +38,30 @@ impl ValArgs {
     }
 }
 
-impl Package {
-    /// Validate the package against an extension registry.
-    ///
-    /// `reg` is updated with any new extensions.
-    ///
-    /// Returns the validated modules.
-    pub fn validate(mut self, reg: &mut ExtensionRegistry) -> Result<Vec<Hugr>, ValError> {
-        // register packed extensions
-        for ext in self.extensions {
-            reg.register_updated(ext)?;
-        }
-
-        for hugr in self.modules.iter_mut() {
-            hugr.update_validate(reg)?;
-        }
-
-        Ok(self.modules)
-    }
-}
-
 impl HugrArgs {
     /// Load the package and validate against an extension registry.
     ///
     /// Returns the validated modules and the extension registry the modules
     /// were validated against.
     pub fn validate(&mut self) -> Result<(Vec<Hugr>, ExtensionRegistry), CliError> {
-        let package = self.get_package()?;
+        let mut package = self.get_package()?;
 
         let mut reg: ExtensionRegistry = if self.no_std {
-            hugr_core::extension::PRELUDE_REGISTRY.to_owned()
+            hugr::extension::PRELUDE_REGISTRY.to_owned()
         } else {
-            hugr_core::std_extensions::STD_REG.to_owned()
+            hugr::std_extensions::STD_REG.to_owned()
         };
 
         // register external extensions
         for ext in &self.extensions {
             let f = std::fs::File::open(ext)?;
             let ext: Extension = serde_json::from_reader(f)?;
-            reg.register_updated(ext).map_err(ValError::ExtReg)?;
+            reg.register_updated(ext)
+                .map_err(PackageValidationError::Extension)?;
         }
 
-        let modules = package.validate(&mut reg)?;
-        Ok((modules, reg))
+        package.validate(&mut reg)?;
+        Ok((package.modules, reg))
     }
 
     /// Test whether a `level` message should be output.

--- a/hugr-cli/tests/validate.rs
+++ b/hugr-cli/tests/validate.rs
@@ -6,10 +6,9 @@
 
 use assert_cmd::Command;
 use assert_fs::{fixture::FileWriteStr, NamedTempFile};
-use hugr_cli::{validate::VALID_PRINT, Package};
-use hugr_core::builder::DFGBuilder;
-use hugr_core::types::Type;
-use hugr_core::{
+use hugr::builder::DFGBuilder;
+use hugr::types::Type;
+use hugr::{
     builder::{Container, Dataflow},
     extension::prelude::{BOOL_T, QB_T},
     std_extensions::arithmetic::float_types::FLOAT64_TYPE,
@@ -17,6 +16,7 @@ use hugr_core::{
     types::Signature,
     Hugr,
 };
+use hugr_cli::{validate::VALID_PRINT, Package};
 use predicates::{prelude::*, str::contains};
 use rstest::{fixture, rstest};
 
@@ -128,7 +128,7 @@ fn test_bad_json(mut val_cmd: Command) {
     val_cmd
         .assert()
         .failure()
-        .stderr(contains("Error parsing input"));
+        .stderr(contains("Error parsing package"));
 }
 
 #[rstest]
@@ -139,7 +139,7 @@ fn test_bad_json_silent(mut val_cmd: Command) {
     val_cmd
         .assert()
         .failure()
-        .stderr(contains("Error parsing input").not());
+        .stderr(contains("Error parsing package").not());
 }
 
 #[rstest]
@@ -188,7 +188,7 @@ fn test_float_extension(float_hugr_string: String, mut val_cmd: Command) {
 #[fixture]
 fn package_string(#[with(FLOAT64_TYPE)] test_hugr: Hugr) -> String {
     let rdr = std::fs::File::open(FLOAT_EXT_FILE).unwrap();
-    let float_ext: hugr_core::Extension = serde_json::from_reader(rdr).unwrap();
+    let float_ext: hugr::Extension = serde_json::from_reader(rdr).unwrap();
     let package = Package::new(vec![test_hugr], vec![float_ext]);
     serde_json::to_string(&package).unwrap()
 }

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -37,7 +37,7 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_yaml = { workspace = true, optional = true }
 typetag = { workspace = true }
 smol_str = { workspace = true, features = ["serde"] }
-derive_more = { workspace = true, features = ["display", "from"] }
+derive_more = { workspace = true, features = ["display", "error", "from"] }
 itertools = { workspace = true }
 html-escape = { workspace = true }
 bitvec = { workspace = true, features = ["serde"] }

--- a/hugr-core/src/lib.rs
+++ b/hugr-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod hugr;
 pub mod import;
 pub mod macros;
 pub mod ops;
+pub mod package;
 pub mod std_extensions;
 pub mod types;
 pub mod utils;

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -1,0 +1,99 @@
+//! Bundles of hugr modules along with the extension required to load them.
+
+use derive_more::{Display, Error, From};
+use std::path::Path;
+use std::{fs, io};
+
+use crate::extension::{ExtensionRegistry, ExtensionRegistryError};
+use crate::hugr::ValidationError;
+use crate::{Extension, Hugr};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// Package of module HUGRs and extensions.
+/// The HUGRs are validated against the extensions.
+pub struct Package {
+    /// Module HUGRs included in the package.
+    pub modules: Vec<Hugr>,
+    /// Extensions to validate against.
+    pub extensions: Vec<Extension>,
+}
+
+impl Package {
+    /// Create a new package.
+    pub fn new(
+        modules: impl IntoIterator<Item = Hugr>,
+        extensions: impl IntoIterator<Item = Extension>,
+    ) -> Self {
+        Self {
+            modules: modules.into_iter().collect(),
+            extensions: extensions.into_iter().collect(),
+        }
+    }
+
+    /// Validate the package against an extension registry.
+    ///
+    /// `reg` is updated with any new extensions.
+    pub fn validate(&mut self, reg: &mut ExtensionRegistry) -> Result<(), PackageValidationError> {
+        for ext in &self.extensions {
+            reg.register_updated_ref(ext)?;
+        }
+        for hugr in self.modules.iter_mut() {
+            hugr.update_validate(reg)?;
+        }
+        Ok(())
+    }
+
+    /// Read a Package in json format from an io reader.
+    ///
+    /// If the json encodes a single [Hugr] instead, it will be inserted in a new [Package].
+    pub fn from_json_reader(reader: impl io::Read) -> Result<Self, PackageLoadError> {
+        let val: serde_json::Value = serde_json::from_reader(reader)?;
+        let pkg_load_err = match serde_json::from_value::<Package>(val.clone()) {
+            Ok(p) => return Ok(p),
+            Err(e) => e,
+        };
+
+        if let Ok(hugr) = serde_json::from_value::<Hugr>(val) {
+            return Ok(Package::new([hugr], []));
+        }
+
+        // Return the original error from parsing the package.
+        Err(PackageLoadError::JsonEncoding(pkg_load_err))
+    }
+
+    /// Read a Package from a json string.
+    ///
+    /// If the json encodes a single [Hugr] instead, it will be inserted in a new [Package].
+    pub fn from_json(json: impl AsRef<str>) -> Result<Self, PackageLoadError> {
+        Self::from_json_reader(json.as_ref().as_bytes())
+    }
+
+    /// Read a Package from a json file.
+    ///
+    /// If the json encodes a single [Hugr] instead, it will be inserted in a new [Package].
+    pub fn from_json_file(path: impl AsRef<Path>) -> Result<Self, PackageLoadError> {
+        let file = fs::File::open(path)?;
+        let reader = io::BufReader::new(file);
+        Self::from_json_reader(reader)
+    }
+}
+
+/// Error raised while loading a package.
+#[derive(Debug, Display, Error, From)]
+#[non_exhaustive]
+pub enum PackageLoadError {
+    /// Error raised while parsing the package json.
+    JsonEncoding(serde_json::Error),
+    /// Error raised while reading from a file.
+    IOError(io::Error),
+}
+
+/// Error raised while validating a package.
+#[derive(Debug, Display, Error, From)]
+#[non_exhaustive]
+pub enum PackageValidationError {
+    /// Error raised while processing the package extensions.
+    Extension(ExtensionRegistryError),
+    /// Error raised while validating the package hugrs.
+    Validation(ValidationError),
+}

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -135,7 +135,7 @@
 
 // These modules are re-exported as-is. If more control is needed, define a new module in this crate with the desired exports.
 // The doc inline directive is necessary for renamed modules to appear as if they were defined in this crate.
-pub use hugr_core::{builder, core, extension, ops, std_extensions, types, utils};
+pub use hugr_core::{builder, core, extension, ops, package, std_extensions, types, utils};
 #[doc(inline)]
 pub use hugr_passes as algorithms;
 


### PR DESCRIPTION
Moves the definition of packages out of `hugr-cli`. (We leave a re-export there to avoid breaking the API, it should be removed on the next breaking release).

Adds some helper functions to load and validate the package.

Closes #1530 

drive-by: Replace `hugr-core` dependency on `hugr-cli` by `hugr`. There's no need to access the internals there.