### PR TITLE
ci: Notify slack when miri checks fail

### DIFF
--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
 
-   miri:
+  miri:
     name: "Miri"
     runs-on: ubuntu-latest
     steps:
@@ -38,3 +38,16 @@ jobs:
         run: sudo apt-get install -y capnproto
       - name: Test with Miri
         run: cargo miri test
+
+  notify-failure:
+    uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@ab/slack-notifier
+    with:
+      channel-id: 'C04SHCL4FKP'
+      slack-message: |
+        The unsoundness check for CQCL/HUGR failed. <https://github.com/CQCL/hugr/actions/runs/${{ github.run_id }}|Please investigate>.
+      # An unique identifier for the message type, to use in rate limiting.
+      message-label: "hugr-unsoundness"
+      # Rate-limit the message to once per day
+      timeout-minutes: 1440
+    secrets:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -24,6 +24,7 @@ jobs:
   miri:
     name: "Miri"
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Install Miri
@@ -39,15 +40,19 @@ jobs:
       - name: Test with Miri
         run: cargo miri test
 
-  notify-failure:
+
+  notify-slack:
     uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@ab/slack-notifier
+    needs: miri
+    if: ${{ needs.miri.result == 'failure' && ( github.event_name == 'workflow_dispatch' || github.event_name == 'push' ) }}
     with:
       channel-id: 'C04SHCL4FKP'
       slack-message: |
-        The unsoundness check for CQCL/HUGR failed. <https://github.com/CQCL/hugr/actions/runs/${{ github.run_id }}|Please investigate>.
-      # An unique identifier for the message type, to use in rate limiting.
-      message-label: "hugr-unsoundness"
+        💥 The unsoundness check for `CQCL/hugr` failed. <https://github.com/CQCL/hugr/actions/runs/${{ github.run_id }}|Please investigate>.
       # Rate-limit the message to once per day
       timeout-minutes: 1440
+      # A repository variable used to store the last message timestamp.
+      timeout-variable: "UNSOUNDNESS_MSG_SENT"
     secrets:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -42,7 +42,7 @@ jobs:
 
 
   notify-slack:
-    uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@ab/slack-notifier
+    uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@main
     needs: miri
     if: ${{ needs.miri.result == 'failure' && ( github.event_name == 'workflow_dispatch' || github.event_name == 'push' ) }}
     with:


### PR DESCRIPTION
Using the new notify-slack workflow from https://github.com/CQCL/hugrverse-actions/pull/18.
I'll update the target branch once that is merged.