### PR TITLE
feat: add op for creating new/empty list

### DIFF
--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -681,6 +681,10 @@ impl ExtensionSet {
             },
         }))
     }
+
+    pub(crate) fn contains_vars(&self) -> bool {
+        self.0.iter().any(|id| as_typevar(id).is_some())
+    }
 }
 
 impl From<ExtensionId> for ExtensionSet {

--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -51,7 +51,9 @@ impl ListValue {
     }
 
     /// Create a new [CustomConst] for an empty list of values of type `typ`.
+    /// Note this will be valid only if `typ` is concrete (does not contain type variables).
     pub fn new_empty(typ: Type) -> Self {
+        debug_assert!(!typ.contains_vars());
         Self(vec![], typ)
     }
 
@@ -123,6 +125,8 @@ impl CustomConst for ListValue {
 #[allow(non_camel_case_types)]
 #[non_exhaustive]
 pub enum ListOp {
+    /// Create a new empty list
+    new,
     /// Pop from the end of list. Return an optional value.
     pop,
     /// Push to end of list. Return the new list.
@@ -160,6 +164,7 @@ impl ListOp {
         let e = Type::new_var_use(0, TypeBound::Any);
         let l = self.list_type(list_type_def, 0);
         match self {
+            new => self.list_polytype(Vec::<Type>::new(), l).into(),
             pop => self
                 .list_polytype(vec![l.clone()], vec![l, Type::from(option_type(e))])
                 .into(),
@@ -237,6 +242,7 @@ impl MakeOpDef for ListOp {
         use ListOp::*;
 
         match self {
+            new => "Create a new empty list",
             pop => "Pop from the back of list. Returns an optional value.",
             push => "Push to the back of list",
             get => "Lookup an element in a list by index. Panics if the index is out of bounds.",

--- a/hugr-core/src/std_extensions/collections/list_fold.rs
+++ b/hugr-core/src/std_extensions/collections/list_fold.rs
@@ -14,6 +14,7 @@ use super::{ListOp, ListValue};
 
 pub(super) fn set_fold(op: &ListOp, def: &mut OpDef) {
     match op {
+        ListOp::new => def.set_constant_folder(NewFold),
         ListOp::pop => def.set_constant_folder(PopFold),
         ListOp::push => def.set_constant_folder(PushFold),
         ListOp::get => def.set_constant_folder(GetFold),
@@ -23,6 +24,24 @@ pub(super) fn set_fold(op: &ListOp, def: &mut OpDef) {
     }
 }
 
+pub struct NewFold;
+
+impl ConstFold for NewFold {
+    fn fold(
+        &self,
+        type_args: &[TypeArg],
+        _consts: &[(crate::IncomingPort, crate::ops::Value)],
+    ) -> ConstFoldResult {
+        let [TypeArg::Type { ty }] = type_args else {
+            panic!("Should have just element type")
+        };
+        if ty.contains_vars() {
+            None
+        } else {
+            Some(vec![(0.into(), ListValue::new_empty(ty.clone()).into())])
+        }
+    }
+}
 pub struct PopFold;
 
 impl ConstFold for PopFold {

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -321,6 +321,16 @@ impl TypeArg {
             } => t.apply_var(*idx, cached_decl),
         }
     }
+
+    pub(crate) fn contains_vars(&self) -> bool {
+        match self {
+            TypeArg::Type { ty } => ty.contains_vars(),
+            TypeArg::BoundedNat { .. } | TypeArg::String { .. } => false,
+            TypeArg::Sequence { elems } => elems.iter().any(TypeArg::contains_vars),
+            TypeArg::Extensions { es } => es.contains_vars(),
+            TypeArg::Variable { .. } => true,
+        }
+    }
 }
 
 impl TypeArgVariable {


### PR DESCRIPTION
Constants cannot refer to type variables, so you can't have a constant for an empty `List<T>`...
* Add `ListOp::new` to handle this
* Constant-fold it to an empty ListValue *if* the element type has no type_vars
* (Most of the PR) add new functions (kept `pub(crate)` for now) for whether a Type, TypeArg or ExtensionSet contains variables.

I'm a bit, ugh, do we have to do this; when we move to hugr-model, we'll have a better way, so we'll end up redoing this again. Hence I've not written any tests yet, but will do if we think we want this....?