### PR TITLE
feat: Add TailLoop::BREAK_TAG and CONTINUE_TAG

### DIFF
--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -623,7 +623,11 @@ pub trait Dataflow: Container {
         tail_loop: ops::TailLoop,
         values: impl IntoIterator<Item = Wire>,
     ) -> Result<Wire, BuildError> {
-        self.make_sum(TailLoop::CONTINUE_TAG, [tail_loop.just_inputs, tail_loop.just_outputs], values)
+        self.make_sum(
+            TailLoop::CONTINUE_TAG,
+            [tail_loop.just_inputs, tail_loop.just_outputs],
+            values,
+        )
     }
 
     /// Use the wires in `values` to return a wire corresponding to the
@@ -640,7 +644,11 @@ pub trait Dataflow: Container {
         loop_op: ops::TailLoop,
         values: impl IntoIterator<Item = Wire>,
     ) -> Result<Wire, BuildError> {
-        self.make_sum(TailLoop::BREAK_TAG, [loop_op.just_inputs, loop_op.just_outputs], values)
+        self.make_sum(
+            TailLoop::BREAK_TAG,
+            [loop_op.just_inputs, loop_op.just_outputs],
+            values,
+        )
     }
 
     /// Add a [`ops::Call`] node, calling `function`, with inputs

--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -2,7 +2,7 @@ use crate::extension::prelude::MakeTuple;
 use crate::hugr::hugrmut::InsertionResult;
 use crate::hugr::views::HugrView;
 use crate::hugr::{NodeMetadata, ValidationError};
-use crate::ops::{self, OpTag, OpTrait, OpType, Tag};
+use crate::ops::{self, OpTag, OpTrait, OpType, Tag, TailLoop};
 use crate::utils::collect_array;
 use crate::{IncomingPort, Node, OutgoingPort};
 
@@ -623,7 +623,7 @@ pub trait Dataflow: Container {
         tail_loop: ops::TailLoop,
         values: impl IntoIterator<Item = Wire>,
     ) -> Result<Wire, BuildError> {
-        self.make_sum(0, [tail_loop.just_inputs, tail_loop.just_outputs], values)
+        self.make_sum(TailLoop::CONTINUE_TAG, [tail_loop.just_inputs, tail_loop.just_outputs], values)
     }
 
     /// Use the wires in `values` to return a wire corresponding to the
@@ -640,7 +640,7 @@ pub trait Dataflow: Container {
         loop_op: ops::TailLoop,
         values: impl IntoIterator<Item = Wire>,
     ) -> Result<Wire, BuildError> {
-        self.make_sum(1, [loop_op.just_inputs, loop_op.just_outputs], values)
+        self.make_sum(TailLoop::BREAK_TAG, [loop_op.just_inputs, loop_op.just_outputs], values)
     }
 
     /// Add a [`ops::Call`] node, calling `function`, with inputs

--- a/hugr-core/src/ops/controlflow.rs
+++ b/hugr-core/src/ops/controlflow.rs
@@ -40,12 +40,12 @@ impl DataflowOpTrait for TailLoop {
 
 impl TailLoop {
     /// The [tag] for a loop body output to indicate the loop should iterate again.
-    /// 
+    ///
     /// [tag]: crate::ops::constant::Sum::tag
     pub const CONTINUE_TAG: usize = 0;
-    
+
     /// The [tag] for a loop body output to indicate the loop should exit with the supplied values.
-    /// 
+    ///
     /// [tag]: crate::ops::constant::Sum::tag
     pub const BREAK_TAG: usize = 1;
 

--- a/hugr-core/src/ops/controlflow.rs
+++ b/hugr-core/src/ops/controlflow.rs
@@ -39,6 +39,16 @@ impl DataflowOpTrait for TailLoop {
 }
 
 impl TailLoop {
+    /// The [tag] for a loop body output to indicate the loop should iterate again.
+    /// 
+    /// [tag]: crate::ops::constant::Sum::tag
+    pub const CONTINUE_TAG: usize = 0;
+    
+    /// The [tag] for a loop body output to indicate the loop should exit with the supplied values.
+    /// 
+    /// [tag]: crate::ops::constant::Sum::tag
+    pub const BREAK_TAG: usize = 1;
+
     /// Build the output TypeRow of the child graph of a TailLoop node.
     pub(crate) fn body_output_row(&self) -> TypeRow {
         let sum_type = Type::new_sum([self.just_inputs.clone(), self.just_outputs.clone()]);


### PR DESCRIPTION
It doesn't seem obvious to me which way round these should be, so add constants, and use for the "definitive" `make_break` and `make_continue`.

No change to python as this doesn't even have `make_break` or `make_continue` ATM.