### PR TITLE
feat: Ensure packages always have modules at the root

### DIFF
--- a/hugr-cli/src/lib.rs
+++ b/hugr-cli/src/lib.rs
@@ -101,7 +101,7 @@ impl PackageOrHugr {
         reg: &mut ExtensionRegistry,
     ) -> Result<(), PackageValidationError> {
         match self {
-            PackageOrHugr::Package(pkg) => pkg.validate(reg),
+            PackageOrHugr::Package(pkg) => pkg.update_validate(reg),
             PackageOrHugr::Hugr(hugr) => hugr.update_validate(reg).map_err(Into::into),
         }
     }

--- a/hugr-cli/src/lib.rs
+++ b/hugr-cli/src/lib.rs
@@ -85,14 +85,6 @@ pub enum PackageOrHugr {
 }
 
 impl PackageOrHugr {
-    /// Returns the slice of hugrs in the package.
-    pub fn hugrs(&self) -> &[Hugr] {
-        match self {
-            PackageOrHugr::Package(pkg) => &pkg.modules,
-            PackageOrHugr::Hugr(hugr) => std::slice::from_ref(hugr),
-        }
-    }
-
     /// Returns the list of hugrs in the package.
     pub fn into_hugrs(self) -> Vec<Hugr> {
         match self {
@@ -111,6 +103,15 @@ impl PackageOrHugr {
         match self {
             PackageOrHugr::Package(pkg) => pkg.validate(reg),
             PackageOrHugr::Hugr(hugr) => hugr.update_validate(reg).map_err(Into::into),
+        }
+    }
+}
+
+impl AsRef<[Hugr]> for PackageOrHugr {
+    fn as_ref(&self) -> &[Hugr] {
+        match self {
+            PackageOrHugr::Package(pkg) => &pkg.modules,
+            PackageOrHugr::Hugr(hugr) => std::slice::from_ref(hugr),
         }
     }
 }

--- a/hugr-cli/src/mermaid.rs
+++ b/hugr-cli/src/mermaid.rs
@@ -32,7 +32,7 @@ impl MermaidArgs {
         let hugrs = if self.validate {
             self.hugr_args.validate()?.0
         } else {
-            self.hugr_args.get_package()?.modules
+            self.hugr_args.get_package_or_hugr()?.into_hugrs()
         };
 
         for hugr in hugrs {

--- a/hugr-cli/src/validate.rs
+++ b/hugr-cli/src/validate.rs
@@ -44,7 +44,7 @@ impl HugrArgs {
     /// Returns the validated modules and the extension registry the modules
     /// were validated against.
     pub fn validate(&mut self) -> Result<(Vec<Hugr>, ExtensionRegistry), CliError> {
-        let mut package = self.get_package()?;
+        let mut package = self.get_package_or_hugr()?;
 
         let mut reg: ExtensionRegistry = if self.no_std {
             hugr::extension::PRELUDE_REGISTRY.to_owned()
@@ -60,8 +60,8 @@ impl HugrArgs {
                 .map_err(PackageValidationError::Extension)?;
         }
 
-        package.validate(&mut reg)?;
-        Ok((package.modules, reg))
+        package.update_validate(&mut reg)?;
+        Ok((package.into_hugrs(), reg))
     }
 
     /// Test whether a `level` message should be output.

--- a/hugr-cli/tests/validate.rs
+++ b/hugr-cli/tests/validate.rs
@@ -6,7 +6,7 @@
 
 use assert_cmd::Command;
 use assert_fs::{fixture::FileWriteStr, NamedTempFile};
-use hugr::builder::DFGBuilder;
+use hugr::builder::{DFGBuilder, DataflowSubContainer, ModuleBuilder};
 use hugr::types::Type;
 use hugr::{
     builder::{Container, Dataflow},
@@ -31,6 +31,29 @@ fn val_cmd(mut cmd: Command) -> Command {
     cmd
 }
 
+// path to the fully serialized float extension
+const FLOAT_EXT_FILE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../specification/std_extensions/arithmetic/float/types.json"
+);
+
+/// A test package, containing a module-rooted HUGR.
+#[fixture]
+fn test_package(#[default(BOOL_T)] id_type: Type) -> Package {
+    let mut module = ModuleBuilder::new();
+    let df = module
+        .define_function("test", Signature::new_endo(id_type))
+        .unwrap();
+    let [i] = df.input_wires_arr();
+    df.finish_with_outputs([i]).unwrap();
+    let hugr = module.hugr().clone(); // unvalidated
+
+    let rdr = std::fs::File::open(FLOAT_EXT_FILE).unwrap();
+    let float_ext: hugr::Extension = serde_json::from_reader(rdr).unwrap();
+    Package::new(vec![hugr], vec![float_ext]).unwrap()
+}
+
+/// A DFG-rooted HUGR.
 #[fixture]
 fn test_hugr(#[default(BOOL_T)] id_type: Type) -> Hugr {
     let mut df = DFGBuilder::new(Signature::new_endo(id_type)).unwrap();
@@ -169,12 +192,6 @@ fn test_no_std_fail(float_hugr_string: String, mut val_cmd: Command) {
         .stderr(contains(" Extension 'arithmetic.float.types' not found"));
 }
 
-// path to the fully serialized float extension
-const FLOAT_EXT_FILE: &str = concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../specification/std_extensions/arithmetic/float/types.json"
-);
-
 #[rstest]
 fn test_float_extension(float_hugr_string: String, mut val_cmd: Command) {
     val_cmd.write_stdin(float_hugr_string);
@@ -186,15 +203,12 @@ fn test_float_extension(float_hugr_string: String, mut val_cmd: Command) {
     val_cmd.assert().success().stderr(contains(VALID_PRINT));
 }
 #[fixture]
-fn package_string(#[with(FLOAT64_TYPE)] test_hugr: Hugr) -> String {
-    let rdr = std::fs::File::open(FLOAT_EXT_FILE).unwrap();
-    let float_ext: hugr::Extension = serde_json::from_reader(rdr).unwrap();
-    let package = Package::new(vec![test_hugr], vec![float_ext]);
-    serde_json::to_string(&package).unwrap()
+fn package_string(#[with(FLOAT64_TYPE)] test_package: Package) -> String {
+    serde_json::to_string(&test_package).unwrap()
 }
 
 #[rstest]
-fn test_package(package_string: String, mut val_cmd: Command) {
+fn test_package_validation(package_string: String, mut val_cmd: Command) {
     // package with float extension and hugr that uses floats can validate
     val_cmd.write_stdin(package_string);
     val_cmd.arg("-");

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -346,7 +346,7 @@ mod test {
 
         let mut pkg = Package::from_hugrs([module, dfg], []).unwrap();
         let mut reg = EMPTY_REG.clone();
-        pkg.validate(&mut reg).unwrap();
+        pkg.update_validate(&mut reg).unwrap();
 
         assert_eq!(pkg.modules.len(), 2);
     }

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -178,6 +178,12 @@ impl PartialEq for Package {
     }
 }
 
+impl AsRef<[Hugr]> for Package {
+    fn as_ref(&self) -> &[Hugr] {
+        &self.modules
+    }
+}
+
 /// Alter an arbitrary hugr to contain an [OpType::Module] root.
 ///
 /// The behaviour depends on the root optype. See [Package::from_hugr] for details.

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -1,11 +1,13 @@
 //! Bundles of hugr modules along with the extension required to load them.
 
 use derive_more::{Display, Error, From};
+use std::collections::HashMap;
 use std::path::Path;
 use std::{fs, io};
 
 use crate::extension::{ExtensionRegistry, ExtensionRegistryError};
-use crate::hugr::ValidationError;
+use crate::hugr::{HugrView, ValidationError};
+use crate::ops::{NamedOp, OpType};
 use crate::{Extension, Hugr};
 
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
@@ -20,14 +22,71 @@ pub struct Package {
 
 impl Package {
     /// Create a new package from a list of hugrs and extensions.
+    ///
+    /// All the HUGRs must have a `Module` operation at the root.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the HUGRs does not have a `Module` root.
     pub fn new(
         modules: impl IntoIterator<Item = Hugr>,
         extensions: impl IntoIterator<Item = Extension>,
-    ) -> Self {
-        Self {
-            modules: modules.into_iter().collect(),
-            extensions: extensions.into_iter().collect(),
+    ) -> Result<Self, PackageError> {
+        let modules: Vec<Hugr> = modules.into_iter().collect();
+        for (idx, module) in modules.iter().enumerate() {
+            let root_op = module.get_optype(module.root());
+            if !root_op.is_module() {
+                return Err(PackageError::NonModuleHugr {
+                    module_index: idx,
+                    root_op: root_op.clone(),
+                });
+            }
         }
+        Ok(Self {
+            modules,
+            extensions: extensions.into_iter().collect(),
+        })
+    }
+
+    /// Create a new package from a list of hugrs and extensions.
+    ///
+    /// HUGRs that do not have a `Module` root will be wrapped in a new `Module` root,
+    /// depending on the root optype.
+    ///
+    /// - Currently all non-module roots will raise [PackageError::CannotWrapHugr].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the HUGRs cannot be wrapped in a module.
+    pub fn from_hugrs(
+        modules: impl IntoIterator<Item = Hugr>,
+        extensions: impl IntoIterator<Item = Extension>,
+    ) -> Result<Self, PackageError> {
+        let modules: Vec<Hugr> = modules
+            .into_iter()
+            .map(to_module_hugr)
+            .collect::<Result<_, PackageError>>()?;
+        Ok(Self {
+            modules,
+            extensions: extensions.into_iter().collect(),
+        })
+    }
+
+    /// Create a new package containing a single HUGR, and no extension definitions.
+    ///
+    /// If the Hugr is not a module, a new [OpType::Module] root will be added.
+    /// This behaviours depends on the root optype.
+    ///
+    /// - Currently all non-module roots will raise [PackageError::CannotWrapHugr].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the hugr cannot be wrapped in a module.
+    pub fn from_hugr(hugr: Hugr) -> Result<Self, PackageError> {
+        let mut package = Self::default();
+        let module = to_module_hugr(hugr)?;
+        package.modules.push(module);
+        Ok(package)
     }
 
     /// Validate the package against an extension registry.
@@ -54,7 +113,7 @@ impl Package {
         };
 
         if let Ok(hugr) = serde_json::from_value::<Hugr>(val) {
-            return Ok(Package::new([hugr], []));
+            return Ok(Package::from_hugr(hugr)?);
         }
 
         // Return the original error from parsing the package.
@@ -99,6 +158,60 @@ impl Package {
     }
 }
 
+impl PartialEq for Package {
+    fn eq(&self, other: &Self) -> bool {
+        if self.modules != other.modules || self.extensions.len() != other.extensions.len() {
+            return false;
+        }
+        // Extensions may be in different orders, so we compare them as sets.
+        let exts = self
+            .extensions
+            .iter()
+            .map(|e| (&e.name, e))
+            .collect::<HashMap<_, _>>();
+        other
+            .extensions
+            .iter()
+            .all(|e| exts.get(&e.name).map_or(false, |&e2| e == e2))
+    }
+}
+
+/// Alter an arbitrary hugr to contain an [OpType::Module] root.
+///
+/// The behaviour depends on the root optype. See [Package::from_hugr] for details.
+///
+/// # Returns
+///
+fn to_module_hugr(hugr: Hugr) -> Result<Hugr, PackageError> {
+    let root_op = hugr.get_optype(hugr.root());
+    match root_op {
+        OpType::Module(_) => Ok(hugr),
+        _ => Err(PackageError::CannotWrapHugr {
+            root_op: root_op.clone(),
+        }),
+    }
+}
+
+/// Error raised while loading a package.
+#[derive(Debug, Display, Error)]
+#[non_exhaustive]
+pub enum PackageError {
+    /// A hugr in the package does not have an [OpType::Module] root.
+    #[display("Module {module_index} in the package does not have an OpType::Module root, but {}", root_op.name())]
+    NonModuleHugr {
+        /// The module index.
+        module_index: usize,
+        /// The invalid root operation.
+        root_op: OpType,
+    },
+    /// Tried to initialize a package with a hugr that cannot be wrapped in a module.
+    #[display("A hugr with optype {} cannot be wrapped in a module.", root_op.name())]
+    CannotWrapHugr {
+        /// The invalid root operation.
+        root_op: OpType,
+    },
+}
+
 /// Error raised while loading a package.
 #[derive(Debug, Display, Error, From)]
 #[non_exhaustive]
@@ -107,6 +220,8 @@ pub enum PackageEncodingError {
     JsonEncoding(serde_json::Error),
     /// Error raised while reading from a file.
     IOError(io::Error),
+    /// Improper package definition.
+    Package(PackageError),
 }
 
 /// Error raised while validating a package.
@@ -117,4 +232,58 @@ pub enum PackageValidationError {
     Extension(ExtensionRegistryError),
     /// Error raised while validating the package hugrs.
     Validation(ValidationError),
+}
+
+#[cfg(test)]
+mod test {
+    use crate::builder::test::{
+        simple_cfg_hugr, simple_dfg_hugr, simple_funcdef_hugr, simple_module_hugr,
+    };
+    use crate::extension::ExtensionId;
+
+    use super::*;
+    use rstest::{fixture, rstest};
+    use semver::Version;
+
+    #[fixture]
+    fn simple_package() -> Package {
+        let hugr0 = simple_module_hugr();
+        let hugr1 = simple_module_hugr();
+
+        let ext_1_id = ExtensionId::new("ext1").unwrap();
+        let ext_2_id = ExtensionId::new("ext2").unwrap();
+        let ext1 = Extension::new(ext_1_id.clone(), Version::new(2, 4, 8));
+        let ext2 = Extension::new(ext_2_id, Version::new(1, 0, 0));
+
+        Package {
+            modules: vec![hugr0, hugr1],
+            extensions: vec![ext1, ext2],
+        }
+    }
+
+    #[rstest]
+    #[case::empty(Package::default())]
+    #[case::simple(simple_package())]
+    fn package_roundtrip(#[case] package: Package) {
+        let json = package.to_json().unwrap();
+        let new_package = Package::from_json(&json).unwrap();
+        assert_eq!(package, new_package);
+    }
+
+    #[rstest]
+    #[case::module(simple_module_hugr(), false)]
+    #[case::dfg(simple_funcdef_hugr(), true)]
+    #[case::dfg(simple_dfg_hugr(), true)]
+    #[case::cfg(simple_cfg_hugr(), true)]
+    fn hugr_to_package(#[case] hugr: Hugr, #[case] errors: bool) {
+        match (Package::from_hugr(hugr), errors) {
+            (Ok(package), false) => {
+                assert_eq!(package.modules.len(), 1);
+                let root_op = package.modules[0].get_optype(package.modules[0].root());
+                assert!(root_op.is_module());
+            }
+            (Err(_), true) => {}
+            (p, _) => panic!("Unexpected result {:?}", p),
+        }
+    }
 }

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -90,11 +90,13 @@ impl Package {
         package.modules.push(module);
         Ok(package)
     }
-
     /// Validate the package against an extension registry.
     ///
     /// `reg` is updated with any new extensions.
-    pub fn validate(&mut self, reg: &mut ExtensionRegistry) -> Result<(), PackageValidationError> {
+    pub fn update_validate(
+        &mut self,
+        reg: &mut ExtensionRegistry,
+    ) -> Result<(), PackageValidationError> {
         for ext in &self.extensions {
             reg.register_updated_ref(ext)?;
         }

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -318,7 +318,7 @@ mod test {
     #[case::cfg(simple_cfg_hugr(), false)]
     #[case::unsupported_input(simple_input_node(), true)]
     fn hugr_to_package(#[case] hugr: Hugr, #[case] errors: bool) {
-        match (&Package::from_hugr(hugr.clone()), errors) {
+        match (&Package::from_hugr(hugr), errors) {
             (Ok(package), false) => {
                 assert_eq!(package.modules.len(), 1);
                 let root_op = package.modules[0].get_optype(package.modules[0].root());


### PR DESCRIPTION
Followup to #1587.

Ensures that rust `Package`s only contain module-rooted hugrs. Returns errors at construction times if the condition is not met.
This required fixing `hugr-cli`, as it should be able to load both packages and arbitrary hugrs.
Added `Package::from_hugr{,s}` methods that try to wrap the hugrs if possible. We'll need these for tket2.

Packages are not on the spec yet, their description should include this restriction. See #1388.

This PR does only modify the (unpublished) API introduced in #1587, so I'm not marking it as breaking.