### PR TITLE
chore: Fix unused warnings on default features

### DIFF
--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -16,13 +16,17 @@ use crate::types::type_param::check_type_arg;
 use crate::utils::display_list_with_separator;
 pub use check::SumTypeError;
 pub use custom::CustomType;
-pub(crate) use poly_func::PolyFuncTypeBase;
 pub use poly_func::{PolyFuncType, PolyFuncTypeRV};
-pub(crate) use signature::FuncTypeBase;
 pub use signature::{FuncValueType, Signature};
 use smol_str::SmolStr;
 pub use type_param::TypeArg;
 pub use type_row::{TypeRow, TypeRowRV};
+
+// Unused in --no-features
+#[allow(unused_imports)]
+pub(crate) use poly_func::PolyFuncTypeBase;
+#[allow(unused_imports)]
+pub(crate) use signature::FuncTypeBase;
 
 use itertools::FoldWhile::{Continue, Done};
 use itertools::{repeat_n, Itertools};


### PR DESCRIPTION
Fixes two unused import errors that only appeared when ignoring some features.
We test `cargo clippy --all-features` on CI, so this didn't get flagged.

```
warning: unused import: `poly_func::PolyFuncTypeBase`
  --> hugr-core/src/types.rs:19:16
   |
19 | pub(crate) use poly_func::PolyFuncTypeBase;
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `signature::FuncTypeBase`
  --> hugr-core/src/types.rs:21:16
   |
21 | pub(crate) use signature::FuncTypeBase;
   |                ^^^
```