### PR TITLE
feat: Add `SiblingSubgraph::from_node`

### DIFF
--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -284,9 +284,19 @@ impl SiblingSubgraph {
     ///
     /// The subgraph signature will be given by signature of the node.
     pub fn from_node(node: Node, hugr: &impl HugrView) -> Self {
+        // TODO once https://github.com/CQCL/portgraph/issues/155
+        // is fixed we can just call try_from_nodes here.
+        // Until then, doing this saves a lot of work.
         let nodes = vec![node];
-        let inputs = hugr.all_linked_inputs(node).map(|x| vec![x]).collect_vec();
-        let outputs = hugr.all_linked_outputs(node).collect_vec();
+        let inputs = hugr
+            .node_inputs(node)
+            .filter_map(|p| hugr.is_linked(node, p).then(|| vec![(node, p)]))
+            .collect_vec();
+        let outputs = hugr
+            .node_outputs(node)
+            .filter_map(|p| hugr.is_linked(node, p).then_some((node, p)))
+            .collect_vec();
+
         Self {
             nodes,
             inputs,

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -220,15 +220,8 @@ impl SiblingSubgraph {
         nodes: impl Into<Vec<Node>>,
         hugr: &impl HugrView,
     ) -> Result<Self, InvalidSubgraph> {
-        let nodes = nodes.into();
-        match nodes.len() {
-            0 => Err(InvalidSubgraph::EmptySubgraph),
-            1 => Ok(Self::from_node(nodes[0], hugr)),
-            _ => {
-                let checker = TopoConvexChecker::new(hugr);
-                Self::try_from_nodes_with_checker(nodes, hugr, &checker)
-            }
-        }
+        let checker = TopoConvexChecker::new(hugr);
+        Self::try_from_nodes_with_checker(nodes, hugr, &checker)
     }
 
     /// Create a subgraph from a set of nodes.
@@ -290,7 +283,8 @@ impl SiblingSubgraph {
         let nodes = vec![node];
         let inputs = hugr
             .node_inputs(node)
-            .filter_map(|p| hugr.is_linked(node, p).then(|| vec![(node, p)]))
+            .filter(|&p| hugr.is_linked(node, p))
+            .map(|p| vec![(node, p)])
             .collect_vec();
         let outputs = hugr
             .node_outputs(node)


### PR DESCRIPTION
Complementary improvement to #1654.
Creating a k-node subgraph in an n-node graph should ideally be `O(k)`.
However, due to https://github.com/CQCL/portgraph/issues/155 this ends up being `O(n)`.

For `k=1`, this results in a linear cost overhead.
This PR adds a special case (written by @doug-q) that completely skips the unnecessary checks.

```
group                         before                                 from_node
-----                         ------                                 ---------
multinode_subgraph/10         1.01     17.7±0.26µs        ? ?/sec    1.00     17.5±0.23µs        ? ?/sec
multinode_subgraph/100        1.00   169.1±11.34µs        ? ?/sec    1.00    168.8±4.37µs        ? ?/sec
multinode_subgraph/1000       1.01      2.3±0.46ms        ? ?/sec    1.00      2.3±0.34ms        ? ?/sec
singleton_subgraph/10         12.26     3.0±0.06µs        ? ?/sec    1.00   245.6±21.24ns        ? ?/sec
singleton_subgraph/100        20.01     4.7±0.06µs        ? ?/sec    1.00    234.4±6.50ns        ? ?/sec
singleton_subgraph/1000       93.34    22.0±0.25µs        ? ?/sec    1.00    235.6±4.93ns        ? ?/sec
```