### PR TITLE
chore: Unbreak release

### DIFF
--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -25,6 +25,13 @@ clio = { workspace = true, features = ["clap-parse"] }
 [lints]
 workspace = true
 
+[package.metadata.cargo-semver-checks.lints]
+workspace = true
+# Temporarily disabled due to Package being moved to `hugr-core` triggering an error in rustdoc
+# https://github.com/obi1kenobi/cargo-semver-checks/issues/355
+enum_missing = "warn"
+struct_missing = "warn"
+
 [dev-dependencies]
 assert_cmd = { workspace = true }
 assert_fs = { workspace = true }

--- a/hugr-cli/src/lib.rs
+++ b/hugr-cli/src/lib.rs
@@ -14,6 +14,8 @@ pub mod mermaid;
 pub mod validate;
 
 // TODO: Deprecated re-export. Remove on a breaking release.
+#[doc(inline)]
+#[deprecated(since = "0.13.2", note = "Use `hugr::package::Package` instead.")]
 pub use hugr::package::Package;
 
 /// CLI arguments.
@@ -109,7 +111,7 @@ impl PackageOrHugr {
         reg: &mut ExtensionRegistry,
     ) -> Result<(), PackageValidationError> {
         match self {
-            PackageOrHugr::Package(pkg) => pkg.validate(reg),
+            PackageOrHugr::Package(pkg) => pkg.update_validate(reg),
             PackageOrHugr::Hugr(hugr) => hugr.update_validate(reg).map_err(Into::into),
         }
     }
@@ -124,5 +126,18 @@ impl HugrArgs {
         }
         let pkg = serde_json::from_value::<Package>(val.clone())?;
         Ok(PackageOrHugr::Package(pkg))
+    }
+
+    /// Read either a package from the input.
+    ///
+    /// deprecated: use [HugrArgs::get_package_or_hugr] instead.
+    #[deprecated(
+        since = "0.13.2",
+        note = "Use `HugrArgs::get_package_or_hugr` instead."
+    )]
+    pub fn get_package(&mut self) -> Result<Package, CliError> {
+        let val: serde_json::Value = serde_json::from_reader(&mut self.input)?;
+        let pkg = serde_json::from_value::<Package>(val.clone())?;
+        Ok(pkg)
     }
 }

--- a/hugr-cli/src/validate.rs
+++ b/hugr-cli/src/validate.rs
@@ -7,6 +7,14 @@ use hugr::{extension::ExtensionRegistry, Extension, Hugr};
 
 use crate::{CliError, HugrArgs};
 
+// TODO: Deprecated re-export. Remove on a breaking release.
+#[doc(inline)]
+#[deprecated(
+    since = "0.13.2",
+    note = "Use `hugr::package::PackageValidationError` instead."
+)]
+pub use hugr::package::PackageValidationError as ValError;
+
 /// Validate and visualise a HUGR file.
 #[derive(Parser, Debug)]
 #[clap(version = "1.0", long_about = None)]

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -94,7 +94,10 @@ impl Package {
     /// Validate the package against an extension registry.
     ///
     /// `reg` is updated with any new extensions.
-    pub fn validate(&mut self, reg: &mut ExtensionRegistry) -> Result<(), PackageValidationError> {
+    pub fn update_validate(
+        &mut self,
+        reg: &mut ExtensionRegistry,
+    ) -> Result<(), PackageValidationError> {
         for ext in &self.extensions {
             reg.register_updated_ref(ext)?;
         }
@@ -102,6 +105,22 @@ impl Package {
             hugr.update_validate(reg)?;
         }
         Ok(())
+    }
+
+    /// Validate the package against an extension registry.
+    ///
+    /// `reg` is updated with any new extensions.
+    ///
+    /// Returns the validated modules.
+    ///
+    /// deprecated: use [Package::update_validate] instead.
+    #[deprecated(since = "0.13.2", note = "Replaced by `Package::update_validate`")]
+    pub fn validate(
+        mut self,
+        reg: &mut ExtensionRegistry,
+    ) -> Result<Vec<Hugr>, PackageValidationError> {
+        self.update_validate(reg)?;
+        Ok(self.modules)
     }
 
     /// Read a Package in json format from an io reader.
@@ -258,6 +277,20 @@ pub enum PackageValidationError {
     Extension(ExtensionRegistryError),
     /// Error raised while validating the package hugrs.
     Validation(ValidationError),
+    /// Error validating HUGR.
+    #[deprecated(
+        since = "0.13.2",
+        note = "Replaced by `PackageValidationError::Validation`"
+    )]
+    #[from(ignore)]
+    Validate(ValidationError),
+    /// Error registering extension.
+    #[deprecated(
+        since = "0.13.2",
+        note = "Replaced by `PackageValidationError::Extension`"
+    )]
+    #[from(ignore)]
+    ExtReg(ExtensionRegistryError),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replaces the breaking changes introduced in #1587 with non-breaking deprecations.
We should be able to remove these on the next breaking release.