### PR TITLE
feat!: Resolve OpaqueOps and CustomType extensions 

### DIFF
--- a/hugr-cli/src/extensions.rs
+++ b/hugr-cli/src/extensions.rs
@@ -28,9 +28,9 @@ impl ExtArgs {
     pub fn run_dump(&self, registry: &ExtensionRegistry) {
         let base_dir = &self.outdir;
 
-        for (name, ext) in registry.iter() {
+        for ext in registry.iter() {
             let mut path = base_dir.clone();
-            for part in name.split('.') {
+            for part in ext.name().split('.') {
                 path.push(part);
             }
             path.set_extension("json");

--- a/hugr-cli/tests/validate.rs
+++ b/hugr-cli/tests/validate.rs
@@ -190,7 +190,7 @@ fn test_no_std_fail(float_hugr_string: String, mut val_cmd: Command) {
     val_cmd
         .assert()
         .failure()
-        .stderr(contains(" Extension 'arithmetic.float.types' not found"));
+        .stderr(contains(" requires extension arithmetic.float.types"));
 }
 
 #[rstest]

--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -241,8 +241,8 @@ pub(crate) mod test {
     use crate::extension::prelude::{bool_t, usize_t};
     use crate::hugr::{views::HugrView, HugrMut};
     use crate::ops;
-    use crate::std_extensions::arithmetic::float_ops::FLOAT_OPS_REGISTRY;
     use crate::types::{PolyFuncType, Signature};
+    use crate::utils::test_quantum_extension;
     use crate::Hugr;
 
     use super::handle::BuildHandle;
@@ -269,7 +269,7 @@ pub(crate) mod test {
 
         f(f_builder)?;
 
-        Ok(module_builder.finish_hugr(&FLOAT_OPS_REGISTRY)?)
+        Ok(module_builder.finish_hugr(&test_quantum_extension::REG)?)
     }
 
     #[fixture]

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -325,7 +325,7 @@ pub(crate) mod test {
     use crate::std_extensions::logic::test::and_op;
     use crate::types::type_param::TypeParam;
     use crate::types::{EdgeKind, FuncValueType, RowVariable, Signature, Type, TypeBound, TypeRV};
-    use crate::utils::test_quantum_extension::h_gate;
+    use crate::utils::test_quantum_extension::{self, h_gate};
     use crate::{builder::test::n_identity, type_row, Wire};
 
     use super::super::test::simple_dfg_hugr;
@@ -342,8 +342,10 @@ pub(crate) mod test {
             let inner_builder = outer_builder.dfg_builder_endo([(usize_t(), int)])?;
             let inner_id = n_identity(inner_builder)?;
 
-            outer_builder
-                .finish_prelude_hugr_with_outputs(inner_id.outputs().chain(q_out.outputs()))
+            outer_builder.finish_hugr_with_outputs(
+                inner_id.outputs().chain(q_out.outputs()),
+                &test_quantum_extension::REG,
+            )
         };
 
         assert_eq!(build_result.err(), None);
@@ -361,7 +363,7 @@ pub(crate) mod test {
 
             f(&mut builder)?;
 
-            builder.finish_hugr(&EMPTY_REG)
+            builder.finish_hugr(&test_quantum_extension::REG)
         };
         assert_matches!(build_result, Ok(_), "Failed on example: {}", msg);
 
@@ -583,7 +585,7 @@ pub(crate) mod test {
 
         let add_c = add_c.finish_with_outputs(wires)?;
         let [w] = add_c.outputs_arr();
-        parent.finish_hugr_with_outputs([w], &EMPTY_REG)?;
+        parent.finish_hugr_with_outputs([w], &test_quantum_extension::REG)?;
 
         Ok(())
     }

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -154,18 +154,13 @@ impl ExtensionRegistry {
     }
 
     /// Returns an iterator over the extensions in the registry.
-    pub fn iter(&self) -> <&BTreeMap<ExtensionId, Arc<Extension>> as IntoIterator>::IntoIter {
-        self.0.iter()
+    pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
+        self.0.values()
     }
 
     /// Returns an iterator over the extensions ids in the registry.
     pub fn ids(&self) -> impl Iterator<Item = &ExtensionId> {
         self.0.keys()
-    }
-
-    /// Returns an iterator over the extensions ids in the registry.
-    pub fn extensions(&self) -> impl Iterator<Item = &Arc<Extension>> {
-        self.0.values()
     }
 
     /// Delete an extension from the registry and return it if it was present.
@@ -175,36 +170,36 @@ impl ExtensionRegistry {
 }
 
 impl IntoIterator for ExtensionRegistry {
-    type Item = (ExtensionId, Arc<Extension>);
+    type Item = Arc<Extension>;
 
-    type IntoIter = <BTreeMap<ExtensionId, Arc<Extension>> as IntoIterator>::IntoIter;
+    type IntoIter = std::collections::btree_map::IntoValues<ExtensionId, Arc<Extension>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.0.into_values()
     }
 }
 
 impl<'a> IntoIterator for &'a ExtensionRegistry {
-    type Item = (&'a ExtensionId, &'a Arc<Extension>);
+    type Item = &'a Arc<Extension>;
 
-    type IntoIter = <&'a BTreeMap<ExtensionId, Arc<Extension>> as IntoIterator>::IntoIter;
+    type IntoIter = std::collections::btree_map::Values<'a, ExtensionId, Arc<Extension>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.iter()
+        self.0.values()
     }
 }
 
-impl<'a> Extend<(&'a ExtensionId, &'a Arc<Extension>)> for ExtensionRegistry {
-    fn extend<T: IntoIterator<Item = (&'a ExtensionId, &'a Arc<Extension>)>>(&mut self, iter: T) {
-        for (_name, ext) in iter {
+impl<'a> Extend<&'a Arc<Extension>> for ExtensionRegistry {
+    fn extend<T: IntoIterator<Item = &'a Arc<Extension>>>(&mut self, iter: T) {
+        for ext in iter {
             self.register_updated_ref(ext);
         }
     }
 }
 
-impl Extend<(ExtensionId, Arc<Extension>)> for ExtensionRegistry {
-    fn extend<T: IntoIterator<Item = (ExtensionId, Arc<Extension>)>>(&mut self, iter: T) {
-        for (_name, ext) in iter {
+impl Extend<Arc<Extension>> for ExtensionRegistry {
+    fn extend<T: IntoIterator<Item = Arc<Extension>>>(&mut self, iter: T) {
+        for ext in iter {
             self.register_updated(ext);
         }
     }

--- a/hugr-core/src/extension/declarative.rs
+++ b/hugr-core/src/extension/declarative.rs
@@ -354,12 +354,9 @@ extensions:
         let new_exts = new_extensions(&reg, dependencies).collect_vec();
 
         assert_eq!(new_exts.len(), num_declarations);
+        assert_eq!(new_exts.iter().flat_map(|e| e.types()).count(), num_types);
         assert_eq!(
-            new_exts.iter().flat_map(|(_, e)| e.types()).count(),
-            num_types
-        );
-        assert_eq!(
-            new_exts.iter().flat_map(|(_, e)| e.operations()).count(),
+            new_exts.iter().flat_map(|e| e.operations()).count(),
             num_operations
         );
         Ok(())
@@ -381,12 +378,9 @@ extensions:
         let new_exts = new_extensions(&reg, dependencies).collect_vec();
 
         assert_eq!(new_exts.len(), num_declarations);
+        assert_eq!(new_exts.iter().flat_map(|e| e.types()).count(), num_types);
         assert_eq!(
-            new_exts.iter().flat_map(|(_, e)| e.types()).count(),
-            num_types
-        );
-        assert_eq!(
-            new_exts.iter().flat_map(|(_, e)| e.operations()).count(),
+            new_exts.iter().flat_map(|e| e.operations()).count(),
             num_operations
         );
         Ok(())
@@ -413,8 +407,8 @@ extensions:
     fn new_extensions<'a>(
         reg: &'a ExtensionRegistry,
         dependencies: &'a ExtensionRegistry,
-    ) -> impl Iterator<Item = (&'a ExtensionId, &'a Arc<Extension>)> {
+    ) -> impl Iterator<Item = &'a Arc<Extension>> {
         reg.iter()
-            .filter(move |(id, _)| !dependencies.contains(id) && *id != &PRELUDE_ID)
+            .filter(move |ext| !dependencies.contains(ext.name()) && ext.name() != &PRELUDE_ID)
     }
 }

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -960,6 +960,7 @@ mod test {
     use crate::builder::inout_sig;
     use crate::std_extensions::arithmetic::float_ops::FLOAT_OPS_REGISTRY;
     use crate::std_extensions::arithmetic::float_types::{float64_type, ConstF64};
+    use crate::utils::test_quantum_extension;
     use crate::{
         builder::{endo_sig, DFGBuilder, Dataflow, DataflowHugr},
         utils::test_quantum_extension::cx_gate,
@@ -1150,7 +1151,8 @@ mod test {
             .add_dataflow_op(panic_op, [err, q0, q1])
             .unwrap()
             .outputs_arr();
-        b.finish_prelude_hugr_with_outputs([q0, q1]).unwrap();
+        b.finish_hugr_with_outputs([q0, q1], &test_quantum_extension::REG)
+            .unwrap();
     }
 
     #[test]

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -1,0 +1,165 @@
+//! Utilities for resolving operations and types present in a HUGR, and updating
+//! the list of used extensions. See [`crate::Hugr::resolve_extension_defs`].
+//!
+//! When listing "used extensions" we only care about _definitional_ extension
+//! requirements, i.e., the operations and types that are required to define the
+//! HUGR nodes and wire types. This is computed from the union of all extension
+//! required across the HUGR.
+//!
+//! This is distinct from _runtime_ extension requirements, which are defined
+//! more granularly in each function signature by the `required_extensions`
+//! field. See the `extension_inference` feature and related modules for that.
+//!
+//! Note: These procedures are only temporary until `hugr-model` is stabilized.
+//! Once that happens, hugrs will no longer be directly deserialized using serde
+//! but instead will be created by the methods in `crate::import`. As these
+//! (should) automatically resolve extensions as the operations are created,
+//! we will no longer require this post-facto resolution step.
+
+mod types;
+
+pub(crate) use types::update_op_types_extensions;
+
+use std::sync::Arc;
+
+use derive_more::{Display, Error, From};
+
+use super::{Extension, ExtensionRegistry};
+use crate::ops::custom::OpaqueOpError;
+use crate::ops::{DataflowOpTrait, ExtensionOp, NamedOp, OpType};
+use crate::Node;
+
+/// The result of resolving an operation.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct OpResolutionResult<'e> {
+    /// If `op` was an opaque operation that got resolved, this contains the new
+    /// [`ExtensionOp`] it should be replaced with.
+    pub replacement_op: Option<OpType>,
+    /// If `op` was an opaque or extension operation, this contains the extension
+    /// reference that should be added to the hugr's extension registry.
+    pub used_extension: Option<&'e Arc<Extension>>,
+}
+
+/// Try to resolve an [`OpType::OpaqueOp`] into an [`OpType::ExtensionOp`] by
+/// looking searching for the operation in the extension registries.
+///
+/// # Errors
+/// If the serialized opaque resolves to a definition that conflicts with what
+/// was serialized. Or if the operation is not found in the registry.
+pub(crate) fn resolve_op_extensions<'e>(
+    node: Node,
+    op: &OpType,
+    extensions: &'e ExtensionRegistry,
+) -> Result<OpResolutionResult<'e>, ExtensionResolutionError> {
+    let OpType::OpaqueOp(opaque) = op else {
+        return Ok(OpResolutionResult {
+            replacement_op: None,
+            used_extension: operation_extension(node, op, extensions)?,
+        });
+    };
+
+    // Fail if the Extension is not in the registry, or if the Extension was
+    // found but did not have the expected operation.
+    let extension =
+        operation_extension(node, op, extensions)?.expect("Opaque ops always have an extension");
+    let Some(def) = extension.get_op(opaque.op_name()) else {
+        return Err(OpaqueOpError::OpNotFoundInExtension {
+            node,
+            op: opaque.name().clone(),
+            extension: extension.name().clone(),
+            available_ops: extension
+                .operations()
+                .map(|(name, _)| name.clone())
+                .collect(),
+        }
+        .into());
+    };
+
+    let ext_op = ExtensionOp::new_with_cached(def.clone(), opaque.args(), opaque, extensions)
+        .map_err(|e| OpaqueOpError::SignatureError {
+            node,
+            name: opaque.name().clone(),
+            cause: e,
+        })?;
+
+    if opaque.signature() != ext_op.signature() {
+        return Err(OpaqueOpError::SignatureMismatch {
+            node,
+            extension: opaque.extension().clone(),
+            op: def.name().clone(),
+            computed: ext_op.signature().clone(),
+            stored: opaque.signature().clone(),
+        }
+        .into());
+    };
+
+    Ok(OpResolutionResult {
+        replacement_op: Some(ext_op.into()),
+        used_extension: Some(extension),
+    })
+}
+
+// Returns the extension in the registry required by the operation.
+//
+// If the operation does not require an extension, returns `None`.
+fn operation_extension<'e>(
+    node: Node,
+    op: &OpType,
+    extensions: &'e ExtensionRegistry,
+) -> Result<Option<&'e Arc<Extension>>, ExtensionResolutionError> {
+    let err = |ext: &str| ExtensionResolutionError::MissingOpExtension {
+        node,
+        op: NamedOp::name(op).to_string(),
+        missing_extension: ext.to_owned(),
+        available_extensions: extensions.ids().map(|id| id.to_string()).collect(),
+    };
+    let extension = match op {
+        OpType::OpaqueOp(opaque) => opaque.extension(),
+        OpType::ExtensionOp(e) => e.def().extension_id(),
+        _ => return Ok(None),
+    };
+    match extensions.get(extension) {
+        Some(e) => Ok(Some(e)),
+        None => Err(err(extension)),
+    }
+}
+
+/// Errors that can occur during extension resolution.
+#[derive(Debug, Display, Clone, Error, From, PartialEq)]
+#[non_exhaustive]
+pub enum ExtensionResolutionError {
+    /// Could not resolve an opaque operation to an extension operation.
+    #[display("Error resolving opaque operation: {_0}")]
+    #[from]
+    OpaqueOpError(OpaqueOpError),
+    /// An operation requires an extension that is not in the given registry.
+    #[display(
+        "{op} ({node}) requires extension {missing_extension}, but it could not be found in the extension list used during resolution. The available extensions are: {}",
+        available_extensions.join(", ")
+    )]
+    MissingOpExtension {
+        /// The node that requires the extension.
+        node: Node,
+        /// The operation that requires the extension.
+        op: String,
+        /// The missing extension
+        missing_extension: String,
+        /// A list of available extensions.
+        available_extensions: Vec<String>,
+    },
+    #[display(
+        "Type {ty} in {node} requires extension {missing_extension}, but it could not be found in the extension list used during resolution. The available extensions are: {}",
+        available_extensions.join(", ")
+    )]
+    /// A type references an extension that is not in the given registry.
+    MissingTypeExtension {
+        /// The node that requires the extension.
+        node: Node,
+        /// The type that requires the extension.
+        ty: String,
+        /// The missing extension
+        missing_extension: String,
+        /// A list of available extensions.
+        available_extensions: Vec<String>,
+    },
+}

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -16,110 +16,19 @@
 //! (will) automatically resolve extensions as the operations are created,
 //! we will no longer require this post-facto resolution step.
 
+mod ops;
 mod types;
 
+pub(crate) use ops::update_op_extensions;
 pub(crate) use types::update_op_types_extensions;
-
-use std::sync::Arc;
 
 use derive_more::{Display, Error, From};
 
 use super::{Extension, ExtensionId, ExtensionRegistry};
 use crate::ops::custom::OpaqueOpError;
-use crate::ops::{DataflowOpTrait, ExtensionOp, NamedOp, OpName, OpType};
+use crate::ops::{NamedOp, OpName, OpType};
 use crate::types::TypeName;
 use crate::Node;
-
-/// The result of resolving an operation.
-#[derive(Debug, Clone, Default)]
-pub(crate) struct OpResolutionResult<'e> {
-    /// If `op` was an opaque operation that got resolved, this contains the new
-    /// [`ExtensionOp`] it should be replaced with.
-    pub replacement_op: Option<OpType>,
-    /// If `op` was an opaque or extension operation, this contains the extension
-    /// reference that should be added to the hugr's extension registry.
-    pub used_extension: Option<&'e Arc<Extension>>,
-}
-
-/// Try to resolve an [`OpType::OpaqueOp`] into an [`OpType::ExtensionOp`] by
-/// looking searching for the operation in the extension registries.
-///
-/// # Errors
-/// If the serialized opaque resolves to a definition that conflicts with what
-/// was serialized. Or if the operation is not found in the registry.
-pub(crate) fn resolve_op_extensions<'e>(
-    node: Node,
-    op: &OpType,
-    extensions: &'e ExtensionRegistry,
-) -> Result<OpResolutionResult<'e>, ExtensionResolutionError> {
-    let OpType::OpaqueOp(opaque) = op else {
-        return Ok(OpResolutionResult {
-            replacement_op: None,
-            used_extension: operation_extension(node, op, extensions)?,
-        });
-    };
-
-    // Fail if the Extension is not in the registry, or if the Extension was
-    // found but did not have the expected operation.
-    let extension =
-        operation_extension(node, op, extensions)?.expect("Opaque ops always have an extension");
-    let Some(def) = extension.get_op(opaque.op_name()) else {
-        return Err(OpaqueOpError::OpNotFoundInExtension {
-            node,
-            op: opaque.name().clone(),
-            extension: extension.name().clone(),
-            available_ops: extension
-                .operations()
-                .map(|(name, _)| name.clone())
-                .collect(),
-        }
-        .into());
-    };
-
-    let ext_op = ExtensionOp::new_with_cached(def.clone(), opaque.args(), opaque, extensions)
-        .map_err(|e| OpaqueOpError::SignatureError {
-            node,
-            name: opaque.name().clone(),
-            cause: e,
-        })?;
-
-    if opaque.signature() != ext_op.signature() {
-        return Err(OpaqueOpError::SignatureMismatch {
-            node,
-            extension: opaque.extension().clone(),
-            op: def.name().clone(),
-            computed: ext_op.signature().clone(),
-            stored: opaque.signature().clone(),
-        }
-        .into());
-    };
-
-    Ok(OpResolutionResult {
-        replacement_op: Some(ext_op.into()),
-        used_extension: Some(extension),
-    })
-}
-
-// Returns the extension in the registry required by the operation.
-//
-// If the operation does not require an extension, returns `None`.
-fn operation_extension<'e>(
-    node: Node,
-    op: &OpType,
-    extensions: &'e ExtensionRegistry,
-) -> Result<Option<&'e Arc<Extension>>, ExtensionResolutionError> {
-    let extension = match op {
-        OpType::OpaqueOp(opaque) => opaque.extension(),
-        OpType::ExtensionOp(e) => e.def().extension_id(),
-        _ => return Ok(None),
-    };
-    match extensions.get(extension) {
-        Some(e) => Ok(Some(e)),
-        None => Err(ExtensionResolutionError::missing_op_extension(
-            node, op, extension, extensions,
-        )),
-    }
-}
 
 /// Errors that can occur during extension resolution.
 #[derive(Debug, Display, Clone, Error, From, PartialEq)]

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -1,0 +1,91 @@
+//! Resolve `OpaqueOp`s into `ExtensionOp`s and return an operation's required extension.
+
+use std::sync::Arc;
+
+use super::{Extension, ExtensionRegistry, ExtensionResolutionError};
+use crate::ops::custom::OpaqueOpError;
+use crate::ops::{DataflowOpTrait, ExtensionOp, NamedOp, OpType};
+use crate::Node;
+
+/// Compute the required extension for an operation.
+///
+/// If the op is a [`OpType::OpaqueOp`], replace it with a resolved
+/// [`OpType::ExtensionOp`] by looking searching for the operation in the
+/// extension registries.
+///
+/// If `op` was an opaque or extension operation, the result contains the
+/// extension reference that should be added to the hugr's extension registry.
+///
+/// # Errors
+///
+/// If the serialized opaque resolves to a definition that conflicts with what
+/// was serialized. Or if the operation is not found in the registry.
+pub(crate) fn update_op_extensions<'e>(
+    node: Node,
+    op: &mut OpType,
+    extensions: &'e ExtensionRegistry,
+) -> Result<Option<&'e Arc<Extension>>, ExtensionResolutionError> {
+    let extension = operation_extension(node, op, extensions)?;
+
+    let OpType::OpaqueOp(opaque) = op else {
+        return Ok(extension);
+    };
+
+    // Fail if the Extension is not in the registry, or if the Extension was
+    // found but did not have the expected operation.
+    let extension = extension.expect("OpaqueOp should have an extension");
+    let Some(def) = extension.get_op(opaque.op_name()) else {
+        return Err(OpaqueOpError::OpNotFoundInExtension {
+            node,
+            op: opaque.name().clone(),
+            extension: extension.name().clone(),
+            available_ops: extension
+                .operations()
+                .map(|(name, _)| name.clone())
+                .collect(),
+        }
+        .into());
+    };
+
+    let ext_op = ExtensionOp::new_with_cached(def.clone(), opaque.args(), opaque, extensions)
+        .map_err(|e| OpaqueOpError::SignatureError {
+            node,
+            name: opaque.name().clone(),
+            cause: e,
+        })?;
+
+    if opaque.signature() != ext_op.signature() {
+        return Err(OpaqueOpError::SignatureMismatch {
+            node,
+            extension: opaque.extension().clone(),
+            op: def.name().clone(),
+            computed: ext_op.signature().clone(),
+            stored: opaque.signature().clone(),
+        }
+        .into());
+    };
+
+    // Replace the opaque operation with the resolved extension operation.
+    *op = ext_op.into();
+
+    Ok(Some(extension))
+}
+
+/// Returns the extension in the registry required by the operation.
+///
+/// If the operation does not require an extension, returns `None`.
+fn operation_extension<'e>(
+    node: Node,
+    op: &OpType,
+    extensions: &'e ExtensionRegistry,
+) -> Result<Option<&'e Arc<Extension>>, ExtensionResolutionError> {
+    let Some(ext) = op.extension_id() else {
+        return Ok(None);
+    };
+    match extensions.get(ext) {
+        Some(e) => Ok(Some(e)),
+        None => Err(ExtensionResolutionError::missing_op_extension(
+            node, op, ext, extensions,
+        )),
+    }
+}

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -47,12 +47,13 @@ pub(crate) fn update_op_extensions<'e>(
         .into());
     };
 
-    let ext_op = ExtensionOp::new_with_cached(def.clone(), opaque.args(), opaque, extensions)
-        .map_err(|e| OpaqueOpError::SignatureError {
-            node,
-            name: opaque.name().clone(),
-            cause: e,
-        })?;
+    let ext_op =
+        ExtensionOp::new_with_cached(def.clone(), opaque.args().to_vec(), opaque, extensions)
+            .map_err(|e| OpaqueOpError::SignatureError {
+                node,
+                name: opaque.name().clone(),
+                cause: e,
+            })?;
 
     if opaque.signature() != ext_op.signature() {
         return Err(OpaqueOpError::SignatureMismatch {

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -109,6 +109,10 @@ fn update_signature_exts(
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
+    // Note that we do not include the signature's `extension_reqs` here, as those refer
+    // to _runtime_ requirements that may not be currently present.
+    // See https://github.com/CQCL/hugr/issues/1734
+    // TODO: Update comment once that issue gets implemented.
     update_type_row_exts(node, &mut signature.input, extensions, used_extensions)?;
     update_type_row_exts(node, &mut signature.output, extensions, used_extensions)?;
     Ok(())

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use super::{ExtensionRegistry, ExtensionResolutionError};
 use crate::ops::OpType;
 use crate::types::type_row::TypeRowBase;
-use crate::types::{CustomType, MaybeRV, Signature, SumType, TypeBase, TypeEnum};
+use crate::types::{MaybeRV, Signature, SumType, TypeBase, TypeEnum};
 use crate::Node;
 
 /// Replace the dangling extension pointer in the [`CustomType`]s inside a
@@ -157,13 +157,7 @@ fn update_type_exts<RV: MaybeRV>(
             // Add the extension to the used extensions registry,
             // and update the CustomType with the valid pointer.
             used_extensions.register_updated_ref(ext);
-            *custom = CustomType::new(
-                custom.name().clone(),
-                custom.args(),
-                custom.extension().clone(),
-                custom.bound(),
-                &Arc::downgrade(ext),
-            );
+            custom.update_extension(Arc::downgrade(ext));
         }
         TypeEnum::Function(f) => {
             update_type_row_exts(node, &mut f.input, extensions, used_extensions)?;

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -142,12 +142,12 @@ fn update_type_exts<RV: MaybeRV>(
         TypeEnum::Extension(custom) => {
             let ext_id = custom.extension();
             let ext = extensions.get(ext_id).ok_or_else(|| {
-                ExtensionResolutionError::MissingTypeExtension {
+                ExtensionResolutionError::missing_type_extension(
                     node,
-                    ty: custom.to_string(),
-                    missing_extension: ext_id.to_string(),
-                    available_extensions: extensions.ids().map(|id| id.to_string()).collect(),
-                }
+                    custom.name(),
+                    ext_id,
+                    extensions,
+                )
             })?;
 
             // Add the extension to the used extensions registry,

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -1,0 +1,176 @@
+//! Resolve weak links inside `CustomType`s in an optype's signature.
+
+use std::sync::Arc;
+
+use super::{ExtensionRegistry, ExtensionResolutionError};
+use crate::ops::OpType;
+use crate::types::type_row::TypeRowBase;
+use crate::types::{CustomType, MaybeRV, Signature, SumType, TypeBase, TypeEnum};
+use crate::Node;
+
+/// Replace the dangling extension pointer in the [`CustomType`]s inside a
+/// signature with a valid pointer to the extension in the `extensions`
+/// registry.
+///
+/// When a pointer is replaced, the extension is added to the
+/// `used_extensions` registry and the new type definition is returned.
+///
+/// This is a helper function used right after deserializing a Hugr.
+pub fn update_op_types_extensions(
+    node: Node,
+    op: &mut OpType,
+    extensions: &ExtensionRegistry,
+    used_extensions: &mut ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    match op {
+        OpType::ExtensionOp(ext) => {
+            update_signature_exts(node, ext.signature_mut(), extensions, used_extensions)?
+        }
+        OpType::FuncDefn(f) => {
+            update_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?
+        }
+        OpType::FuncDecl(f) => {
+            update_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?
+        }
+        OpType::Const(_c) => {
+            // TODO: Is it OK to assume that `Value::get_type` returns a well-resolved value?
+        }
+        OpType::Input(inp) => {
+            update_type_row_exts(node, &mut inp.types, extensions, used_extensions)?
+        }
+        OpType::Output(out) => {
+            update_type_row_exts(node, &mut out.types, extensions, used_extensions)?
+        }
+        OpType::Call(c) => {
+            update_signature_exts(node, c.func_sig.body_mut(), extensions, used_extensions)?;
+            update_signature_exts(node, &mut c.instantiation, extensions, used_extensions)?;
+        }
+        OpType::CallIndirect(c) => {
+            update_signature_exts(node, &mut c.signature, extensions, used_extensions)?
+        }
+        OpType::LoadConstant(lc) => {
+            update_type_exts(node, &mut lc.datatype, extensions, used_extensions)?
+        }
+        OpType::LoadFunction(lf) => {
+            update_signature_exts(node, lf.func_sig.body_mut(), extensions, used_extensions)?;
+            update_signature_exts(node, &mut lf.signature, extensions, used_extensions)?;
+        }
+        OpType::DFG(dfg) => {
+            update_signature_exts(node, &mut dfg.signature, extensions, used_extensions)?
+        }
+        OpType::OpaqueOp(op) => {
+            update_signature_exts(node, op.signature_mut(), extensions, used_extensions)?
+        }
+        OpType::Tag(t) => {
+            for variant in t.variants.iter_mut() {
+                update_type_row_exts(node, variant, extensions, used_extensions)?
+            }
+        }
+        OpType::DataflowBlock(db) => {
+            update_type_row_exts(node, &mut db.inputs, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut db.other_outputs, extensions, used_extensions)?;
+            for row in db.sum_rows.iter_mut() {
+                update_type_row_exts(node, row, extensions, used_extensions)?;
+            }
+        }
+        OpType::ExitBlock(e) => {
+            update_type_row_exts(node, &mut e.cfg_outputs, extensions, used_extensions)?;
+        }
+        OpType::TailLoop(tl) => {
+            update_type_row_exts(node, &mut tl.just_inputs, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut tl.just_outputs, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut tl.rest, extensions, used_extensions)?;
+        }
+        OpType::CFG(cfg) => {
+            update_signature_exts(node, &mut cfg.signature, extensions, used_extensions)?;
+        }
+        OpType::Conditional(cond) => {
+            for row in cond.sum_rows.iter_mut() {
+                update_type_row_exts(node, row, extensions, used_extensions)?;
+            }
+            update_type_row_exts(node, &mut cond.other_inputs, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut cond.outputs, extensions, used_extensions)?;
+        }
+        OpType::Case(case) => {
+            update_signature_exts(node, &mut case.signature, extensions, used_extensions)?;
+        }
+        // Ignore optypes that do not store a signature.
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside a signature.
+///
+/// Adds the extensions used in the signature to the `used_extensions` registry.
+fn update_signature_exts(
+    node: Node,
+    signature: &mut Signature,
+    extensions: &ExtensionRegistry,
+    used_extensions: &mut ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    update_type_row_exts(node, &mut signature.input, extensions, used_extensions)?;
+    update_type_row_exts(node, &mut signature.output, extensions, used_extensions)?;
+    Ok(())
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside a type row.
+///
+/// Adds the extensions used in the row to the `used_extensions` registry.
+fn update_type_row_exts<RV: MaybeRV>(
+    node: Node,
+    row: &mut TypeRowBase<RV>,
+    extensions: &ExtensionRegistry,
+    used_extensions: &mut ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    for ty in row.iter_mut() {
+        update_type_exts(node, ty, extensions, used_extensions)?;
+    }
+    Ok(())
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside a type.
+///
+/// Adds the extensions used in the type to the `used_extensions` registry.
+fn update_type_exts<RV: MaybeRV>(
+    node: Node,
+    typ: &mut TypeBase<RV>,
+    extensions: &ExtensionRegistry,
+    used_extensions: &mut ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    match typ.as_type_enum_mut() {
+        TypeEnum::Extension(custom) => {
+            let ext_id = custom.extension();
+            let ext = extensions.get(ext_id).ok_or_else(|| {
+                ExtensionResolutionError::MissingTypeExtension {
+                    node,
+                    ty: custom.to_string(),
+                    missing_extension: ext_id.to_string(),
+                    available_extensions: extensions.ids().map(|id| id.to_string()).collect(),
+                }
+            })?;
+
+            // Add the extension to the used extensions registry,
+            // and update the CustomType with the valid pointer.
+            used_extensions.register_updated_ref(ext);
+            *custom = CustomType::new(
+                custom.name().clone(),
+                custom.args(),
+                custom.extension().clone(),
+                custom.bound(),
+                &Arc::downgrade(ext),
+            );
+        }
+        TypeEnum::Function(f) => {
+            update_type_row_exts(node, &mut f.input, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut f.output, extensions, used_extensions)?;
+        }
+        TypeEnum::Sum(SumType::General { rows }) => {
+            for row in rows.iter_mut() {
+                update_type_row_exts(node, row, extensions, used_extensions)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -24,8 +24,10 @@ use thiserror::Error;
 
 pub use self::views::{HugrView, RootTagged};
 use crate::core::NodeIndex;
+use crate::extension::resolution::{
+    resolve_op_extensions, update_op_types_extensions, ExtensionResolutionError,
+};
 use crate::extension::{ExtensionRegistry, ExtensionSet, TO_BE_INFERRED};
-use crate::ops::custom::resolve_extension_ops;
 use crate::ops::{OpTag, OpTrait};
 pub use crate::ops::{OpType, DEFAULT_OPTYPE};
 use crate::{Direction, Node};
@@ -87,7 +89,7 @@ impl Hugr {
         &mut self,
         extension_registry: &ExtensionRegistry,
     ) -> Result<(), ValidationError> {
-        resolve_extension_ops(self, extension_registry)?;
+        self.resolve_extension_defs(extension_registry)?;
         self.validate_no_extensions(extension_registry)?;
         #[cfg(feature = "extension_inference")]
         {
@@ -166,6 +168,72 @@ impl Hugr {
         }
         infer(self, self.root(), remove)?;
         Ok(())
+    }
+
+    /// Given a Hugr that has been deserialized, collect all extensions used to
+    /// define the HUGR while resolving all [`OpType::OpaqueOp`] operations into
+    /// [`OpType::ExtensionOp`]s and updating the extension pointer in all
+    /// internal [`crate::types::CustomType`]s to point to the extensions in the
+    /// register.
+    ///
+    /// When listing "used extensions" we only care about _definitional_
+    /// extension requirements, i.e., the operations and types that are required
+    /// to define the HUGR nodes and wire types. This is computed from the union
+    /// of all extension required across the HUGR.
+    ///
+    /// This is distinct from _runtime_ extension requirements computed in
+    /// [`Hugr::infer_extensions`], which are computed more granularly in each
+    /// function signature by the `required_extensions` field and define the set
+    /// of capabilities required by the runtime to execute each function.
+    ///
+    /// Returns a new extension registry with the extensions used in the Hugr.
+    ///
+    /// # Parameters
+    ///
+    /// - `extensions`: The extension set considered when resolving opaque
+    ///     operations and types. The original Hugr's internal extension
+    ///     registry is ignored and replaced with the newly computed one.
+    ///
+    /// # Errors
+    ///
+    /// - If an opaque operation cannot be resolved to an extension operation.
+    /// - If an extension operation references an extension that is missing from
+    ///   the registry.
+    /// - If a custom type references an extension that is missing from the
+    ///   registry.
+    pub fn resolve_extension_defs(
+        &mut self,
+        extensions: &ExtensionRegistry,
+    ) -> Result<ExtensionRegistry, ExtensionResolutionError> {
+        let mut used_extensions = ExtensionRegistry::default();
+
+        // Here we need to iterate the optypes in the hugr mutably, to avoid
+        // having to clone and accumulate all replacements before finally
+        // applying them.
+        //
+        // This is not something we want to expose it the API, so we manually
+        // iterate instead of writing it as a method.
+        for n in 0..self.node_count() {
+            let pg_node = portgraph::NodeIndex::new(n);
+            let node: Node = pg_node.into();
+            if !self.contains_node(node) {
+                continue;
+            }
+
+            let op = &mut self.op_types[pg_node];
+
+            let op_resolution = resolve_op_extensions(node, op, extensions)?;
+            if let Some(extension) = op_resolution.used_extension {
+                used_extensions.register_updated_ref(extension);
+            }
+            if let Some(replacement) = op_resolution.replacement_op {
+                *op = replacement;
+            }
+
+            update_op_types_extensions(node, op, extensions, &mut used_extensions)?;
+        }
+
+        Ok(used_extensions)
     }
 }
 

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 pub use self::views::{HugrView, RootTagged};
 use crate::core::NodeIndex;
 use crate::extension::resolution::{
-    resolve_op_extensions, update_op_types_extensions, ExtensionResolutionError,
+    update_op_extensions, update_op_types_extensions, ExtensionResolutionError,
 };
 use crate::extension::{ExtensionRegistry, ExtensionSet, TO_BE_INFERRED};
 use crate::ops::{OpTag, OpTrait};
@@ -222,14 +222,9 @@ impl Hugr {
 
             let op = &mut self.op_types[pg_node];
 
-            let op_resolution = resolve_op_extensions(node, op, extensions)?;
-            if let Some(extension) = op_resolution.used_extension {
+            if let Some(extension) = update_op_extensions(node, op, extensions)? {
                 used_extensions.register_updated_ref(extension);
             }
-            if let Some(replacement) = op_resolution.replacement_op {
-                *op = replacement;
-            }
-
             update_op_types_extensions(node, op, extensions, &mut used_extensions)?;
         }
 

--- a/hugr-core/src/hugr/rewrite/insert_identity.rs
+++ b/hugr-core/src/hugr/rewrite/insert_identity.rs
@@ -101,10 +101,8 @@ mod tests {
 
     use super::super::simple_replace::test::dfg_hugr;
     use super::*;
-    use crate::{
-        extension::{prelude::qb_t, PRELUDE_REGISTRY},
-        Hugr,
-    };
+    use crate::utils::test_quantum_extension;
+    use crate::{extension::prelude::qb_t, Hugr};
 
     #[rstest]
     fn correct_insertion(dfg_hugr: Hugr) {
@@ -129,6 +127,6 @@ mod tests {
 
         assert_eq!(noop, Noop(qb_t()));
 
-        h.update_validate(&PRELUDE_REGISTRY).unwrap();
+        h.update_validate(&test_quantum_extension::REG).unwrap();
     }
 }

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -462,7 +462,7 @@ mod test {
     use crate::ops::{self, Case, DataflowBlock, OpTag, OpType, DFG};
     use crate::std_extensions::collections::{self, list_type, ListOp};
     use crate::types::{Signature, Type, TypeRow};
-    use crate::utils::depth;
+    use crate::utils::{depth, test_quantum_extension};
     use crate::{type_row, Direction, Extension, Hugr, HugrView, OutgoingPort};
 
     use super::{NewEdgeKind, NewEdgeSpec, ReplaceError, Replacement};
@@ -657,6 +657,8 @@ mod test {
         let baz = ext
             .instantiate_extension_op("baz", [], &PRELUDE_REGISTRY)
             .unwrap();
+        let mut registry = test_quantum_extension::REG.clone();
+        registry.register(ext).unwrap();
 
         let mut h = DFGBuilder::new(
             Signature::new(vec![usize_t(), bool_t()], vec![usize_t()])
@@ -688,7 +690,7 @@ mod test {
         let case2 = case2.finish_with_outputs(baz_dfg.outputs()).unwrap().node();
         let cond = cond.finish_sub_container().unwrap();
         let h = h
-            .finish_hugr_with_outputs(cond.outputs(), &PRELUDE_REGISTRY)
+            .finish_hugr_with_outputs(cond.outputs(), &registry)
             .unwrap();
 
         let mut r_hugr = Hugr::new(h.get_optype(cond.node()).clone());

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -560,7 +560,7 @@ fn roundtrip_optype(#[case] optype: impl Into<OpType> + std::fmt::Debug) {
 // test all standard extension serialisations are valid against scheme
 fn std_extensions_valid() {
     let std_reg = crate::std_extensions::std_reg();
-    for (_, ext) in std_reg.into_iter() {
+    for ext in std_reg {
         let val = serde_json::to_value(ext).unwrap();
         NamedSchema::check_schemas(&val, get_schemas(true));
         // check deserialises correctly, can't check equality because of custom binaries.

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -11,7 +11,8 @@ use crate::extension::simple_op::MakeRegisteredOp;
 use crate::extension::{test::SimpleOpDef, ExtensionSet, EMPTY_REG, PRELUDE_REGISTRY};
 use crate::hugr::internal::HugrMutInternals;
 use crate::hugr::validate::ValidationError;
-use crate::ops::custom::{ExtensionOp, OpaqueOp, OpaqueOpError};
+use crate::hugr::ExtensionResolutionError;
+use crate::ops::custom::{ExtensionOp, OpaqueOp};
 use crate::ops::{self, dataflow::IOTrait, Input, Module, Output, Value, DFG};
 use crate::std_extensions::arithmetic::float_types::float64_type;
 use crate::std_extensions::arithmetic::int_ops::INT_OPS_REGISTRY;
@@ -22,6 +23,7 @@ use crate::types::{
     FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature, SumType, Type, TypeArg, TypeBound,
     TypeRV,
 };
+use crate::utils::test_quantum_extension;
 use crate::{type_row, OutgoingPort};
 
 use itertools::Itertools;
@@ -331,7 +333,7 @@ fn dfg_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap()
             .out_wire(0);
     }
-    let hugr = dfg.finish_hugr_with_outputs(params, &EMPTY_REG)?;
+    let hugr = dfg.finish_hugr_with_outputs(params, &test_quantum_extension::REG)?;
 
     check_hugr_roundtrip(&hugr, true);
     Ok(())
@@ -350,7 +352,7 @@ fn extension_ops() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap()
         .out_wire(0);
 
-    let hugr = dfg.finish_hugr_with_outputs([wire], &PRELUDE_REGISTRY)?;
+    let hugr = dfg.finish_hugr_with_outputs([wire], &test_quantum_extension::REG)?;
 
     check_hugr_roundtrip(&hugr, true);
     Ok(())
@@ -368,6 +370,7 @@ fn opaque_ops() -> Result<(), Box<dyn std::error::Error>> {
         .add_dataflow_op(extension_op.clone(), [wire])
         .unwrap()
         .out_wire(0);
+    let not_node = wire.node();
 
     // Add an unresolved opaque operation
     let opaque_op: OpaqueOp = extension_op.into();

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -376,11 +376,14 @@ fn opaque_ops() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(
         dfg.finish_hugr_with_outputs([wire], &PRELUDE_REGISTRY),
-        Err(ValidationError::OpaqueOpError(OpaqueOpError::UnresolvedOp(
-            wire.node(),
-            "Not".into(),
-            ext_name
-        ))
+        Err(ValidationError::ExtensionResolutionError(
+            ExtensionResolutionError::MissingOpExtension {
+                node: not_node,
+                op: "logic.Not".into(),
+                missing_extension: ext_name.to_string(),
+                available_extensions: vec!["prelude".into()]
+            }
+        )
         .into())
     );
 

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -8,6 +8,7 @@ use crate::builder::{
 use crate::extension::prelude::Noop;
 use crate::extension::prelude::{bool_t, qb_t, usize_t, PRELUDE_ID};
 use crate::extension::simple_op::MakeRegisteredOp;
+use crate::extension::ExtensionId;
 use crate::extension::{test::SimpleOpDef, ExtensionSet, EMPTY_REG, PRELUDE_REGISTRY};
 use crate::hugr::internal::HugrMutInternals;
 use crate::hugr::validate::ValidationError;
@@ -383,8 +384,8 @@ fn opaque_ops() -> Result<(), Box<dyn std::error::Error>> {
             ExtensionResolutionError::MissingOpExtension {
                 node: not_node,
                 op: "logic.Not".into(),
-                missing_extension: ext_name.to_string(),
-                available_extensions: vec!["prelude".into()]
+                missing_extension: ext_name,
+                available_extensions: vec![ExtensionId::new("prelude").unwrap()]
             }
         )
         .into())

--- a/hugr-core/src/hugr/serialize/upgrade/test.rs
+++ b/hugr-core/src/hugr/serialize/upgrade/test.rs
@@ -4,6 +4,7 @@ use crate::{
     hugr::serialize::test::check_hugr_deserialize,
     std_extensions::logic::LogicOp,
     types::Signature,
+    utils::test_quantum_extension,
 };
 use lazy_static::lazy_static;
 use std::{
@@ -50,7 +51,7 @@ pub fn hugr_with_named_op() -> Hugr {
     let [a, b] = builder.input_wires_arr();
     let x = builder.add_dataflow_op(LogicOp::And, [a, b]).unwrap();
     builder
-        .finish_prelude_hugr_with_outputs(x.outputs())
+        .finish_hugr_with_outputs(x.outputs(), &test_quantum_extension::REG)
         .unwrap()
 }
 

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -361,13 +361,10 @@ fn identity_hugr_with_type(t: Type) -> (Hugr, Node) {
 }
 #[test]
 fn unregistered_extension() {
-    let (mut h, def) = identity_hugr_with_type(usize_t());
-    assert_eq!(
+    let (mut h, _def) = identity_hugr_with_type(usize_t());
+    assert_matches!(
         h.validate(&EMPTY_REG),
-        Err(ValidationError::SignatureError {
-            node: def,
-            cause: SignatureError::ExtensionNotFound(PRELUDE.name.clone())
-        })
+        Err(ValidationError::SignatureError { .. })
     );
     h.update_validate(&PRELUDE_REGISTRY).unwrap();
 }
@@ -392,7 +389,7 @@ fn invalid_types() {
     let validate_to_sig_error = |t: CustomType| {
         let (h, def) = identity_hugr_with_type(Type::new_extension(t));
         match h.validate(&reg) {
-            Err(ValidationError::SignatureError { node, cause }) if node == def => cause,
+            Err(ValidationError::SignatureError { node, cause, .. }) if node == def => cause,
             e => panic!(
                 "Expected SignatureError at def node, got {}",
                 match e {

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -176,7 +176,7 @@ pub(super) mod test {
     use rstest::rstest;
 
     use crate::extension::prelude::{qb_t, usize_t};
-    use crate::extension::PRELUDE_REGISTRY;
+    use crate::utils::test_quantum_extension;
     use crate::IncomingPort;
     use crate::{
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
@@ -214,7 +214,7 @@ pub(super) mod test {
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?;
             (f_id, inner_id)
         };
-        let hugr = module_builder.finish_prelude_hugr()?;
+        let hugr = module_builder.finish_hugr(&test_quantum_extension::REG)?;
         Ok((hugr, f_id.handle().node(), inner_id.handle().node()))
     }
 
@@ -291,7 +291,7 @@ pub(super) mod test {
 
         let region: DescendantsGraph = DescendantsGraph::try_new(&hugr, def)?;
         let extracted = region.extract_hugr();
-        extracted.validate(&PRELUDE_REGISTRY)?;
+        extracted.validate(&test_quantum_extension::REG)?;
 
         let region: DescendantsGraph = DescendantsGraph::try_new(&hugr, def)?;
 

--- a/hugr-core/src/hugr/views/sibling.rs
+++ b/hugr-core/src/hugr/views/sibling.rs
@@ -337,12 +337,11 @@ mod test {
     use crate::builder::test::simple_dfg_hugr;
     use crate::builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder};
     use crate::extension::prelude::{qb_t, usize_t};
-    use crate::extension::PRELUDE_REGISTRY;
     use crate::ops::handle::{CfgID, DataflowParentID, DfgID, FuncID};
     use crate::ops::{dataflow::IOTrait, Input, OpTag, Output};
     use crate::ops::{OpTrait, OpType};
     use crate::types::Signature;
-    use crate::utils::test_quantum_extension::EXTENSION_ID;
+    use crate::utils::test_quantum_extension::{self, EXTENSION_ID};
     use crate::IncomingPort;
 
     use super::super::descendants::test::make_module_hgr;
@@ -457,7 +456,7 @@ mod test {
         let ins = dfg.input_wires();
         let sub_dfg = dfg.finish_with_outputs(ins)?;
         let fun = fbuild.finish_with_outputs(sub_dfg.outputs())?;
-        let h = module_builder.finish_hugr(&PRELUDE_REGISTRY)?;
+        let h = module_builder.finish_hugr(&test_quantum_extension::REG)?;
         let sub_dfg = sub_dfg.node();
 
         // We can create a view from a child or grandchild of a hugr:
@@ -486,7 +485,9 @@ mod test {
     /// Mutate a SiblingMut wrapper
     #[rstest]
     fn flat_mut(mut simple_dfg_hugr: Hugr) {
-        simple_dfg_hugr.update_validate(&PRELUDE_REGISTRY).unwrap();
+        simple_dfg_hugr
+            .update_validate(&test_quantum_extension::REG)
+            .unwrap();
         let root = simple_dfg_hugr.root();
         let signature = simple_dfg_hugr.inner_function_type().unwrap().clone();
 
@@ -511,7 +512,9 @@ mod test {
 
         // In contrast, performing this on the Hugr (where the allowed root type is 'Any') is only detected by validation
         simple_dfg_hugr.replace_op(root, bad_nodetype).unwrap();
-        assert!(simple_dfg_hugr.validate(&PRELUDE_REGISTRY).is_err());
+        assert!(simple_dfg_hugr
+            .validate(&test_quantum_extension::REG)
+            .is_err());
     }
 
     #[rstest]
@@ -540,7 +543,7 @@ mod test {
 
         let region: SiblingGraph = SiblingGraph::try_new(&hugr, inner)?;
         let extracted = region.extract_hugr();
-        extracted.validate(&PRELUDE_REGISTRY)?;
+        extracted.validate(&test_quantum_extension::REG)?;
 
         let region: SiblingGraph = SiblingGraph::try_new(&hugr, inner)?;
 

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -795,10 +795,7 @@ mod tests {
             BuildError, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer, HugrBuilder,
             ModuleBuilder,
         },
-        extension::{
-            prelude::{bool_t, qb_t},
-            EMPTY_REG,
-        },
+        extension::prelude::{bool_t, qb_t},
         hugr::views::{HierarchyView, SiblingGraph},
         ops::handle::{DfgID, FuncID, NodeHandle},
         std_extensions::logic::test::and_op,
@@ -881,7 +878,7 @@ mod tests {
             dfg.finish_with_outputs(outs3.outputs())?
         };
         let hugr = mod_builder
-            .finish_prelude_hugr()
+            .finish_hugr(&test_quantum_extension::REG)
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -903,7 +900,7 @@ mod tests {
             dfg.finish_with_outputs([b1, b2])?
         };
         let hugr = mod_builder
-            .finish_prelude_hugr()
+            .finish_hugr(&test_quantum_extension::REG)
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -924,7 +921,7 @@ mod tests {
             dfg.finish_with_outputs(outs.outputs())?
         };
         let hugr = mod_builder
-            .finish_hugr(&EMPTY_REG)
+            .finish_hugr(&test_quantum_extension::REG)
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -1170,7 +1167,9 @@ mod tests {
             .unwrap()
             .outputs();
         let outw = [outw1].into_iter().chain(outw2);
-        let h = builder.finish_hugr_with_outputs(outw, &EMPTY_REG).unwrap();
+        let h = builder
+            .finish_hugr_with_outputs(outw, &test_quantum_extension::REG)
+            .unwrap();
         let view = SiblingGraph::<DfgID>::try_new(&h, h.root()).unwrap();
         let subg = SiblingSubgraph::try_new_dataflow_subgraph(&view).unwrap();
         assert_eq!(subg.nodes().len(), 2);

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -10,7 +10,7 @@ pub mod sum;
 pub mod tag;
 pub mod validate;
 use crate::extension::simple_op::MakeExtensionOp;
-use crate::extension::ExtensionSet;
+use crate::extension::{ExtensionId, ExtensionSet};
 use crate::types::{EdgeKind, Signature};
 use crate::{Direction, OutgoingPort, Port};
 use crate::{IncomingPort, PortIndex};
@@ -299,6 +299,15 @@ impl OpType {
     pub fn cast<T: MakeExtensionOp>(&self) -> Option<T> {
         self.as_extension_op()
             .and_then(|o| T::from_extension_op(o).ok())
+    }
+
+    /// Returns the extension where the operation is defined, if any.
+    pub fn extension_id(&self) -> Option<&ExtensionId> {
+        match self {
+            OpType::OpaqueOp(opaque) => Some(opaque.extension()),
+            OpType::ExtensionOp(e) => Some(e.def().extension_id()),
+            _ => None,
+        }
     }
 }
 

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -57,11 +57,11 @@ impl ExtensionOp {
     /// If OpDef is missing binary computation, trust the cached signature.
     pub(crate) fn new_with_cached(
         def: Arc<OpDef>,
-        args: impl Into<Vec<TypeArg>>,
+        args: impl IntoIterator<Item = TypeArg>,
         opaque: &OpaqueOp,
         exts: &ExtensionRegistry,
     ) -> Result<Self, SignatureError> {
-        let args: Vec<TypeArg> = args.into();
+        let args: Vec<TypeArg> = args.into_iter().collect();
         // TODO skip computation depending on config
         // see https://github.com/CQCL/hugr/issues/1363
         let signature = match def.compute_signature(&args, exts) {
@@ -113,7 +113,7 @@ impl ExtensionOp {
     }
 
     /// Returns a mutable reference to the cached signature of the operation.
-    pub(crate) fn signature_mut(&mut self) -> &mut Signature {
+    pub fn signature_mut(&mut self) -> &mut Signature {
         &mut self.signature
     }
 }
@@ -209,7 +209,7 @@ impl OpaqueOp {
     }
 
     /// Returns a mutable reference to the signature of the operation.
-    pub(crate) fn signature_mut(&mut self) -> &mut Signature {
+    pub fn signature_mut(&mut self) -> &mut Signature {
         &mut self.signature
     }
 }

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -297,7 +297,9 @@ pub enum OpaqueOpError {
 #[cfg(test)]
 mod test {
 
-    use crate::extension::resolution::{resolve_op_extensions, OpResolutionResult};
+    use ops::OpType;
+
+    use crate::extension::resolution::update_op_extensions;
     use crate::std_extensions::arithmetic::conversions::{self, CONVERT_OPS_REGISTRY};
     use crate::{
         extension::{
@@ -312,13 +314,8 @@ mod test {
     use super::*;
 
     /// Unwrap the replacement type's `OpDef` from the return type of `resolve_op_definition`.
-    fn resolve_res_definition<'a>(res: &'a OpResolutionResult) -> &'a OpDef {
-        res.replacement_op
-            .as_ref()
-            .unwrap()
-            .as_extension_op()
-            .unwrap()
-            .def()
+    fn resolve_res_definition(res: &OpType) -> &OpDef {
+        res.as_extension_op().unwrap().def()
     }
 
     #[test]
@@ -351,9 +348,10 @@ mod test {
             vec![],
             Signature::new(i0.clone(), bool_t()),
         );
-        let resolved = resolve_op_extensions(
+        let mut resolved = opaque.into();
+        update_op_extensions(
             Node::from(portgraph::NodeIndex::new(1)),
-            &opaque.into(),
+            &mut resolved,
             registry,
         )
         .unwrap();
@@ -394,17 +392,19 @@ mod test {
             endo_sig.clone(),
         );
         let opaque_comp = OpaqueOp::new(ext_id.clone(), comp_name, "".into(), vec![], endo_sig);
-        let resolved_val = resolve_op_extensions(
+        let mut resolved_val = opaque_val.into();
+        update_op_extensions(
             Node::from(portgraph::NodeIndex::new(1)),
-            &opaque_val.into(),
+            &mut resolved_val,
             &registry,
         )
         .unwrap();
         assert_eq!(resolve_res_definition(&resolved_val).name(), val_name);
 
-        let resolved_comp = resolve_op_extensions(
+        let mut resolved_comp = opaque_comp.into();
+        update_op_extensions(
             Node::from(portgraph::NodeIndex::new(2)),
-            &opaque_comp.into(),
+            &mut resolved_comp,
             &registry,
         )
         .unwrap();

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -1,5 +1,6 @@
 //! Extensible operations.
 
+use itertools::Itertools;
 use std::sync::Arc;
 use thiserror::Error;
 #[cfg(test)]
@@ -11,14 +12,12 @@ use {
 };
 
 use crate::extension::{ConstFoldResult, ExtensionId, ExtensionRegistry, OpDef, SignatureError};
-use crate::hugr::internal::HugrMutInternals;
-use crate::hugr::HugrView;
 use crate::types::{type_param::TypeArg, Signature};
-use crate::{ops, Hugr, IncomingPort, Node};
+use crate::{ops, IncomingPort, Node};
 
 use super::dataflow::DataflowOpTrait;
 use super::tag::OpTag;
-use super::{NamedOp, OpName, OpNameRef, OpTrait, OpType};
+use super::{NamedOp, OpName, OpNameRef};
 
 /// An operation defined by an [OpDef] from a loaded [Extension].
 ///
@@ -56,7 +55,7 @@ impl ExtensionOp {
     }
 
     /// If OpDef is missing binary computation, trust the cached signature.
-    fn new_with_cached(
+    pub(crate) fn new_with_cached(
         def: Arc<OpDef>,
         args: impl Into<Vec<TypeArg>>,
         opaque: &OpaqueOp,
@@ -99,7 +98,8 @@ impl ExtensionOp {
     /// [`ExtensionOp`].
     ///
     /// Regenerating the [`ExtensionOp`] back from the [`OpaqueOp`] requires a
-    /// registry with the appropriate extension. See [`resolve_opaque_op`].
+    /// registry with the appropriate extension. See
+    /// [`crate::Hugr::resolve_extension_defs`].
     ///
     /// For a non-cloning version of this operation, use [`OpaqueOp::from`].
     pub fn make_opaque(&self) -> OpaqueOp {
@@ -110,6 +110,11 @@ impl ExtensionOp {
             args: self.args.clone(),
             signature: self.signature.clone(),
         }
+    }
+
+    /// Returns a mutable reference to the cached signature of the operation.
+    pub(crate) fn signature_mut(&mut self) -> &mut Signature {
+        &mut self.signature
     }
 }
 
@@ -202,6 +207,11 @@ impl OpaqueOp {
             signature,
         }
     }
+
+    /// Returns a mutable reference to the signature of the operation.
+    pub(crate) fn signature_mut(&mut self) -> &mut Signature {
+        &mut self.signature
+    }
 }
 
 impl NamedOp for OpaqueOp {
@@ -241,89 +251,25 @@ impl DataflowOpTrait for OpaqueOp {
     }
 }
 
-/// Resolve serialized names of operations into concrete implementation (OpDefs) where possible
-pub fn resolve_extension_ops(
-    h: &mut Hugr,
-    extension_registry: &ExtensionRegistry,
-) -> Result<(), OpaqueOpError> {
-    let mut replacements = Vec::new();
-    for n in h.nodes() {
-        if let OpType::OpaqueOp(opaque) = h.get_optype(n) {
-            let resolved = resolve_opaque_op(n, opaque, extension_registry)?;
-            replacements.push((n, resolved));
-        }
-    }
-    // Only now can we perform the replacements as the 'for' loop was borrowing 'h' preventing use from using it mutably
-    for (n, op) in replacements {
-        debug_assert_eq!(h.get_optype(n).tag(), OpTag::Leaf);
-        debug_assert_eq!(op.tag(), OpTag::Leaf);
-        h.replace_op(n, op).unwrap();
-    }
-    Ok(())
-}
-
-/// Try to resolve a [`OpaqueOp`] to a [`ExtensionOp`] by looking the op up in
-/// the registry.
-///
-/// # Return
-/// Some if the serialized opaque resolves to an extension-defined op and all is
-/// ok; None if the serialized opaque doesn't identify an extension
-///
-/// # Errors
-/// If the serialized opaque resolves to a definition that conflicts with what
-/// was serialized
-pub fn resolve_opaque_op(
-    node: Node,
-    opaque: &OpaqueOp,
-    extension_registry: &ExtensionRegistry,
-) -> Result<ExtensionOp, OpaqueOpError> {
-    if let Some(r) = extension_registry.get(&opaque.extension) {
-        // Fail if the Extension was found but did not have the expected operation
-        let Some(def) = r.get_op(&opaque.name) else {
-            return Err(OpaqueOpError::OpNotFoundInExtension(
-                node,
-                opaque.name.clone(),
-                r.name().clone(),
-            ));
-        };
-        let ext_op = ExtensionOp::new_with_cached(
-            def.clone(),
-            opaque.args.clone(),
-            opaque,
-            extension_registry,
-        )
-        .map_err(|e| OpaqueOpError::SignatureError {
-            node,
-            name: opaque.name.clone(),
-            cause: e,
-        })?;
-        if opaque.signature() != ext_op.signature() {
-            return Err(OpaqueOpError::SignatureMismatch {
-                node,
-                extension: opaque.extension.clone(),
-                op: def.name().clone(),
-                computed: ext_op.signature.clone(),
-                stored: opaque.signature.clone(),
-            });
-        };
-        Ok(ext_op)
-    } else {
-        Err(OpaqueOpError::UnresolvedOp(
-            node,
-            opaque.name.clone(),
-            opaque.extension.clone(),
-        ))
-    }
-}
-
 /// Errors that arise after loading a Hugr containing opaque ops (serialized just as their names)
 /// when trying to resolve the serialized names against a registry of known Extensions.
 #[derive(Clone, Debug, Error, PartialEq)]
 #[non_exhaustive]
 pub enum OpaqueOpError {
     /// The Extension was found but did not contain the expected OpDef
-    #[error("Operation '{1}' in {0} not found in Extension {2}")]
-    OpNotFoundInExtension(Node, OpName, ExtensionId),
+    #[error("Operation '{op}' in {node} not found in Extension {extension}. Available operations: {}",
+            available_ops.iter().join(", ")
+    )]
+    OpNotFoundInExtension {
+        /// The node where the error occurred.
+        node: Node,
+        /// The missing operation.
+        op: OpName,
+        /// The extension where the operation was expected.
+        extension: ExtensionId,
+        /// The available operations in the extension.
+        available_ops: Vec<OpName>,
+    },
     /// Extension and OpDef found, but computed signature did not match stored
     #[error("Conflicting signature: resolved {op} in extension {extension} to a concrete implementation which computed {computed} but stored signature was {stored}")]
     #[allow(missing_docs)]
@@ -351,6 +297,7 @@ pub enum OpaqueOpError {
 #[cfg(test)]
 mod test {
 
+    use crate::extension::resolution::{resolve_op_extensions, OpResolutionResult};
     use crate::std_extensions::arithmetic::conversions::{self, CONVERT_OPS_REGISTRY};
     use crate::{
         extension::{
@@ -363,6 +310,16 @@ mod test {
     };
 
     use super::*;
+
+    /// Unwrap the replacement type's `OpDef` from the return type of `resolve_op_definition`.
+    fn resolve_res_definition<'a>(res: &'a OpResolutionResult) -> &'a OpDef {
+        res.replacement_op
+            .as_ref()
+            .unwrap()
+            .as_extension_op()
+            .unwrap()
+            .def()
+    }
 
     #[test]
     fn new_opaque_op() {
@@ -394,10 +351,13 @@ mod test {
             vec![],
             Signature::new(i0.clone(), bool_t()),
         );
-        let resolved =
-            super::resolve_opaque_op(Node::from(portgraph::NodeIndex::new(1)), &opaque, registry)
-                .unwrap();
-        assert_eq!(resolved.def().name(), "itobool");
+        let resolved = resolve_op_extensions(
+            Node::from(portgraph::NodeIndex::new(1)),
+            &opaque.into(),
+            registry,
+        )
+        .unwrap();
+        assert_eq!(resolve_res_definition(&resolved).name(), "itobool");
     }
 
     #[test]
@@ -434,20 +394,20 @@ mod test {
             endo_sig.clone(),
         );
         let opaque_comp = OpaqueOp::new(ext_id.clone(), comp_name, "".into(), vec![], endo_sig);
-        let resolved_val = super::resolve_opaque_op(
+        let resolved_val = resolve_op_extensions(
             Node::from(portgraph::NodeIndex::new(1)),
-            &opaque_val,
+            &opaque_val.into(),
             &registry,
         )
         .unwrap();
-        assert_eq!(resolved_val.def().name(), val_name);
+        assert_eq!(resolve_res_definition(&resolved_val).name(), val_name);
 
-        let resolved_comp = super::resolve_opaque_op(
+        let resolved_comp = resolve_op_extensions(
             Node::from(portgraph::NodeIndex::new(2)),
-            &opaque_comp,
+            &opaque_comp.into(),
             &registry,
         )
         .unwrap();
-        assert_eq!(resolved_comp.def().name(), comp_name);
+        assert_eq!(resolve_res_definition(&resolved_comp).name(), comp_name);
     }
 }

--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -372,7 +372,7 @@ impl ListOpInst {
                 .clone()
                 .into_iter()
                 // ignore self if already in registry
-                .filter_map(|(_, ext)| (ext.name() != EXTENSION.name()).then_some(ext))
+                .filter(|ext| ext.name() != EXTENSION.name())
                 .chain(std::iter::once(EXTENSION.to_owned())),
         )
         .unwrap();

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -397,7 +397,7 @@ impl<RV: MaybeRV> TypeBase<RV> {
 
     /// Report a mutable reference to the component TypeEnum.
     #[inline(always)]
-    pub(crate) fn as_type_enum_mut(&mut self) -> &mut TypeEnum<RV> {
+    pub fn as_type_enum_mut(&mut self) -> &mut TypeEnum<RV> {
         &mut self.0
     }
 

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -395,6 +395,12 @@ impl<RV: MaybeRV> TypeBase<RV> {
         &self.0
     }
 
+    /// Report a mutable reference to the component TypeEnum.
+    #[inline(always)]
+    pub(crate) fn as_type_enum_mut(&mut self) -> &mut TypeEnum<RV> {
+        &mut self.0
+    }
+
     /// Report if the type is copyable - i.e.the least upper bound of the type
     /// is contained by the copyable bound.
     pub const fn copyable(&self) -> bool {

--- a/hugr-core/src/types/custom.rs
+++ b/hugr-core/src/types/custom.rs
@@ -98,7 +98,10 @@ impl CustomType {
         let ex = extension_registry.get(&self.extension);
         // Even if OpDef's (+binaries) are not available, the part of the Extension definition
         // describing the TypeDefs can easily be passed around (serialized), so should be available.
-        let ex = ex.ok_or(SignatureError::ExtensionNotFound(self.extension.clone()))?;
+        let ex = ex.ok_or(SignatureError::ExtensionNotFound {
+            missing: self.extension.clone(),
+            available: extension_registry.ids().cloned().collect(),
+        })?;
         ex.get_type(&self.id)
             .ok_or(SignatureError::ExtensionTypeNotFound {
                 exn: self.extension.clone(),

--- a/hugr-core/src/types/custom.rs
+++ b/hugr-core/src/types/custom.rs
@@ -146,6 +146,11 @@ impl CustomType {
     pub fn extension_ref(&self) -> Weak<Extension> {
         self.extension_ref.clone()
     }
+
+    /// Update the internal extension reference with a new weak pointer.
+    pub fn update_extension(&mut self, extension_ref: Weak<Extension>) {
+        self.extension_ref = extension_ref;
+    }
 }
 
 impl Display for CustomType {

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -147,7 +147,7 @@ impl<RV: MaybeRV> PolyFuncTypeBase<RV> {
     }
 
     /// Returns a mutable reference to the body of the function type.
-    pub(crate) fn body_mut(&mut self) -> &mut FuncTypeBase<RV> {
+    pub fn body_mut(&mut self) -> &mut FuncTypeBase<RV> {
         &mut self.body
     }
 }

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -145,6 +145,11 @@ impl<RV: MaybeRV> PolyFuncTypeBase<RV> {
             self.params.iter().map(ToString::to_string).join(" ")
         )
     }
+
+    /// Returns a mutable reference to the body of the function type.
+    pub(crate) fn body_mut(&mut self) -> &mut FuncTypeBase<RV> {
+        &mut self.body
+    }
 }
 
 #[cfg(test)]

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -106,6 +106,8 @@ pub(crate) mod test_quantum_extension {
     use std::sync::Arc;
 
     use crate::ops::{OpName, OpNameRef};
+    use crate::std_extensions::arithmetic::float_ops;
+    use crate::std_extensions::logic;
     use crate::types::FuncValueType;
     use crate::{
         extension::{
@@ -190,7 +192,15 @@ pub(crate) mod test_quantum_extension {
     lazy_static! {
         /// Quantum extension definition.
         pub static ref EXTENSION: Arc<Extension> = extension();
-        static ref REG: ExtensionRegistry = ExtensionRegistry::try_new([EXTENSION.clone(), PRELUDE.clone(), float_types::EXTENSION.clone()]).unwrap();
+
+        /// A registry with all necessary extensions to run tests internally, including the test quantum extension.
+        pub static ref REG: ExtensionRegistry = ExtensionRegistry::try_new([
+            EXTENSION.clone(),
+            PRELUDE.clone(),
+            float_types::EXTENSION.clone(),
+            float_ops::EXTENSION.clone(),
+            logic::EXTENSION.clone()
+        ]).unwrap();
 
     }
 

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -218,4 +218,4 @@ pub fn constant_fold_pass<H: HugrMut>(h: &mut H, reg: &ExtensionRegistry) {
 }
 
 #[cfg(test)]
-mod test;
+pub(crate) mod test;

--- a/hugr-passes/src/const_fold/test.rs
+++ b/hugr-passes/src/const_fold/test.rs
@@ -1,15 +1,13 @@
 use crate::const_fold::constant_fold_pass;
+use crate::test::TEST_REG;
 use hugr_core::builder::{DFGBuilder, Dataflow, DataflowHugr};
 use hugr_core::extension::prelude::{
     bool_t, const_ok, error_type, string_type, sum_with_error, ConstError, ConstString, UnpackTuple,
 };
-use hugr_core::extension::{ExtensionRegistry, PRELUDE};
 use hugr_core::ops::Value;
 use hugr_core::std_extensions::arithmetic::int_ops::IntOpDef;
 use hugr_core::std_extensions::arithmetic::int_types::{ConstInt, INT_TYPES};
-use hugr_core::std_extensions::arithmetic::{self, float_ops, float_types};
-use hugr_core::std_extensions::collections;
-use hugr_core::std_extensions::logic::{self, LogicOp};
+use hugr_core::std_extensions::logic::LogicOp;
 use hugr_core::type_row;
 use hugr_core::types::{Signature, Type, TypeRow, TypeRowRV};
 
@@ -23,21 +21,6 @@ use hugr_core::ops::OpType;
 use hugr_core::std_extensions::arithmetic::conversions::ConvertOpDef;
 use hugr_core::std_extensions::arithmetic::float_ops::FloatOps;
 use hugr_core::std_extensions::arithmetic::float_types::{float64_type, ConstF64};
-
-lazy_static! {
-    /// A registry containing various extensions for testing.
-    pub(crate) static ref TEST_REG: ExtensionRegistry = ExtensionRegistry::try_new([
-        PRELUDE.clone(),
-        arithmetic::int_ops::EXTENSION.clone(),
-        arithmetic::int_types::EXTENSION.clone(),
-        float_types::EXTENSION.clone(),
-        float_ops::EXTENSION.clone(),
-        logic::EXTENSION.clone(),
-        arithmetic::conversions::EXTENSION.to_owned(),
-        collections::EXTENSION.to_owned(),
-    ])
-    .unwrap();
-}
 
 /// Check that a hugr just loads and returns a single expected constant.
 pub fn assert_fully_folded(h: &Hugr, expected_value: &Value) {

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -25,12 +25,12 @@ pub(crate) mod test {
     lazy_static! {
         /// A registry containing various extensions for testing.
         pub(crate) static ref TEST_REG: ExtensionRegistry = ExtensionRegistry::try_new([
-            PRELUDE.clone(),
-            arithmetic::int_ops::EXTENSION.clone(),
-            arithmetic::int_types::EXTENSION.clone(),
-            arithmetic::float_types::EXTENSION.clone(),
-            arithmetic::float_ops::EXTENSION.clone(),
-            logic::EXTENSION.clone(),
+            PRELUDE.to_owned(),
+            arithmetic::int_ops::EXTENSION.to_owned(),
+            arithmetic::int_types::EXTENSION.to_owned(),
+            arithmetic::float_types::EXTENSION.to_owned(),
+            arithmetic::float_ops::EXTENSION.to_owned(),
+            logic::EXTENSION.to_owned(),
             arithmetic::conversions::EXTENSION.to_owned(),
             collections::EXTENSION.to_owned(),
         ])

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -11,3 +11,29 @@ pub mod validation;
 pub use force_order::{force_order, force_order_by_key};
 pub use lower::{lower_ops, replace_many_ops};
 pub use non_local::{ensure_no_nonlocal_edges, nonlocal_edges};
+
+#[cfg(test)]
+pub(crate) mod test {
+
+    use lazy_static::lazy_static;
+
+    use hugr_core::extension::{ExtensionRegistry, PRELUDE};
+    use hugr_core::std_extensions::arithmetic;
+    use hugr_core::std_extensions::collections;
+    use hugr_core::std_extensions::logic;
+
+    lazy_static! {
+        /// A registry containing various extensions for testing.
+        pub(crate) static ref TEST_REG: ExtensionRegistry = ExtensionRegistry::try_new([
+            PRELUDE.clone(),
+            arithmetic::int_ops::EXTENSION.clone(),
+            arithmetic::int_types::EXTENSION.clone(),
+            arithmetic::float_types::EXTENSION.clone(),
+            arithmetic::float_ops::EXTENSION.clone(),
+            logic::EXTENSION.clone(),
+            arithmetic::conversions::EXTENSION.to_owned(),
+            collections::EXTENSION.to_owned(),
+        ])
+        .unwrap();
+    }
+}

--- a/hugr-passes/src/non_local.rs
+++ b/hugr-passes/src/non_local.rs
@@ -48,7 +48,7 @@ mod test {
         types::Signature,
     };
 
-    use crate::const_fold::test::TEST_REG;
+    use crate::test::TEST_REG;
 
     use super::*;
 

--- a/hugr-passes/src/non_local.rs
+++ b/hugr-passes/src/non_local.rs
@@ -42,14 +42,13 @@ pub fn ensure_no_nonlocal_edges(hugr: &impl HugrView) -> Result<(), NonLocalEdge
 mod test {
     use hugr_core::{
         builder::{DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer},
-        extension::{
-            prelude::{bool_t, Noop},
-            EMPTY_REG,
-        },
+        extension::prelude::{bool_t, Noop},
         ops::handle::NodeHandle,
         type_row,
         types::Signature,
     };
+
+    use crate::const_fold::test::TEST_REG;
 
     use super::*;
 
@@ -64,7 +63,7 @@ mod test {
                 .unwrap()
                 .outputs_arr();
             builder
-                .finish_hugr_with_outputs([out_w], &EMPTY_REG)
+                .finish_hugr_with_outputs([out_w], &TEST_REG)
                 .unwrap()
         };
         ensure_no_nonlocal_edges(&hugr).unwrap();
@@ -94,7 +93,7 @@ mod test {
             };
             (
                 builder
-                    .finish_hugr_with_outputs([out_w], &EMPTY_REG)
+                    .finish_hugr_with_outputs([out_w], &TEST_REG)
                     .unwrap(),
                 edge,
             )

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -81,7 +81,7 @@
 //!     lazy_static! {
 //!         /// Quantum extension definition.
 //!         pub static ref EXTENSION: Arc<Extension> = extension();
-//!         static ref REG: ExtensionRegistry =
+//!         pub static ref REG: ExtensionRegistry =
 //!             ExtensionRegistry::try_new([EXTENSION.clone(), PRELUDE.clone()]).unwrap();
 //!     }
 //!     fn get_gate(gate_name: impl Into<OpName>) -> ExtensionOp {
@@ -103,7 +103,7 @@
 //!     }
 //! }
 //!
-//! use mini_quantum_extension::{cx_gate, h_gate, measure};
+//! use mini_quantum_extension::{cx_gate, h_gate, measure, REG};
 //!
 //! //      ┌───┐
 //! // q_0: ┤ H ├──■─────
@@ -121,7 +121,7 @@
 //!     let h1 = dfg_builder.add_dataflow_op(h_gate(), vec![wire1])?;
 //!     let cx = dfg_builder.add_dataflow_op(cx_gate(), h0.outputs().chain(h1.outputs()))?;
 //!     let measure = dfg_builder.add_dataflow_op(measure(), cx.outputs().last())?;
-//!     dfg_builder.finish_prelude_hugr_with_outputs(cx.outputs().take(1).chain(measure.outputs()))
+//!     dfg_builder.finish_hugr_with_outputs(cx.outputs().take(1).chain(measure.outputs()), &REG)
 //! }
 //!
 //! let h: Hugr = make_dfg_hugr().unwrap();


### PR DESCRIPTION
When we do a serialization roundtrip on a hugr, its custom optypes are downgraded to `OpaqueOp`s and its `CustomType`s lose the weak link to their extension.

This PR moves the pre-existing `OpaqueOp` resolution into a new `crate::extension::resolution` module and expands it to also update the custom type pointers. This can be run via the new `Hugr::resolve_extension_defs` method (currently called by `update_validate`).
In addition, we accumulate the exact list of extensions required to define the hugr (this will be necessary for #1613).

Note that this will probably be no longer necessary after we stabilize `hugr-model`, as we manually build the hugr when importing the model so the extensions should already be present at that point.

In contrast to extension inference, this detects extensions needed to _define_ a hugr (vs runtime requirements). The inference one will be renamed as per #1734.

A big chunk of this PR is fixing tests that used `finish_prelude_hugr` even though they required more extensions -.-'
Look at the first commit for the actual changes.

BREAKING CHANGE: Removed `resolve_opaque_op` and `resolve_extension_ops`. Use `Hugr::resolve_extension_defs` instead.