### PR TITLE
feat!: Allow static inputs to extension operations

### DIFF
--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -672,7 +672,7 @@ pub trait Dataflow: Container {
             }
         };
         let op: OpType = ops::Call::try_new(type_scheme, type_args, exts)?.into();
-        let const_in_port = op.static_input_port().unwrap();
+        let const_in_port = op.static_input_ports()[0];
         let op_id = self.add_dataflow_op(op, input_wires)?;
         let src_port = self.hugr_mut().num_outputs(function.node()) - 1;
 

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -151,7 +151,7 @@ impl<'a> Context<'a> {
     /// Get the node that declares or defines the function associated with the given
     /// node via the static input. Returns `None` if the node is not connected to a function.
     fn connected_function(&self, node: Node) -> Option<Node> {
-        let func_node = self.hugr.static_source(node)?;
+        let func_node = *self.hugr.static_sources(node).first()?;
 
         match self.hugr.get_optype(func_node) {
             OpType::FuncDecl(_) => Some(func_node),

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -417,7 +417,7 @@ impl<'a> Context<'a> {
         use std::collections::hash_map::Entry;
 
         let poly_func_type = match opdef.signature_func() {
-            SignatureFunc::PolyFuncType(poly_func_type) => poly_func_type,
+            SignatureFunc::PolyFuncType(op_def_sig) => op_def_sig.poly_func_type(),
             _ => return self.make_named_global_ref(opdef.extension(), opdef.name()),
         };
 

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -22,8 +22,8 @@ use crate::types::{Signature, TypeNameRef};
 
 mod op_def;
 pub use op_def::{
-    CustomSignatureFunc, CustomValidator, LowerFunc, OpDef, SignatureFromArgs, SignatureFunc,
-    ValidateJustArgs, ValidateTypeArgs,
+    CustomSignatureFunc, CustomValidator, ExtOpSignature, LowerFunc, OpDef, SignatureFromArgs,
+    SignatureFunc, ValidateJustArgs, ValidateTypeArgs,
 };
 mod type_def;
 pub use type_def::{TypeDef, TypeDefBound};

--- a/hugr-core/src/extension/declarative/signature.rs
+++ b/hugr-core/src/extension/declarative/signature.rs
@@ -14,7 +14,7 @@ use smol_str::SmolStr;
 use crate::extension::prelude::PRELUDE_ID;
 use crate::extension::{ExtensionSet, SignatureFunc, TypeDef};
 use crate::types::type_param::TypeParam;
-use crate::types::{CustomType, FuncValueType, PolyFuncTypeRV, Type, TypeRowRV};
+use crate::types::{CustomType, FuncValueType, OpDefSignature, Type, TypeRowRV};
 use crate::Extension;
 
 use super::{DeclarationContext, ExtensionDeclarationError};
@@ -56,7 +56,7 @@ impl SignatureDeclaration {
             extension_reqs: self.extensions.clone(),
         };
 
-        let poly_func = PolyFuncTypeRV::new(op_params, body);
+        let poly_func = OpDefSignature::new(op_params, body);
         Ok(poly_func.into())
     }
 }

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -262,13 +262,12 @@ impl SignatureFunc {
 }
 
 /// Instantiated [OpDef] signature.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(Arbitrary), proptest(params = "RecursionDepth"))]
 pub struct ExtOpSignature {
-    #[serde(flatten)]
+    // #[serde(flatten)]
     /// The dataflow function type of the signature.
     pub func_type: Signature,
-    #[serde(default, skip_serializing_if = "TypeRow::is_empty")]
     /// The static inputs of the signature.
     pub static_inputs: TypeRow,
 }
@@ -881,7 +880,8 @@ pub(super) mod test {
         ));
         let [inq] = dfg.input_wires_arr();
         let ext_op_node = dfg.add_dataflow_op_with_static(ext_op, vec![inq], [cnst.wire()])?;
-        dfg.finish_hugr_with_outputs(ext_op_node.outputs(), &reg)?;
+        let h = dfg.finish_hugr_with_outputs(ext_op_node.outputs(), &reg)?;
+        println!("{}", serde_json::to_string_pretty(&h).unwrap());
         Ok(())
     }
 

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -145,7 +145,7 @@ impl CustomValidator {
 pub enum SignatureFunc {
     /// An explicit polymorphic function type.
     PolyFuncType(OpDefSignature),
-    /// A polymorphic function type (like [Self::PolyFuncType] but also with a custom binary for validating type arguments.
+    /// A polymorphic function type (like [Self::PolyFuncType]) but also with a custom binary for validating type arguments.
     CustomValidator(CustomValidator),
     /// Serialized declaration specified a custom validate binary but it was not provided.
     MissingValidateFunc(OpDefSignature),

--- a/hugr-core/src/extension/op_def/serialize_signature_func.rs
+++ b/hugr-core/src/extension/op_def/serialize_signature_func.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use super::{CustomValidator, PolyFuncTypeRV, SignatureFunc};
+use super::{CustomValidator, OpDefSignature, SignatureFunc};
 #[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug, Clone)]
 struct SerSignatureFunc {
     /// If the type scheme is available explicitly, store it.
-    signature: Option<PolyFuncTypeRV>,
+    signature: Option<OpDefSignature>,
     /// Whether an associated binary function is expected.
     /// If `signature` is `None`, a true value here indicates a custom compute function.
     /// If `signature` is not `None`, a true value here indicates a custom validation function.
@@ -97,7 +97,7 @@ mod test {
             _arg_values: &[TypeArg],
             _def: &'o crate::extension::op_def::OpDef,
             _extension_registry: &crate::extension::ExtensionRegistry,
-        ) -> Result<crate::types::PolyFuncTypeRV, crate::extension::SignatureError> {
+        ) -> Result<crate::types::OpDefSignature, crate::extension::SignatureError> {
             Ok(Default::default())
         }
 
@@ -146,7 +146,7 @@ mod test {
         let mut deser = SignatureFunc::try_from(ser.clone()).unwrap();
         assert_matches!(&deser,
             SignatureFunc::MissingValidateFunc(poly_func) => {
-                assert_eq!(poly_func, &PolyFuncTypeRV::from(sig.clone()));
+                assert_eq!(poly_func, &OpDefSignature::from(sig.clone()));
             }
         );
 

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -15,7 +15,7 @@ use crate::ops::OpName;
 use crate::ops::{NamedOp, Value};
 use crate::types::type_param::{TypeArg, TypeParam};
 use crate::types::{
-    CustomType, FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature, SumType, Type, TypeBound,
+    CustomType, FuncValueType, OpDefSignature, PolyFuncType, Signature, SumType, Type, TypeBound,
     TypeName, TypeRV, TypeRow, TypeRowRV,
 };
 use crate::utils::sorted_consts;
@@ -87,7 +87,7 @@ lazy_static! {
         .add_op(
             PANIC_OP_ID,
             "Panic with input error".to_string(),
-            PolyFuncTypeRV::new(
+            OpDefSignature::new(
                 [TypeParam::new_list(TypeBound::Any), TypeParam::new_list(TypeBound::Any)],
                 FuncValueType::new(
                     vec![TypeRV::new_extension(ERROR_CUSTOM_TYPE), TypeRV::new_row_var_use(0, TypeBound::Any)],
@@ -502,10 +502,10 @@ impl MakeOpDef for TupleOpDef {
         let param = TypeParam::new_list(TypeBound::Any);
         match self {
             TupleOpDef::MakeTuple => {
-                PolyFuncTypeRV::new([param], FuncValueType::new(rv, tuple_type))
+                OpDefSignature::new([param], FuncValueType::new(rv, tuple_type))
             }
             TupleOpDef::UnpackTuple => {
-                PolyFuncTypeRV::new([param], FuncValueType::new(tuple_type, rv))
+                OpDefSignature::new([param], FuncValueType::new(tuple_type, rv))
             }
         }
         .into()
@@ -784,7 +784,7 @@ impl std::str::FromStr for LiftDef {
 
 impl MakeOpDef for LiftDef {
     fn signature(&self) -> SignatureFunc {
-        PolyFuncTypeRV::new(
+        OpDefSignature::new(
             vec![TypeParam::Extensions, TypeParam::new_list(TypeBound::Any)],
             FuncValueType::new_endo(TypeRV::new_row_var_use(1, TypeBound::Any))
                 .with_extension_delta(ExtensionSet::type_var(0)),

--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -184,9 +184,8 @@ impl TryFrom<&Hugr> for SerHugrLatest {
             let value_count = op.value_port_count(dir);
             let is_value_port = offset < value_count;
             let static_len = op.static_ports(dir).len();
-            let is_static_input = offset < (value_count + static_len);
-            // let is_static_input = op.static_port(dir).map_or(false, |p| p.index() == offset);
-            let offset = (is_value_port || is_static_input).then_some(offset as u16);
+            let value_or_static = offset < (value_count + static_len);
+            let offset = (is_value_port || value_or_static).then_some(offset as u16);
             (node_rekey[&node], offset)
         };
 

--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -181,8 +181,11 @@ impl TryFrom<&Hugr> for SerHugrLatest {
 
         let find_offset = |node: Node, offset: usize, dir: Direction, hugr: &Hugr| {
             let op = hugr.get_optype(node);
-            let is_value_port = offset < op.value_port_count(dir);
-            let is_static_input = op.static_port(dir).map_or(false, |p| p.index() == offset);
+            let value_count = op.value_port_count(dir);
+            let is_value_port = offset < value_count;
+            let static_len = op.static_ports(dir).len();
+            let is_static_input = offset < (value_count + static_len);
+            // let is_static_input = op.static_port(dir).map_or(false, |p| p.index() == offset);
             let offset = (is_value_port || is_static_input).then_some(offset as u16);
             (node_rekey[&node], offset)
         };

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -22,7 +22,7 @@ use crate::std_extensions::logic::LogicOp;
 use crate::std_extensions::logic::{self};
 use crate::types::type_param::{TypeArg, TypeArgError};
 use crate::types::{
-    CustomType, FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature, Type, TypeBound, TypeRV,
+    CustomType, FuncValueType, OpDefSignature, PolyFuncType, Signature, Type, TypeBound, TypeRV,
     TypeRow,
 };
 use crate::{
@@ -594,14 +594,14 @@ pub(crate) fn extension_with_eval_parallel() -> Extension {
     let inputs = TypeRV::new_row_var_use(0, TypeBound::Any);
     let outputs = TypeRV::new_row_var_use(1, TypeBound::Any);
     let evaled_fn = TypeRV::new_function(FuncValueType::new(inputs.clone(), outputs.clone()));
-    let pf = PolyFuncTypeRV::new(
+    let pf = OpDefSignature::new(
         [rowp.clone(), rowp.clone()],
         FuncValueType::new(vec![evaled_fn, inputs], outputs),
     );
     e.add_op("eval".into(), "".into(), pf).unwrap();
 
     let rv = |idx| TypeRV::new_row_var_use(idx, TypeBound::Any);
-    let pf = PolyFuncTypeRV::new(
+    let pf = OpDefSignature::new(
         [rowp.clone(), rowp.clone(), rowp.clone(), rowp.clone()],
         Signature::new(
             vec![
@@ -709,7 +709,7 @@ fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
     e.add_op(
         "eval".into(),
         "".into(),
-        PolyFuncTypeRV::new(
+        OpDefSignature::new(
             params.clone(),
             Signature::new(
                 vec![evaled_fn, Type::new_var_use(0, TypeBound::Any)],

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -322,7 +322,7 @@ fn test_local_const() {
 
     h.connect(cst, 0, lcst, 0);
     h.connect(lcst, 0, and, 1);
-    assert_eq!(h.static_source(lcst), Some(cst));
+    assert_eq!(h.static_sources(lcst), vec![cst]);
     // There is no edge from Input to LoadConstant, but that's OK:
     h.update_validate(&EMPTY_REG).unwrap();
 }

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -416,11 +416,13 @@ pub trait HugrView: HugrInternals {
             .finish()
     }
 
-    /// If a node has a static input, return the source node.
-    fn static_source(&self, node: Node) -> Option<Node> {
-        self.linked_outputs(node, self.get_optype(node).static_input_port()?)
-            .next()
-            .map(|(n, _)| n)
+    /// If a node has static inputs, return the source nodes.
+    fn static_sources(&self, node: Node) -> Vec<Node> {
+        self.get_optype(node)
+            .static_input_ports()
+            .into_iter()
+            .filter_map(|port| self.linked_outputs(node, port).next().map(|(n, _)| n))
+            .collect()
     }
 
     /// If a node has a static output, return the targets.

--- a/hugr-core/src/hugr/views/tests.rs
+++ b/hugr-core/src/hugr/views/tests.rs
@@ -160,7 +160,7 @@ fn static_targets() {
 
     let h = dfg.finish_prelude_hugr_with_outputs([load]).unwrap();
 
-    assert_eq!(h.static_source(load.node()), Some(c.node()));
+    assert_eq!(h.static_sources(load.node()), vec![c.node()]);
 
     assert_eq!(
         &h.static_targets(c.node()).unwrap().collect_vec()[..],

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -500,6 +500,7 @@ impl<'a> Context<'a> {
                     String::default(),
                     args,
                     signature,
+                    vec![],
                 ));
 
                 let node = self.make_node(node_id, optype, parent)?;

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -500,7 +500,6 @@ impl<'a> Context<'a> {
                     String::default(),
                     args,
                     signature,
-                    vec![],
                 ));
 
                 let node = self.make_node(node_id, optype, parent)?;

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -251,7 +251,12 @@ impl<'a> Context<'a> {
             let src = self.nodes[&src_id];
             let dst = self.nodes[&dst_id];
             let src_port = self.hugr.get_optype(src).static_output_port().unwrap();
-            let dst_port = self.hugr.get_optype(dst).static_input_port().unwrap();
+            let dst_port = *self
+                .hugr
+                .get_optype(dst)
+                .static_input_ports()
+                .first()
+                .unwrap();
             self.hugr.connect(src, src_port, dst, dst_port);
         }
 

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -12,6 +12,7 @@ use crate::{
         FuncDecl, FuncDefn, Input, LoadFunction, Module, OpType, OpaqueOp, Output, Tag, TailLoop,
         CFG, DFG,
     },
+    type_row,
     types::{
         type_param::TypeParam, type_row::TypeRowBase, CustomType, FuncTypeBase, MaybeRV, NoRV,
         PolyFuncType, PolyFuncTypeBase, RowVariable, Signature, Type, TypeArg, TypeBase, TypeBound,
@@ -500,6 +501,7 @@ impl<'a> Context<'a> {
                     String::default(),
                     args,
                     signature,
+                    type_row![],
                 ));
 
                 let node = self.make_node(node_id, optype, parent)?;

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -159,7 +159,14 @@ impl OpType {
     #[inline]
     pub fn static_port_kind(&self, dir: Direction) -> Option<EdgeKind> {
         match dir {
-            Direction::Incoming => self.static_input(),
+            Direction::Incoming => {
+                let mut v = self.static_input();
+                if v.is_empty() {
+                    None
+                } else {
+                   Some(v.remove(0))
+                }
+            }
             Direction::Outgoing => self.static_output(),
         }
     }
@@ -384,8 +391,8 @@ pub trait OpTrait {
     ///
     /// If not None, an extra input port of that kind will be present after the
     /// dataflow input ports and before any [`OpTrait::other_input`] ports.
-    fn static_input(&self) -> Option<EdgeKind> {
-        None
+    fn static_input(&self) -> Vec<EdgeKind> {
+        vec![]
     }
 
     /// The edge kind for a single constant output of the operation, not

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -159,7 +159,7 @@ impl OpType {
     #[inline]
     pub fn static_port_kind(&self, dir: Direction) -> Vec<EdgeKind> {
         match dir {
-            Direction::Incoming => self.static_input(),
+            Direction::Incoming => self.static_inputs(),
             Direction::Outgoing => self.static_output().map(|k| vec![k]).unwrap_or_default(),
         }
     }
@@ -385,12 +385,12 @@ pub trait OpTrait {
         None
     }
 
-    /// The edge kind for a single constant input of the operation, not
+    /// The edge kinds for static inputs to the operation, not
     /// described by the dataflow signature.
     ///
-    /// If not None, an extra input port of that kind will be present after the
-    /// dataflow input ports and before any [`OpTrait::other_input`] ports.
-    fn static_input(&self) -> Vec<EdgeKind> {
+    /// If not empty, extra input ports of those kinds will be present after the
+    /// dataflow input ports and before any [`DataflowOpTrait::other_input`] ports.
+    fn static_inputs(&self) -> Vec<EdgeKind> {
         vec![]
     }
 

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -111,6 +111,11 @@ impl ExtensionOp {
             signature: self.signature.clone(),
         }
     }
+
+    /// Returns the [`ExtOpSignature`] of this [`ExtensionOp`].
+    pub fn ext_op_signature(&self) -> &ExtOpSignature {
+        &self.signature
+    }
 }
 
 impl From<ExtensionOp> for OpaqueOp {

--- a/hugr-core/src/ops/dataflow.rs
+++ b/hugr-core/src/ops/dataflow.rs
@@ -40,13 +40,13 @@ pub trait DataflowOpTrait {
         Some(EdgeKind::StateOrder)
     }
 
-    /// The edge kind for a single constant input of the operation, not
+    /// The edge kinds for static inputs to the operation, not
     /// described by the dataflow signature.
     ///
-    /// If not None, an extra input port of that kind will be present after the
+    /// If not empty, extra input ports of those kinds will be present after the
     /// dataflow input ports and before any [`DataflowOpTrait::other_input`] ports.
     #[inline]
-    fn static_input(&self) -> Vec<EdgeKind> {
+    fn static_inputs(&self) -> Vec<EdgeKind> {
         vec![]
     }
 }
@@ -148,8 +148,8 @@ impl<T: DataflowOpTrait> OpTrait for T {
         DataflowOpTrait::other_output(self)
     }
 
-    fn static_input(&self) -> Vec<EdgeKind> {
-        DataflowOpTrait::static_input(self)
+    fn static_inputs(&self) -> Vec<EdgeKind> {
+        DataflowOpTrait::static_inputs(self)
     }
 }
 impl<T: DataflowOpTrait> StaticTag for T {
@@ -184,7 +184,7 @@ impl DataflowOpTrait for Call {
         self.instantiation.clone()
     }
 
-    fn static_input(&self) -> Vec<EdgeKind> {
+    fn static_inputs(&self) -> Vec<EdgeKind> {
         vec![EdgeKind::Function(self.called_function_type().clone())]
     }
 }
@@ -300,7 +300,7 @@ impl DataflowOpTrait for LoadConstant {
         Signature::new(TypeRow::new(), vec![self.datatype.clone()])
     }
 
-    fn static_input(&self) -> Vec<EdgeKind> {
+    fn static_inputs(&self) -> Vec<EdgeKind> {
         vec![EdgeKind::Const(self.constant_type().clone())]
     }
 }
@@ -355,7 +355,7 @@ impl DataflowOpTrait for LoadFunction {
         self.signature.clone()
     }
 
-    fn static_input(&self) -> Vec<EdgeKind> {
+    fn static_inputs(&self) -> Vec<EdgeKind> {
         vec![EdgeKind::Function(self.func_sig.clone())]
     }
 }

--- a/hugr-core/src/ops/dataflow.rs
+++ b/hugr-core/src/ops/dataflow.rs
@@ -46,8 +46,8 @@ pub trait DataflowOpTrait {
     /// If not None, an extra input port of that kind will be present after the
     /// dataflow input ports and before any [`DataflowOpTrait::other_input`] ports.
     #[inline]
-    fn static_input(&self) -> Option<EdgeKind> {
-        None
+    fn static_input(&self) -> Vec<EdgeKind> {
+        vec![]
     }
 }
 
@@ -148,7 +148,7 @@ impl<T: DataflowOpTrait> OpTrait for T {
         DataflowOpTrait::other_output(self)
     }
 
-    fn static_input(&self) -> Option<EdgeKind> {
+    fn static_input(&self) ->Vec<EdgeKind> {
         DataflowOpTrait::static_input(self)
     }
 }
@@ -184,8 +184,8 @@ impl DataflowOpTrait for Call {
         self.instantiation.clone()
     }
 
-    fn static_input(&self) -> Option<EdgeKind> {
-        Some(EdgeKind::Function(self.called_function_type().clone()))
+    fn static_input(&self) -> Vec<EdgeKind> {
+        vec![EdgeKind::Function(self.called_function_type().clone())]
     }
 }
 impl Call {
@@ -300,8 +300,8 @@ impl DataflowOpTrait for LoadConstant {
         Signature::new(TypeRow::new(), vec![self.datatype.clone()])
     }
 
-    fn static_input(&self) -> Option<EdgeKind> {
-        Some(EdgeKind::Const(self.constant_type().clone()))
+    fn static_input(&self) -> Vec<EdgeKind> {
+        vec![EdgeKind::Const(self.constant_type().clone())]
     }
 }
 impl LoadConstant {
@@ -355,8 +355,8 @@ impl DataflowOpTrait for LoadFunction {
         self.signature.clone()
     }
 
-    fn static_input(&self) -> Option<EdgeKind> {
-        Some(EdgeKind::Function(self.func_sig.clone()))
+    fn static_input(&self) -> Vec<EdgeKind> {
+        vec![EdgeKind::Function(self.func_sig.clone())]
     }
 }
 impl LoadFunction {

--- a/hugr-core/src/ops/dataflow.rs
+++ b/hugr-core/src/ops/dataflow.rs
@@ -148,7 +148,7 @@ impl<T: DataflowOpTrait> OpTrait for T {
         DataflowOpTrait::other_output(self)
     }
 
-    fn static_input(&self) ->Vec<EdgeKind> {
+    fn static_input(&self) -> Vec<EdgeKind> {
         DataflowOpTrait::static_input(self)
     }
 }
@@ -215,7 +215,7 @@ impl Call {
 
     /// The IncomingPort which links to the function being called.
     ///
-    /// This matches [`OpType::static_input_port`].
+    /// This matches [`OpType::static_input_ports`].
     ///
     /// ```
     /// # use hugr::ops::dataflow::Call;
@@ -226,10 +226,10 @@ impl Call {
     /// let signature = Signature::new(vec![QB_T, QB_T], vec![QB_T, QB_T]);
     /// let call = Call::try_new(signature.into(), &[], &PRELUDE_REGISTRY).unwrap();
     /// let op = OpType::Call(call.clone());
-    /// assert_eq!(op.static_input_port(), Some(call.called_function_port()));
+    /// assert_eq!(op.static_input_ports(), vec![call.called_function_port()]);
     /// ```
     ///
-    /// [`OpType::static_input_port`]: crate::ops::OpType::static_input_port
+    /// [`OpType::static_input_ports`]: crate::ops::OpType::static_input_ports
     #[inline]
     pub fn called_function_port(&self) -> IncomingPort {
         self.instantiation.input_count().into()
@@ -313,7 +313,7 @@ impl LoadConstant {
 
     /// The IncomingPort which links to the loaded constant.
     ///
-    /// This matches [`OpType::static_input_port`].
+    /// This matches [`OpType::static_input_ports`].
     ///
     /// ```
     /// # use hugr::ops::dataflow::LoadConstant;
@@ -322,10 +322,10 @@ impl LoadConstant {
     /// let datatype = Type::UNIT;
     /// let load_constant = LoadConstant { datatype };
     /// let op = OpType::LoadConstant(load_constant.clone());
-    /// assert_eq!(op.static_input_port(), Some(load_constant.constant_port()));
+    /// assert_eq!(op.static_input_ports(), vec![load_constant.constant_port()]);
     /// ```
     ///
-    /// [`OpType::static_input_port`]: crate::ops::OpType::static_input_port
+    /// [`OpType::static_input_ports`]: crate::ops::OpType::static_input_ports
     #[inline]
     pub fn constant_port(&self) -> IncomingPort {
         0.into()
@@ -387,9 +387,9 @@ impl LoadFunction {
 
     /// The IncomingPort which links to the loaded function.
     ///
-    /// This matches [`OpType::static_input_port`].
+    /// This matches [`OpType::static_input_ports`].
     ///
-    /// [`OpType::static_input_port`]: crate::ops::OpType::static_input_port
+    /// [`OpType::static_input_ports`]: crate::ops::OpType::static_input_ports
     #[inline]
     pub fn function_port(&self) -> IncomingPort {
         0.into()

--- a/hugr-core/src/ops/dataflow.rs
+++ b/hugr-core/src/ops/dataflow.rs
@@ -5,7 +5,7 @@ use super::{impl_op_name, OpTag, OpTrait};
 use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
 use crate::ops::StaticTag;
 use crate::types::{EdgeKind, PolyFuncType, Signature, Type, TypeArg, TypeRow};
-use crate::IncomingPort;
+use crate::{Direction, IncomingPort};
 
 #[cfg(test)]
 use ::proptest_derive::Arbitrary;
@@ -48,6 +48,15 @@ pub trait DataflowOpTrait {
     #[inline]
     fn static_inputs(&self) -> Vec<EdgeKind> {
         vec![]
+    }
+
+    /// The number of static input ports in the given direction.
+    #[inline]
+    fn static_port_count(&self, dir: Direction) -> usize {
+        match dir {
+            Direction::Incoming => self.static_inputs().len(),
+            Direction::Outgoing => 0,
+        }
     }
 }
 
@@ -150,6 +159,10 @@ impl<T: DataflowOpTrait> OpTrait for T {
 
     fn static_inputs(&self) -> Vec<EdgeKind> {
         DataflowOpTrait::static_inputs(self)
+    }
+
+    fn static_port_count(&self, dir: Direction) -> usize {
+        DataflowOpTrait::static_port_count(self, dir)
     }
 }
 impl<T: DataflowOpTrait> StaticTag for T {

--- a/hugr-core/src/ops/handle.rs
+++ b/hugr-core/src/ops/handle.rs
@@ -1,6 +1,6 @@
 //! Handles to nodes in HUGR.
 use crate::types::{Type, TypeBound};
-use crate::Node;
+use crate::{Node, OutgoingPort, Wire};
 
 use derive_more::From as DerFrom;
 use smol_str::SmolStr;
@@ -100,6 +100,12 @@ impl<const DEF: bool> AliasID<DEF> {
 #[derive(DerFrom, Debug, Clone, PartialEq, Eq)]
 /// Handle to a [Const](crate::ops::OpType::Const) node.
 pub struct ConstID(Node);
+impl ConstID {
+    /// Retrieve the outgoing wire for the constant node.
+    pub fn wire(&self) -> Wire {
+        Wire::new(self.node(), OutgoingPort::from(0))
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, DerFrom, Debug)]
 /// Handle to a [DataflowBlock](crate::ops::DataflowBlock) or [Exit](crate::ops::ExitBlock) node.

--- a/hugr-core/src/ops/tag.rs
+++ b/hugr-core/src/ops/tag.rs
@@ -46,8 +46,6 @@ pub enum OpTag {
     Input,
     /// A dataflow output.
     Output,
-    /// Dataflow node that has a static input
-    StaticInput,
     /// Node that has a static output
     StaticOutput,
     /// A function call.
@@ -127,11 +125,10 @@ impl OpTag {
             ],
             OpTag::TailLoop => &[OpTag::DataflowChild, OpTag::DataflowParent],
             OpTag::Conditional => &[OpTag::DataflowChild],
-            OpTag::StaticInput => &[OpTag::Any],
             OpTag::StaticOutput => &[OpTag::Any],
-            OpTag::FnCall => &[OpTag::StaticInput, OpTag::DataflowChild],
-            OpTag::LoadConst => &[OpTag::StaticInput, OpTag::DataflowChild],
-            OpTag::LoadFunc => &[OpTag::StaticInput, OpTag::DataflowChild],
+            OpTag::FnCall => &[OpTag::DataflowChild],
+            OpTag::LoadConst => &[OpTag::DataflowChild],
+            OpTag::LoadFunc => &[OpTag::DataflowChild],
             OpTag::Leaf => &[OpTag::DataflowChild],
             OpTag::DataflowParent => &[OpTag::Any],
         }
@@ -159,7 +156,6 @@ impl OpTag {
             OpTag::Cfg => "Nested control-flow operation",
             OpTag::TailLoop => "Tail-recursive loop",
             OpTag::Conditional => "Conditional operation",
-            OpTag::StaticInput => "Node with static input (LoadConst, LoadFunc, or FnCall)",
             OpTag::StaticOutput => "Node with static output (FuncDefn, FuncDecl, Const)",
             OpTag::FnCall => "Function call",
             OpTag::LoadConst => "Constant load operation",

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -11,7 +11,7 @@ use crate::extension::{
 use crate::ops::custom::ExtensionOp;
 use crate::ops::{NamedOp, OpName};
 use crate::type_row;
-use crate::types::{FuncValueType, PolyFuncTypeRV, TypeRowRV};
+use crate::types::{FuncValueType, OpDefSignature, TypeRowRV};
 use crate::utils::collect_array;
 
 use crate::{
@@ -227,20 +227,20 @@ pub(in crate::std_extensions::arithmetic) fn int_polytype(
     n_vars: usize,
     input: impl Into<TypeRowRV>,
     output: impl Into<TypeRowRV>,
-) -> PolyFuncTypeRV {
-    PolyFuncTypeRV::new(
+) -> OpDefSignature {
+    OpDefSignature::new(
         vec![LOG_WIDTH_TYPE_PARAM; n_vars],
         FuncValueType::new(input, output),
     )
 }
 
-fn ibinop_sig() -> PolyFuncTypeRV {
+fn ibinop_sig() -> OpDefSignature {
     let int_type_var = int_tv(0);
 
     int_polytype(1, vec![int_type_var.clone(); 2], vec![int_type_var])
 }
 
-fn iunop_sig() -> PolyFuncTypeRV {
+fn iunop_sig() -> OpDefSignature {
     let int_type_var = int_tv(0);
     int_polytype(1, vec![int_type_var.clone()], vec![int_type_var])
 }

--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -26,7 +26,7 @@ use crate::{
     ops::{custom::ExtensionOp, NamedOp},
     types::{
         type_param::{TypeArg, TypeParam},
-        CustomCheckFailure, CustomType, FuncValueType, PolyFuncTypeRV, Type, TypeBound,
+        CustomCheckFailure, CustomType, FuncValueType, OpDefSignature, Type, TypeBound,
     },
     Extension,
 };
@@ -187,8 +187,8 @@ impl ListOp {
         self,
         input: impl Into<TypeRowRV>,
         output: impl Into<TypeRowRV>,
-    ) -> PolyFuncTypeRV {
-        PolyFuncTypeRV::new(vec![Self::TP], FuncValueType::new(input, output))
+    ) -> OpDefSignature {
+        OpDefSignature::new(vec![Self::TP], FuncValueType::new(input, output))
     }
 
     /// Returns the type of a generic list, associated with the element type parameter at index `idx`.

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -16,7 +16,7 @@ use crate::types::type_param::check_type_arg;
 use crate::utils::display_list_with_separator;
 pub use check::SumTypeError;
 pub use custom::CustomType;
-pub use poly_func::{PolyFuncType, PolyFuncTypeRV};
+pub use poly_func::{OpDefSignature, PolyFuncType};
 pub use signature::{FuncValueType, Signature};
 use smol_str::SmolStr;
 pub use type_param::TypeArg;

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -102,8 +102,8 @@ impl OpDefSignature {
     /// # Arguments
     ///
     /// * `static_inputs` - A `TypeRow` representing the static input types.
-    pub fn with_static_inputs(mut self, static_inputs: TypeRow) -> Self {
-        self.static_inputs = static_inputs;
+    pub fn with_static_inputs(mut self, static_inputs: impl Into<TypeRow>) -> Self {
+        self.static_inputs = static_inputs.into();
         self
     }
 

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -57,23 +57,11 @@ pub type PolyFuncType = PolyFuncTypeBase<NoRV>;
 /// It may also have a row of static inputs.
 ///
 /// [OpDef]: crate::extension::OpDef
-#[derive(
-    Clone,
-    PartialEq,
-    Debug,
-    Default,
-    Eq,
-    Hash,
-    derive_more::Display,
-    serde::Serialize,
-    serde::Deserialize,
-)]
+#[derive(Clone, PartialEq, Debug, Default, Eq, Hash, derive_more::Display)]
 #[cfg_attr(test, derive(Arbitrary), proptest(params = "RecursionDepth"))]
 #[display("{}{}{}", self.display_params(), self.static_inputs, self.body())]
 pub struct OpDefSignature {
-    #[serde(flatten)]
     signature: PolyFuncTypeBase<RowVariable>,
-    #[serde(default, skip_serializing_if = "TypeRow::is_empty")]
     static_inputs: TypeRow,
 }
 

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -45,11 +45,11 @@ impl UpperBound {
     }
 }
 
-/// A *kind* of [TypeArg]. Thus, a parameter declared by a [PolyFuncType] or [PolyFuncTypeRV],
+/// A *kind* of [TypeArg]. Thus, a parameter declared by a [PolyFuncType] or [OpDefSignature],
 /// specifying a value that must be provided statically in order to instantiate it.
 ///
 /// [PolyFuncType]: super::PolyFuncType
-/// [PolyFuncTypeRV]: super::PolyFuncTypeRV
+/// [OpDefSignature]: super::OpDefSignature
 #[derive(
     Clone, Debug, PartialEq, Eq, Hash, derive_more::Display, serde::Deserialize, serde::Serialize,
 )]

--- a/hugr-core/src/types/type_row.rs
+++ b/hugr-core/src/types/type_row.rs
@@ -102,6 +102,8 @@ impl<RV: MaybeRV> TypeRowBase<RV> {
         self.iter().try_for_each(|t| t.validate(exts, var_decls))
     }
 }
+/// Empty row of types.
+pub static EMPTY_ROW: TypeRow = TypeRow::new();
 
 impl TypeRow {
     delegate! {

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -113,17 +113,17 @@ pub(crate) mod test_quantum_extension {
         ops::ExtensionOp,
         std_extensions::arithmetic::float_types,
         type_row,
-        types::{PolyFuncTypeRV, Signature},
+        types::{OpDefSignature, Signature},
         Extension,
     };
 
     use lazy_static::lazy_static;
 
-    fn one_qb_func() -> PolyFuncTypeRV {
+    fn one_qb_func() -> OpDefSignature {
         FuncValueType::new_endo(QB_T).into()
     }
 
-    fn two_qb_func() -> PolyFuncTypeRV {
+    fn two_qb_func() -> OpDefSignature {
         FuncValueType::new_endo(type_row![QB_T, QB_T]).into()
     }
     /// The extension identifier.

--- a/hugr-py/src/hugr/_serialization/extension.py
+++ b/hugr-py/src/hugr/_serialization/extension.py
@@ -15,6 +15,7 @@ from .tys import (
     ExtensionId,
     ExtensionSet,
     PolyFuncType,
+    Type,
     TypeBound,
     TypeParam,
 )
@@ -98,6 +99,7 @@ class OpDef(ConfiguredBaseModel, populate_by_name=True):
     misc: dict[str, Any] | None = None
     signature: PolyFuncType | None = None
     binary: bool = False
+    static_inputs: list[Type] = pd.Field(default_factory=list)
     lower_funcs: list[FixedHugr] = pd.Field(default_factory=list)
 
     def deserialize(self, extension: ext.Extension) -> ext.OpDef:
@@ -108,7 +110,8 @@ class OpDef(ConfiguredBaseModel, populate_by_name=True):
                 misc=self.misc or {},
                 signature=ext.OpDefSig(
                     self.signature.deserialize() if self.signature else None,
-                    self.binary,
+                    static_inputs=[t.deserialize() for t in self.static_inputs],
+                    binary=self.binary,
                 ),
                 lower_funcs=[f.deserialize() for f in self.lower_funcs],
             )

--- a/hugr-py/src/hugr/_serialization/ops.py
+++ b/hugr-py/src/hugr/_serialization/ops.py
@@ -512,6 +512,7 @@ class ExtensionOp(DataflowOp):
     signature: stys.FunctionType = Field(default_factory=stys.FunctionType.empty)
     description: str = ""
     args: list[stys.TypeArg] = Field(default_factory=list)
+    static_inputs: list[Type] = Field(default_factory=list)
 
     def insert_port_types(self, in_types: TypeRow, out_types: TypeRow) -> None:
         self.signature = stys.FunctionType(input=list(in_types), output=list(out_types))
@@ -525,6 +526,7 @@ class ExtensionOp(DataflowOp):
             op_name=self.name,
             signature=self.signature.deserialize(),
             args=deser_it(self.args),
+            static_inputs=deser_it(self.static_inputs),
         )
 
     model_config = ConfigDict(

--- a/hugr-py/src/hugr/build/tracked_dfg.py
+++ b/hugr-py/src/hugr/build/tracked_dfg.py
@@ -124,7 +124,13 @@ class TrackedDfg(Dfg):
             raise IndexError(msg)
         return tracked
 
-    def add(self, com: Command, *, metadata: dict[str, Any] | None = None) -> Node:
+    def add(
+        self,
+        com: Command,
+        *,
+        static_in: Iterable[Wire] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Node:
         """Add a command to the DFG.
 
         Overrides :meth:`Dfg.add <hugr.dfg.Dfg.add>` to allow Command inputs
@@ -139,6 +145,7 @@ class TrackedDfg(Dfg):
 
         Args:
             com: Command to append.
+            static_in: Any static input wires to the command.
             metadata: Metadata to attach to the function definition. Defaults to None.
 
         Returns:

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -164,12 +164,15 @@ class OpDefSig:
 
     #: The polymorphic function type of the operation (type scheme).
     poly_func: tys.PolyFuncType | None
+    #: Static input types of the operation.
+    static_inputs: tys.TypeRow
     #: If no static type scheme known, flag indicates a computation of the signature.
     binary: bool
 
     def __init__(
         self,
         poly_func: tys.PolyFuncType | tys.FunctionType | None,
+        static_inputs: tys.TypeRow | None = None,
         binary: bool = False,
     ) -> None:
         if poly_func is None and not binary:
@@ -182,6 +185,7 @@ class OpDefSig:
             poly_func = tys.PolyFuncType([], poly_func)
         self.poly_func = poly_func
         self.binary = binary
+        self.static_inputs = static_inputs or tys.TypeRow()
 
 
 @dataclass
@@ -209,6 +213,7 @@ class OpDef(ExtensionObject):
             if self.signature.poly_func
             else None,
             binary=self.signature.binary,
+            static_inputs=[t._to_serial_root() for t in self.signature.static_inputs],
             lower_funcs=[f._to_serial() for f in self.lower_funcs],
         )
 
@@ -413,7 +418,7 @@ class Extension:
         """
         if not isinstance(signature, OpDefSig):
             binary = signature is None
-            signature = OpDefSig(signature, binary)
+            signature = OpDefSig(signature, binary=binary)
 
         def _inner(cls: type[T]) -> type[T]:
             new_description = cls.__doc__ if description is None and cls.__doc__ else ""

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -313,6 +313,7 @@ class Custom(DataflowOp):
     description: str = ""
     extension: tys.ExtensionId = ""
     args: list[tys.TypeArg] = field(default_factory=list)
+    static_inputs: tys.TypeRow = field(default_factory=tys.TypeRow)
 
     def _to_serial(self, parent: Node) -> sops.ExtensionOp:
         return sops.ExtensionOp(
@@ -322,6 +323,7 @@ class Custom(DataflowOp):
             signature=self.signature._to_serial(),
             description=self.description,
             args=ser_it(self.args),
+            static_inputs=ser_it(self.static_inputs),
         )
 
     def outer_signature(self) -> tys.FunctionType:
@@ -378,12 +380,12 @@ class ExtOp(AsExtOp):
             sig = poly_func.body
         else:
             sig = self.signature
-
         return Custom(
             op_name=self._op_def.name,
             signature=sig,
             extension=ext.name if ext else "",
             args=self.args,
+            static_inputs=self._op_def.signature.static_inputs,
         )
 
     def _to_serial(self, parent: Node) -> sops.ExtensionOp:

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -43,17 +43,17 @@
 //!         },
 //!         ops::{ExtensionOp, OpName},
 //!         type_row,
-//!         types::{FuncValueType, PolyFuncTypeRV},
+//!         types::{FuncValueType, OpDefSignature},
 //!         Extension,
 //!     };
 //!
 //!     use lazy_static::lazy_static;
 //!
-//!     fn one_qb_func() -> PolyFuncTypeRV {
+//!     fn one_qb_func() -> OpDefSignature {
 //!         FuncValueType::new_endo(type_row![QB_T]).into()
 //!     }
 //!
-//!     fn two_qb_func() -> PolyFuncTypeRV {
+//!     fn two_qb_func() -> OpDefSignature {
 //!         FuncValueType::new_endo(type_row![QB_T, QB_T]).into()
 //!     }
 //!     /// The extension identifier.

--- a/specification/schema/hugr_schema_live.json
+++ b/specification/schema/hugr_schema_live.json
@@ -657,6 +657,13 @@
                     },
                     "title": "Args",
                     "type": "array"
+                },
+                "static_inputs": {
+                    "items": {
+                        "$ref": "#/$defs/Type"
+                    },
+                    "title": "Static Inputs",
+                    "type": "array"
                 }
             },
             "required": [
@@ -1133,6 +1140,13 @@
                     "default": false,
                     "title": "Binary",
                     "type": "boolean"
+                },
+                "static_inputs": {
+                    "items": {
+                        "$ref": "#/$defs/Type"
+                    },
+                    "title": "Static Inputs",
+                    "type": "array"
                 },
                 "lower_funcs": {
                     "items": {

--- a/specification/schema/hugr_schema_strict_live.json
+++ b/specification/schema/hugr_schema_strict_live.json
@@ -657,6 +657,13 @@
                     },
                     "title": "Args",
                     "type": "array"
+                },
+                "static_inputs": {
+                    "items": {
+                        "$ref": "#/$defs/Type"
+                    },
+                    "title": "Static Inputs",
+                    "type": "array"
                 }
             },
             "required": [
@@ -1133,6 +1140,13 @@
                     "default": false,
                     "title": "Binary",
                     "type": "boolean"
+                },
+                "static_inputs": {
+                    "items": {
+                        "$ref": "#/$defs/Type"
+                    },
+                    "title": "Static Inputs",
+                    "type": "array"
                 },
                 "lower_funcs": {
                     "items": {

--- a/specification/schema/testing_hugr_schema_live.json
+++ b/specification/schema/testing_hugr_schema_live.json
@@ -657,6 +657,13 @@
                     },
                     "title": "Args",
                     "type": "array"
+                },
+                "static_inputs": {
+                    "items": {
+                        "$ref": "#/$defs/Type"
+                    },
+                    "title": "Static Inputs",
+                    "type": "array"
                 }
             },
             "required": [
@@ -1133,6 +1140,13 @@
                     "default": false,
                     "title": "Binary",
                     "type": "boolean"
+                },
+                "static_inputs": {
+                    "items": {
+                        "$ref": "#/$defs/Type"
+                    },
+                    "title": "Static Inputs",
+                    "type": "array"
                 },
                 "lower_funcs": {
                     "items": {

--- a/specification/schema/testing_hugr_schema_strict_live.json
+++ b/specification/schema/testing_hugr_schema_strict_live.json
@@ -657,6 +657,13 @@
                     },
                     "title": "Args",
                     "type": "array"
+                },
+                "static_inputs": {
+                    "items": {
+                        "$ref": "#/$defs/Type"
+                    },
+                    "title": "Static Inputs",
+                    "type": "array"
                 }
             },
             "required": [
@@ -1133,6 +1140,13 @@
                     "default": false,
                     "title": "Binary",
                     "type": "boolean"
+                },
+                "static_inputs": {
+                    "items": {
+                        "$ref": "#/$defs/Type"
+                    },
+                    "title": "Static Inputs",
+                    "type": "array"
                 },
                 "lower_funcs": {
                     "items": {


### PR DESCRIPTION
Extension operations can now have some number of static inputs that come between their dataflow input ports and the state order input port.

This can be used for compile-time-known inputs to operations. 
I have attempted to keep the serialization backwards compatible.

OpDefs can either declare their static inputs as a row, or it can be calculated like the rest of the signature.


Closes #1594


BREAKING CHANGE: `OpType, OpTrait, DataflowOpTrait` methods which assumed one static input now support many. E.g. `static_input_port` -> `static_input_ports`. Returning a `Vec` rather than an `Option`. Operation definitions support static input type declarations, so a new type `OpDefSignature` has been introduced for this to hold the `PolyFuncTypeRV` and the static inputs. The cached signature of an ExtensionOp is also a new type `ExtOpSignature` that holds the dataflow `Signature` and the static inputs. `OpTag::StaticInput` removed because it doesn't actually narrow things down any more. 