### PR TITLE
feat: make errors more readable with Display impls

### DIFF
--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -152,10 +152,10 @@ pub enum BuildError {
     #[error("Constant failed typechecking: {0}")]
     BadConstant(#[from] ConstTypeError),
     /// CFG can only have one entry.
-    #[error("CFG entry node already built for CFG node: {0:?}.")]
+    #[error("CFG entry node already built for CFG node: {0}.")]
     EntryBuiltError(Node),
     /// Node was expected to have a certain type but was found to not.
-    #[error("Node with index {node:?} does not have type {op_desc:?} as expected.")]
+    #[error("Node with index {node} does not have type {op_desc} as expected.")]
     #[allow(missing_docs)]
     UnexpectedType {
         /// Index of node where error occurred.
@@ -168,7 +168,7 @@ pub enum BuildError {
     ConditionalError(#[from] conditional::ConditionalBuildError),
 
     /// Wire not found in Hugr
-    #[error("Wire not found in Hugr: {0:?}.")]
+    #[error("Wire not found in Hugr: {0}.")]
     WireNotFound(Wire),
 
     /// Error in CircuitBuilder

--- a/hugr-core/src/builder/conditional.rs
+++ b/hugr-core/src/builder/conditional.rs
@@ -29,13 +29,13 @@ pub type CaseBuilder<B> = DFGWrapper<B, BuildHandle<CaseID>>;
 #[non_exhaustive]
 pub enum ConditionalBuildError {
     /// Case already built.
-    #[error("Case {case} of Conditional node {conditional:?} has already been built.")]
+    #[error("Case {case} of Conditional node {conditional} has already been built.")]
     CaseBuilt { conditional: Node, case: usize },
     /// Case already built.
-    #[error("Conditional node {conditional:?} has no case with index {case}.")]
+    #[error("Conditional node {conditional} has no case with index {case}.")]
     NotCase { conditional: Node, case: usize },
     /// Not all cases of Conditional built.
-    #[error("Cases {cases:?} of Conditional node {conditional:?} have not been built.")]
+    #[error("Cases {cases:?} of Conditional node {conditional} have not been built.")]
     NotAllCasesBuilt {
         conditional: Node,
         cases: HashSet<usize>,

--- a/hugr-core/src/core.rs
+++ b/hugr-core/src/core.rs
@@ -224,6 +224,12 @@ impl Wire {
     }
 }
 
+impl std::fmt::Display for Wire {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Wire({}, {})", self.0.index(), self.1.index)
+    }
+}
+
 /// Enum for uniquely identifying the origin of linear wires in a circuit-like
 /// dataflow region.
 ///
@@ -323,4 +329,4 @@ macro_rules! impl_display_from_debug {
         )*
     };
 }
-impl_display_from_debug!(Node, Port, IncomingPort, OutgoingPort, Wire, CircuitUnit);
+impl_display_from_debug!(Node, Port, IncomingPort, OutgoingPort, CircuitUnit);

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -177,7 +177,7 @@ pub enum SignatureError {
     #[error("Definition name ({0}) and instantiation name ({1}) do not match.")]
     NameMismatch(TypeName, TypeName),
     /// Extension mismatch
-    #[error("Definition extension ({0:?}) and instantiation extension ({1:?}) do not match.")]
+    #[error("Definition extension ({0}) and instantiation extension ({1}) do not match.")]
     ExtensionMismatch(ExtensionId, ExtensionId),
     /// When the type arguments of the node did not match the params declared by the OpDef
     #[error("Type arguments of node did not match params declared by definition: {0}")]
@@ -198,7 +198,7 @@ pub enum SignatureError {
         expected: TypeBound,
     },
     /// A Type Variable's cache of its declared kind is incorrect
-    #[error("Type Variable claims to be {cached:?} but actual declaration {actual:?}")]
+    #[error("Type Variable claims to be {cached} but actual declaration {actual}")]
     TypeVarDoesNotMatchDeclaration {
         actual: TypeParam,
         cached: TypeParam,

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -348,7 +348,7 @@ impl ConstUsize {
 #[typetag::serde]
 impl CustomConst for ConstUsize {
     fn name(&self) -> ValueName {
-        format!("ConstUsize({:?})", self.0).into()
+        format!("ConstUsize({})", self.0).into()
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
@@ -394,7 +394,7 @@ impl ConstError {
 #[typetag::serde]
 impl CustomConst for ConstError {
     fn name(&self) -> ValueName {
-        format!("ConstError({:?}, {:?})", self.signal, self.message).into()
+        format!("ConstError({}, {:?})", self.signal, self.message).into()
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {

--- a/hugr-core/src/hugr/rewrite/consts.rs
+++ b/hugr-core/src/hugr/rewrite/consts.rs
@@ -20,7 +20,7 @@ pub enum RemoveError {
     #[error("Node is invalid (either not in HUGR or not correct operation).")]
     InvalidNode(Node),
     /// Node in use.
-    #[error("Node: {0:?} has non-zero outgoing connections.")]
+    #[error("Node: {0} has non-zero outgoing connections.")]
     ValueUsed(Node),
 }
 

--- a/hugr-core/src/hugr/rewrite/insert_identity.rs
+++ b/hugr-core/src/hugr/rewrite/insert_identity.rs
@@ -43,7 +43,7 @@ pub enum IdentityInsertionError {
     #[error("Node is invalid.")]
     InvalidNode(),
     /// Invalid port kind.
-    #[error("post_port has invalid kind {0:?}. Must be Value.")]
+    #[error("post_port has invalid kind {}. Must be Value.", _0.as_ref().map_or("None".to_string(), ToString::to_string))]
     InvalidPortKind(Option<EdgeKind>),
 }
 

--- a/hugr-core/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr-core/src/hugr/rewrite/outline_cfg.rs
@@ -223,17 +223,17 @@ pub enum OutlineCfgError {
     #[error("The nodes did not all have the same parent")]
     NotSiblings,
     /// The parent node was not a CFG node
-    #[error("The parent node {0:?} was not a CFG but a {1:?}")]
+    #[error("The parent node {0} was not a CFG but a {1}")]
     ParentNotCfg(Node, OpType),
     /// Multiple blocks had incoming edges
-    #[error("Multiple blocks had predecessors outside the set - at least {0:?} and {1:?}")]
+    #[error("Multiple blocks had predecessors outside the set - at least {0} and {1}")]
     MultipleEntryNodes(Node, Node),
     /// Multiple blocks had outgoing edges
     // Note possible TODO: straightforward if all outgoing edges target the same BB
-    #[error("Multiple blocks had edges leaving the set - at least {0:?} and {1:?}")]
+    #[error("Multiple blocks had edges leaving the set - at least {0} and {1}")]
     MultipleExitNodes(Node, Node),
     /// One block had multiple outgoing edges
-    #[error("Exit block {0:?} had edges to multiple external blocks {1:?}")]
+    #[error("Exit block {0} had edges to multiple external blocks {1:?}")]
     MultipleExitEdges(Node, Vec<Node>),
     /// No block was identified as an entry block
     #[error("No block had predecessors outside the set")]

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -404,7 +404,7 @@ pub enum ReplaceError {
         replacement: OpTag,
     },
     /// Keys in [Replacement::adoptions] were not valid container nodes in [Replacement::replacement]
-    #[error("Node {0:?} was not an empty container node in the replacement")]
+    #[error("Node {0} was not an empty container node in the replacement")]
     InvalidAdoptingParent(Node),
     /// Some values in [Replacement::adoptions] were either descendants of other values, or not
     /// descendants of the [Replacement::removal]. The nodes are indicated on a best-effort basis.
@@ -599,7 +599,7 @@ mod test {
 
     fn find_node(h: &Hugr, s: &str) -> crate::Node {
         h.nodes()
-            .filter(|n| format!("{:?}", h.get_optype(*n)).contains(s))
+            .filter(|n| format!("{}", h.get_optype(*n)).contains(s))
             .exactly_one()
             .ok()
             .unwrap()

--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -103,13 +103,13 @@ struct SerHugrLatest {
 #[non_exhaustive]
 pub enum HUGRSerializationError {
     /// Unexpected hierarchy error.
-    #[error("Failed to attach child to parent: {0:?}.")]
+    #[error("Failed to attach child to parent: {0}.")]
     AttachError(#[from] AttachError),
     /// Failed to add edge.
-    #[error("Failed to build edge when deserializing: {0:?}.")]
+    #[error("Failed to build edge when deserializing: {0}.")]
     LinkError(#[from] LinkError),
     /// Edges without port offsets cannot be present in operations without non-dataflow ports.
-    #[error("Cannot connect an {dir:?} edge without port offset to node {node:?} with operation type {op_type:?}.")]
+    #[error("Cannot connect an {dir:?} edge without port offset to node {node} with operation type {op_type}.")]
     MissingPortOffset {
         /// The node that has the port without offset.
         node: Node,
@@ -119,13 +119,13 @@ pub enum HUGRSerializationError {
         op_type: OpType,
     },
     /// Edges with wrong node indices
-    #[error("The edge endpoint {node:?} is not a node in the graph.")]
+    #[error("The edge endpoint {node} is not a node in the graph.")]
     UnknownEdgeNode {
         /// The node that has the port without offset.
         node: Node,
     },
     /// First node in node list must be the HUGR root.
-    #[error("The first node in the node list has parent {0:?}, should be itself (index 0)")]
+    #[error("The first node in the node list has parent {0}, should be itself (index 0)")]
     FirstNodeNotRoot(Node),
 }
 

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -72,7 +72,7 @@ impl Hugr {
                     OpTag::ModuleRoot => continue,
                     _ => {
                         assert!(self.children(parent).next().is_none(),
-                            "Unknown parent node type {:?} - not a DataflowParent, Module, Cfg or Conditional",
+                            "Unknown parent node type {} - not a DataflowParent, Module, Cfg or Conditional",
                             parent_op);
                         continue;
                     }
@@ -635,13 +635,13 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
 #[non_exhaustive]
 pub enum ValidationError {
     /// The root node of the Hugr is not a root in the hierarchy.
-    #[error("The root node of the Hugr {node:?} is not a root in the hierarchy.")]
+    #[error("The root node of the Hugr {node} is not a root in the hierarchy.")]
     RootNotRoot { node: Node },
     /// The root node of the Hugr should not have any edges.
-    #[error("The root node of the Hugr {node:?} has edges when it should not.")]
+    #[error("The root node of the Hugr {node} has edges when it should not.")]
     RootWithEdges { node: Node },
     /// The node ports do not match the operation signature.
-    #[error("The node {node:?} has an invalid number of ports. The operation {optype:?} cannot have {actual:?} {dir:?} ports. Expected {expected:?}.")]
+    #[error("The node {node} has an invalid number of ports. The operation {optype} cannot have {actual} {dir:?} ports. Expected {expected}.")]
     WrongNumberOfPorts {
         node: Node,
         optype: OpType,
@@ -650,21 +650,23 @@ pub enum ValidationError {
         dir: Direction,
     },
     /// A dataflow port is not connected.
-    #[error("The node {node:?} has an unconnected port {port:?} of type {port_kind:?}.")]
+    #[error("The node {node} has an unconnected port {port} of type {port_kind}.")]
     UnconnectedPort {
         node: Node,
         port: Port,
         port_kind: EdgeKind,
     },
     /// A linear port is connected to more than one thing.
-    #[error("The node {node:?} has a port {port:?} of type {port_kind:?} with more than one connection.")]
+    #[error(
+        "The node {node} has a port {port} of type {port_kind} with more than one connection."
+    )]
     TooManyConnections {
         node: Node,
         port: Port,
         port_kind: EdgeKind,
     },
     /// Connected ports have different types, or non-unifiable types.
-    #[error("Connected ports {from_port:?} in node {from:?} and {to_port:?} in node {to:?} have incompatible kinds. Cannot connect {from_kind:?} to {to_kind:?}.")]
+    #[error("Connected ports {from_port} in node {from} and {to_port} in node {to} have incompatible kinds. Cannot connect {from_kind} to {to_kind}.")]
     IncompatiblePorts {
         from: Node,
         from_port: Port,
@@ -674,10 +676,10 @@ pub enum ValidationError {
         to_kind: EdgeKind,
     },
     /// The non-root node has no parent.
-    #[error("The node {node:?} has no parent.")]
+    #[error("The node {node} has no parent.")]
     NoParent { node: Node },
     /// The parent node is not compatible with the child node.
-    #[error("The operation {parent_optype:?} cannot contain a {child_optype:?} as a child. Allowed children: {}. In node {child:?} with parent {parent:?}.", allowed_children.description())]
+    #[error("The operation {parent_optype} cannot contain a {child_optype} as a child. Allowed children: {}. In node {child} with parent {parent}.", allowed_children.description())]
     InvalidParentOp {
         child: Node,
         child_optype: OpType,
@@ -686,7 +688,7 @@ pub enum ValidationError {
         allowed_children: OpTag,
     },
     /// Invalid first/second child.
-    #[error("A {optype:?} operation cannot be the {position} child of a {parent_optype:?}. Expected {expected}. In parent node {parent:?}")]
+    #[error("A {optype} operation cannot be the {position} child of a {parent_optype}. Expected {expected}. In parent node {parent}")]
     InvalidInitialChild {
         parent: Node,
         parent_optype: OpType,
@@ -696,8 +698,8 @@ pub enum ValidationError {
     },
     /// The children list has invalid elements.
     #[error(
-        "An operation {parent_optype:?} contains invalid children: {source}. In parent {parent:?}, child {child:?}",
-        child=source.child(),
+        "An operation {parent_optype} contains invalid children: {source}. In parent {parent}, child Node({child})",
+        child=source.child().index(),
     )]
     InvalidChildren {
         parent: Node,
@@ -706,7 +708,7 @@ pub enum ValidationError {
     },
     /// The children graph has invalid edges.
     #[error(
-        "An operation {parent_optype:?} contains invalid edges between its children: {source}. In parent {parent:?}, edge from {from:?} port {from_port:?} to {to:?} port {to_port:?}",
+        "An operation {parent_optype} contains invalid edges between its children: {source}. In parent {parent}, edge from {from:?} port {from_port:?} to {to:?} port {to_port:?}",
         from=source.edge().source,
         from_port=source.edge().source_port,
         to=source.edge().target,
@@ -718,13 +720,13 @@ pub enum ValidationError {
         source: EdgeValidationError,
     },
     /// The node operation is not a container, but has children.
-    #[error("The node {node:?} with optype {optype:?} is not a container, but has children.")]
+    #[error("The node {node} with optype {optype} is not a container, but has children.")]
     NonContainerWithChildren { node: Node, optype: OpType },
     /// The node must have children, but has none.
-    #[error("The node {node:?} with optype {optype:?} must have children, but has none.")]
+    #[error("The node {node} with optype {optype} must have children, but has none.")]
     ContainerWithoutChildren { node: Node, optype: OpType },
     /// The children of a node do not form a DAG.
-    #[error("The children of an operation {optype:?} must form a DAG. Loops are not allowed. In node {node:?}.")]
+    #[error("The children of an operation {optype} must form a DAG. Loops are not allowed. In node {node}.")]
     NotADag { node: Node, optype: OpType },
     /// There are invalid inter-graph edges.
     #[error(transparent)]
@@ -733,7 +735,7 @@ pub enum ValidationError {
     #[error(transparent)]
     ExtensionError(#[from] ExtensionError),
     /// A node claims to still be awaiting extension inference. Perhaps it is not acted upon by inference.
-    #[error("Node {node:?} needs a concrete ExtensionSet - inference will provide this for Case/CFG/Conditional/DataflowBlock/DFG/TailLoop only")]
+    #[error("Node {node} needs a concrete ExtensionSet - inference will provide this for Case/CFG/Conditional/DataflowBlock/DFG/TailLoop only")]
     ExtensionsNotInferred { node: Node },
     /// Error in a node signature
     #[error("Error in signature of node {node}: {cause}")]
@@ -763,7 +765,7 @@ pub enum ValidationError {
 #[non_exhaustive]
 pub enum InterGraphEdgeError {
     /// Inter-Graph edges can only carry copyable data.
-    #[error("Inter-graph edges can only carry copyable data. In an inter-graph edge from {from:?} ({from_offset:?}) to {to:?} ({to_offset:?}) with type {ty:?}.")]
+    #[error("Inter-graph edges can only carry copyable data. In an inter-graph edge from {from} ({from_offset}) to {to} ({to_offset}) with type {ty}.")]
     NonCopyableData {
         from: Node,
         from_offset: Port,
@@ -772,7 +774,7 @@ pub enum InterGraphEdgeError {
         ty: EdgeKind,
     },
     /// Inter-Graph edges may not enter into FuncDefns unless they are static
-    #[error("Inter-graph Value edges cannot enter into FuncDefns. Inter-graph edge from {from:?} ({from_offset:?}) to {to:?} ({to_offset:?} enters FuncDefn {func:?}")]
+    #[error("Inter-graph Value edges cannot enter into FuncDefns. Inter-graph edge from {from} ({from_offset}) to {to} ({to_offset} enters FuncDefn {func}")]
     ValueEdgeIntoFunc {
         from: Node,
         from_offset: Port,
@@ -781,7 +783,7 @@ pub enum InterGraphEdgeError {
         func: Node,
     },
     /// The grandparent of a dominator inter-graph edge must be a CFG container.
-    #[error("The grandparent of a dominator inter-graph edge must be a CFG container. Found operation {ancestor_parent_op:?}. In a dominator inter-graph edge from {from:?} ({from_offset:?}) to {to:?} ({to_offset:?}).")]
+    #[error("The grandparent of a dominator inter-graph edge must be a CFG container. Found operation {ancestor_parent_op}. In a dominator inter-graph edge from {from} ({from_offset}) to {to} ({to_offset}).")]
     NonCFGAncestor {
         from: Node,
         from_offset: Port,
@@ -790,7 +792,7 @@ pub enum InterGraphEdgeError {
         ancestor_parent_op: OpType,
     },
     /// The sibling ancestors of the external inter-graph edge endpoints must be have an order edge between them.
-    #[error("Missing state order between the external inter-graph source {from:?} and the ancestor of the target {to_ancestor:?}. In an external inter-graph edge from {from:?} ({from_offset:?}) to {to:?} ({to_offset:?}).")]
+    #[error("Missing state order between the external inter-graph source {from} and the ancestor of the target {to_ancestor}. In an external inter-graph edge from {from} ({from_offset}) to {to} ({to_offset}).")]
     MissingOrderEdge {
         from: Node,
         from_offset: Port,
@@ -799,7 +801,7 @@ pub enum InterGraphEdgeError {
         to_ancestor: Node,
     },
     /// The ancestors of an inter-graph edge are not related.
-    #[error("The ancestors of an inter-graph edge are not related. In an inter-graph edge from {from:?} ({from_offset:?}) to {to:?} ({to_offset:?}).")]
+    #[error("The ancestors of an inter-graph edge are not related. In an inter-graph edge from {from} ({from_offset}) to {to} ({to_offset}).")]
     NoRelation {
         from: Node,
         from_offset: Port,
@@ -807,7 +809,7 @@ pub enum InterGraphEdgeError {
         to_offset: Port,
     },
     /// The basic block containing the source node does not dominate the basic block containing the target node.
-    #[error(" The basic block containing the source node does not dominate the basic block containing the target node in the CFG. Expected node {from_parent:?} to dominate {ancestor:?}. In a dominator inter-graph edge from {from:?} ({from_offset:?}) to {to:?} ({to_offset:?}).")]
+    #[error(" The basic block containing the source node does not dominate the basic block containing the target node in the CFG. Expected node {from_parent} to dominate {ancestor}. In a dominator inter-graph edge from {from} ({from_offset}) to {to} ({to_offset}).")]
     NonDominatedAncestor {
         from: Node,
         from_offset: Port,

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -392,7 +392,13 @@ fn invalid_types() {
         let (h, def) = identity_hugr_with_type(Type::new_extension(t));
         match h.validate(&reg) {
             Err(ValidationError::SignatureError { node, cause }) if node == def => cause,
-            e => panic!("Expected SignatureError at def node, got {:?}", e),
+            e => panic!(
+                "Expected SignatureError at def node, got {}",
+                match e {
+                    Ok(()) => "Ok".to_owned(),
+                    Err(e) => format!("{}", e),
+                }
+            ),
         }
     };
 

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -709,10 +709,10 @@ pub enum InvalidSubgraph {
 #[non_exhaustive]
 pub enum InvalidSubgraphBoundary {
     /// A boundary port's node is not in the set of nodes.
-    #[error("(node {0:?}, port {1:?}) is in the boundary, but node {0:?} is not in the set.")]
+    #[error("(node {0}, port {1}) is in the boundary, but node {0} is not in the set.")]
     PortNodeNotInSet(Node, Port),
     /// A boundary port has no connections outside the subgraph.
-    #[error("(node {0:?}, port {1:?}) is in the boundary, but the port is not connected to a node outside the subgraph.")]
+    #[error("(node {0}, port {1}) is in the boundary, but the port is not connected to a node outside the subgraph.")]
     DisconnectedBoundaryPort(Node, Port),
     /// There's a non-unique input-boundary port.
     #[error("A port in the input boundary is used multiple times.")]

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -221,7 +221,7 @@ impl<'a> Context<'a> {
 
             if inputs.is_empty() || outputs.is_empty() {
                 return Err(error_unsupported!(
-                    "link {:?} is missing either an input or an output port",
+                    "link {} is missing either an input or an output port",
                     link_id
                 ));
             }

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -14,8 +14,8 @@ use crate::extension::ExtensionSet;
 use crate::types::{EdgeKind, Signature};
 use crate::{Direction, OutgoingPort, Port};
 use crate::{IncomingPort, PortIndex};
+use derive_more::Display;
 use paste::paste;
-
 use portgraph::NodeIndex;
 
 use enum_dispatch::enum_dispatch;
@@ -127,6 +127,12 @@ pub const DEFAULT_OPTYPE: OpType = OpType::Module(Module::new());
 impl Default for OpType {
     fn default() -> Self {
         DEFAULT_OPTYPE
+    }
+}
+
+impl Display for OpType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
     }
 }
 

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -333,7 +333,7 @@ pub enum ConstTypeError {
     SumType(#[from] SumTypeError),
     /// Function constant missing a function type.
     #[error(
-        "A function constant cannot be defined using a Hugr with root of type {hugr_root_type:?}. Must be a monomorphic function.",
+        "A function constant cannot be defined using a Hugr with root of type {hugr_root_type}. Must be a monomorphic function.",
     )]
     NotMonomorphicFunction {
         /// The root node type of the Hugr that (claims to) define the function constant.
@@ -343,7 +343,7 @@ pub enum ConstTypeError {
     #[error("Value {1:?} does not match expected type {0}")]
     ConstCheckFail(Type, Value),
     /// Error when checking a custom value.
-    #[error("Error when checking custom type: {0:?}")]
+    #[error("Error when checking custom type: {0}")]
     CustomCheckFail(#[from] CustomCheckFailure),
 }
 

--- a/hugr-core/src/ops/validate.rs
+++ b/hugr-core/src/ops/validate.rs
@@ -168,14 +168,14 @@ pub enum ChildrenValidationError {
     #[error("Exit basic blocks are only allowed as the second child in a CFG graph")]
     InternalExitChildren { child: NodeIndex },
     /// An operation only allowed as the first/second child was found as an intermediate child.
-    #[error("A {optype:?} operation is only allowed as a {expected_position} child")]
+    #[error("A {optype} operation is only allowed as a {expected_position} child")]
     InternalIOChildren {
         child: NodeIndex,
         optype: OpType,
         expected_position: &'static str,
     },
     /// The signature of the contained dataflow graph does not match the one of the container.
-    #[error("The {node_desc} node of a {container_desc} has a signature of {actual:?}, which differs from the expected type row {expected:?}")]
+    #[error("The {node_desc} node of a {container_desc} has a signature of {actual}, which differs from the expected type row {expected}")]
     IOSignatureMismatch {
         child: NodeIndex,
         actual: TypeRow,
@@ -184,7 +184,7 @@ pub enum ChildrenValidationError {
         container_desc: &'static str,
     },
     /// The signature of a child case in a conditional operation does not match the container's signature.
-    #[error("A conditional case has optype {optype:?}, which differs from the signature of Conditional container")]
+    #[error("A conditional case has optype {sig}, which differs from the signature of Conditional container", sig=optype.dataflow_signature().unwrap_or_default())]
     ConditionalCaseSignature { child: NodeIndex, optype: OpType },
     /// The conditional container's branching value does not match the number of children.
     #[error("The conditional container's branch Sum input should be a sum with {expected_count} elements, but it had {} elements. Sum rows: {actual_sum_rows:?}",
@@ -215,7 +215,7 @@ impl ChildrenValidationError {
 #[non_exhaustive]
 pub enum EdgeValidationError {
     /// The dataflow signature of two connected basic blocks does not match.
-    #[error("The dataflow signature of two connected basic blocks does not match. Output signature: {source_op:?}, input signature: {target_op:?}",
+    #[error("The dataflow signature of two connected basic blocks does not match. Output signature: {source_op}, input signature: {target_op}",
         source_op = edge.source_op,
         target_op = edge.target_op
     )]

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -43,7 +43,9 @@ pub type TypeName = SmolStr;
 pub type TypeNameRef = str;
 
 /// The kinds of edges in a HUGR, excluding Hierarchy.
-#[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize, derive_more::Display,
+)]
 #[non_exhaustive]
 pub enum EdgeKind {
     /// Control edges of a CFG region.

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -138,7 +138,9 @@ impl From<UpperBound> for TypeParam {
 }
 
 /// A statically-known argument value to an operation.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize, derive_more::Display,
+)]
 #[non_exhaustive]
 #[serde(tag = "tya")]
 pub enum TypeArg {
@@ -159,6 +161,7 @@ pub enum TypeArg {
     },
     /// Instance of [TypeParam::List] or [TypeParam::Tuple], defined by a
     /// sequence of elements.
+    #[display("Sequence({})", "elems.iter().map(|t|t.to_string()).join(\", \")")]
     Sequence {
         #[allow(missing_docs)]
         elems: Vec<TypeArg>,
@@ -214,7 +217,10 @@ impl From<ExtensionSet> for TypeArg {
 /// Variable in a TypeArg, that is neither a [TypeArg::Extensions]
 /// nor a single [TypeArg::Type] (i.e. not a [Type::new_var_use]
 /// - it might be a [Type::new_row_var_use]).
-#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize, derive_more::Display,
+)]
+#[display("TypeArgVariable({idx})")]
 pub struct TypeArgVariable {
     idx: usize,
     cached_decl: TypeParam,
@@ -408,7 +414,7 @@ pub enum TypeArgError {
     /// For now, general case of a type arg not fitting a param.
     /// We'll have more cases when we allow general Containers.
     // TODO It may become possible to combine this with ConstTypeError.
-    #[error("Type argument {arg:?} does not fit declared parameter {param:?}")]
+    #[error("Type argument {arg} does not fit declared parameter {param}")]
     TypeMismatch { param: TypeParam, arg: TypeArg },
     /// Wrong number of type arguments (actual vs expected).
     // For now this only happens at the top level (TypeArgs of op/type vs TypeParams of Op/TypeDef).
@@ -420,7 +426,7 @@ pub enum TypeArgError {
     #[error("Wrong number of type arguments to tuple parameter: {0} vs expected {1} declared type parameters")]
     WrongNumberTuple(usize, usize),
     /// Opaque value type check error.
-    #[error("Opaque type argument does not fit declared parameter type: {0:?}")]
+    #[error("Opaque type argument does not fit declared parameter type: {0}")]
     OpaqueTypeMismatch(#[from] crate::types::CustomCheckFailure),
     /// Invalid value
     #[error("Invalid value of type argument")]

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -278,7 +278,7 @@ pub(crate) mod test {
             match op {
                 OpType::Input(_) | OpType::Output(_) | OpType::LoadConstant(_) => node_count += 1,
                 OpType::Const(c) if check_value(c.value()) => node_count += 1,
-                _ => panic!("unexpected op: {:?}\n{}", op, h.mermaid_string()),
+                _ => panic!("unexpected op: {}\n{}", op, h.mermaid_string()),
             }
         }
 

--- a/hugr-model/Cargo.toml
+++ b/hugr-model/Cargo.toml
@@ -15,6 +15,7 @@ license.workspace = true
 [dependencies]
 bumpalo = { workspace = true, features = ["collections"] }
 capnp = "0.20.1"
+derive_more = { version = "1.0.0", features = ["display"] }
 fxhash.workspace = true
 indexmap.workspace = true
 pest = "2.7.12"

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -133,25 +133,25 @@ macro_rules! define_index {
 
 define_index! {
     /// Index of a node in a hugr graph.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
     pub struct NodeId(pub u32);
 }
 
 define_index! {
     /// Index of a link in a hugr graph.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
     pub struct LinkId(pub u32);
 }
 
 define_index! {
     /// Index of a region in a hugr graph.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
     pub struct RegionId(pub u32);
 }
 
 define_index! {
     /// Index of a term in a hugr graph.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
     pub struct TermId(pub u32);
 }
 
@@ -662,38 +662,38 @@ pub enum Param<'a> {
 #[derive(Debug, Clone, Error)]
 pub enum ModelError {
     /// There is a reference to a node that does not exist.
-    #[error("node not found: {0:?}")]
+    #[error("node not found: {0}")]
     NodeNotFound(NodeId),
     /// There is a reference to a term that does not exist.
-    #[error("term not found: {0:?}")]
+    #[error("term not found: {0}")]
     TermNotFound(TermId),
     /// There is a reference to a region that does not exist.
-    #[error("region not found: {0:?}")]
+    #[error("region not found: {0}")]
     RegionNotFound(RegionId),
     /// There is a local reference that does not resolve.
-    #[error("local variable invalid: {0:?}")]
+    #[error("local variable invalid: {0}")]
     InvalidLocal(String),
     /// There is a global reference that does not resolve to a node
     /// that defines a global variable.
-    #[error("global variable invalid: {0:?}")]
+    #[error("global variable invalid: {0}")]
     InvalidGlobal(String),
     /// The model contains an operation in a place where it is not allowed.
-    #[error("unexpected operation on node: {0:?}")]
+    #[error("unexpected operation on node: {0}")]
     UnexpectedOperation(NodeId),
     /// There is a term that is not well-typed.
-    #[error("type error in term: {0:?}")]
+    #[error("type error in term: {0}")]
     TypeError(TermId),
     /// There is a node whose regions are not well-formed according to the node's operation.
-    #[error("node has invalid regions: {0:?}")]
+    #[error("node has invalid regions: {0}")]
     InvalidRegions(NodeId),
     /// There is a name that is not well-formed.
     #[error("malformed name: {0}")]
     MalformedName(SmolStr),
     /// There is a condition node that lacks a case for a tag or
     /// defines two cases for the same tag.
-    #[error("condition node is malformed: {0:?}")]
+    #[error("condition node is malformed: {0}")]
     MalformedCondition(NodeId),
     /// There is a node that is not well-formed or has the invalid operation.
-    #[error("invalid operation on node: {0:?}")]
+    #[error("invalid operation on node: {0}")]
     InvalidOperation(NodeId),
 }

--- a/hugr-passes/src/const_fold/test.rs
+++ b/hugr-passes/src/const_fold/test.rs
@@ -41,7 +41,7 @@ fn assert_fully_folded_with(h: &Hugr, check_value: impl Fn(&Value) -> bool) {
         match op {
             OpType::Input(_) | OpType::Output(_) | OpType::LoadConstant(_) => node_count += 1,
             OpType::Const(c) if check_value(c.value()) => node_count += 1,
-            _ => panic!("unexpected op: {:?}\n{}", op, h.mermaid_string()),
+            _ => panic!("unexpected op: {}\n{}", op, h.mermaid_string()),
         }
     }
 


### PR DESCRIPTION
Particularly useful for cli validation errors.

- Blanket Display for OpType that uses name, can be made more specific in future.
- user derive_more::Display in more places