### PR TITLE
feat!: OpDefs and TypeDefs keep a reference to their extension

### DIFF
--- a/hugr-cli/src/validate.rs
+++ b/hugr-cli/src/validate.rs
@@ -2,7 +2,6 @@
 
 use clap::Parser;
 use clap_verbosity_flag::Level;
-use hugr::package::PackageValidationError;
 use hugr::{extension::ExtensionRegistry, Extension, Hugr};
 
 use crate::{CliError, HugrArgs};
@@ -64,8 +63,7 @@ impl HugrArgs {
         for ext in &self.extensions {
             let f = std::fs::File::open(ext)?;
             let ext: Extension = serde_json::from_reader(f)?;
-            reg.register_updated(ext)
-                .map_err(PackageValidationError::Extension)?;
+            reg.register_updated(ext);
         }
 
         package.update_validate(&mut reg)?;

--- a/hugr-core/src/builder/circuit.rs
+++ b/hugr-core/src/builder/circuit.rs
@@ -243,7 +243,7 @@ mod test {
     use super::*;
     use cool_asserts::assert_matches;
 
-    use crate::extension::{ExtensionId, ExtensionSet};
+    use crate::extension::{ExtensionId, ExtensionSet, PRELUDE_REGISTRY};
     use crate::std_extensions::arithmetic::float_types::{self, ConstF64};
     use crate::utils::test_quantum_extension::{
         self, cx_gate, h_gate, measure, q_alloc, q_discard, rz_f64,
@@ -298,8 +298,18 @@ mod test {
     #[test]
     fn with_nonlinear_and_outputs() {
         let my_ext_name: ExtensionId = "MyExt".try_into().unwrap();
-        let mut my_ext = Extension::new_test(my_ext_name.clone());
-        let my_custom_op = my_ext.simple_ext_op("MyOp", Signature::new(vec![QB, NAT], vec![QB]));
+        let my_ext = Extension::new_test_arc(my_ext_name.clone(), |ext, extension_ref| {
+            ext.add_op(
+                "MyOp".into(),
+                "".to_string(),
+                Signature::new(vec![QB, NAT], vec![QB]),
+                extension_ref,
+            )
+            .unwrap();
+        });
+        let my_custom_op = my_ext
+            .instantiate_extension_op("MyOp", [], &PRELUDE_REGISTRY)
+            .unwrap();
 
         let build_res = build_main(
             Signature::new(type_row![QB, QB, NAT], type_row![QB, QB, BOOL_T])

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -443,10 +443,10 @@ impl<'a> Context<'a> {
 
         let poly_func_type = match opdef.signature_func() {
             SignatureFunc::PolyFuncType(poly_func_type) => poly_func_type,
-            _ => return self.make_named_global_ref(opdef.extension(), opdef.name()),
+            _ => return self.make_named_global_ref(opdef.extension_id(), opdef.name()),
         };
 
-        let key = (opdef.extension().clone(), opdef.name().clone());
+        let key = (opdef.extension_id().clone(), opdef.name().clone());
         let entry = self.decl_operations.entry(key);
 
         let node = match entry {
@@ -467,7 +467,7 @@ impl<'a> Context<'a> {
         };
 
         let decl = self.with_local_scope(node, |this| {
-            let name = this.make_qualified_name(opdef.extension(), opdef.name());
+            let name = this.make_qualified_name(opdef.extension_id(), opdef.name());
             let (params, constraints, r#type) = this.export_poly_func_type(poly_func_type);
             let decl = this.bump.alloc(model::OperationDecl {
                 name,

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -104,10 +104,7 @@ impl ExtensionRegistry {
     ///
     /// Takes an Arc to the extension. To avoid cloning Arcs unless necessary, see
     /// [`ExtensionRegistry::register_updated_ref`].
-    pub fn register_updated(
-        &mut self,
-        extension: impl Into<Arc<Extension>>,
-    ) -> Result<(), ExtensionRegistryError> {
+    pub fn register_updated(&mut self, extension: impl Into<Arc<Extension>>) {
         let extension = extension.into();
         match self.0.entry(extension.name().clone()) {
             btree_map::Entry::Occupied(mut prev) => {
@@ -119,7 +116,6 @@ impl ExtensionRegistry {
                 ve.insert(extension);
             }
         }
-        Ok(())
     }
 
     /// Registers a new extension to the registry, keeping most up to date if
@@ -131,10 +127,7 @@ impl ExtensionRegistry {
     ///
     /// Clones the Arc only when required. For no-cloning version see
     /// [`ExtensionRegistry::register_updated`].
-    pub fn register_updated_ref(
-        &mut self,
-        extension: &Arc<Extension>,
-    ) -> Result<(), ExtensionRegistryError> {
+    pub fn register_updated_ref(&mut self, extension: &Arc<Extension>) {
         match self.0.entry(extension.name().clone()) {
             btree_map::Entry::Occupied(mut prev) => {
                 if prev.get().version() < extension.version() {
@@ -145,7 +138,6 @@ impl ExtensionRegistry {
                 ve.insert(extension.clone());
             }
         }
-        Ok(())
     }
 
     /// Returns the number of extensions in the registry.
@@ -777,14 +769,14 @@ pub mod test {
         );
 
         // register with update works
-        reg_ref.register_updated_ref(&ext1_1).unwrap();
-        reg.register_updated(ext1_1.clone()).unwrap();
+        reg_ref.register_updated_ref(&ext1_1);
+        reg.register_updated(ext1_1.clone());
         assert_eq!(reg.get("ext1").unwrap().version(), &Version::new(1, 1, 0));
         assert_eq!(&reg, &reg_ref);
 
         // register with lower version does not change version
-        reg_ref.register_updated_ref(&ext1_2).unwrap();
-        reg.register_updated(ext1_2.clone()).unwrap();
+        reg_ref.register_updated_ref(&ext1_2);
+        reg.register_updated(ext1_2.clone());
         assert_eq!(reg.get("ext1").unwrap().version(), &Version::new(1, 1, 0));
         assert_eq!(&reg, &reg_ref);
 

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -462,7 +462,7 @@ impl Extension {
     }
 
     /// Extend the requirements of this extension with another set of extensions.
-    pub fn set_reqs(&mut self, extension_reqs: impl Into<ExtensionSet>) {
+    pub fn add_requirements(&mut self, extension_reqs: impl Into<ExtensionSet>) {
         let reqs = mem::take(&mut self.extension_reqs);
         self.extension_reqs = reqs.union(extension_reqs.into());
     }

--- a/hugr-core/src/extension/declarative.rs
+++ b/hugr-core/src/extension/declarative.rs
@@ -29,6 +29,7 @@ mod types;
 
 use std::fs::File;
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::extension::prelude::PRELUDE_ID;
 use crate::ops::OpName;
@@ -150,19 +151,24 @@ impl ExtensionDeclaration {
         &self,
         imports: &ExtensionSet,
         ctx: DeclarationContext<'_>,
-    ) -> Result<Extension, ExtensionDeclarationError> {
-        let mut ext = Extension::new(self.name.clone(), crate::extension::Version::new(0, 0, 0))
-            .with_reqs(imports.clone());
+    ) -> Result<Arc<Extension>, ExtensionDeclarationError> {
+        Extension::try_new_arc(
+            self.name.clone(),
+            // TODO: Get the version as a parameter.
+            crate::extension::Version::new(0, 0, 0),
+            |ext, extension_ref| {
+                for t in &self.types {
+                    t.register(ext, ctx, extension_ref)?;
+                }
 
-        for t in &self.types {
-            t.register(&mut ext, ctx)?;
-        }
+                for o in &self.operations {
+                    o.register(ext, ctx, extension_ref)?;
+                }
+                ext.set_reqs(imports.clone());
 
-        for o in &self.operations {
-            o.register(&mut ext, ctx)?;
-        }
-
-        Ok(ext)
+                Ok(())
+            },
+        )
     }
 }
 

--- a/hugr-core/src/extension/declarative.rs
+++ b/hugr-core/src/extension/declarative.rs
@@ -164,7 +164,7 @@ impl ExtensionDeclaration {
                 for o in &self.operations {
                     o.register(ext, ctx, extension_ref)?;
                 }
-                ext.set_reqs(imports.clone());
+                ext.add_requirements(imports.clone());
 
                 Ok(())
             },

--- a/hugr-core/src/extension/declarative/types.rs
+++ b/hugr-core/src/extension/declarative/types.rs
@@ -7,6 +7,8 @@
 //! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
 //! [`ExtensionSetDeclaration`]: super::ExtensionSetDeclaration
 
+use std::sync::Weak;
+
 use crate::extension::{TypeDef, TypeDefBound};
 use crate::types::type_param::TypeParam;
 use crate::types::{TypeBound, TypeName};
@@ -49,10 +51,14 @@ impl TypeDeclaration {
     ///
     /// Types in the definition will be resolved using the extensions in `scope`
     /// and the current extension.
+    ///
+    /// Requires a [`Weak`] reference to the extension defining the operation.
+    /// This method is intended to be used inside the closure passed to [`Extension::new_arc`].
     pub fn register<'ext>(
         &self,
         ext: &'ext mut Extension,
         ctx: DeclarationContext<'_>,
+        extension_ref: &Weak<Extension>,
     ) -> Result<&'ext TypeDef, ExtensionDeclarationError> {
         let params = self
             .params
@@ -64,6 +70,7 @@ impl TypeDeclaration {
             params,
             self.description.clone(),
             self.bound.into(),
+            extension_ref,
         )?;
         Ok(type_def)
     }

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 use std::collections::btree_map::Entry;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use super::{
     ConstFold, ConstFoldResult, Extension, ExtensionBuildError, ExtensionId, ExtensionRegistry,
@@ -302,6 +302,9 @@ impl Debug for LowerFunc {
 pub struct OpDef {
     /// The unique Extension owning this OpDef (of which this OpDef is a member)
     extension: ExtensionId,
+    /// A weak reference to the extension defining this operation.
+    #[serde(skip)]
+    extension_ref: Weak<Extension>,
     /// Unique identifier of the operation. Used to look up OpDefs in the registry
     /// when deserializing nodes (which store only the name).
     name: OpName,
@@ -394,9 +397,14 @@ impl OpDef {
         &self.name
     }
 
-    /// Returns a reference to the extension of this [`OpDef`].
-    pub fn extension(&self) -> &ExtensionId {
+    /// Returns a reference to the extension id of this [`OpDef`].
+    pub fn extension_id(&self) -> &ExtensionId {
         &self.extension
+    }
+
+    /// Returns a weak reference to the extension defining this operation.
+    pub fn extension(&self) -> Weak<Extension> {
+        self.extension_ref.clone()
     }
 
     /// Returns a reference to the description of this [`OpDef`].
@@ -467,15 +475,41 @@ impl Extension {
     /// Add an operation definition to the extension. Must be a type scheme
     /// (defined by a [`PolyFuncTypeRV`]), a type scheme along with binary
     /// validation for type arguments ([`CustomValidator`]), or a custom binary
-    /// function for computing the signature given type arguments (`impl [CustomSignatureFunc]`).
+    /// function for computing the signature given type arguments (implementing
+    /// `[CustomSignatureFunc]`).
+    ///
+    /// This method requires a [`Weak`] reference to the [`Arc`] containing the
+    /// extension being defined. The intended way to call this method is inside
+    /// the closure passed to [`Extension::new_arc`] when defining the extension.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use hugr_core::types::Signature;
+    /// # use hugr_core::extension::{Extension, ExtensionId, Version};
+    /// Extension::new_arc(
+    ///     ExtensionId::new_unchecked("my.extension"),
+    ///     Version::new(0, 1, 0),
+    ///     |ext, extension_ref| {
+    ///         ext.add_op(
+    ///             "MyOp".into(),
+    ///             "Some operation".into(),
+    ///             Signature::new_endo(vec![]),
+    ///             extension_ref,
+    ///         );
+    ///     },
+    /// );
+    /// ```
     pub fn add_op(
         &mut self,
         name: OpName,
         description: String,
         signature_func: impl Into<SignatureFunc>,
+        extension_ref: &Weak<Extension>,
     ) -> Result<&mut OpDef, ExtensionBuildError> {
         let op = OpDef {
             extension: self.name.clone(),
+            extension_ref: extension_ref.clone(),
             name,
             description,
             signature_func: signature_func.into(),
@@ -544,6 +578,7 @@ pub(super) mod test {
         fn eq(&self, other: &Self) -> bool {
             let OpDef {
                 extension,
+                extension_ref: _,
                 name,
                 description,
                 misc,
@@ -553,6 +588,7 @@ pub(super) mod test {
             } = &self.0;
             let OpDef {
                 extension: other_extension,
+                extension_ref: _,
                 name: other_name,
                 description: other_description,
                 misc: other_misc,
@@ -601,25 +637,28 @@ pub(super) mod test {
     #[test]
     fn op_def_with_type_scheme() -> Result<(), Box<dyn std::error::Error>> {
         let list_def = EXTENSION.get_type(&LIST_TYPENAME).unwrap();
-        let mut e = Extension::new_test(EXT_ID);
-        const TP: TypeParam = TypeParam::Type { b: TypeBound::Any };
-        let list_of_var =
-            Type::new_extension(list_def.instantiate(vec![TypeArg::new_var_use(0, TP)])?);
         const OP_NAME: OpName = OpName::new_inline("Reverse");
-        let type_scheme = PolyFuncTypeRV::new(vec![TP], Signature::new_endo(vec![list_of_var]));
 
-        let def = e.add_op(OP_NAME, "desc".into(), type_scheme)?;
-        def.add_lower_func(LowerFunc::FixedHugr {
-            extensions: ExtensionSet::new(),
-            hugr: crate::builder::test::simple_dfg_hugr(), // this is nonsense, but we are not testing the actual lowering here
-        });
-        def.add_misc("key", Default::default());
-        assert_eq!(def.description(), "desc");
-        assert_eq!(def.lower_funcs.len(), 1);
-        assert_eq!(def.misc.len(), 1);
+        let ext = Extension::try_new_test_arc(EXT_ID, |ext, extension_ref| {
+            const TP: TypeParam = TypeParam::Type { b: TypeBound::Any };
+            let list_of_var =
+                Type::new_extension(list_def.instantiate(vec![TypeArg::new_var_use(0, TP)])?);
+            let type_scheme = PolyFuncTypeRV::new(vec![TP], Signature::new_endo(vec![list_of_var]));
 
-        let reg =
-            ExtensionRegistry::try_new([PRELUDE.clone(), EXTENSION.clone(), e.into()]).unwrap();
+            let def = ext.add_op(OP_NAME, "desc".into(), type_scheme, extension_ref)?;
+            def.add_lower_func(LowerFunc::FixedHugr {
+                extensions: ExtensionSet::new(),
+                hugr: crate::builder::test::simple_dfg_hugr(), // this is nonsense, but we are not testing the actual lowering here
+            });
+            def.add_misc("key", Default::default());
+            assert_eq!(def.description(), "desc");
+            assert_eq!(def.lower_funcs.len(), 1);
+            assert_eq!(def.misc.len(), 1);
+
+            Ok(())
+        })?;
+
+        let reg = ExtensionRegistry::try_new([PRELUDE.clone(), EXTENSION.clone(), ext]).unwrap();
         let e = reg.get(&EXT_ID).unwrap();
 
         let list_usize =
@@ -666,60 +705,63 @@ pub(super) mod test {
                 MAX_NAT
             }
         }
-        let mut e = Extension::new_test(EXT_ID);
-        let def: &mut crate::extension::OpDef =
-            e.add_op("MyOp".into(), "".to_string(), SigFun())?;
+        let _ext = Extension::try_new_test_arc(EXT_ID, |ext, extension_ref| {
+            let def: &mut crate::extension::OpDef =
+                ext.add_op("MyOp".into(), "".to_string(), SigFun(), extension_ref)?;
 
-        // Base case, no type variables:
-        let args = [TypeArg::BoundedNat { n: 3 }, USIZE_T.into()];
-        assert_eq!(
-            def.compute_signature(&args, &PRELUDE_REGISTRY),
-            Ok(
-                Signature::new(vec![USIZE_T; 3], vec![Type::new_tuple(vec![USIZE_T; 3])])
-                    .with_extension_delta(EXT_ID)
-            )
-        );
-        assert_eq!(def.validate_args(&args, &PRELUDE_REGISTRY, &[]), Ok(()));
+            // Base case, no type variables:
+            let args = [TypeArg::BoundedNat { n: 3 }, USIZE_T.into()];
+            assert_eq!(
+                def.compute_signature(&args, &PRELUDE_REGISTRY),
+                Ok(
+                    Signature::new(vec![USIZE_T; 3], vec![Type::new_tuple(vec![USIZE_T; 3])])
+                        .with_extension_delta(EXT_ID)
+                )
+            );
+            assert_eq!(def.validate_args(&args, &PRELUDE_REGISTRY, &[]), Ok(()));
 
-        // Second arg may be a variable (substitutable)
-        let tyvar = Type::new_var_use(0, TypeBound::Copyable);
-        let tyvars: Vec<Type> = vec![tyvar.clone(); 3];
-        let args = [TypeArg::BoundedNat { n: 3 }, tyvar.clone().into()];
-        assert_eq!(
-            def.compute_signature(&args, &PRELUDE_REGISTRY),
-            Ok(
-                Signature::new(tyvars.clone(), vec![Type::new_tuple(tyvars)])
-                    .with_extension_delta(EXT_ID)
-            )
-        );
-        def.validate_args(&args, &PRELUDE_REGISTRY, &[TypeBound::Copyable.into()])
-            .unwrap();
+            // Second arg may be a variable (substitutable)
+            let tyvar = Type::new_var_use(0, TypeBound::Copyable);
+            let tyvars: Vec<Type> = vec![tyvar.clone(); 3];
+            let args = [TypeArg::BoundedNat { n: 3 }, tyvar.clone().into()];
+            assert_eq!(
+                def.compute_signature(&args, &PRELUDE_REGISTRY),
+                Ok(
+                    Signature::new(tyvars.clone(), vec![Type::new_tuple(tyvars)])
+                        .with_extension_delta(EXT_ID)
+                )
+            );
+            def.validate_args(&args, &PRELUDE_REGISTRY, &[TypeBound::Copyable.into()])
+                .unwrap();
 
-        // quick sanity check that we are validating the args - note changed bound:
-        assert_eq!(
-            def.validate_args(&args, &PRELUDE_REGISTRY, &[TypeBound::Any.into()]),
-            Err(SignatureError::TypeVarDoesNotMatchDeclaration {
-                actual: TypeBound::Any.into(),
-                cached: TypeBound::Copyable.into()
-            })
-        );
+            // quick sanity check that we are validating the args - note changed bound:
+            assert_eq!(
+                def.validate_args(&args, &PRELUDE_REGISTRY, &[TypeBound::Any.into()]),
+                Err(SignatureError::TypeVarDoesNotMatchDeclaration {
+                    actual: TypeBound::Any.into(),
+                    cached: TypeBound::Copyable.into()
+                })
+            );
 
-        // First arg must be concrete, not a variable
-        let kind = TypeParam::bounded_nat(NonZeroU64::new(5).unwrap());
-        let args = [TypeArg::new_var_use(0, kind.clone()), USIZE_T.into()];
-        // We can't prevent this from getting into our compute_signature implementation:
-        assert_eq!(
-            def.compute_signature(&args, &PRELUDE_REGISTRY),
-            Err(SignatureError::InvalidTypeArgs)
-        );
-        // But validation rules it out, even when the variable is declared:
-        assert_eq!(
-            def.validate_args(&args, &PRELUDE_REGISTRY, &[kind]),
-            Err(SignatureError::FreeTypeVar {
-                idx: 0,
-                num_decls: 0
-            })
-        );
+            // First arg must be concrete, not a variable
+            let kind = TypeParam::bounded_nat(NonZeroU64::new(5).unwrap());
+            let args = [TypeArg::new_var_use(0, kind.clone()), USIZE_T.into()];
+            // We can't prevent this from getting into our compute_signature implementation:
+            assert_eq!(
+                def.compute_signature(&args, &PRELUDE_REGISTRY),
+                Err(SignatureError::InvalidTypeArgs)
+            );
+            // But validation rules it out, even when the variable is declared:
+            assert_eq!(
+                def.validate_args(&args, &PRELUDE_REGISTRY, &[kind]),
+                Err(SignatureError::FreeTypeVar {
+                    idx: 0,
+                    num_decls: 0
+                })
+            );
+
+            Ok(())
+        })?;
 
         Ok(())
     }
@@ -728,34 +770,37 @@ pub(super) mod test {
     fn type_scheme_instantiate_var() -> Result<(), Box<dyn std::error::Error>> {
         // Check that we can instantiate a PolyFuncTypeRV-scheme with an (external)
         // type variable
-        let mut e = Extension::new_test(EXT_ID);
-        let def = e.add_op(
-            "SimpleOp".into(),
-            "".into(),
-            PolyFuncTypeRV::new(
-                vec![TypeBound::Any.into()],
-                Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
-            ),
-        )?;
-        let tv = Type::new_var_use(1, TypeBound::Copyable);
-        let args = [TypeArg::Type { ty: tv.clone() }];
-        let decls = [TypeParam::Extensions, TypeBound::Copyable.into()];
-        def.validate_args(&args, &EMPTY_REG, &decls).unwrap();
-        assert_eq!(
-            def.compute_signature(&args, &EMPTY_REG),
-            Ok(Signature::new_endo(tv).with_extension_delta(EXT_ID))
-        );
-        // But not with an external row variable
-        let arg: TypeArg = TypeRV::new_row_var_use(0, TypeBound::Copyable).into();
-        assert_eq!(
-            def.compute_signature(&[arg.clone()], &EMPTY_REG),
-            Err(SignatureError::TypeArgMismatch(
-                TypeArgError::TypeMismatch {
-                    param: TypeBound::Any.into(),
-                    arg
-                }
-            ))
-        );
+        let _ext = Extension::try_new_test_arc(EXT_ID, |ext, extension_ref| {
+            let def = ext.add_op(
+                "SimpleOp".into(),
+                "".into(),
+                PolyFuncTypeRV::new(
+                    vec![TypeBound::Any.into()],
+                    Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
+                ),
+                extension_ref,
+            )?;
+            let tv = Type::new_var_use(1, TypeBound::Copyable);
+            let args = [TypeArg::Type { ty: tv.clone() }];
+            let decls = [TypeParam::Extensions, TypeBound::Copyable.into()];
+            def.validate_args(&args, &EMPTY_REG, &decls).unwrap();
+            assert_eq!(
+                def.compute_signature(&args, &EMPTY_REG),
+                Ok(Signature::new_endo(tv).with_extension_delta(EXT_ID))
+            );
+            // But not with an external row variable
+            let arg: TypeArg = TypeRV::new_row_var_use(0, TypeBound::Copyable).into();
+            assert_eq!(
+                def.compute_signature(&[arg.clone()], &EMPTY_REG),
+                Err(SignatureError::TypeArgMismatch(
+                    TypeArgError::TypeMismatch {
+                        param: TypeBound::Any.into(),
+                        arg
+                    }
+                ))
+            );
+            Ok(())
+        })?;
         Ok(())
     }
 
@@ -763,33 +808,39 @@ pub(super) mod test {
     fn instantiate_extension_delta() -> Result<(), Box<dyn std::error::Error>> {
         use crate::extension::prelude::{BOOL_T, PRELUDE_REGISTRY};
 
-        let mut e = Extension::new_test(EXT_ID);
+        let _ext = Extension::try_new_test_arc(EXT_ID, |ext, extension_ref| {
+            let params: Vec<TypeParam> = vec![TypeParam::Extensions];
+            let db_set = ExtensionSet::type_var(0);
+            let fun_ty = Signature::new_endo(BOOL_T).with_extension_delta(db_set);
 
-        let params: Vec<TypeParam> = vec![TypeParam::Extensions];
-        let db_set = ExtensionSet::type_var(0);
-        let fun_ty = Signature::new_endo(BOOL_T).with_extension_delta(db_set);
+            let def = ext.add_op(
+                "SimpleOp".into(),
+                "".into(),
+                PolyFuncTypeRV::new(params.clone(), fun_ty),
+                extension_ref,
+            )?;
 
-        let def = e.add_op(
-            "SimpleOp".into(),
-            "".into(),
-            PolyFuncTypeRV::new(params.clone(), fun_ty),
-        )?;
+            // Concrete extension set
+            let es = ExtensionSet::singleton(&EXT_ID);
+            let exp_fun_ty = Signature::new_endo(BOOL_T).with_extension_delta(es.clone());
+            let args = [TypeArg::Extensions { es }];
 
-        // Concrete extension set
-        let es = ExtensionSet::singleton(&EXT_ID);
-        let exp_fun_ty = Signature::new_endo(BOOL_T).with_extension_delta(es.clone());
-        let args = [TypeArg::Extensions { es }];
+            def.validate_args(&args, &PRELUDE_REGISTRY, &params)
+                .unwrap();
+            assert_eq!(
+                def.compute_signature(&args, &PRELUDE_REGISTRY),
+                Ok(exp_fun_ty)
+            );
 
-        def.validate_args(&args, &PRELUDE_REGISTRY, &params)
-            .unwrap();
-        assert_eq!(
-            def.compute_signature(&args, &PRELUDE_REGISTRY),
-            Ok(exp_fun_ty)
-        );
+            Ok(())
+        })?;
+
         Ok(())
     }
 
     mod proptest {
+        use std::sync::Weak;
+
         use super::SimpleOpDef;
         use ::proptest::prelude::*;
 
@@ -846,6 +897,8 @@ pub(super) mod test {
                         |(extension, name, description, misc, signature_func, lower_funcs)| {
                             Self::new(OpDef {
                                 extension,
+                                // Use a dead weak reference. Trying to access the extension will always return None.
+                                extension_ref: Weak::default(),
                                 name,
                                 description,
                                 misc,

--- a/hugr-core/src/extension/prelude/array.rs
+++ b/hugr-core/src/extension/prelude/array.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::sync::Weak;
 
 use itertools::Itertools;
 use strum_macros::EnumIter;
@@ -180,7 +181,7 @@ impl MakeOpDef for ArrayOpDef {
     where
         Self: Sized,
     {
-        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn signature(&self) -> SignatureFunc {
@@ -216,9 +217,10 @@ impl MakeOpDef for ArrayOpDef {
     fn add_to_extension(
         &self,
         extension: &mut Extension,
+        extension_ref: &Weak<Extension>,
     ) -> Result<(), crate::extension::ExtensionBuildError> {
         let sig = self.signature_from_def(extension.get_type(ARRAY_TYPE_NAME).unwrap());
-        let def = extension.add_op(self.name(), self.description(), sig)?;
+        let def = extension.add_op(self.name(), self.description(), sig, extension_ref)?;
 
         self.post_opdef(def);
 
@@ -394,7 +396,7 @@ impl MakeOpDef for ArrayScanDef {
     where
         Self: Sized,
     {
-        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn signature(&self) -> SignatureFunc {
@@ -421,9 +423,10 @@ impl MakeOpDef for ArrayScanDef {
     fn add_to_extension(
         &self,
         extension: &mut Extension,
+        extension_ref: &Weak<Extension>,
     ) -> Result<(), crate::extension::ExtensionBuildError> {
         let sig = self.signature_from_def(extension.get_type(ARRAY_TYPE_NAME).unwrap());
-        let def = extension.add_op(self.name(), self.description(), sig)?;
+        let def = extension.add_op(self.name(), self.description(), sig, extension_ref)?;
 
         self.post_opdef(def);
 

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -1,4 +1,5 @@
 use std::collections::btree_map::Entry;
+use std::sync::Weak;
 
 use super::{CustomConcrete, ExtensionBuildError};
 use super::{Extension, ExtensionId, SignatureError};
@@ -56,6 +57,9 @@ impl TypeDefBound {
 pub struct TypeDef {
     /// The unique Extension owning this TypeDef (of which this TypeDef is a member)
     extension: ExtensionId,
+    /// A weak reference to the extension defining this operation.
+    #[serde(skip)]
+    extension_ref: Weak<Extension>,
     /// The unique name of the type
     name: TypeName,
     /// Declaration of type parameters. The TypeDef must be instantiated
@@ -82,9 +86,9 @@ impl TypeDef {
     /// This function will return an error if the type of the instance does not
     /// match the definition.
     pub fn check_custom(&self, custom: &CustomType) -> Result<(), SignatureError> {
-        if self.extension() != custom.parent_extension() {
+        if self.extension_id() != custom.parent_extension() {
             return Err(SignatureError::ExtensionMismatch(
-                self.extension().clone(),
+                self.extension_id().clone(),
                 custom.parent_extension().clone(),
             ));
         }
@@ -121,7 +125,7 @@ impl TypeDef {
         Ok(CustomType::new(
             self.name().clone(),
             args,
-            self.extension().clone(),
+            self.extension_id().clone(),
             bound,
         ))
     }
@@ -156,22 +160,55 @@ impl TypeDef {
         &self.name
     }
 
-    fn extension(&self) -> &ExtensionId {
+    /// Returns a reference to the extension id of this [`TypeDef`].
+    pub fn extension_id(&self) -> &ExtensionId {
         &self.extension
+    }
+
+    /// Returns a weak reference to the extension defining this type.
+    pub fn extension(&self) -> Weak<Extension> {
+        self.extension_ref.clone()
     }
 }
 
 impl Extension {
     /// Add an exported type to the extension.
+    ///
+    /// This method requires a [`Weak`] reference to the [`std::sync::Arc`] containing the
+    /// extension being defined. The intended way to call this method is inside
+    /// the closure passed to [`Extension::new_arc`] when defining the extension.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use hugr_core::types::Signature;
+    /// # use hugr_core::extension::{Extension, ExtensionId, Version};
+    /// # use hugr_core::extension::{TypeDefBound};
+    /// Extension::new_arc(
+    ///     ExtensionId::new_unchecked("my.extension"),
+    ///     Version::new(0, 1, 0),
+    ///     |ext, extension_ref| {
+    ///         ext.add_type(
+    ///             "MyType".into(),
+    ///             vec![], // No type parameters
+    ///             "Some type".into(),
+    ///             TypeDefBound::any(),
+    ///             extension_ref,
+    ///         );
+    ///     },
+    /// );
+    /// ```
     pub fn add_type(
         &mut self,
         name: TypeName,
         params: Vec<TypeParam>,
         description: String,
         bound: TypeDefBound,
+        extension_ref: &Weak<Extension>,
     ) -> Result<&TypeDef, ExtensionBuildError> {
         let ty = TypeDef {
             extension: self.name.clone(),
+            extension_ref: extension_ref.clone(),
             name,
             params,
             description,
@@ -202,6 +239,8 @@ mod test {
                 b: TypeBound::Copyable,
             }],
             extension: "MyRsrc".try_into().unwrap(),
+            // Dummy extension. Will return `None` when trying to upgrade it into an `Arc`.
+            extension_ref: Default::default(),
             description: "Some parametrised type".into(),
             bound: TypeDefBound::FromParams { indices: vec![0] },
         };

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -99,7 +99,7 @@ impl Package {
         reg: &mut ExtensionRegistry,
     ) -> Result<(), PackageValidationError> {
         for ext in &self.extensions {
-            reg.register_updated_ref(ext)?;
+            reg.register_updated_ref(ext);
         }
         for hugr in self.modules.iter_mut() {
             hugr.update_validate(reg)?;

--- a/hugr-core/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions.rs
@@ -50,7 +50,7 @@ pub enum ConvertOpDef {
 
 impl MakeOpDef for ConvertOpDef {
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn extension(&self) -> ExtensionId {
@@ -158,18 +158,15 @@ impl MakeExtensionOp for ConvertOpType {
 lazy_static! {
     /// Extension for conversions between integers and floats.
     pub static ref EXTENSION: Arc<Extension> = {
-        let mut extension = Extension::new(
-            EXTENSION_ID,
-            VERSION).with_reqs(
-            ExtensionSet::from_iter(vec![
-                super::int_types::EXTENSION_ID,
-                super::float_types::EXTENSION_ID,
-            ]),
-        );
+        Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
+            extension.set_reqs(
+                ExtensionSet::from_iter(vec![
+                    super::int_types::EXTENSION_ID,
+                    super::float_types::EXTENSION_ID,
+            ]));
 
-        ConvertOpDef::load_all_ops(&mut extension).unwrap();
-
-        Arc::new(extension)
+            ConvertOpDef::load_all_ops(extension, extension_ref).unwrap();
+        })
     };
 
     /// Registry of extensions required to validate integer operations.

--- a/hugr-core/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions.rs
@@ -159,7 +159,7 @@ lazy_static! {
     /// Extension for conversions between integers and floats.
     pub static ref EXTENSION: Arc<Extension> = {
         Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
-            extension.set_reqs(
+            extension.add_requirements(
                 ExtensionSet::from_iter(vec![
                     super::int_types::EXTENSION_ID,
                     super::float_types::EXTENSION_ID,

--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -50,7 +50,7 @@ pub enum FloatOps {
 
 impl MakeOpDef for FloatOps {
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn extension(&self) -> ExtensionId {
@@ -107,15 +107,10 @@ impl MakeOpDef for FloatOps {
 lazy_static! {
     /// Extension for basic float operations.
     pub static ref EXTENSION: Arc<Extension> = {
-        let mut extension = Extension::new(
-            EXTENSION_ID,
-            VERSION).with_reqs(
-            ExtensionSet::singleton(&super::int_types::EXTENSION_ID),
-        );
-
-        FloatOps::load_all_ops(&mut extension).unwrap();
-
-        Arc::new(extension)
+        Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
+            extension.set_reqs(ExtensionSet::singleton(&super::int_types::EXTENSION_ID));
+            FloatOps::load_all_ops(extension, extension_ref).unwrap();
+        })
     };
 
     /// Registry of extensions required to validate float operations.

--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -108,7 +108,7 @@ lazy_static! {
     /// Extension for basic float operations.
     pub static ref EXTENSION: Arc<Extension> = {
         Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
-            extension.set_reqs(ExtensionSet::singleton(&super::int_types::EXTENSION_ID));
+            extension.add_requirements(ExtensionSet::singleton(&super::int_types::EXTENSION_ID));
             FloatOps::load_all_ops(extension, extension_ref).unwrap();
         })
     };

--- a/hugr-core/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_types.rs
@@ -82,18 +82,17 @@ impl CustomConst for ConstF64 {
 lazy_static! {
     /// Extension defining the float type.
     pub static ref EXTENSION: Arc<Extension> = {
-        let mut extension = Extension::new(EXTENSION_ID, VERSION);
-
-        extension
-            .add_type(
-                FLOAT_TYPE_ID,
-                vec![],
-                "64-bit IEEE 754-2019 floating-point value".to_owned(),
-                TypeBound::Copyable.into(),
-            )
-            .unwrap();
-
-        Arc::new(extension)
+        Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
+            extension
+                .add_type(
+                    FLOAT_TYPE_ID,
+                    vec![],
+                    "64-bit IEEE 754-2019 floating-point value".to_owned(),
+                    TypeBound::Copyable.into(),
+                    extension_ref,
+                )
+                .unwrap();
+        })
     };
 }
 #[cfg(test)]

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -251,7 +251,7 @@ lazy_static! {
     /// Extension for basic integer operations.
     pub static ref EXTENSION: Arc<Extension> = {
         Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
-            extension.set_reqs(ExtensionSet::singleton(&super::int_types::EXTENSION_ID));
+            extension.add_requirements(ExtensionSet::singleton(&super::int_types::EXTENSION_ID));
             IntOpDef::load_all_ops(extension, extension_ref).unwrap();
         })
     };

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -104,7 +104,7 @@ pub enum IntOpDef {
 
 impl MakeOpDef for IntOpDef {
     fn from_def(op_def: &OpDef) -> Result<Self, crate::extension::simple_op::OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn extension(&self) -> ExtensionId {
@@ -250,15 +250,10 @@ fn iunop_sig() -> PolyFuncTypeRV {
 lazy_static! {
     /// Extension for basic integer operations.
     pub static ref EXTENSION: Arc<Extension> = {
-        let mut extension = Extension::new(
-            EXTENSION_ID,
-            VERSION).with_reqs(
-            ExtensionSet::singleton(&super::int_types::EXTENSION_ID)
-        );
-
-        IntOpDef::load_all_ops(&mut extension).unwrap();
-
-        Arc::new(extension)
+        Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
+            extension.set_reqs(ExtensionSet::singleton(&super::int_types::EXTENSION_ID));
+            IntOpDef::load_all_ops(extension, extension_ref).unwrap();
+        })
     };
 
     /// Registry of extensions required to validate integer operations.

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -188,18 +188,17 @@ impl CustomConst for ConstInt {
 
 /// Extension for basic integer types.
 pub fn extension() -> Arc<Extension> {
-    let mut extension = Extension::new(EXTENSION_ID, VERSION);
-
-    extension
-        .add_type(
-            INT_TYPE_ID,
-            vec![LOG_WIDTH_TYPE_PARAM],
-            "integral value of a given bit width".to_owned(),
-            TypeBound::Copyable.into(),
-        )
-        .unwrap();
-
-    Arc::new(extension)
+    Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
+        extension
+            .add_type(
+                INT_TYPE_ID,
+                vec![LOG_WIDTH_TYPE_PARAM],
+                "integral value of a given bit width".to_owned(),
+                TypeBound::Copyable.into(),
+                extension_ref,
+            )
+            .unwrap();
+    })
 }
 
 lazy_static! {

--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -5,7 +5,7 @@ use std::hash::{Hash, Hasher};
 mod list_fold;
 
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -204,7 +204,7 @@ impl ListOp {
 
 impl MakeOpDef for ListOp {
     fn from_def(op_def: &OpDef) -> Result<Self, crate::extension::simple_op::OpLoadError> {
-        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn extension(&self) -> ExtensionId {
@@ -216,9 +216,13 @@ impl MakeOpDef for ListOp {
     //
     // This method is re-defined here since we need to pass the list type def while computing the signature,
     // to avoid recursive loops initializing the extension.
-    fn add_to_extension(&self, extension: &mut Extension) -> Result<(), ExtensionBuildError> {
+    fn add_to_extension(
+        &self,
+        extension: &mut Extension,
+        extension_ref: &Weak<Extension>,
+    ) -> Result<(), ExtensionBuildError> {
         let sig = self.compute_signature(extension.get_type(&LIST_TYPENAME).unwrap());
-        let def = extension.add_op(self.name(), self.description(), sig)?;
+        let def = extension.add_op(self.name(), self.description(), sig, extension_ref)?;
 
         self.post_opdef(def);
 
@@ -251,20 +255,19 @@ impl MakeOpDef for ListOp {
 lazy_static! {
     /// Extension for list operations.
     pub static ref EXTENSION: Arc<Extension> = {
-        let mut extension = Extension::new(EXTENSION_ID, VERSION);
+        Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
+            extension.add_type(
+                LIST_TYPENAME,
+                vec![ListOp::TP],
+                "Generic dynamically sized list of type T.".into(),
+                TypeDefBound::from_params(vec![0]),
+                extension_ref
+            )
+            .unwrap();
 
-        // The list type must be defined before the operations are added.
-        extension.add_type(
-            LIST_TYPENAME,
-            vec![ListOp::TP],
-            "Generic dynamically sized list of type T.".into(),
-            TypeDefBound::from_params(vec![0]),
-        )
-        .unwrap();
-
-        ListOp::load_all_ops(&mut extension).unwrap();
-
-        Arc::new(extension)
+            // The list type must be defined before the operations are added.
+            ListOp::load_all_ops(extension, extension_ref).unwrap();
+        })
     };
 
     /// Registry of extensions required to validate list operations.
@@ -392,7 +395,7 @@ mod test {
         assert_eq!(&ListOp::push.extension(), EXTENSION.name());
         assert!(ListOp::pop.registry().contains(EXTENSION.name()));
         for (_, op_def) in EXTENSION.operations() {
-            assert_eq!(op_def.extension(), &EXTENSION_ID);
+            assert_eq!(op_def.extension_id(), &EXTENSION_ID);
         }
     }
 

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -91,7 +91,7 @@ impl MakeOpDef for LogicOp {
     }
 
     fn from_def(op_def: &OpDef) -> Result<Self, OpLoadError> {
-        try_from_name(op_def.name(), op_def.extension())
+        try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn extension(&self) -> ExtensionId {
@@ -110,16 +110,16 @@ pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 
 /// Extension for basic logical operations.
 fn extension() -> Arc<Extension> {
-    let mut extension = Extension::new(EXTENSION_ID, VERSION);
-    LogicOp::load_all_ops(&mut extension).unwrap();
+    Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
+        LogicOp::load_all_ops(extension, extension_ref).unwrap();
 
-    extension
-        .add_value(FALSE_NAME, ops::Value::false_val())
-        .unwrap();
-    extension
-        .add_value(TRUE_NAME, ops::Value::true_val())
-        .unwrap();
-    Arc::new(extension)
+        extension
+            .add_value(FALSE_NAME, ops::Value::false_val())
+            .unwrap();
+        extension
+            .add_value(TRUE_NAME, ops::Value::true_val())
+            .unwrap();
+    })
 }
 
 lazy_static! {

--- a/hugr-core/src/std_extensions/ptr.rs
+++ b/hugr-core/src/std_extensions/ptr.rs
@@ -47,7 +47,7 @@ impl MakeOpDef for PtrOpDef {
     where
         Self: Sized,
     {
-        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
+        crate::extension::simple_op::try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn signature(&self) -> SignatureFunc {
@@ -87,17 +87,18 @@ pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 
 /// Extension for pointer operations.
 fn extension() -> Arc<Extension> {
-    let mut extension = Extension::new(EXTENSION_ID, VERSION);
-    extension
-        .add_type(
-            PTR_TYPE_ID,
-            TYPE_PARAMS.into(),
-            "Standard extension pointer type.".into(),
-            TypeDefBound::copyable(),
-        )
-        .unwrap();
-    PtrOpDef::load_all_ops(&mut extension).unwrap();
-    Arc::new(extension)
+    Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
+        extension
+            .add_type(
+                PTR_TYPE_ID,
+                TYPE_PARAMS.into(),
+                "Standard extension pointer type.".into(),
+                TypeDefBound::copyable(),
+                extension_ref,
+            )
+            .unwrap();
+        PtrOpDef::load_all_ops(extension, extension_ref).unwrap();
+    })
 }
 
 lazy_static! {

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -321,16 +321,18 @@ pub(crate) mod test {
         const EXT_ID: ExtensionId = ExtensionId::new_unchecked("my_ext");
         const TYPE_NAME: TypeName = TypeName::new_inline("MyType");
 
-        let mut e = Extension::new_test(EXT_ID);
-        e.add_type(
-            TYPE_NAME,
-            vec![bound.clone()],
-            "".into(),
-            TypeDefBound::any(),
-        )
-        .unwrap();
+        let ext = Extension::new_test_arc(EXT_ID, |ext, extension_ref| {
+            ext.add_type(
+                TYPE_NAME,
+                vec![bound.clone()],
+                "".into(),
+                TypeDefBound::any(),
+                extension_ref,
+            )
+            .unwrap();
+        });
 
-        let reg = ExtensionRegistry::try_new([e.into()]).unwrap();
+        let reg = ExtensionRegistry::try_new([ext]).unwrap();
 
         let make_scheme = |tp: TypeParam| {
             PolyFuncTypeBase::new_validated(

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -131,48 +131,60 @@ pub(crate) mod test_quantum_extension {
     /// The extension identifier.
     pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("test.quantum");
     fn extension() -> Arc<Extension> {
-        let mut extension = Extension::new_test(EXTENSION_ID);
+        Extension::new_test_arc(EXTENSION_ID, |extension, extension_ref| {
+            extension
+                .add_op(
+                    OpName::new_inline("H"),
+                    "Hadamard".into(),
+                    one_qb_func(),
+                    extension_ref,
+                )
+                .unwrap();
+            extension
+                .add_op(
+                    OpName::new_inline("RzF64"),
+                    "Rotation specified by float".into(),
+                    Signature::new(type_row![QB_T, float_types::FLOAT64_TYPE], type_row![QB_T]),
+                    extension_ref,
+                )
+                .unwrap();
 
-        extension
-            .add_op(OpName::new_inline("H"), "Hadamard".into(), one_qb_func())
-            .unwrap();
-        extension
-            .add_op(
-                OpName::new_inline("RzF64"),
-                "Rotation specified by float".into(),
-                Signature::new(type_row![QB_T, float_types::FLOAT64_TYPE], type_row![QB_T]),
-            )
-            .unwrap();
+            extension
+                .add_op(
+                    OpName::new_inline("CX"),
+                    "CX".into(),
+                    two_qb_func(),
+                    extension_ref,
+                )
+                .unwrap();
 
-        extension
-            .add_op(OpName::new_inline("CX"), "CX".into(), two_qb_func())
-            .unwrap();
+            extension
+                .add_op(
+                    OpName::new_inline("Measure"),
+                    "Measure a qubit, returning the qubit and the measurement result.".into(),
+                    Signature::new(type_row![QB_T], type_row![QB_T, BOOL_T]),
+                    extension_ref,
+                )
+                .unwrap();
 
-        extension
-            .add_op(
-                OpName::new_inline("Measure"),
-                "Measure a qubit, returning the qubit and the measurement result.".into(),
-                Signature::new(type_row![QB_T], type_row![QB_T, BOOL_T]),
-            )
-            .unwrap();
+            extension
+                .add_op(
+                    OpName::new_inline("QAlloc"),
+                    "Allocate a new qubit.".into(),
+                    Signature::new(type_row![], type_row![QB_T]),
+                    extension_ref,
+                )
+                .unwrap();
 
-        extension
-            .add_op(
-                OpName::new_inline("QAlloc"),
-                "Allocate a new qubit.".into(),
-                Signature::new(type_row![], type_row![QB_T]),
-            )
-            .unwrap();
-
-        extension
-            .add_op(
-                OpName::new_inline("QDiscard"),
-                "Discard a qubit.".into(),
-                Signature::new(type_row![QB_T], type_row![]),
-            )
-            .unwrap();
-
-        Arc::new(extension)
+            extension
+                .add_op(
+                    OpName::new_inline("QDiscard"),
+                    "Discard a qubit.".into(),
+                    Signature::new(type_row![QB_T], type_row![]),
+                    extension_ref,
+                )
+                .unwrap();
+        })
     }
 
     lazy_static! {

--- a/hugr-llvm/src/custom/extension_op.rs
+++ b/hugr-llvm/src/custom/extension_op.rs
@@ -100,7 +100,7 @@ impl<'a, H: HugrView> ExtensionOpMap<'a, H> {
         args: EmitOpArgs<'c, '_, ExtensionOp, H>,
     ) -> Result<()> {
         let node = args.node();
-        let key = (node.def().extension().clone(), node.def().name().clone());
+        let key = (node.def().extension_id().clone(), node.def().name().clone());
         let Some(handler) = self.0.get(&key) else {
             bail!("No extension could emit extension op: {key:?}")
         };

--- a/hugr/benches/benchmarks/hugr/examples.rs
+++ b/hugr/benches/benchmarks/hugr/examples.rs
@@ -1,5 +1,7 @@
 //! Builders and utilities for benchmarks.
 
+use std::sync::Arc;
+
 use hugr::builder::{
     BuildError, CFGBuilder, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
     HugrBuilder, ModuleBuilder,
@@ -53,35 +55,35 @@ pub fn simple_cfg_hugr() -> Hugr {
 }
 
 lazy_static! {
-    static ref QUANTUM_EXT: Extension = {
-        let mut extension = Extension::new(
+    static ref QUANTUM_EXT: Arc<Extension> = {
+        Extension::new_arc(
             "bench.quantum".try_into().unwrap(),
             hugr::extension::Version::new(0, 0, 0),
-        );
+            |ext, extension_ref| {
+                ext.add_op(
+                    OpName::new_inline("H"),
+                    "".into(),
+                    Signature::new_endo(QB_T),
+                    extension_ref,
+                )
+                .unwrap();
+                ext.add_op(
+                    OpName::new_inline("Rz"),
+                    "".into(),
+                    Signature::new(type_row![QB_T, FLOAT64_TYPE], type_row![QB_T]),
+                    extension_ref,
+                )
+                .unwrap();
 
-        extension
-            .add_op(
-                OpName::new_inline("H"),
-                "".into(),
-                Signature::new_endo(QB_T),
-            )
-            .unwrap();
-        extension
-            .add_op(
-                OpName::new_inline("Rz"),
-                "".into(),
-                Signature::new(type_row![QB_T, FLOAT64_TYPE], type_row![QB_T]),
-            )
-            .unwrap();
-
-        extension
-            .add_op(
-                OpName::new_inline("CX"),
-                "".into(),
-                Signature::new_endo(type_row![QB_T, QB_T]),
-            )
-            .unwrap();
-        extension
+                ext.add_op(
+                    OpName::new_inline("CX"),
+                    "".into(),
+                    Signature::new_endo(type_row![QB_T, QB_T]),
+                    extension_ref,
+                )
+                .unwrap();
+            },
+        )
     };
 }
 

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -61,25 +61,21 @@
 //!     pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("mini.quantum");
 //!     pub const VERSION: Version = Version::new(0, 1, 0);
 //!     fn extension() -> Arc<Extension> {
-//!         let mut extension = Extension::new(EXTENSION_ID, VERSION);
+//!         Extension::new_arc(EXTENSION_ID, VERSION, |ext, extension_ref| {
+//!             ext.add_op(OpName::new_inline("H"), "Hadamard".into(), one_qb_func(), extension_ref)
+//!                 .unwrap();
 //!
-//!         extension
-//!             .add_op(OpName::new_inline("H"), "Hadamard".into(), one_qb_func())
-//!             .unwrap();
+//!             ext.add_op(OpName::new_inline("CX"), "CX".into(), two_qb_func(), extension_ref)
+//!                 .unwrap();
 //!
-//!         extension
-//!             .add_op(OpName::new_inline("CX"), "CX".into(), two_qb_func())
-//!             .unwrap();
-//!
-//!         extension
-//!             .add_op(
+//!             ext.add_op(
 //!                 OpName::new_inline("Measure"),
 //!                 "Measure a qubit, returning the qubit and the measurement result.".into(),
 //!                 FuncValueType::new(type_row![QB_T], type_row![QB_T, BOOL_T]),
+//!                 extension_ref,
 //!             )
 //!             .unwrap();
-//!
-//!         Arc::new(extension)
+//!         })
 //!     }
 //!
 //!     lazy_static! {


### PR DESCRIPTION
This change was extracted from the work towards #1613.
Now `OpDef`s and `TypeDef`s keep a `Weak` reference to their extension's `Arc`.

This way we will be able to automatically set the extension requirements when adding operations, so we can get rid of `update_validate` and the explicit registries when building hugrs.

To implement this, the building interface for `Extension`s is sightly modified.
Once an `Arc` is built it cannot be modified without doing internal mutation.
But we need the `Arc`'s weak reference to define the ops and types.
Thankfully, we can use `Arc::new_cyclic` which provides us with a `Weak` ref at build time so we are able to define things as needed.

This is wrapped in a new `Extension::new_arc` method, so the user doesn't need to think about that.

BREAKING CHANGE: Renamed `OpDef::extension` and `TypeDef::extension` to `extension_id`. `extension` now returns weak references to the `Extension` defining them.
BREAKING CHANGE: `Extension::with_reqs` moved to `set_reqs`, which takes `&mut self` instead of `self`.
BREAKING CHANGE: `Extension::add_type` and `Extension::add_op` now take an extra parameter. See docs for example usage.
BREAKING CHANGE: `ExtensionRegistry::register_updated` and `register_updated_ref` are no longer fallible.