### PR TITLE
chore: Fix new lints in rust 1.83

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@beta
         with:
           components: rustfmt, clippy
       - name: Install CapnProto

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@beta
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - name: Install CapnProto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,14 @@ lto = "thin"
 
 [workspace]
 resolver = "2"
-members = ["hugr", "hugr-core", "hugr-passes", "hugr-cli", "hugr-model", "hugr-llvm"]
+members = [
+    "hugr",
+    "hugr-core",
+    "hugr-passes",
+    "hugr-cli",
+    "hugr-model",
+    "hugr-llvm",
+]
 default-members = ["hugr", "hugr-core", "hugr-passes", "hugr-cli", "hugr-model"]
 
 [workspace.package]

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -624,6 +624,7 @@ impl FromIterator<ExtensionId> for ExtensionSet {
     }
 }
 
+/// Extension tests.
 #[cfg(test)]
 pub mod test {
     // We re-export this here because mod op_def is private.

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -514,10 +514,12 @@ pub(super) mod test {
         const EXT_ID: ExtensionId = "MyExt";
     }
 
+    /// A dummy wrapper over an operation definition.
     #[derive(serde::Serialize, serde::Deserialize, Debug)]
     pub struct SimpleOpDef(OpDef);
 
     impl SimpleOpDef {
+        /// Create a new dummy opdef.
         pub fn new(op_def: OpDef) -> Self {
             assert!(op_def.constant_folder.is_none());
             assert!(matches!(

--- a/hugr-core/src/hugr/internal.rs
+++ b/hugr-core/src/hugr/internal.rs
@@ -32,7 +32,10 @@ pub trait HugrInternals {
 }
 
 impl<T: AsRef<Hugr>> HugrInternals for T {
-    type Portgraph<'p> = &'p MultiPortGraph where Self: 'p;
+    type Portgraph<'p>
+        = &'p MultiPortGraph
+    where
+        Self: 'p;
 
     #[inline]
     fn portgraph(&self) -> Self::Portgraph<'_> {

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -1,3 +1,5 @@
+//! Tests for the HUGR serialization format.
+
 use super::*;
 use crate::builder::{
     endo_sig, inout_sig, test::closed_dfg_root_hugr, Container, DFGBuilder, Dataflow, DataflowHugr,
@@ -182,6 +184,7 @@ pub fn check_hugr_roundtrip(hugr: &Hugr, check_schema: bool) -> Hugr {
     new_hugr
 }
 
+/// Deserialize a HUGR json, ensuring that it is valid against the schema.
 pub fn check_hugr_deserialize(hugr: &Hugr, value: serde_json::Value, check_schema: bool) -> Hugr {
     let new_hugr = ser_deserialize_check_schema(value, get_schemas(check_schema));
 
@@ -189,6 +192,7 @@ pub fn check_hugr_deserialize(hugr: &Hugr, value: serde_json::Value, check_schem
     new_hugr
 }
 
+/// Check that two HUGRs are equivalent, up to node renumbering.
 pub fn check_hugr(lhs: &Hugr, rhs: &Hugr) {
     // Original HUGR, with canonicalized node indices
     //

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -124,7 +124,7 @@ impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
         self.graph.all_neighbours(node.pg_index()).map_into()
     }
 }
-impl<'g, Root: NodeHandle> RootTagged for DescendantsGraph<'g, Root> {
+impl<Root: NodeHandle> RootTagged for DescendantsGraph<'_, Root> {
     type RootHandle = Root;
 }
 
@@ -144,13 +144,16 @@ where
     }
 }
 
-impl<'g, Root: NodeHandle> ExtractHugr for DescendantsGraph<'g, Root> {}
+impl<Root: NodeHandle> ExtractHugr for DescendantsGraph<'_, Root> {}
 
 impl<'g, Root> super::HugrInternals for DescendantsGraph<'g, Root>
 where
     Root: NodeHandle,
 {
-    type Portgraph<'p> = &'p RegionGraph<'g> where Self: 'p;
+    type Portgraph<'p>
+        = &'p RegionGraph<'g>
+    where
+        Self: 'p;
 
     #[inline]
     fn portgraph(&self) -> Self::Portgraph<'_> {

--- a/hugr-core/src/hugr/views/petgraph.rs
+++ b/hugr-core/src/hugr/views/petgraph.rs
@@ -16,13 +16,13 @@ pub struct PetgraphWrapper<'a, T> {
     pub(crate) hugr: &'a T,
 }
 
-impl<'a, T> Clone for PetgraphWrapper<'a, T> {
+impl<T> Clone for PetgraphWrapper<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, T> Copy for PetgraphWrapper<'a, T> {}
+impl<T> Copy for PetgraphWrapper<'_, T> {}
 
 impl<'a, T> From<&'a T> for PetgraphWrapper<'a, T>
 where
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<'a, T> pv::GraphBase for PetgraphWrapper<'a, T>
+impl<T> pv::GraphBase for PetgraphWrapper<'_, T>
 where
     T: HugrView,
 {
@@ -41,16 +41,16 @@ where
     type EdgeId = ((Node, Port), (Node, Port));
 }
 
-impl<'a, T> pv::GraphProp for PetgraphWrapper<'a, T>
+impl<T> pv::GraphProp for PetgraphWrapper<'_, T>
 where
     T: HugrView,
 {
     type EdgeType = petgraph::Directed;
 }
 
-impl<'a, T> pv::GraphRef for PetgraphWrapper<'a, T> where T: HugrView {}
+impl<T> pv::GraphRef for PetgraphWrapper<'_, T> where T: HugrView {}
 
-impl<'a, T> pv::NodeCount for PetgraphWrapper<'a, T>
+impl<T> pv::NodeCount for PetgraphWrapper<'_, T>
 where
     T: HugrView,
 {
@@ -59,7 +59,7 @@ where
     }
 }
 
-impl<'a, T> pv::NodeIndexable for PetgraphWrapper<'a, T>
+impl<T> pv::NodeIndexable for PetgraphWrapper<'_, T>
 where
     T: HugrView,
 {
@@ -76,7 +76,7 @@ where
     }
 }
 
-impl<'a, T> pv::EdgeCount for PetgraphWrapper<'a, T>
+impl<T> pv::EdgeCount for PetgraphWrapper<'_, T>
 where
     T: HugrView,
 {
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<'a, T> pv::Data for PetgraphWrapper<'a, T>
+impl<T> pv::Data for PetgraphWrapper<'_, T>
 where
     T: HugrView,
 {
@@ -146,7 +146,7 @@ where
     }
 }
 
-impl<'a, T> pv::Visitable for PetgraphWrapper<'a, T>
+impl<T> pv::Visitable for PetgraphWrapper<'_, T>
 where
     T: HugrView,
 {
@@ -161,7 +161,7 @@ where
     }
 }
 
-impl<'a, T> pv::GetAdjacencyMatrix for PetgraphWrapper<'a, T>
+impl<T> pv::GetAdjacencyMatrix for PetgraphWrapper<'_, T>
 where
     T: HugrView,
 {

--- a/hugr-core/src/hugr/views/sibling.rs
+++ b/hugr-core/src/hugr/views/sibling.rs
@@ -140,7 +140,7 @@ impl<'g, Root: NodeHandle> HugrView for SiblingGraph<'g, Root> {
         self.graph.all_neighbours(node.pg_index()).map_into()
     }
 }
-impl<'g, Root: NodeHandle> RootTagged for SiblingGraph<'g, Root> {
+impl<Root: NodeHandle> RootTagged for SiblingGraph<'_, Root> {
     type RootHandle = Root;
 }
 
@@ -171,13 +171,16 @@ where
     }
 }
 
-impl<'g, Root: NodeHandle> ExtractHugr for SiblingGraph<'g, Root> {}
+impl<Root: NodeHandle> ExtractHugr for SiblingGraph<'_, Root> {}
 
 impl<'g, Root> HugrInternals for SiblingGraph<'g, Root>
 where
     Root: NodeHandle,
 {
-    type Portgraph<'p> = &'p FlatRegionGraph<'g> where Self: 'p;
+    type Portgraph<'p>
+        = &'p FlatRegionGraph<'g>
+    where
+        Self: 'p;
 
     #[inline]
     fn portgraph(&self) -> Self::Portgraph<'_> {
@@ -236,10 +239,14 @@ impl<'g, Root: NodeHandle> SiblingMut<'g, Root> {
     }
 }
 
-impl<'g, Root: NodeHandle> ExtractHugr for SiblingMut<'g, Root> {}
+impl<Root: NodeHandle> ExtractHugr for SiblingMut<'_, Root> {}
 
 impl<'g, Root: NodeHandle> HugrInternals for SiblingMut<'g, Root> {
-    type Portgraph<'p> = FlatRegionGraph<'p> where 'g: 'p, Root: 'p;
+    type Portgraph<'p>
+        = FlatRegionGraph<'p>
+    where
+        'g: 'p,
+        Root: 'p;
 
     fn portgraph(&self) -> Self::Portgraph<'_> {
         FlatRegionGraph::new_flat_region(
@@ -311,17 +318,17 @@ impl<'g, Root: NodeHandle> HugrView for SiblingMut<'g, Root> {
     }
 }
 
-impl<'g, Root: NodeHandle> RootTagged for SiblingMut<'g, Root> {
+impl<Root: NodeHandle> RootTagged for SiblingMut<'_, Root> {
     type RootHandle = Root;
 }
 
-impl<'g, Root: NodeHandle> HugrMutInternals for SiblingMut<'g, Root> {
+impl<Root: NodeHandle> HugrMutInternals for SiblingMut<'_, Root> {
     fn hugr_mut(&mut self) -> &mut Hugr {
         self.hugr
     }
 }
 
-impl<'g, Root: NodeHandle> HugrMut for SiblingMut<'g, Root> {}
+impl<Root: NodeHandle> HugrMut for SiblingMut<'_, Root> {}
 
 #[cfg(test)]
 mod test {

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -514,7 +514,7 @@ impl<'g, Base: HugrView> TopoConvexChecker<'g, Base> {
     }
 }
 
-impl<'g, Base: HugrView> ConvexChecker for TopoConvexChecker<'g, Base> {
+impl<Base: HugrView> ConvexChecker for TopoConvexChecker<'_, Base> {
     fn is_convex(
         &self,
         nodes: impl IntoIterator<Item = portgraph::NodeIndex>,

--- a/hugr-core/src/proptest.rs
+++ b/hugr-core/src/proptest.rs
@@ -186,7 +186,7 @@ pub fn any_serde_json_value() -> impl Strategy<Value = serde_json::Value> {
         .boxed()
 }
 
-/// A strategy for generating an arbitrary HUGRs.
+/// A strategy for generating an arbitrary HUGR.
 pub fn any_hugr() -> SBoxedStrategy<Hugr> {
     ANY_HUGR.to_owned()
 }

--- a/hugr-core/src/proptest.rs
+++ b/hugr-core/src/proptest.rs
@@ -1,3 +1,5 @@
+//! Generator functions for property testing the Hugr data structures.
+
 use ::proptest::collection::vec;
 use ::proptest::prelude::*;
 use lazy_static::lazy_static;

--- a/hugr-core/src/proptest.rs
+++ b/hugr-core/src/proptest.rs
@@ -38,6 +38,7 @@ pub struct RecursionDepth(usize);
 
 impl RecursionDepth {
     const DEFAULT_RECURSION_DEPTH: usize = 4;
+    /// Decrement the recursion depth counter.
     pub fn descend(&self) -> Self {
         if self.leaf() {
             *self
@@ -46,10 +47,12 @@ impl RecursionDepth {
         }
     }
 
+    /// Returns `true` if the recursion depth counter is zero.
     pub fn leaf(&self) -> bool {
         self.0 == 0
     }
 
+    /// Create a new [RecursionDepth] with the default recursion depth.
     pub fn new() -> Self {
         Self(Self::DEFAULT_RECURSION_DEPTH)
     }
@@ -135,26 +138,32 @@ lazy_static! {
     };
 }
 
+/// A strategy for generating an arbitrary nonempty [String].
 pub fn any_nonempty_string() -> SBoxedStrategy<String> {
     ANY_NONEMPTY_STRING.to_owned()
 }
 
+/// A strategy for generating an arbitrary nonempty [SmolStr].
 pub fn any_nonempty_smolstr() -> SBoxedStrategy<SmolStr> {
     ANY_NONEMPTY_STRING.to_owned().prop_map_into().sboxed()
 }
 
+/// A strategy for generating an arbitrary nonempty identity [String].
 pub fn any_ident_string() -> SBoxedStrategy<String> {
     ANY_IDENT_STRING.to_owned()
 }
 
+/// A strategy for generating an arbitrary [String].
 pub fn any_string() -> SBoxedStrategy<String> {
     ANY_STRING.to_owned()
 }
 
+/// A strategy for generating an arbitrary [SmolStr].
 pub fn any_smolstr() -> SBoxedStrategy<SmolStr> {
     ANY_STRING.clone().prop_map_into().sboxed()
 }
 
+/// A strategy for generating an arbitrary [serde_json::Value].
 pub fn any_serde_json_value() -> impl Strategy<Value = serde_json::Value> {
     ANY_SERDE_JSON_VALUE_LEAF
         .clone()
@@ -175,6 +184,7 @@ pub fn any_serde_json_value() -> impl Strategy<Value = serde_json::Value> {
         .boxed()
 }
 
+/// A strategy for generating an arbitrary HUGRs.
 pub fn any_hugr() -> SBoxedStrategy<Hugr> {
     ANY_HUGR.to_owned()
 }

--- a/hugr-core/src/proptest.rs
+++ b/hugr-core/src/proptest.rs
@@ -150,7 +150,7 @@ pub fn any_nonempty_smolstr() -> SBoxedStrategy<SmolStr> {
     ANY_NONEMPTY_STRING.to_owned().prop_map_into().sboxed()
 }
 
-/// A strategy for generating an arbitrary nonempty identity [String].
+/// A strategy for generating an arbitrary nonempty identifier [String].
 pub fn any_ident_string() -> SBoxedStrategy<String> {
     ANY_IDENT_STRING.to_owned()
 }

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -540,7 +540,7 @@ impl From<Type> for TypeRV {
 /// (Variables out of the range of the list will result in a panic)
 pub(crate) struct Substitution<'a>(&'a [TypeArg], &'a ExtensionRegistry);
 
-impl<'a> Substitution<'a> {
+impl Substitution<'_> {
     pub(crate) fn apply_var(&self, idx: usize, decl: &TypeParam) -> TypeArg {
         let arg = self
             .0

--- a/hugr-core/src/types/custom.rs
+++ b/hugr-core/src/types/custom.rs
@@ -139,7 +139,7 @@ impl From<CustomType> for Type {
 }
 
 #[cfg(test)]
-pub mod test {
+mod test {
 
     pub mod proptest {
         use crate::extension::ExtensionId;

--- a/hugr-core/tests/model.rs
+++ b/hugr-core/tests/model.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use hugr::std_extensions::std_reg;
 use hugr_core::{export::export_hugr, import::import_hugr};
 use hugr_model::v0 as model;

--- a/hugr-model/src/v0/text/print.rs
+++ b/hugr-model/src/v0/text/print.rs
@@ -109,7 +109,7 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
         let root_data = self
             .module
             .get_region(root_id)
-            .ok_or_else(|| PrintError::RegionNotFound(root_id))?;
+            .ok_or(PrintError::RegionNotFound(root_id))?;
 
         self.print_meta(root_data.meta)?;
         self.print_nodes(root_id)?;
@@ -132,7 +132,7 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
         let node_data = self
             .module
             .get_node(node_id)
-            .ok_or_else(|| PrintError::NodeNotFound(node_id))?;
+            .ok_or(PrintError::NodeNotFound(node_id))?;
 
         self.print_parens(|this| match &node_data.operation {
             Operation::Invalid => Err(ModelError::InvalidOperation(node_id)),
@@ -473,7 +473,7 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
         let term_data = self
             .module
             .get_term(term_id)
-            .ok_or_else(|| PrintError::TermNotFound(term_id))?;
+            .ok_or(PrintError::TermNotFound(term_id))?;
 
         match term_data {
             Term::Wildcard => {
@@ -617,7 +617,7 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
                 let node_data = self
                     .module
                     .get_node(node_id)
-                    .ok_or_else(|| PrintError::NodeNotFound(node_id))?;
+                    .ok_or(PrintError::NodeNotFound(node_id))?;
 
                 let name = match &node_data.operation {
                     Operation::DefineFunc { decl } => decl.name,

--- a/hugr-model/tests/binary.rs
+++ b/hugr-model/tests/binary.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use bumpalo::Bump;
 use hugr_model::v0 as model;
 use pretty_assertions::assert_eq;

--- a/hugr-model/tests/text.rs
+++ b/hugr-model/tests/text.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use hugr_model::v0 as model;
 
 fn roundtrip(source: &str) -> String {


### PR DESCRIPTION
New rust coming on 2024-11-28. This PR fixes new lints that would make our CI runs fail.

A big noisy change is due to public test definitions now triggering the `missing_docs` lint.
See [rust-lang/rust#130025](https://www.github.com/rust-lang/rust/pull/130025). This can be fixed avoided either by adding the docs or by making functions private.

Passing check: https://github.com/CQCL/hugr/actions/runs/12013283775/job/33486450494#step:7:1