### PR TITLE
feat: Emulate `TypeBound`s on parameters via constraints.

### DIFF
--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 extension_inference = []
 declarative = ["serde_yaml"]
 model_unstable = ["hugr-model"]
-default = ["model_unstable"]
 
 [[test]]
 name = "model"

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 extension_inference = []
 declarative = ["serde_yaml"]
 model_unstable = ["hugr-model"]
+default = ["model_unstable"]
 
 [[test]]
 name = "model"

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -693,7 +693,11 @@ impl<'a> Context<'a> {
         for (i, param) in t.params().iter().enumerate() {
             let name = self.bump.alloc_str(&i.to_string());
             let r#type = self.export_type_param(param, Some(model::LocalRef::Index(scope, i as _)));
-            let param = model::Param::Implicit { name, r#type };
+            let param = model::Param {
+                name,
+                r#type,
+                sort: model::ParamSort::Implicit,
+            };
             params.push(param)
         }
 

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -269,7 +269,6 @@ impl<'a> Context<'a> {
                 let decl = this.bump.alloc(model::AliasDecl {
                     name: &alias.name,
                     params: &[],
-                    constraints: &[],
                     r#type,
                 });
                 model::Operation::DeclareAlias { decl }
@@ -282,7 +281,6 @@ impl<'a> Context<'a> {
                 let decl = this.bump.alloc(model::AliasDecl {
                     name: &alias.name,
                     params: &[],
-                    constraints: &[],
                     r#type,
                 });
                 model::Operation::DefineAlias { decl, value }

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -825,9 +825,8 @@ impl<'a> Context<'a> {
             TypeParam::Type { b } => {
                 if let (Some(var), TypeBound::Copyable) = (var, b) {
                     let term = self.make_term(model::Term::Var(var));
-                    let copy = self.make_term(model::Term::CopyConstraint { term });
-                    let discard = self.make_term(model::Term::DiscardConstraint { term });
-                    self.local_constraints.extend([copy, discard]);
+                    let non_linear = self.make_term(model::Term::NonLinearConstraint { term });
+                    self.local_constraints.push(non_linear);
                 }
 
                 self.make_term(model::Term::Type)

--- a/hugr-core/tests/model.rs
+++ b/hugr-core/tests/model.rs
@@ -58,3 +58,10 @@ pub fn test_roundtrip_params() {
         "../../hugr-model/tests/fixtures/model-params.edn"
     )));
 }
+
+#[test]
+pub fn test_roundtrip_constraints() {
+    insta::assert_snapshot!(roundtrip(include_str!(
+        "../../hugr-model/tests/fixtures/model-constraints.edn"
+    )));
+}

--- a/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
@@ -7,12 +7,10 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
 (declare-func array.replicate
   (forall ?0 type)
   (forall ?1 nat)
-  (where (copy ?0))
-  (where (discard ?0))
+  (where (nonlinear ?0))
   [?0] [(@ array.Array ?0 ?1)] (ext))
 
-(declare-func tuple.copy
+(declare-func array.copy
   (forall ?0 type)
-  (where (copy ?0))
-  (where (discard ?0))
-  [(@ foo.tuple ?0)] [(@ foo.tuple ?0) (@ foo.tuple ?0)] (ext))
+  (where (nonlinear ?0))
+  [(@ array.Array ?0)] [(@ array.Array ?0) (@ array.Array ?0)] (ext))

--- a/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
@@ -1,0 +1,18 @@
+---
+source: hugr-core/tests/model.rs
+expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-constraints.edn\"))"
+---
+(hugr 0)
+
+(declare-func array.replicate
+  (forall ?0 type)
+  (forall ?1 nat)
+  (where (copy ?0))
+  (where (discard ?0))
+  [?0] [(@ array.Array ?0 ?1)] (ext))
+
+(declare-func tuple.copy
+  (forall ?0 type)
+  (where (copy ?0))
+  (where (discard ?0))
+  [(@ foo.tuple ?0)] [(@ foo.tuple ?0) (@ foo.tuple ?0)] (ext))

--- a/hugr-model/capnp/hugr-v0.capnp
+++ b/hugr-model/capnp/hugr-v0.capnp
@@ -195,18 +195,12 @@ struct Term {
 }
 
 struct Param {
-    union {
-        implicit @0 :Implicit;
-        explicit @1 :Explicit;
-    }
+    name @0 :Text;
+    type @1 :TermId;
+    sort @2 :ParamSort;
+}
 
-    struct Implicit {
-        name @0 :Text;
-        type @1 :TermId;
-    }
-
-    struct Explicit {
-        name @0 :Text;
-        type @1 :TermId;
-    }
+enum ParamSort {
+    implicit @0;
+    explicit @1;
 }

--- a/hugr-model/capnp/hugr-v0.capnp
+++ b/hugr-model/capnp/hugr-v0.capnp
@@ -56,38 +56,44 @@ struct Operation {
     struct FuncDefn {
         name @0 :Text;
         params @1 :List(Param);
-        signature @2 :TermId;
+        constraints @2 :List(TermId);
+        signature @3 :TermId;
     }
 
     struct FuncDecl {
         name @0 :Text;
         params @1 :List(Param);
-        signature @2 :TermId;
+        constraints @2 :List(TermId);
+        signature @3 :TermId;
     }
 
     struct AliasDefn {
         name @0 :Text;
         params @1 :List(Param);
-        type @2 :TermId;
-        value @3 :TermId;
+        constraints @2 :List(TermId);
+        type @3 :TermId;
+        value @4 :TermId;
     }
 
     struct AliasDecl {
         name @0 :Text;
         params @1 :List(Param);
-        type @2 :TermId;
+        constraints @2 :List(TermId);
+        type @3 :TermId;
     }
 
     struct ConstructorDecl {
         name @0 :Text;
         params @1 :List(Param);
-        type @2 :TermId;
+        constraints @2 :List(TermId);
+        type @3 :TermId;
     }
 
     struct OperationDecl {
         name @0 :Text;
         params @1 :List(Param);
-        type @2 :TermId;
+        constraints @2 :List(TermId);
+        type @3 :TermId;
     }
 }
 
@@ -192,7 +198,6 @@ struct Param {
     union {
         implicit @0 :Implicit;
         explicit @1 :Explicit;
-        constraint @2 :TermId;
     }
 
     struct Implicit {

--- a/hugr-model/capnp/hugr-v0.capnp
+++ b/hugr-model/capnp/hugr-v0.capnp
@@ -157,6 +157,8 @@ struct Term {
         funcType @17 :FuncType;
         control @18 :TermId;
         controlType @19 :Void;
+        copyConstraint @20 :TermId;
+        discardConstraint @21 :TermId;
     }
 
     struct Apply {

--- a/hugr-model/capnp/hugr-v0.capnp
+++ b/hugr-model/capnp/hugr-v0.capnp
@@ -70,16 +70,14 @@ struct Operation {
     struct AliasDefn {
         name @0 :Text;
         params @1 :List(Param);
-        constraints @2 :List(TermId);
-        type @3 :TermId;
-        value @4 :TermId;
+        type @2 :TermId;
+        value @3 :TermId;
     }
 
     struct AliasDecl {
         name @0 :Text;
         params @1 :List(Param);
-        constraints @2 :List(TermId);
-        type @3 :TermId;
+        type @2 :TermId;
     }
 
     struct ConstructorDecl {

--- a/hugr-model/capnp/hugr-v0.capnp
+++ b/hugr-model/capnp/hugr-v0.capnp
@@ -163,8 +163,7 @@ struct Term {
         funcType @17 :FuncType;
         control @18 :TermId;
         controlType @19 :Void;
-        copyConstraint @20 :TermId;
-        discardConstraint @21 :TermId;
+        nonLinearConstraint @20 :TermId;
     }
 
     struct Apply {

--- a/hugr-model/src/v0/binary/read.rs
+++ b/hugr-model/src/v0/binary/read.rs
@@ -345,10 +345,7 @@ fn read_term<'a>(bump: &'a Bump, reader: hugr_capnp::term::Reader) -> ReadResult
             values: model::TermId(values),
         },
 
-        Which::CopyConstraint(term) => model::Term::CopyConstraint {
-            term: model::TermId(term),
-        },
-        Which::DiscardConstraint(term) => model::Term::DiscardConstraint {
+        Which::NonLinearConstraint(term) => model::Term::NonLinearConstraint {
             term: model::TermId(term),
         },
     })

--- a/hugr-model/src/v0/binary/read.rs
+++ b/hugr-model/src/v0/binary/read.rs
@@ -140,10 +140,12 @@ fn read_operation<'a>(
             let reader = reader?;
             let name = bump.alloc_str(reader.get_name()?.to_str()?);
             let params = read_list!(bump, reader, get_params, read_param);
+            let constraints = read_scalar_list!(bump, reader, get_constraints, model::TermId);
             let signature = model::TermId(reader.get_signature());
             let decl = bump.alloc(model::FuncDecl {
                 name,
                 params,
+                constraints,
                 signature,
             });
             model::Operation::DefineFunc { decl }
@@ -152,10 +154,12 @@ fn read_operation<'a>(
             let reader = reader?;
             let name = bump.alloc_str(reader.get_name()?.to_str()?);
             let params = read_list!(bump, reader, get_params, read_param);
+            let constraints = read_scalar_list!(bump, reader, get_constraints, model::TermId);
             let signature = model::TermId(reader.get_signature());
             let decl = bump.alloc(model::FuncDecl {
                 name,
                 params,
+                constraints,
                 signature,
             });
             model::Operation::DeclareFunc { decl }
@@ -164,11 +168,13 @@ fn read_operation<'a>(
             let reader = reader?;
             let name = bump.alloc_str(reader.get_name()?.to_str()?);
             let params = read_list!(bump, reader, get_params, read_param);
+            let constraints = read_scalar_list!(bump, reader, get_constraints, model::TermId);
             let r#type = model::TermId(reader.get_type());
             let value = model::TermId(reader.get_value());
             let decl = bump.alloc(model::AliasDecl {
                 name,
                 params,
+                constraints,
                 r#type,
             });
             model::Operation::DefineAlias { decl, value }
@@ -177,10 +183,12 @@ fn read_operation<'a>(
             let reader = reader?;
             let name = bump.alloc_str(reader.get_name()?.to_str()?);
             let params = read_list!(bump, reader, get_params, read_param);
+            let constraints = read_scalar_list!(bump, reader, get_constraints, model::TermId);
             let r#type = model::TermId(reader.get_type());
             let decl = bump.alloc(model::AliasDecl {
                 name,
                 params,
+                constraints,
                 r#type,
             });
             model::Operation::DeclareAlias { decl }
@@ -189,10 +197,12 @@ fn read_operation<'a>(
             let reader = reader?;
             let name = bump.alloc_str(reader.get_name()?.to_str()?);
             let params = read_list!(bump, reader, get_params, read_param);
+            let constraints = read_scalar_list!(bump, reader, get_constraints, model::TermId);
             let r#type = model::TermId(reader.get_type());
             let decl = bump.alloc(model::ConstructorDecl {
                 name,
                 params,
+                constraints,
                 r#type,
             });
             model::Operation::DeclareConstructor { decl }
@@ -201,10 +211,12 @@ fn read_operation<'a>(
             let reader = reader?;
             let name = bump.alloc_str(reader.get_name()?.to_str()?);
             let params = read_list!(bump, reader, get_params, read_param);
+            let constraints = read_scalar_list!(bump, reader, get_constraints, model::TermId);
             let r#type = model::TermId(reader.get_type());
             let decl = bump.alloc(model::OperationDecl {
                 name,
                 params,
+                constraints,
                 r#type,
             });
             model::Operation::DeclareOperation { decl }
@@ -368,10 +380,6 @@ fn read_param<'a>(
             let name = bump.alloc_str(reader.get_name()?.to_str()?);
             let r#type = model::TermId(reader.get_type());
             model::Param::Explicit { name, r#type }
-        }
-        Which::Constraint(constraint) => {
-            let constraint = model::TermId(constraint);
-            model::Param::Constraint { constraint }
         }
     })
 }

--- a/hugr-model/src/v0/binary/read.rs
+++ b/hugr-model/src/v0/binary/read.rs
@@ -168,13 +168,11 @@ fn read_operation<'a>(
             let reader = reader?;
             let name = bump.alloc_str(reader.get_name()?.to_str()?);
             let params = read_list!(bump, reader, get_params, read_param);
-            let constraints = read_scalar_list!(bump, reader, get_constraints, model::TermId);
             let r#type = model::TermId(reader.get_type());
             let value = model::TermId(reader.get_value());
             let decl = bump.alloc(model::AliasDecl {
                 name,
                 params,
-                constraints,
                 r#type,
             });
             model::Operation::DefineAlias { decl, value }
@@ -183,12 +181,10 @@ fn read_operation<'a>(
             let reader = reader?;
             let name = bump.alloc_str(reader.get_name()?.to_str()?);
             let params = read_list!(bump, reader, get_params, read_param);
-            let constraints = read_scalar_list!(bump, reader, get_constraints, model::TermId);
             let r#type = model::TermId(reader.get_type());
             let decl = bump.alloc(model::AliasDecl {
                 name,
                 params,
-                constraints,
                 r#type,
             });
             model::Operation::DeclareAlias { decl }

--- a/hugr-model/src/v0/binary/read.rs
+++ b/hugr-model/src/v0/binary/read.rs
@@ -332,6 +332,13 @@ fn read_term<'a>(bump: &'a Bump, reader: hugr_capnp::term::Reader) -> ReadResult
         Which::Control(values) => model::Term::Control {
             values: model::TermId(values),
         },
+
+        Which::CopyConstraint(term) => model::Term::CopyConstraint {
+            term: model::TermId(term),
+        },
+        Which::DiscardConstraint(term) => model::Term::DiscardConstraint {
+            term: model::TermId(term),
+        },
     })
 }
 

--- a/hugr-model/src/v0/binary/read.rs
+++ b/hugr-model/src/v0/binary/read.rs
@@ -367,19 +367,13 @@ fn read_param<'a>(
     bump: &'a Bump,
     reader: hugr_capnp::param::Reader,
 ) -> ReadResult<model::Param<'a>> {
-    use hugr_capnp::param::Which;
-    Ok(match reader.which()? {
-        Which::Implicit(reader) => {
-            let reader = reader?;
-            let name = bump.alloc_str(reader.get_name()?.to_str()?);
-            let r#type = model::TermId(reader.get_type());
-            model::Param::Implicit { name, r#type }
-        }
-        Which::Explicit(reader) => {
-            let reader = reader?;
-            let name = bump.alloc_str(reader.get_name()?.to_str()?);
-            let r#type = model::TermId(reader.get_type());
-            model::Param::Explicit { name, r#type }
-        }
-    })
+    let name = bump.alloc_str(reader.get_name()?.to_str()?);
+    let r#type = model::TermId(reader.get_type());
+
+    let sort = match reader.get_sort()? {
+        hugr_capnp::ParamSort::Implicit => model::ParamSort::Implicit,
+        hugr_capnp::ParamSort::Explicit => model::ParamSort::Explicit,
+    };
+
+    Ok(model::Param { name, r#type, sort })
 }

--- a/hugr-model/src/v0/binary/write.rs
+++ b/hugr-model/src/v0/binary/write.rs
@@ -60,12 +60,14 @@ fn write_operation(mut builder: hugr_capnp::operation::Builder, operation: &mode
             let mut builder = builder.init_func_defn();
             builder.set_name(decl.name);
             write_list!(builder, init_params, write_param, decl.params);
+            let _ = builder.set_constraints(model::TermId::unwrap_slice(decl.constraints));
             builder.set_signature(decl.signature.0);
         }
         model::Operation::DeclareFunc { decl } => {
             let mut builder = builder.init_func_decl();
             builder.set_name(decl.name);
             write_list!(builder, init_params, write_param, decl.params);
+            let _ = builder.set_constraints(model::TermId::unwrap_slice(decl.constraints));
             builder.set_signature(decl.signature.0);
         }
 
@@ -73,6 +75,7 @@ fn write_operation(mut builder: hugr_capnp::operation::Builder, operation: &mode
             let mut builder = builder.init_alias_defn();
             builder.set_name(decl.name);
             write_list!(builder, init_params, write_param, decl.params);
+            let _ = builder.set_constraints(model::TermId::unwrap_slice(decl.constraints));
             builder.set_type(decl.r#type.0);
             builder.set_value(value.0);
         }
@@ -80,6 +83,7 @@ fn write_operation(mut builder: hugr_capnp::operation::Builder, operation: &mode
             let mut builder = builder.init_alias_decl();
             builder.set_name(decl.name);
             write_list!(builder, init_params, write_param, decl.params);
+            let _ = builder.set_constraints(model::TermId::unwrap_slice(decl.constraints));
             builder.set_type(decl.r#type.0);
         }
 
@@ -87,12 +91,14 @@ fn write_operation(mut builder: hugr_capnp::operation::Builder, operation: &mode
             let mut builder = builder.init_constructor_decl();
             builder.set_name(decl.name);
             write_list!(builder, init_params, write_param, decl.params);
+            let _ = builder.set_constraints(model::TermId::unwrap_slice(decl.constraints));
             builder.set_type(decl.r#type.0);
         }
         model::Operation::DeclareOperation { decl } => {
             let mut builder = builder.init_operation_decl();
             builder.set_name(decl.name);
             write_list!(builder, init_params, write_param, decl.params);
+            let _ = builder.set_constraints(model::TermId::unwrap_slice(decl.constraints));
             builder.set_type(decl.r#type.0);
         }
 

--- a/hugr-model/src/v0/binary/write.rs
+++ b/hugr-model/src/v0/binary/write.rs
@@ -100,19 +100,13 @@ fn write_operation(mut builder: hugr_capnp::operation::Builder, operation: &mode
     }
 }
 
-fn write_param(builder: hugr_capnp::param::Builder, param: &model::Param) {
-    match param {
-        model::Param::Implicit { name, r#type } => {
-            let mut builder = builder.init_implicit();
-            builder.set_name(name);
-            builder.set_type(r#type.0);
-        }
-        model::Param::Explicit { name, r#type } => {
-            let mut builder = builder.init_explicit();
-            builder.set_name(name);
-            builder.set_type(r#type.0);
-        }
-    }
+fn write_param(mut builder: hugr_capnp::param::Builder, param: &model::Param) {
+    builder.set_name(param.name);
+    builder.set_type(param.r#type.0);
+    builder.set_sort(match param.sort {
+        model::ParamSort::Implicit => hugr_capnp::ParamSort::Implicit,
+        model::ParamSort::Explicit => hugr_capnp::ParamSort::Explicit,
+    });
 }
 
 fn write_global_ref(mut builder: hugr_capnp::global_ref::Builder, global_ref: &model::GlobalRef) {

--- a/hugr-model/src/v0/binary/write.rs
+++ b/hugr-model/src/v0/binary/write.rs
@@ -212,12 +212,8 @@ fn write_term(mut builder: hugr_capnp::term::Builder, term: &model::Term) {
             builder.set_extensions(extensions.0);
         }
 
-        model::Term::CopyConstraint { term } => {
-            builder.set_copy_constraint(term.0);
-        }
-
-        model::Term::DiscardConstraint { term } => {
-            builder.set_discard_constraint(term.0);
+        model::Term::NonLinearConstraint { term } => {
+            builder.set_non_linear_constraint(term.0);
         }
     }
 }

--- a/hugr-model/src/v0/binary/write.rs
+++ b/hugr-model/src/v0/binary/write.rs
@@ -100,7 +100,7 @@ fn write_operation(mut builder: hugr_capnp::operation::Builder, operation: &mode
     }
 }
 
-fn write_param(mut builder: hugr_capnp::param::Builder, param: &model::Param) {
+fn write_param(builder: hugr_capnp::param::Builder, param: &model::Param) {
     match param {
         model::Param::Implicit { name, r#type } => {
             let mut builder = builder.init_implicit();
@@ -112,7 +112,6 @@ fn write_param(mut builder: hugr_capnp::param::Builder, param: &model::Param) {
             builder.set_name(name);
             builder.set_type(r#type.0);
         }
-        model::Param::Constraint { constraint } => builder.set_constraint(constraint.0),
     }
 }
 

--- a/hugr-model/src/v0/binary/write.rs
+++ b/hugr-model/src/v0/binary/write.rs
@@ -212,5 +212,13 @@ fn write_term(mut builder: hugr_capnp::term::Builder, term: &model::Term) {
             builder.set_outputs(outputs.0);
             builder.set_extensions(extensions.0);
         }
+
+        model::Term::CopyConstraint { term } => {
+            builder.set_copy_constraint(term.0);
+        }
+
+        model::Term::DiscardConstraint { term } => {
+            builder.set_discard_constraint(term.0);
+        }
     }
 }

--- a/hugr-model/src/v0/binary/write.rs
+++ b/hugr-model/src/v0/binary/write.rs
@@ -75,7 +75,6 @@ fn write_operation(mut builder: hugr_capnp::operation::Builder, operation: &mode
             let mut builder = builder.init_alias_defn();
             builder.set_name(decl.name);
             write_list!(builder, init_params, write_param, decl.params);
-            let _ = builder.set_constraints(model::TermId::unwrap_slice(decl.constraints));
             builder.set_type(decl.r#type.0);
             builder.set_value(value.0);
         }
@@ -83,7 +82,6 @@ fn write_operation(mut builder: hugr_capnp::operation::Builder, operation: &mode
             let mut builder = builder.init_alias_decl();
             builder.set_name(decl.name);
             write_list!(builder, init_params, write_param, decl.params);
-            let _ = builder.set_constraints(model::TermId::unwrap_slice(decl.constraints));
             builder.set_type(decl.r#type.0);
         }
 

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -689,26 +689,23 @@ pub enum Term<'a> {
 /// Parameter names must be unique within a parameter list.
 /// Implicit and explicit parameters share a namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Param<'a> {
-    /// An implicit parameter that should be inferred, unless a full application form is used
+pub struct Param<'a> {
+    /// The name of the parameter.
+    pub name: &'a str,
+    /// The type of the parameter.
+    pub r#type: TermId,
+    /// The sort of the parameter (implicit or explicit).
+    pub sort: ParamSort,
+}
+
+/// The sort of a parameter (implicit or explicit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ParamSort {
+    /// The parameter is implicit and should be inferred, unless a full application form is used
     /// (see [`Term::ApplyFull`] and [`Operation::CustomFull`]).
-    Implicit {
-        /// The name of the parameter.
-        name: &'a str,
-        /// The type of the parameter.
-        ///
-        /// This must be a term of type `static`.
-        r#type: TermId,
-    },
-    /// An explicit parameter that should always be provided.
-    Explicit {
-        /// The name of the parameter.
-        name: &'a str,
-        /// The type of the parameter.
-        ///
-        /// This must be a term of type `static`.
-        r#type: TermId,
-    },
+    Implicit,
+    /// The parameter is explicit and should always be provided.
+    Explicit,
 }
 
 /// Errors that can occur when traversing and interpreting the model.

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -662,6 +662,18 @@ pub enum Term<'a> {
     ///
     /// `ctrl : static`
     ControlType,
+
+    /// Constraint that requires a runtime type to be copyable.
+    CopyConstraint {
+        /// The runtime type that must be copyable.
+        term: TermId,
+    },
+
+    /// Constraint that requires a runtime type to be discardable.
+    DiscardConstraint {
+        /// The runtime type that must be discardable.
+        term: TermId,
+    },
 }
 
 /// A parameter to a function or alias.

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -671,15 +671,9 @@ pub enum Term<'a> {
     /// `ctrl : static`
     ControlType,
 
-    /// Constraint that requires a runtime type to be copyable.
-    CopyConstraint {
-        /// The runtime type that must be copyable.
-        term: TermId,
-    },
-
-    /// Constraint that requires a runtime type to be discardable.
-    DiscardConstraint {
-        /// The runtime type that must be discardable.
+    /// Constraint that requires a runtime type to be copyable and discardable.
+    NonLinearConstraint {
+        /// The runtime type that must be copyable and discardable.
         term: TermId,
     },
 }

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -410,8 +410,6 @@ pub struct AliasDecl<'a> {
     pub name: &'a str,
     /// The static parameters of the alias.
     pub params: &'a [Param<'a>],
-    /// The constraints on the static parameters.
-    pub constraints: &'a [TermId],
     /// The type of the alias.
     pub r#type: TermId,
 }

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -397,6 +397,8 @@ pub struct FuncDecl<'a> {
     pub name: &'a str,
     /// The static parameters of the function.
     pub params: &'a [Param<'a>],
+    /// The constraints on the static parameters.
+    pub constraints: &'a [TermId],
     /// The signature of the function.
     pub signature: TermId,
 }
@@ -408,6 +410,8 @@ pub struct AliasDecl<'a> {
     pub name: &'a str,
     /// The static parameters of the alias.
     pub params: &'a [Param<'a>],
+    /// The constraints on the static parameters.
+    pub constraints: &'a [TermId],
     /// The type of the alias.
     pub r#type: TermId,
 }
@@ -419,6 +423,8 @@ pub struct ConstructorDecl<'a> {
     pub name: &'a str,
     /// The static parameters of the constructor.
     pub params: &'a [Param<'a>],
+    /// The constraints on the static parameters.
+    pub constraints: &'a [TermId],
     /// The type of the constructed term.
     pub r#type: TermId,
 }
@@ -430,6 +436,8 @@ pub struct OperationDecl<'a> {
     pub name: &'a str,
     /// The static parameters of the operation.
     pub params: &'a [Param<'a>],
+    /// The constraints on the static parameters.
+    pub constraints: &'a [TermId],
     /// The type of the operation. This must be a function type.
     pub r#type: TermId,
 }
@@ -700,13 +708,6 @@ pub enum Param<'a> {
         ///
         /// This must be a term of type `static`.
         r#type: TermId,
-    },
-    /// A constraint that should be satisfied by other parameters in a parameter list.
-    Constraint {
-        /// The constraint to be satisfied.
-        ///
-        /// This must be a term of type `constraint`.
-        constraint: TermId,
     },
 }
 

--- a/hugr-model/src/v0/text/hugr.pest
+++ b/hugr-model/src/v0/text/hugr.pest
@@ -56,16 +56,16 @@ node_tag               = { "(" ~ "tag" ~ tag ~ port_lists? ~ signature? ~ meta* 
 node_custom            = { "(" ~ (term_apply | term_apply_full) ~ port_lists? ~ signature? ~ meta* ~ region* ~ ")" }
 
 signature        = { "(" ~ "signature" ~ term ~ ")" }
-func_header      = { symbol ~ param* ~ term ~ term ~ term }
-alias_header     = { symbol ~ param* ~ term }
-ctr_header       = { symbol ~ param* ~ term }
-operation_header = { symbol ~ param* ~ term }
+func_header      = { symbol ~ param* ~ where_clause* ~ term ~ term ~ term }
+alias_header     = { symbol ~ param* ~ where_clause* ~ term }
+ctr_header       = { symbol ~ param* ~ where_clause* ~ term }
+operation_header = { symbol ~ param* ~ where_clause* ~ term }
 
-param = { param_implicit | param_explicit | param_constraint }
+param = { param_implicit | param_explicit }
 
-param_implicit   = { "(" ~ "forall" ~ term_var ~ term ~ ")" }
-param_explicit   = { "(" ~ "param" ~ term_var ~ term ~ ")" }
-param_constraint = { "(" ~ "where" ~ term ~ ")" }
+param_implicit = { "(" ~ "forall" ~ term_var ~ term ~ ")" }
+param_explicit = { "(" ~ "param" ~ term_var ~ term ~ ")" }
+where_clause   = { "(" ~ "where" ~ term ~ ")" }
 
 region     = { region_dfg | region_cfg }
 region_dfg = { "(" ~ "dfg" ~ port_lists? ~ signature? ~ meta* ~ node* ~ ")" }

--- a/hugr-model/src/v0/text/hugr.pest
+++ b/hugr-model/src/v0/text/hugr.pest
@@ -92,8 +92,7 @@ term = {
   | term_ctrl_type
   | term_apply_full
   | term_apply
-  | term_copy
-  | term_discard
+  | term_non_linear
 }
 
 term_wildcard     = { "_" }
@@ -116,5 +115,4 @@ term_adt          = { "(" ~ "adt" ~ term ~ ")" }
 term_func_type    = { "(" ~ "fn" ~ term ~ term ~ term ~ ")" }
 term_ctrl         = { "(" ~ "ctrl" ~ term ~ ")" }
 term_ctrl_type    = { "ctrl" }
-term_copy         = { "(" ~ "copy" ~ term ~ ")" }
-term_discard      = { "(" ~ "discard" ~ term ~ ")" }
+term_non_linear   = { "(" ~ "nonlinear" ~ term ~ ")" }

--- a/hugr-model/src/v0/text/hugr.pest
+++ b/hugr-model/src/v0/text/hugr.pest
@@ -92,6 +92,8 @@ term = {
   | term_ctrl_type
   | term_apply_full
   | term_apply
+  | term_copy
+  | term_discard
 }
 
 term_wildcard     = { "_" }
@@ -114,3 +116,5 @@ term_adt          = { "(" ~ "adt" ~ term ~ ")" }
 term_func_type    = { "(" ~ "fn" ~ term ~ term ~ term ~ ")" }
 term_ctrl         = { "(" ~ "ctrl" ~ term ~ ")" }
 term_ctrl_type    = { "ctrl" }
+term_copy         = { "(" ~ "copy" ~ term ~ ")" }
+term_discard      = { "(" ~ "discard" ~ term ~ ")" }

--- a/hugr-model/src/v0/text/hugr.pest
+++ b/hugr-model/src/v0/text/hugr.pest
@@ -57,7 +57,7 @@ node_custom            = { "(" ~ (term_apply | term_apply_full) ~ port_lists? ~ 
 
 signature        = { "(" ~ "signature" ~ term ~ ")" }
 func_header      = { symbol ~ param* ~ where_clause* ~ term ~ term ~ term }
-alias_header     = { symbol ~ param* ~ where_clause* ~ term }
+alias_header     = { symbol ~ param* ~ term }
 ctr_header       = { symbol ~ param* ~ where_clause* ~ term }
 operation_header = { symbol ~ param* ~ where_clause* ~ term }
 

--- a/hugr-model/src/v0/text/parse.rs
+++ b/hugr-model/src/v0/text/parse.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 use crate::v0::{
     AliasDecl, ConstructorDecl, FuncDecl, GlobalRef, LinkRef, LocalRef, MetaItem, Module, Node,
-    NodeId, Operation, OperationDecl, Param, Region, RegionId, RegionKind, Term, TermId,
+    NodeId, Operation, OperationDecl, Param, ParamSort, Region, RegionId, RegionKind, Term, TermId,
 };
 
 mod pest_parser {
@@ -637,13 +637,21 @@ impl<'a> ParseContext<'a> {
                     let mut inner = param.into_inner();
                     let name = &inner.next().unwrap().as_str()[1..];
                     let r#type = self.parse_term(inner.next().unwrap())?;
-                    Param::Implicit { name, r#type }
+                    Param {
+                        name,
+                        r#type,
+                        sort: ParamSort::Implicit,
+                    }
                 }
                 Rule::param_explicit => {
                     let mut inner = param.into_inner();
                     let name = &inner.next().unwrap().as_str()[1..];
                     let r#type = self.parse_term(inner.next().unwrap())?;
-                    Param::Explicit { name, r#type }
+                    Param {
+                        name,
+                        r#type,
+                        sort: ParamSort::Explicit,
+                    }
                 }
                 _ => unreachable!(),
             };

--- a/hugr-model/src/v0/text/parse.rs
+++ b/hugr-model/src/v0/text/parse.rs
@@ -576,13 +576,11 @@ impl<'a> ParseContext<'a> {
         let mut inner = pair.into_inner();
         let name = self.parse_symbol(&mut inner)?;
         let params = self.parse_params(&mut inner)?;
-        let constraints = self.parse_constraints(&mut inner)?;
         let r#type = self.parse_term(inner.next().unwrap())?;
 
         Ok(self.bump.alloc(AliasDecl {
             name,
             params,
-            constraints,
             r#type,
         }))
     }

--- a/hugr-model/src/v0/text/parse.rs
+++ b/hugr-model/src/v0/text/parse.rs
@@ -209,6 +209,16 @@ impl<'a> ParseContext<'a> {
                 Term::Control { values }
             }
 
+            Rule::term_copy => {
+                let term = self.parse_term(inner.next().unwrap())?;
+                Term::CopyConstraint { term }
+            }
+
+            Rule::term_discard => {
+                let term = self.parse_term(inner.next().unwrap())?;
+                Term::DiscardConstraint { term }
+            }
+
             r => unreachable!("term: {:?}", r),
         };
 

--- a/hugr-model/src/v0/text/parse.rs
+++ b/hugr-model/src/v0/text/parse.rs
@@ -209,14 +209,9 @@ impl<'a> ParseContext<'a> {
                 Term::Control { values }
             }
 
-            Rule::term_copy => {
+            Rule::term_non_linear => {
                 let term = self.parse_term(inner.next().unwrap())?;
-                Term::CopyConstraint { term }
-            }
-
-            Rule::term_discard => {
-                let term = self.parse_term(inner.next().unwrap())?;
-                Term::DiscardConstraint { term }
+                Term::NonLinearConstraint { term }
             }
 
             r => unreachable!("term: {:?}", r),

--- a/hugr-model/src/v0/text/print.rs
+++ b/hugr-model/src/v0/text/print.rs
@@ -370,10 +370,9 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
     }
 
     fn print_regions(&mut self, regions: &'a [RegionId]) -> PrintResult<()> {
-        for region in regions {
-            self.print_region(*region)?;
-        }
-        Ok(())
+        regions
+            .iter()
+            .try_for_each(|region| self.print_region(*region))
     }
 
     fn print_region(&mut self, region: RegionId) -> PrintResult<()> {
@@ -408,11 +407,10 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
             .get_region(region)
             .ok_or(PrintError::RegionNotFound(region))?;
 
-        for node_id in region_data.children {
-            self.print_node(*node_id)?;
-        }
-
-        Ok(())
+        region_data
+            .children
+            .iter()
+            .try_for_each(|node_id| self.print_node(*node_id))
     }
 
     fn print_port_lists(
@@ -447,11 +445,7 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
     }
 
     fn print_params(&mut self, params: &'a [Param<'a>]) -> PrintResult<()> {
-        for param in params {
-            self.print_param(*param)?;
-        }
-
-        Ok(())
+        params.iter().try_for_each(|param| self.print_param(*param))
     }
 
     fn print_param(&mut self, param: Param<'a>) -> PrintResult<()> {

--- a/hugr-model/src/v0/text/print.rs
+++ b/hugr-model/src/v0/text/print.rs
@@ -596,12 +596,8 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
                 self.print_text("ctrl");
                 Ok(())
             }
-            Term::CopyConstraint { term } => self.print_parens(|this| {
-                this.print_text("copy");
-                this.print_term(*term)
-            }),
-            Term::DiscardConstraint { term } => self.print_parens(|this| {
-                this.print_text("discard");
+            Term::NonLinearConstraint { term } => self.print_parens(|this| {
+                this.print_text("nonlinear");
                 this.print_term(*term)
             }),
         }

--- a/hugr-model/src/v0/text/print.rs
+++ b/hugr-model/src/v0/text/print.rs
@@ -294,7 +294,6 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
                 });
 
                 this.print_params(decl.params)?;
-                this.print_constraints(decl.constraints)?;
 
                 this.print_term(decl.r#type)?;
                 this.print_term(*value)?;
@@ -308,7 +307,6 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
                 });
 
                 this.print_params(decl.params)?;
-                this.print_constraints(decl.constraints)?;
 
                 this.print_term(decl.r#type)?;
                 this.print_meta(node_data.meta)?;

--- a/hugr-model/src/v0/text/print.rs
+++ b/hugr-model/src/v0/text/print.rs
@@ -598,6 +598,14 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
                 self.print_text("ctrl");
                 Ok(())
             }
+            Term::CopyConstraint { term } => self.print_parens(|this| {
+                this.print_text("copy");
+                this.print_term(*term)
+            }),
+            Term::DiscardConstraint { term } => self.print_parens(|this| {
+                this.print_text("discard");
+                this.print_term(*term)
+            }),
         }
     }
 

--- a/hugr-model/tests/binary.rs
+++ b/hugr-model/tests/binary.rs
@@ -51,3 +51,8 @@ pub fn test_params() {
 pub fn test_decl_exts() {
     binary_roundtrip(include_str!("fixtures/model-decl-exts.edn"));
 }
+
+#[test]
+pub fn test_constraints() {
+    binary_roundtrip(include_str!("fixtures/model-constraints.edn"));
+}

--- a/hugr-model/tests/fixtures/model-constraints.edn
+++ b/hugr-model/tests/fixtures/model-constraints.edn
@@ -3,13 +3,11 @@
 (declare-func array.replicate
   (forall ?t type)
   (forall ?n nat)
-  (where (copy ?t))
-  (where (discard ?t))
+  (where (nonlinear ?t))
   [?t] [(@ array.Array ?t ?n)]
   (ext))
 
-(declare-func tuple.copy
+(declare-func array.copy
   (forall ?t type)
-  (where (copy ?t))
-  (where (discard ?t))
-  [(@ foo.tuple ?t)] [(@ foo.tuple ?t) (@ foo.tuple ?t)] (ext))
+  (where (nonlinear ?t))
+  [(@ array.Array ?t)] [(@ array.Array ?t) (@ array.Array ?t)] (ext))

--- a/hugr-model/tests/fixtures/model-constraints.edn
+++ b/hugr-model/tests/fixtures/model-constraints.edn
@@ -1,0 +1,15 @@
+(hugr 0)
+
+(declare-func array.replicate
+  (forall ?t type)
+  (forall ?n nat)
+  (where (copy ?t))
+  (where (discard ?t))
+  [?t] [(@ array.Array ?t ?n)]
+  (ext))
+
+(declare-func tuple.copy
+  (forall ?t type)
+  (where (copy ?t))
+  (where (discard ?t))
+  [(@ foo.tuple ?t)] [(@ foo.tuple ?t) (@ foo.tuple ?t)] (ext))


### PR DESCRIPTION
This PR translates some `TypeBound`s in `hugr-core` to the `nonlinear` constraint in `hugr-model`. This translation only occurs on parameters that take a runtime type directly.

As a driveby change before the model stabilises, this PR also moves constraints out of the parameter lists into their own list. In its previous form this could have led to confusions about which parameter a local variable index refers to when a constraint is situated between two parameters in the list. We also remove constraints from aliases for now.

Closes https://github.com/CQCL/hugr/issues/1637.