### PR TITLE
chore: Fix unsoundness tests

### DIFF
--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -43,7 +43,7 @@ jobs:
   notify-slack:
     uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@main
     needs: miri
-    if: always() && needs.miri.result == 'failure'
+    if: always() && needs.miri.result == 'failure' && github.event_name == 'push'
     with:
       channel-id: 'C04SHCL4FKP'
       slack-message: |

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -402,6 +402,7 @@ mod test {
     #[case::dfg("dfg", simple_dfg_hugr(), false)]
     #[case::cfg("cfg", simple_cfg_hugr(), false)]
     #[case::unsupported_input("input", simple_input_node(), true)]
+    #[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
     fn hugr_to_package(#[case] test_name: &str, #[case] hugr: Hugr, #[case] errors: bool) {
         match (&Package::from_hugr(hugr), errors) {
             (Ok(package), false) => {

--- a/hugr-model/tests/text.rs
+++ b/hugr-model/tests/text.rs
@@ -7,6 +7,7 @@ fn roundtrip(source: &str) -> String {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
 pub fn test_declarative_extensions() {
     insta::assert_snapshot!(roundtrip(include_str!("fixtures/model-decl-exts.edn")))
 }

--- a/hugr-passes/src/nest_cfgs.rs
+++ b/hugr-passes/src/nest_cfgs.rs
@@ -191,7 +191,7 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash> EdgeDest<T> {
 fn all_edges<'a, T: Copy + Clone + PartialEq + Eq + Hash + 'a>(
     cfg: &'a impl CfgNodeMap<T>,
     n: T,
-) -> impl Iterator<Item = EdgeDest<T>> + '_ {
+) -> impl Iterator<Item = EdgeDest<T>> + 'a {
     let extra = if n == cfg.exit_node() {
         vec![cfg.entry_node()]
     } else {

--- a/justfile
+++ b/justfile
@@ -43,8 +43,8 @@ coverage language="[rust|python]": (_run_lang language \
     )
 
 # Run unsoundness checks using miri
-miri:
-    PROPTEST_DISABLE_FAILURE_PERSISTENCE=true MIRIFLAGS='-Zmiri-env-forward=PROPTEST_DISABLE_FAILURE_PERSISTENCE' cargo +nightly miri test
+miri *TEST_ARGS:
+    PROPTEST_DISABLE_FAILURE_PERSISTENCE=true MIRIFLAGS='-Zmiri-env-forward=PROPTEST_DISABLE_FAILURE_PERSISTENCE' cargo +nightly miri test {{TEST_ARGS}}
 
 # Update the HUGR schema.
 update-schema:


### PR DESCRIPTION
A test was using the filesystem to check insta snapshots. This is not supported by miri.

drive-by: Fix lint warning
drive-by: Don't send a slack notification when running the miri checks manually on an arbitrary commit.

CI run:
https://github.com/CQCL/hugr/actions/runs/11726988593