### PR TITLE
feat: Export/import of JSON metadata

### DIFF
--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 extension_inference = []
 declarative = ["serde_yaml"]
 model_unstable = ["hugr-model"]
-default = ["model_unstable"]
 
 [[test]]
 name = "model"

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 extension_inference = []
 declarative = ["serde_yaml"]
 model_unstable = ["hugr-model"]
+default = ["model_unstable"]
 
 [[test]]
 name = "model"

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -435,6 +435,11 @@ impl OpDef {
         self.misc.insert(k.to_string(), v)
     }
 
+    /// Iterate over all miscellaneous data in the [OpDef].
+    pub(crate) fn iter_misc(&self) -> impl ExactSizeIterator<Item = (&str, &serde_json::Value)> {
+        self.misc.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
     /// Set the constant folding function for this Op, which can evaluate it
     /// given constant inputs.
     pub fn set_constant_folder(&mut self, fold: impl ConstFold + 'static) {

--- a/hugr-core/tests/snapshots/model__roundtrip_call.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_call.snap
@@ -8,12 +8,20 @@ expression: "roundtrip(include_str!(\"fixtures/model-call.edn\"))"
   (forall ?0 ext-set)
   [(@ arithmetic.int.types.int)]
   [(@ arithmetic.int.types.int)]
-  (ext arithmetic.int . ?0))
+  (ext arithmetic.int . ?0)
+  (meta doc.description (@ prelude.json "\"This is a function declaration.\""))
+  (meta doc.title (@ prelude.json "\"Callee\"")))
 
 (define-func example.caller
   [(@ arithmetic.int.types.int)]
   [(@ arithmetic.int.types.int)]
   (ext arithmetic.int)
+  (meta
+    doc.description
+    (@
+      prelude.json
+      "\"This defines a function that calls the function which we declared earlier.\""))
+  (meta doc.title (@ prelude.json "\"Caller\""))
   (dfg
     [%0] [%1]
     (signature

--- a/hugr-core/tests/snapshots/model__roundtrip_call.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_call.snap
@@ -1,6 +1,6 @@
 ---
 source: hugr-core/tests/model.rs
-expression: "roundtrip(include_str!(\"fixtures/model-call.edn\"))"
+expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-call.edn\"))"
 ---
 (hugr 0)
 
@@ -16,8 +16,7 @@ expression: "roundtrip(include_str!(\"fixtures/model-call.edn\"))"
   [(@ arithmetic.int.types.int)]
   [(@ arithmetic.int.types.int)]
   (ext arithmetic.int)
-  (meta
-    doc.description
+  (meta doc.description
     (@
       prelude.json
       "\"This defines a function that calls the function which we declared earlier.\""))

--- a/hugr-model/src/v0/text/hugr.pest
+++ b/hugr-model/src/v0/text/hugr.pest
@@ -6,7 +6,7 @@ symbol     = @{ identifier ~ ("." ~ identifier)+ }
 tag        = @{ (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) | "0" }
 
 string         =  { "\"" ~ (string_raw | string_escape | string_unicode)* ~ "\"" }
-string_raw     = @{ (!("\"") ~ ANY)+ }
+string_raw     = @{ (!("\\" | "\"") ~ ANY)+ }
 string_escape  = @{ "\\" ~ ("\"" | "\\" | "n" | "r" | "t") }
 string_unicode = @{ "\\u" ~ "{" ~ ASCII_HEX_DIGIT+ ~ "}" }
 

--- a/hugr-model/src/v0/text/hugr.pest
+++ b/hugr-model/src/v0/text/hugr.pest
@@ -5,8 +5,12 @@ ext_name   = @{ identifier ~ ("." ~ identifier)* }
 symbol     = @{ identifier ~ ("." ~ identifier)+ }
 tag        = @{ (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) | "0" }
 
-string    = @{ "\"" ~ (!("\"") ~ ANY)* ~ "\"" }
-list_tail =  { "." }
+string         =  { "\"" ~ (string_raw | string_escape | string_unicode)* ~ "\"" }
+string_raw     = @{ (!("\"") ~ ANY)+ }
+string_escape  = @{ "\\" ~ ("\"" | "\\" | "n" | "r" | "t") }
+string_unicode = @{ "\\u" ~ "{" ~ ASCII_HEX_DIGIT+ ~ "}" }
+
+list_tail = { "." }
 
 module = { "(" ~ "hugr" ~ "0" ~ ")" ~ meta* ~ node* ~ EOI }
 

--- a/hugr-model/src/v0/text/parse.rs
+++ b/hugr-model/src/v0/text/parse.rs
@@ -60,7 +60,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_module(&mut self, pair: Pair<'a, Rule>) -> ParseResult<()> {
-        debug_assert!(matches!(pair.as_rule(), Rule::module));
+        debug_assert_eq!(pair.as_rule(), Rule::module);
         let mut inner = pair.into_inner();
         let meta = self.parse_meta(&mut inner)?;
 
@@ -81,7 +81,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_term(&mut self, pair: Pair<'a, Rule>) -> ParseResult<TermId> {
-        debug_assert!(matches!(pair.as_rule(), Rule::term));
+        debug_assert_eq!(pair.as_rule(), Rule::term);
         let pair = pair.into_inner().next().unwrap();
         let rule = pair.as_rule();
         let mut inner = pair.into_inner();
@@ -216,7 +216,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_node(&mut self, pair: Pair<'a, Rule>) -> ParseResult<NodeId> {
-        debug_assert!(matches!(pair.as_rule(), Rule::node));
+        debug_assert_eq!(pair.as_rule(), Rule::node);
         let pair = pair.into_inner().next().unwrap();
         let rule = pair.as_rule();
 
@@ -501,7 +501,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_region(&mut self, pair: Pair<'a, Rule>) -> ParseResult<RegionId> {
-        debug_assert!(matches!(pair.as_rule(), Rule::region));
+        debug_assert_eq!(pair.as_rule(), Rule::region);
         let pair = pair.into_inner().next().unwrap();
         let rule = pair.as_rule();
         let mut inner = pair.into_inner();
@@ -539,7 +539,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_func_header(&mut self, pair: Pair<'a, Rule>) -> ParseResult<&'a FuncDecl<'a>> {
-        debug_assert!(matches!(pair.as_rule(), Rule::func_header));
+        debug_assert_eq!(pair.as_rule(), Rule::func_header);
 
         let mut inner = pair.into_inner();
         let name = self.parse_symbol(&mut inner)?;
@@ -564,7 +564,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_alias_header(&mut self, pair: Pair<'a, Rule>) -> ParseResult<&'a AliasDecl<'a>> {
-        debug_assert!(matches!(pair.as_rule(), Rule::alias_header));
+        debug_assert_eq!(pair.as_rule(), Rule::alias_header);
 
         let mut inner = pair.into_inner();
         let name = self.parse_symbol(&mut inner)?;
@@ -579,7 +579,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_ctr_header(&mut self, pair: Pair<'a, Rule>) -> ParseResult<&'a ConstructorDecl<'a>> {
-        debug_assert!(matches!(pair.as_rule(), Rule::ctr_header));
+        debug_assert_eq!(pair.as_rule(), Rule::ctr_header);
 
         let mut inner = pair.into_inner();
         let name = self.parse_symbol(&mut inner)?;
@@ -594,7 +594,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_op_header(&mut self, pair: Pair<'a, Rule>) -> ParseResult<&'a OperationDecl<'a>> {
-        debug_assert!(matches!(pair.as_rule(), Rule::operation_header));
+        debug_assert_eq!(pair.as_rule(), Rule::operation_header);
 
         let mut inner = pair.into_inner();
         let name = self.parse_symbol(&mut inner)?;
@@ -668,7 +668,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_port(&mut self, pair: Pair<'a, Rule>) -> ParseResult<LinkRef<'a>> {
-        debug_assert!(matches!(pair.as_rule(), Rule::port));
+        debug_assert_eq!(pair.as_rule(), Rule::port);
         let mut inner = pair.into_inner();
         let link = LinkRef::Named(&inner.next().unwrap().as_str()[1..]);
         Ok(link)
@@ -697,7 +697,7 @@ impl<'a> ParseContext<'a> {
     }
 
     fn parse_string(&self, token: Pair<'a, Rule>) -> ParseResult<&'a str> {
-        assert_eq!(token.as_rule(), Rule::string);
+        debug_assert_eq!(token.as_rule(), Rule::string);
 
         // Any escape sequence is longer than the character it represents.
         // Therefore the length of this token (minus 2 for the quotes on either

--- a/hugr-model/src/v0/text/parse.rs
+++ b/hugr-model/src/v0/text/parse.rs
@@ -718,7 +718,10 @@ impl<'a> ParseContext<'a> {
                     _ => unreachable!(),
                 },
                 Rule::string_unicode => {
-                    let code_str = &token.as_str()[3..token.as_str().len() - 1];
+                    let token_str = token.as_str();
+                    debug_assert_eq!(&token_str[0..3], r"\u{");
+                    debug_assert_eq!(&token_str[token_str.len() - 1..], "}");
+                    let code_str = &token_str[3..token_str.len() - 1];
                     let code = u32::from_str_radix(code_str, 16).map_err(|_| {
                         ParseError::custom("invalid unicode escape sequence", token.as_span())
                     })?;

--- a/hugr-model/src/v0/text/print.rs
+++ b/hugr-model/src/v0/text/print.rs
@@ -1,4 +1,4 @@
-use pretty::{docs, Arena, DocAllocator, RefDoc};
+use pretty::{Arena, DocAllocator, RefDoc};
 use std::borrow::Cow;
 
 use crate::v0::{
@@ -668,16 +668,22 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
     }
 
     /// Print a string literal.
-    fn print_string(&mut self, string: &'p str) {
-        // TODO: escape
-        self.docs.push(
-            docs![
-                self.arena,
-                self.arena.text("\""),
-                self.arena.text(string),
-                self.arena.text("\"")
-            ]
-            .into_doc(),
-        );
+    fn print_string(&mut self, string: &str) {
+        let mut output = String::with_capacity(string.len() + 2);
+        output.push('"');
+
+        for c in string.chars() {
+            match c {
+                '\\' => output.push_str("\\\\"),
+                '"' => output.push_str("\\\""),
+                '\n' => output.push_str("\\n"),
+                '\r' => output.push_str("\\r"),
+                '\t' => output.push_str("\\t"),
+                _ => output.push(c),
+            }
+        }
+
+        output.push('"');
+        self.print_text(output);
     }
 }

--- a/hugr-model/tests/fixtures/model-call.edn
+++ b/hugr-model/tests/fixtures/model-call.edn
@@ -3,13 +3,13 @@
 (declare-func example.callee
   (forall ?ext ext-set)
   [(@ arithmetic.int.types.int)] [(@ arithmetic.int.types.int)] (ext arithmetic.int . ?ext)
-  (meta doc.title (prelude.json "Callee"))
-  (meta doc.description (prelude.json "This is a function declaration.")))
+  (meta doc.title (prelude.json "\"Callee\""))
+  (meta doc.description (prelude.json "\"This is a function declaration.\"")))
 
 (define-func example.caller
   [(@ arithmetic.int.types.int)] [(@ arithmetic.int.types.int)] (ext arithmetic.int)
-  (meta doc.title (prelude.json "Caller"))
-  (meta doc.description (prelude.json "This defines a function that calls the function which we declared earlier.")))
+  (meta doc.title (prelude.json "\"Caller\""))
+  (meta doc.description (prelude.json "\"This defines a function that calls the function which we declared earlier.\""))
   (dfg [%3] [%4]
     (signature (fn [(@ arithmetic.int.types.int)] [(@ arithmetic.int.types.int)] (ext)))
     (call (@ example.callee (ext)) [%3] [%4]

--- a/hugr-model/tests/fixtures/model-call.edn
+++ b/hugr-model/tests/fixtures/model-call.edn
@@ -3,13 +3,13 @@
 (declare-func example.callee
   (forall ?ext ext-set)
   [(@ arithmetic.int.types.int)] [(@ arithmetic.int.types.int)] (ext arithmetic.int . ?ext)
-  (meta doc.title "Callee")
-  (meta doc.description "This is a function declaration."))
+  (meta doc.title (prelude.json "Callee"))
+  (meta doc.description (prelude.json "This is a function declaration.")))
 
 (define-func example.caller
   [(@ arithmetic.int.types.int)] [(@ arithmetic.int.types.int)] (ext arithmetic.int)
-  (meta doc.title "Caller")
-  (meta doc.description "This defines a function that calls the function which we declared earlier.")
+  (meta doc.title (prelude.json "Caller"))
+  (meta doc.description (prelude.json "This defines a function that calls the function which we declared earlier.")))
   (dfg [%3] [%4]
     (signature (fn [(@ arithmetic.int.types.int)] [(@ arithmetic.int.types.int)] (ext)))
     (call (@ example.callee (ext)) [%3] [%4]

--- a/hugr-model/tests/fixtures/model-literals.edn
+++ b/hugr-model/tests/fixtures/model-literals.edn
@@ -1,0 +1,3 @@
+(hugr 0)
+
+(define-alias mod.string str "\"\n\r\t\\\u{1F44D}")

--- a/hugr-model/tests/snapshots/text__literals.snap
+++ b/hugr-model/tests/snapshots/text__literals.snap
@@ -1,0 +1,7 @@
+---
+source: hugr-model/tests/text.rs
+expression: "roundtrip(include_str!(\"fixtures/model-literals.edn\"))"
+---
+(hugr 0)
+
+(define-alias mod.string str "\"\n\r\t\\👍")

--- a/hugr-model/tests/text.rs
+++ b/hugr-model/tests/text.rs
@@ -10,3 +10,8 @@ fn roundtrip(source: &str) -> String {
 pub fn test_declarative_extensions() {
     insta::assert_snapshot!(roundtrip(include_str!("fixtures/model-decl-exts.edn")))
 }
+
+#[test]
+pub fn test_literals() {
+    insta::assert_snapshot!(roundtrip(include_str!("fixtures/model-literals.edn")))
+}


### PR DESCRIPTION
Metadata in `hugr-core` is attached to nodes and to `OpDef`s, consisting of a map from string names to `serde_json::Value`s. On top of that, `OpDef` also has a `description` field. This PR imports and exports node metadata by serializing it to a JSON string and wrapping that string with a `prelude.json` constructor. It also exports the metadata of `OpDef`s, in which case the description field can be exported as a string directly. This PR also introduces string escaping for the text format (#1549).

By wrapping the metadata in a JSON type on the `hugr-model` side, we leave open the option to have typed metadata via the usual term system in the future.

Closes #1631.