### PR TITLE
feat!: Replace GATs with `impl Iterator` returns (RPITIT) on `HugrView`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ portgraph = { version = "0.12.2" }
 insta = { version = "1.34.0" }
 bitvec = "1.0.1"
 cgmath = "0.18.0"
-context-iterators = "0.2.0"
 cool_asserts = "2.0.3"
 criterion = "0.5.1"
 delegate = "0.13.0"

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -47,7 +47,6 @@ bitvec = { workspace = true, features = ["serde"] }
 enum_dispatch = { workspace = true }
 lazy_static = { workspace = true }
 petgraph = { workspace = true }
-context-iterators = { workspace = true }
 serde_json = { workspace = true }
 delegate = { workspace = true }
 paste = { workspace = true }

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -436,6 +436,7 @@ impl OpDef {
     }
 
     /// Iterate over all miscellaneous data in the [OpDef].
+    #[allow(unused)] // Unused when no features are enabled
     pub(crate) fn iter_misc(&self) -> impl ExactSizeIterator<Item = (&str, &serde_json::Value)> {
         self.misc.iter().map(|(k, v)| (k.as_str(), v))
     }

--- a/hugr-core/src/hugr/rewrite/inline_dfg.rs
+++ b/hugr-core/src/hugr/rewrite/inline_dfg.rs
@@ -208,7 +208,7 @@ mod test {
 
         // Sanity checks
         assert_eq!(
-            outer.children(inner.node()).len(),
+            outer.children(inner.node()).count(),
             if nonlocal { 3 } else { 6 }
         ); // Input, Output, add; + const, load_const, lift
         assert_eq!(find_dfgs(&outer), vec![outer.root(), inner.node()]);
@@ -217,7 +217,7 @@ mod test {
             outer.get_parent(outer.get_parent(add).unwrap()),
             outer.get_parent(sub)
         );
-        assert_eq!(outer.nodes().len(), 11); // 6 above + inner DFG + outer (DFG + Input + Output + sub)
+        assert_eq!(outer.nodes().count(), 11); // 6 above + inner DFG + outer (DFG + Input + Output + sub)
         {
             // Check we can't inline the outer DFG
             let mut h = outer.clone();
@@ -230,7 +230,7 @@ mod test {
 
         outer.apply_rewrite(InlineDFG(*inner.handle()))?;
         outer.validate(&reg)?;
-        assert_eq!(outer.nodes().len(), 8);
+        assert_eq!(outer.nodes().count(), 8);
         assert_eq!(find_dfgs(&outer), vec![outer.root()]);
         let [_lift, add, sub] = extension_ops(&outer).try_into().unwrap();
         assert_eq!(outer.get_parent(add), Some(outer.root()));
@@ -265,8 +265,8 @@ mod test {
 
         let mut h = h.finish_hugr_with_outputs(cx.outputs(), &reg)?;
         assert_eq!(find_dfgs(&h), vec![h.root(), swap.node()]);
-        assert_eq!(h.nodes().len(), 8); // Dfg+I+O, H, CX, Dfg+I+O
-                                        // No permutation outside the swap DFG:
+        assert_eq!(h.nodes().count(), 8); // Dfg+I+O, H, CX, Dfg+I+O
+                                          // No permutation outside the swap DFG:
         assert_eq!(
             h.node_connections(p_h.node(), swap.node())
                 .collect::<Vec<_>>(),
@@ -292,7 +292,7 @@ mod test {
 
         h.apply_rewrite(InlineDFG(*swap.handle()))?;
         assert_eq!(find_dfgs(&h), vec![h.root()]);
-        assert_eq!(h.nodes().len(), 5); // Dfg+I+O
+        assert_eq!(h.nodes().count(), 5); // Dfg+I+O
         let mut ops = extension_ops(&h);
         ops.sort_by_key(|n| h.num_outputs(*n)); // Put H before CX
         let [h_gate, cx] = ops.try_into().unwrap();

--- a/hugr-core/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr-core/src/hugr/rewrite/outline_cfg.rs
@@ -453,8 +453,8 @@ mod test {
         // `add_hugr_with_wires` does not return an InsertionResult, so recover the nodes manually:
         let cfg = cfg.node();
         let exit_node = h.children(cfg).nth(1).unwrap();
-        let tail = h.input_neighbours(exit_node).exactly_one().unwrap();
-        let head = h.input_neighbours(tail).exactly_one().unwrap();
+        let tail = h.input_neighbours(exit_node).exactly_one().ok().unwrap();
+        let head = h.input_neighbours(tail).exactly_one().ok().unwrap();
         // Just sanity-check we have the correct nodes
         assert!(h.get_optype(exit_node).is_exit_block());
         assert_eq!(

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -10,8 +10,6 @@ pub mod sibling_subgraph;
 #[cfg(test)]
 mod tests;
 
-use std::iter::Map;
-
 pub use self::petgraph::PetgraphWrapper;
 use self::render::RenderConfig;
 pub use descendants::DescendantsGraph;
@@ -19,10 +17,9 @@ pub use root_checked::RootChecked;
 pub use sibling::SiblingGraph;
 pub use sibling_subgraph::SiblingSubgraph;
 
-use context_iterators::{ContextIterator, IntoContextIterator, MapWithCtx};
-use itertools::{Itertools, MapInto};
+use itertools::Itertools;
 use portgraph::render::{DotFormat, MermaidFormat};
-use portgraph::{multiportgraph, LinkView, PortView};
+use portgraph::{LinkView, PortView};
 
 use super::internal::HugrInternals;
 use super::{
@@ -40,36 +37,6 @@ use itertools::Either;
 /// A trait for inspecting HUGRs.
 /// For end users we intend this to be superseded by region-specific APIs.
 pub trait HugrView: HugrInternals {
-    /// An Iterator over the nodes in a Hugr(View)
-    type Nodes<'a>: Iterator<Item = Node>
-    where
-        Self: 'a;
-
-    /// An Iterator over (some or all) ports of a node
-    type NodePorts<'a>: Iterator<Item = Port>
-    where
-        Self: 'a;
-
-    /// An Iterator over the children of a node
-    type Children<'a>: Iterator<Item = Node>
-    where
-        Self: 'a;
-
-    /// An Iterator over (some or all) the nodes neighbouring a node
-    type Neighbours<'a>: Iterator<Item = Node>
-    where
-        Self: 'a;
-
-    /// Iterator over the children of a node
-    type PortLinks<'a>: Iterator<Item = (Node, Port)>
-    where
-        Self: 'a;
-
-    /// Iterator over the links between two nodes.
-    type NodeConnections<'a>: Iterator<Item = [Port; 2]>
-    where
-        Self: 'a;
-
     /// Return the root node of this view.
     #[inline]
     fn root(&self) -> Node {
@@ -147,16 +114,16 @@ pub trait HugrView: HugrInternals {
     fn edge_count(&self) -> usize;
 
     /// Iterates over the nodes in the port graph.
-    fn nodes(&self) -> Self::Nodes<'_>;
+    fn nodes(&self) -> impl Iterator<Item = Node> + Clone;
 
     /// Iterator over ports of node in a given direction.
-    fn node_ports(&self, node: Node, dir: Direction) -> Self::NodePorts<'_>;
+    fn node_ports(&self, node: Node, dir: Direction) -> impl Iterator<Item = Port> + Clone;
 
     /// Iterator over output ports of node.
     /// Like [`node_ports`][HugrView::node_ports]`(node, Direction::Outgoing)`
     /// but preserves knowledge that the ports are [OutgoingPort]s.
     #[inline]
-    fn node_outputs(&self, node: Node) -> OutgoingPorts<Self::NodePorts<'_>> {
+    fn node_outputs(&self, node: Node) -> impl Iterator<Item = OutgoingPort> + Clone {
         self.node_ports(node, Direction::Outgoing)
             .map(|p| p.as_outgoing().unwrap())
     }
@@ -165,16 +132,20 @@ pub trait HugrView: HugrInternals {
     /// Like [`node_ports`][HugrView::node_ports]`(node, Direction::Incoming)`
     /// but preserves knowledge that the ports are [IncomingPort]s.
     #[inline]
-    fn node_inputs(&self, node: Node) -> IncomingPorts<Self::NodePorts<'_>> {
+    fn node_inputs(&self, node: Node) -> impl Iterator<Item = IncomingPort> + Clone {
         self.node_ports(node, Direction::Incoming)
             .map(|p| p.as_incoming().unwrap())
     }
 
     /// Iterator over both the input and output ports of node.
-    fn all_node_ports(&self, node: Node) -> Self::NodePorts<'_>;
+    fn all_node_ports(&self, node: Node) -> impl Iterator<Item = Port> + Clone;
 
     /// Iterator over the nodes and ports connected to a port.
-    fn linked_ports(&self, node: Node, port: impl Into<Port>) -> Self::PortLinks<'_>;
+    fn linked_ports(
+        &self,
+        node: Node,
+        port: impl Into<Port>,
+    ) -> impl Iterator<Item = (Node, Port)> + Clone;
 
     /// Iterator over all the nodes and ports connected to a node in a given direction.
     fn all_linked_ports(
@@ -245,7 +216,7 @@ pub trait HugrView: HugrInternals {
         &self,
         node: Node,
         port: impl Into<IncomingPort>,
-    ) -> OutgoingNodePorts<Self::PortLinks<'_>> {
+    ) -> impl Iterator<Item = (Node, OutgoingPort)> {
         self.linked_ports(node, port.into())
             .map(|(n, p)| (n, p.as_outgoing().unwrap()))
     }
@@ -257,13 +228,13 @@ pub trait HugrView: HugrInternals {
         &self,
         node: Node,
         port: impl Into<OutgoingPort>,
-    ) -> IncomingNodePorts<Self::PortLinks<'_>> {
+    ) -> impl Iterator<Item = (Node, IncomingPort)> {
         self.linked_ports(node, port.into())
             .map(|(n, p)| (n, p.as_incoming().unwrap()))
     }
 
     /// Iterator the links between two nodes.
-    fn node_connections(&self, node: Node, other: Node) -> Self::NodeConnections<'_>;
+    fn node_connections(&self, node: Node, other: Node) -> impl Iterator<Item = [Port; 2]> + Clone;
 
     /// Returns whether a port is connected.
     fn is_linked(&self, node: Node, port: impl Into<Port>) -> bool {
@@ -288,28 +259,28 @@ pub trait HugrView: HugrInternals {
     }
 
     /// Return iterator over the direct children of node.
-    fn children(&self, node: Node) -> Self::Children<'_>;
+    fn children(&self, node: Node) -> impl DoubleEndedIterator<Item = Node> + Clone;
 
     /// Iterates over neighbour nodes in the given direction.
     /// May contain duplicates if the graph has multiple links between nodes.
-    fn neighbours(&self, node: Node, dir: Direction) -> Self::Neighbours<'_>;
+    fn neighbours(&self, node: Node, dir: Direction) -> impl Iterator<Item = Node> + Clone;
 
     /// Iterates over the input neighbours of the `node`.
     /// Shorthand for [`neighbours`][HugrView::neighbours]`(node, Direction::Incoming)`.
     #[inline]
-    fn input_neighbours(&self, node: Node) -> Self::Neighbours<'_> {
+    fn input_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone {
         self.neighbours(node, Direction::Incoming)
     }
 
     /// Iterates over the output neighbours of the `node`.
     /// Shorthand for [`neighbours`][HugrView::neighbours]`(node, Direction::Outgoing)`.
     #[inline]
-    fn output_neighbours(&self, node: Node) -> Self::Neighbours<'_> {
+    fn output_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone {
         self.neighbours(node, Direction::Outgoing)
     }
 
     /// Iterates over the input and output neighbours of the `node` in sequence.
-    fn all_neighbours(&self, node: Node) -> Self::Neighbours<'_>;
+    fn all_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone;
 
     /// Get the input and output child nodes of a dataflow parent.
     /// If the node isn't a dataflow parent, then return None
@@ -469,18 +440,6 @@ pub trait HugrView: HugrInternals {
     }
 }
 
-/// Wraps an iterator over [Port]s that are known to be [OutgoingPort]s
-pub type OutgoingPorts<I> = Map<I, fn(Port) -> OutgoingPort>;
-
-/// Wraps an iterator over [Port]s that are known to be [IncomingPort]s
-pub type IncomingPorts<I> = Map<I, fn(Port) -> IncomingPort>;
-
-/// Wraps an iterator over `(`[`Node`],[`Port`]`)` when the ports are known to be [OutgoingPort]s
-pub type OutgoingNodePorts<I> = Map<I, fn((Node, Port)) -> (Node, OutgoingPort)>;
-
-/// Wraps an iterator over `(`[`Node`],[`Port`]`)` when the ports are known to be [IncomingPort]s
-pub type IncomingNodePorts<I> = Map<I, fn((Node, Port)) -> (Node, IncomingPort)>;
-
 /// Trait for views that provides a guaranteed bound on the type of the root node.
 pub trait RootTagged: HugrView {
     /// The kind of handle that can be used to refer to the root node.
@@ -555,25 +514,6 @@ impl ExtractHugr for &mut Hugr {
 }
 
 impl<T: AsRef<Hugr>> HugrView for T {
-    /// An Iterator over the nodes in a Hugr(View)
-    type Nodes<'a> = MapInto<multiportgraph::Nodes<'a>, Node> where Self: 'a;
-
-    /// An Iterator over (some or all) ports of a node
-    type NodePorts<'a> = MapInto<portgraph::portgraph::NodePortOffsets, Port> where Self: 'a;
-
-    /// An Iterator over the children of a node
-    type Children<'a> = MapInto<portgraph::hierarchy::Children<'a>, Node> where Self: 'a;
-
-    /// An Iterator over (some or all) the nodes neighbouring a node
-    type Neighbours<'a> = MapInto<multiportgraph::Neighbours<'a>, Node> where Self: 'a;
-
-    /// Iterator over the children of a node
-    type PortLinks<'a> = MapWithCtx<multiportgraph::PortLinks<'a>, &'a Hugr, (Node, Port)>
-    where
-        Self: 'a;
-
-    type NodeConnections<'a> = MapWithCtx<multiportgraph::NodeConnections<'a>,&'a Hugr, [Port; 2]> where Self: 'a;
-
     #[inline]
     fn contains_node(&self, node: Node) -> bool {
         self.as_ref().graph.contains_node(node.pg_index())
@@ -590,12 +530,12 @@ impl<T: AsRef<Hugr>> HugrView for T {
     }
 
     #[inline]
-    fn nodes(&self) -> Self::Nodes<'_> {
+    fn nodes(&self) -> impl Iterator<Item = Node> + Clone {
         self.as_ref().graph.nodes_iter().map_into()
     }
 
     #[inline]
-    fn node_ports(&self, node: Node, dir: Direction) -> Self::NodePorts<'_> {
+    fn node_ports(&self, node: Node, dir: Direction) -> impl Iterator<Item = Port> + Clone {
         self.as_ref()
             .graph
             .port_offsets(node.pg_index(), dir)
@@ -603,7 +543,7 @@ impl<T: AsRef<Hugr>> HugrView for T {
     }
 
     #[inline]
-    fn all_node_ports(&self, node: Node) -> Self::NodePorts<'_> {
+    fn all_node_ports(&self, node: Node) -> impl Iterator<Item = Port> + Clone {
         self.as_ref()
             .graph
             .all_port_offsets(node.pg_index())
@@ -611,36 +551,33 @@ impl<T: AsRef<Hugr>> HugrView for T {
     }
 
     #[inline]
-    fn linked_ports(&self, node: Node, port: impl Into<Port>) -> Self::PortLinks<'_> {
+    fn linked_ports(
+        &self,
+        node: Node,
+        port: impl Into<Port>,
+    ) -> impl Iterator<Item = (Node, Port)> + Clone {
         let port = port.into();
         let hugr = self.as_ref();
         let port = hugr
             .graph
             .port_index(node.pg_index(), port.pg_offset())
             .unwrap();
-        hugr.graph
-            .port_links(port)
-            .with_context(hugr)
-            .map_with_context(|(_, link), hugr| {
-                let port = link.port();
-                let node = hugr.graph.port_node(port).unwrap();
-                let offset = hugr.graph.port_offset(port).unwrap();
-                (node.into(), offset.into())
-            })
+        hugr.graph.port_links(port).map(|(_, link)| {
+            let port = link.port();
+            let node = hugr.graph.port_node(port).unwrap();
+            let offset = hugr.graph.port_offset(port).unwrap();
+            (node.into(), offset.into())
+        })
     }
 
     #[inline]
-    fn node_connections(&self, node: Node, other: Node) -> Self::NodeConnections<'_> {
+    fn node_connections(&self, node: Node, other: Node) -> impl Iterator<Item = [Port; 2]> + Clone {
         let hugr = self.as_ref();
 
         hugr.graph
             .get_connections(node.pg_index(), other.pg_index())
-            .with_context(hugr)
-            .map_with_context(|(p1, p2), hugr| {
-                [p1, p2].map(|link| {
-                    let offset = hugr.graph.port_offset(link.port()).unwrap();
-                    offset.into()
-                })
+            .map(|(p1, p2)| {
+                [p1, p2].map(|link| hugr.graph.port_offset(link.port()).unwrap().into())
             })
     }
 
@@ -650,12 +587,12 @@ impl<T: AsRef<Hugr>> HugrView for T {
     }
 
     #[inline]
-    fn children(&self, node: Node) -> Self::Children<'_> {
+    fn children(&self, node: Node) -> impl DoubleEndedIterator<Item = Node> + Clone {
         self.as_ref().hierarchy.children(node.pg_index()).map_into()
     }
 
     #[inline]
-    fn neighbours(&self, node: Node, dir: Direction) -> Self::Neighbours<'_> {
+    fn neighbours(&self, node: Node, dir: Direction) -> impl Iterator<Item = Node> + Clone {
         self.as_ref()
             .graph
             .neighbours(node.pg_index(), dir)
@@ -663,7 +600,7 @@ impl<T: AsRef<Hugr>> HugrView for T {
     }
 
     #[inline]
-    fn all_neighbours(&self, node: Node) -> Self::Neighbours<'_> {
+    fn all_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone {
         self.as_ref()
             .graph
             .all_neighbours(node.pg_index())

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -246,8 +246,35 @@ pub(super) mod test {
             Some(Signature::new(type_row![NAT], type_row![NAT]))
         );
         assert_eq!(inner_region.node_count(), 3);
+        assert_eq!(inner_region.edge_count(), 2);
         assert_eq!(inner_region.children(inner).count(), 2);
+        assert_eq!(inner_region.children(hugr.root()).count(), 0);
+        assert_eq!(
+            inner_region.num_ports(inner, Direction::Outgoing),
+            inner_region.node_ports(inner, Direction::Outgoing).count()
+        );
+        assert_eq!(
+            inner_region.num_ports(inner, Direction::Incoming)
+                + inner_region.num_ports(inner, Direction::Outgoing),
+            inner_region.all_node_ports(inner).count()
+        );
+
+        // The inner region filters out the connections to the main function I/O nodes,
+        // while the outer region includes them.
         assert_eq!(inner_region.node_connections(inner, def_io[1]).count(), 0);
+        assert_eq!(region.node_connections(inner, def_io[1]).count(), 1);
+        assert_eq!(
+            inner_region
+                .linked_ports(inner, IncomingPort::from(0))
+                .count(),
+            0
+        );
+        assert_eq!(region.linked_ports(inner, IncomingPort::from(0)).count(), 1);
+        assert_eq!(
+            inner_region.neighbours(inner, Direction::Outgoing).count(),
+            0
+        );
+        assert_eq!(inner_region.all_neighbours(inner).count(), 0);
         assert_eq!(
             inner_region
                 .linked_ports(inner, IncomingPort::from(0))

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -1,8 +1,7 @@
 //! DescendantsGraph: view onto the subgraph of the HUGR starting from a root
 //! (all descendants at all depths).
 
-use context_iterators::{ContextIterator, IntoContextIterator, MapWithCtx};
-use itertools::{Itertools, MapInto};
+use itertools::Itertools;
 use portgraph::{LinkView, MultiPortGraph, PortIndex, PortView};
 
 use crate::hugr::HugrError;
@@ -40,36 +39,6 @@ pub struct DescendantsGraph<'g, Root = Node> {
     _phantom: std::marker::PhantomData<Root>,
 }
 impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
-    type Nodes<'a> = MapInto<<RegionGraph<'g> as PortView>::Nodes<'a>, Node>
-    where
-        Self: 'a;
-
-    type NodePorts<'a> = MapInto<<RegionGraph<'g> as PortView>::NodePortOffsets<'a>, Port>
-    where
-        Self: 'a;
-
-    type Children<'a> = MapInto<portgraph::hierarchy::Children<'a>, Node>
-    where
-        Self: 'a;
-
-    type Neighbours<'a> = MapInto<<RegionGraph<'g> as LinkView>::Neighbours<'a>, Node>
-    where
-        Self: 'a;
-
-    type PortLinks<'a> = MapWithCtx<
-        <RegionGraph<'g> as LinkView>::PortLinks<'a>,
-        &'a Self,
-        (Node, Port),
-    > where
-        Self: 'a;
-
-    type NodeConnections<'a> = MapWithCtx<
-        <RegionGraph<'g> as LinkView>::NodeConnections<'a>,
-        &'a Self,
-        [Port; 2],
-    > where
-        Self: 'a;
-
     #[inline]
     fn contains_node(&self, node: Node) -> bool {
         self.graph.contains_node(node.pg_index())
@@ -86,43 +55,43 @@ impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
     }
 
     #[inline]
-    fn nodes(&self) -> Self::Nodes<'_> {
+    fn nodes(&self) -> impl Iterator<Item = Node> + Clone {
         self.graph.nodes_iter().map_into()
     }
 
     #[inline]
-    fn node_ports(&self, node: Node, dir: Direction) -> Self::NodePorts<'_> {
+    fn node_ports(&self, node: Node, dir: Direction) -> impl Iterator<Item = Port> + Clone {
         self.graph.port_offsets(node.pg_index(), dir).map_into()
     }
 
     #[inline]
-    fn all_node_ports(&self, node: Node) -> Self::NodePorts<'_> {
+    fn all_node_ports(&self, node: Node) -> impl Iterator<Item = Port> + Clone {
         self.graph.all_port_offsets(node.pg_index()).map_into()
     }
 
-    fn linked_ports(&self, node: Node, port: impl Into<Port>) -> Self::PortLinks<'_> {
+    fn linked_ports(
+        &self,
+        node: Node,
+        port: impl Into<Port>,
+    ) -> impl Iterator<Item = (Node, Port)> + Clone {
         let port = self
             .graph
             .port_index(node.pg_index(), port.into().pg_offset())
             .unwrap();
-        self.graph
-            .port_links(port)
-            .with_context(self)
-            .map_with_context(|(_, link), region| {
-                let port: PortIndex = link.into();
-                let node = region.graph.port_node(port).unwrap();
-                let offset = region.graph.port_offset(port).unwrap();
-                (node.into(), offset.into())
-            })
+        self.graph.port_links(port).map(|(_, link)| {
+            let port: PortIndex = link.into();
+            let node = self.graph.port_node(port).unwrap();
+            let offset = self.graph.port_offset(port).unwrap();
+            (node.into(), offset.into())
+        })
     }
 
-    fn node_connections(&self, node: Node, other: Node) -> Self::NodeConnections<'_> {
+    fn node_connections(&self, node: Node, other: Node) -> impl Iterator<Item = [Port; 2]> + Clone {
         self.graph
             .get_connections(node.pg_index(), other.pg_index())
-            .with_context(self)
-            .map_with_context(|(p1, p2), hugr| {
+            .map(|(p1, p2)| {
                 [p1, p2].map(|link| {
-                    let offset = hugr.graph.port_offset(link).unwrap();
+                    let offset = self.graph.port_offset(link).unwrap();
                     offset.into()
                 })
             })
@@ -134,7 +103,7 @@ impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
     }
 
     #[inline]
-    fn children(&self, node: Node) -> Self::Children<'_> {
+    fn children(&self, node: Node) -> impl DoubleEndedIterator<Item = Node> + Clone {
         match self.graph.contains_node(node.pg_index()) {
             true => self
                 .base_hugr()
@@ -146,12 +115,12 @@ impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
     }
 
     #[inline]
-    fn neighbours(&self, node: Node, dir: Direction) -> Self::Neighbours<'_> {
+    fn neighbours(&self, node: Node, dir: Direction) -> impl Iterator<Item = Node> + Clone {
         self.graph.neighbours(node.pg_index(), dir).map_into()
     }
 
     #[inline]
-    fn all_neighbours(&self, node: Node) -> Self::Neighbours<'_> {
+    fn all_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone {
         self.graph.all_neighbours(node.pg_index()).map_into()
     }
 }

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -173,6 +173,7 @@ pub(super) mod test {
     use rstest::rstest;
 
     use crate::extension::PRELUDE_REGISTRY;
+    use crate::IncomingPort;
     use crate::{
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
         type_row,
@@ -222,6 +223,7 @@ pub(super) mod test {
         let (hugr, def, inner) = make_module_hgr()?;
 
         let region: DescendantsGraph = DescendantsGraph::try_new(&hugr, def)?;
+        let def_io = region.get_io(def).unwrap();
 
         assert_eq!(region.node_count(), 7);
         assert!(region.nodes().all(|n| n == def
@@ -237,10 +239,20 @@ pub(super) mod test {
                     .into()
             )
         );
+
         let inner_region: DescendantsGraph = DescendantsGraph::try_new(&hugr, inner)?;
         assert_eq!(
             inner_region.inner_function_type(),
             Some(Signature::new(type_row![NAT], type_row![NAT]))
+        );
+        assert_eq!(inner_region.node_count(), 3);
+        assert_eq!(inner_region.children(inner).count(), 2);
+        assert_eq!(inner_region.node_connections(inner, def_io[1]).count(), 0);
+        assert_eq!(
+            inner_region
+                .linked_ports(inner, IncomingPort::from(0))
+                .count(),
+            0
         );
 
         Ok(())

--- a/hugr-core/src/hugr/views/petgraph.rs
+++ b/hugr-core/src/hugr/views/petgraph.rs
@@ -6,7 +6,6 @@ use crate::types::EdgeKind;
 use crate::NodeIndex;
 use crate::{Node, Port};
 
-use context_iterators::{ContextIterator, IntoContextIterator, MapWithCtx};
 use petgraph::visit as pv;
 
 /// Wrapper for a HugrView that implements petgraph's traits.
@@ -99,13 +98,14 @@ where
     T: HugrView,
 {
     type NodeRef = HugrNodeRef<'a>;
-    type NodeReferences = MapWithCtx<<T as HugrView>::Nodes<'a>, Self, HugrNodeRef<'a>>;
+    type NodeReferences = Box<dyn Iterator<Item = HugrNodeRef<'a>> + 'a>;
 
     fn node_references(self) -> Self::NodeReferences {
-        self.hugr
-            .nodes()
-            .with_context(self)
-            .map_with_context(|n, &wrapper| HugrNodeRef::from_node(n, wrapper.hugr))
+        Box::new(
+            self.hugr
+                .nodes()
+                .map(|n| HugrNodeRef::from_node(n, self.hugr)),
+        )
     }
 }
 
@@ -113,10 +113,10 @@ impl<'a, T> pv::IntoNodeIdentifiers for PetgraphWrapper<'a, T>
 where
     T: HugrView,
 {
-    type NodeIdentifiers = <T as HugrView>::Nodes<'a>;
+    type NodeIdentifiers = Box<dyn Iterator<Item = Node> + 'a>;
 
     fn node_identifiers(self) -> Self::NodeIdentifiers {
-        self.hugr.nodes()
+        Box::new(self.hugr.nodes())
     }
 }
 
@@ -124,10 +124,10 @@ impl<'a, T> pv::IntoNeighbors for PetgraphWrapper<'a, T>
 where
     T: HugrView,
 {
-    type Neighbors = <T as HugrView>::Neighbours<'a>;
+    type Neighbors = Box<dyn Iterator<Item = Node> + 'a>;
 
     fn neighbors(self, n: Self::NodeId) -> Self::Neighbors {
-        self.hugr.output_neighbours(n)
+        Box::new(self.hugr.output_neighbours(n))
     }
 }
 
@@ -135,14 +135,14 @@ impl<'a, T> pv::IntoNeighborsDirected for PetgraphWrapper<'a, T>
 where
     T: HugrView,
 {
-    type NeighborsDirected = <T as HugrView>::Neighbours<'a>;
+    type NeighborsDirected = Box<dyn Iterator<Item = Node> + 'a>;
 
     fn neighbors_directed(
         self,
         n: Self::NodeId,
         d: petgraph::Direction,
     ) -> Self::NeighborsDirected {
-        self.hugr.neighbours(n, d.into())
+        Box::new(self.hugr.neighbours(n, d.into()))
     }
 }
 

--- a/hugr-core/src/hugr/views/petgraph.rs
+++ b/hugr-core/src/hugr/views/petgraph.rs
@@ -211,3 +211,39 @@ impl pv::NodeRef for HugrNodeRef<'_> {
         self.op
     }
 }
+
+#[cfg(test)]
+mod test {
+    use petgraph::visit::{
+        EdgeCount, GetAdjacencyMatrix, IntoNodeReferences, NodeCount, NodeIndexable, NodeRef,
+    };
+
+    use crate::hugr::views::tests::sample_hugr;
+    use crate::ops::handle::NodeHandle;
+    use crate::HugrView;
+
+    use super::PetgraphWrapper;
+
+    #[test]
+    fn test_petgraph_wrapper() {
+        let (hugr, cx1, cx2) = sample_hugr();
+        let wrapper = PetgraphWrapper::from(&hugr);
+
+        assert_eq!(wrapper.node_count(), 5);
+        assert_eq!(wrapper.node_bound(), 5);
+        assert_eq!(wrapper.edge_count(), 7);
+
+        let cx1_index = cx1.node().pg_index().index();
+        assert_eq!(wrapper.to_index(cx1.node()), cx1_index);
+        assert_eq!(wrapper.from_index(cx1_index), cx1.node());
+
+        let cx1_ref = wrapper
+            .node_references()
+            .find(|n| n.id() == cx1.node())
+            .unwrap();
+        assert_eq!(cx1_ref.weight(), hugr.get_optype(cx1.node()));
+
+        let adj = wrapper.adjacency_matrix();
+        assert!(wrapper.is_adjacent(&adj, cx1.node(), cx2.node()));
+    }
+}

--- a/hugr-core/src/hugr/views/tests.rs
+++ b/hugr-core/src/hugr/views/tests.rs
@@ -17,8 +17,11 @@ use crate::{
     Hugr, HugrView,
 };
 
+/// A Dataflow graph from two qubits to two qubits that applies two CX operations on them.
+///
+/// Returns the Hugr and the two CX node ids.
 #[fixture]
-fn sample_hugr() -> (Hugr, BuildHandle<DataflowOpID>, BuildHandle<DataflowOpID>) {
+pub(crate) fn sample_hugr() -> (Hugr, BuildHandle<DataflowOpID>, BuildHandle<DataflowOpID>) {
     let mut dfg = DFGBuilder::new(endo_sig(type_row![QB_T, QB_T])).unwrap();
 
     let [q1, q2] = dfg.input_wires_arr();

--- a/hugr-core/src/hugr/views/tests.rs
+++ b/hugr-core/src/hugr/views/tests.rs
@@ -99,6 +99,7 @@ fn all_ports(sample_hugr: (Hugr, BuildHandle<DataflowOpID>, BuildHandle<Dataflow
     let (h, n1, n2) = sample_hugr;
 
     let all_output_ports = h.all_linked_outputs(n2.node()).collect_vec();
+    let all_ports = h.all_node_ports(n2.node()).collect_vec();
 
     assert_eq!(
         &all_output_ports[..],
@@ -108,6 +109,9 @@ fn all_ports(sample_hugr: (Hugr, BuildHandle<DataflowOpID>, BuildHandle<Dataflow
             (n1.node(), 2.into()),
         ]
     );
+    assert!(all_output_ports
+        .iter()
+        .all(|&(_, p)| all_ports.contains(&p.into())));
 
     let all_linked_inputs = h.all_linked_inputs(n1.node()).collect_vec();
     assert_eq!(

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -810,9 +810,11 @@ impl<'a> Context<'a> {
             // Connect the input node to the tag node
             let input_outputs = self.hugr.node_outputs(node_input);
             let tag_inputs = self.hugr.node_inputs(node_tag);
+            let mut connections =
+                Vec::with_capacity(input_outputs.size_hint().0 + tag_inputs.size_hint().0);
 
             for (a, b) in input_outputs.zip(tag_inputs) {
-                self.hugr.connect(node_input, a, node_tag, b);
+                connections.push((node_input, a, node_tag, b));
             }
 
             // Connect the tag node to the output node
@@ -820,7 +822,11 @@ impl<'a> Context<'a> {
             let output_inputs = self.hugr.node_inputs(node_output);
 
             for (a, b) in tag_outputs.zip(output_inputs) {
-                self.hugr.connect(node_tag, a, node_output, b);
+                connections.push((node_tag, a, node_output, b));
+            }
+
+            for (src, src_port, dst, dst_port) in connections {
+                self.hugr.connect(src, src_port, dst, dst_port);
             }
         }
 

--- a/hugr-passes/src/half_node.rs
+++ b/hugr-passes/src/half_node.rs
@@ -64,7 +64,6 @@ impl<H: RootTagged<RootHandle = CfgID>> HalfNodeView<H> {
 }
 
 impl<H: RootTagged<RootHandle = CfgID>> CfgNodeMap<HalfNode> for HalfNodeView<H> {
-    type Iterator<'c> = <Vec<HalfNode> as IntoIterator>::IntoIter where Self: 'c;
     fn entry_node(&self) -> HalfNode {
         HalfNode::N(self.entry)
     }
@@ -72,7 +71,7 @@ impl<H: RootTagged<RootHandle = CfgID>> CfgNodeMap<HalfNode> for HalfNodeView<H>
         assert!(self.bb_succs(self.exit).count() == 0);
         HalfNode::N(self.exit)
     }
-    fn predecessors(&self, h: HalfNode) -> Self::Iterator<'_> {
+    fn predecessors(&self, h: HalfNode) -> impl Iterator<Item = HalfNode> {
         let mut ps = Vec::new();
         match h {
             HalfNode::N(ni) => ps.extend(self.bb_preds(ni).map(|n| self.resolve_out(n))),
@@ -83,7 +82,7 @@ impl<H: RootTagged<RootHandle = CfgID>> CfgNodeMap<HalfNode> for HalfNodeView<H>
         }
         ps.into_iter()
     }
-    fn successors(&self, n: HalfNode) -> Self::Iterator<'_> {
+    fn successors(&self, n: HalfNode) -> impl Iterator<Item = HalfNode> {
         let mut succs = Vec::new();
         match n {
             HalfNode::N(ni) if self.is_multi_node(ni) => succs.push(HalfNode::X(ni)),

--- a/hugr-passes/src/merge_bbs.rs
+++ b/hugr-passes/src/merge_bbs.rs
@@ -276,7 +276,7 @@ mod test {
             .nodes()
             .filter(|n| h.get_optype(*n).cast::<Noop>().is_some());
         let (entry_nop, expected_backedge_target) = if self_loop {
-            assert_eq!(h.children(r).len(), 2);
+            assert_eq!(h.children(r).count(), 2);
             (nops.exactly_one().ok().unwrap(), entry)
         } else {
             let [_, _, no_b2] = h.children(r).collect::<Vec<_>>().try_into().unwrap();


### PR DESCRIPTION
This will simplify the update to the next portgraph release (which also moved to RPITIT), avoiding the need to use boxes around iterators to be able to name them.

- drops the dependency on `context-iterators`
- drive-by: Cleanup the implementations of `SiblingGraph` / `SiblingMut` to avoid `collect_vec().into_iter()`s.

BREAKING CHANGE: Removed `HugrView` associated iterator types, replaced with `impl Iterator` returns.