### PR TITLE
fix: Ignare lint warnings in capnproto generated code

### DIFF
--- a/hugr-model/src/lib.rs
+++ b/hugr-model/src/lib.rs
@@ -4,6 +4,7 @@
 //! are not designed for efficient traversal or modification, but for simplicity and serialization.
 pub mod v0;
 
+#[allow(clippy::needless_lifetimes)]
 pub(crate) mod hugr_v0_capnp {
     include!(concat!(env!("OUT_DIR"), "/hugr_v0_capnp.rs"));
 }

--- a/hugr-model/src/v0/text/print.rs
+++ b/hugr-model/src/v0/text/print.rs
@@ -587,7 +587,7 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
         let term_data = self
             .module
             .get_term(term_id)
-            .ok_or_else(|| PrintError::TermNotFound(term_id))?;
+            .ok_or(PrintError::TermNotFound(term_id))?;
 
         if let Term::List { parts } = term_data {
             for part in *parts {
@@ -611,7 +611,7 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
         let term_data = self
             .module
             .get_term(term_id)
-            .ok_or_else(|| PrintError::TermNotFound(term_id))?;
+            .ok_or(PrintError::TermNotFound(term_id))?;
 
         if let Term::ExtSet { parts } = term_data {
             for part in *parts {


### PR DESCRIPTION
Fixes #1727 