### PR TITLE
ci: Use `uv --frozen` instead of `--locked`

### DIFF
--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -15,6 +15,9 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   HUGR_BIN_DIR: ${{ github.workspace }}/target/debug
   HUGR_BIN: ${{ github.workspace }}/target/debug/hugr
+  # Pinned version for the uv package manager
+  UV_VERSION: "0.4.20"
+  UV_FROZEN: 1
 
 jobs:
   # Check if changes were made to the relevant files.
@@ -54,13 +57,10 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.18"
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
-      - name: Install Python
-        run: uv python install ${{ matrix.python-version }}
-
-      - name: Setup dependencies. Fail if the lockfile is outdated.
-        run: uv sync --locked
+      - name: Setup dependencies.
+        run: uv sync --python ${{ matrix.python-version }}
 
       - name: Type check with mypy
         run: uv run mypy .
@@ -112,10 +112,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.18"
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
-      - name: Install Python
-        run: uv python install ${{ matrix.python-version.py }}
 
       - name: Download the hugr binary
         uses: actions/download-artifact@v4
@@ -124,7 +122,7 @@ jobs:
           path: ${{env.HUGR_BIN_DIR}}
 
       - name: Setup dependencies
-        run: uv sync
+        run: uv sync --python ${{ matrix.python-version.py }}
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
@@ -164,12 +162,10 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.18"
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
-      - name: Install Python
-        run: uv python install 3.13
 
-      - name: Setup dependencies
+      - name: Setup dependencies.
         run: uv sync
 
       - name: Generate the updated schema


### PR DESCRIPTION
drive-by: Ensure `uv sync` uses the right python version and uv version