### PR TITLE
feat!: Hugrs now keep a `ExtensionRegistry` with their requirements

### DIFF
--- a/hugr-cli/src/main.rs
+++ b/hugr-cli/src/main.rs
@@ -2,7 +2,7 @@
 
 use clap::Parser as _;
 
-use hugr_cli::{validate, CliArgs};
+use hugr_cli::{mermaid, validate, CliArgs};
 
 use clap_verbosity_flag::log::Level;
 
@@ -10,7 +10,7 @@ fn main() {
     match CliArgs::parse() {
         CliArgs::Validate(args) => run_validate(args),
         CliArgs::GenExtensions(args) => args.run_dump(&hugr::std_extensions::STD_REG),
-        CliArgs::Mermaid(mut args) => args.run_print().unwrap(),
+        CliArgs::Mermaid(args) => run_mermaid(args),
         CliArgs::External(_) => {
             // TODO: Implement support for external commands.
             // Running `hugr COMMAND` would look for `hugr-COMMAND` in the path
@@ -31,6 +31,18 @@ fn run_validate(mut args: validate::ValArgs) {
 
     if let Err(e) = result {
         if args.verbosity(Level::Error) {
+            eprintln!("{}", e);
+        }
+        std::process::exit(1);
+    }
+}
+
+/// Run the `mermaid` subcommand.
+fn run_mermaid(mut args: mermaid::MermaidArgs) {
+    let result = args.run_print();
+
+    if let Err(e) = result {
+        if args.hugr_args.verbosity(Level::Error) {
             eprintln!("{}", e);
         }
         std::process::exit(1);

--- a/hugr-cli/src/mermaid.rs
+++ b/hugr-cli/src/mermaid.rs
@@ -30,9 +30,12 @@ impl MermaidArgs {
     /// Write the mermaid diagram to the output.
     pub fn run_print(&mut self) -> Result<(), crate::CliError> {
         let hugrs = if self.validate {
-            self.hugr_args.validate()?.0
+            self.hugr_args.validate()?
         } else {
-            self.hugr_args.get_package_or_hugr()?.into_hugrs()
+            let extensions = self.hugr_args.extensions()?;
+            self.hugr_args
+                .get_package_or_hugr(&extensions)?
+                .into_hugrs()
         };
 
         for hugr in hugrs {

--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -75,11 +75,11 @@
 //!     // Finish building the HUGR, consuming the builder.
 //!     //
 //!     // Requires a registry with all the extensions used in the module.
-//!     module_builder.finish_hugr(&LOGIC_REG)
+//!     module_builder.finish_hugr()
 //! }?;
 //!
 //! // The built HUGR is always valid.
-//! hugr.validate(&LOGIC_REG).unwrap_or_else(|e| {
+//! hugr.validate().unwrap_or_else(|e| {
 //!     panic!("HUGR validation failed: {e}");
 //! });
 //! # Ok(())
@@ -242,7 +242,6 @@ pub(crate) mod test {
     use crate::hugr::{views::HugrView, HugrMut};
     use crate::ops;
     use crate::types::{PolyFuncType, Signature};
-    use crate::utils::test_quantum_extension;
     use crate::Hugr;
 
     use super::handle::BuildHandle;
@@ -269,14 +268,14 @@ pub(crate) mod test {
 
         f(f_builder)?;
 
-        Ok(module_builder.finish_hugr(&test_quantum_extension::REG)?)
+        Ok(module_builder.finish_hugr()?)
     }
 
     #[fixture]
     pub(crate) fn simple_dfg_hugr() -> Hugr {
         let dfg_builder = DFGBuilder::new(Signature::new(vec![bool_t()], vec![bool_t()])).unwrap();
         let [i1] = dfg_builder.input_wires_arr();
-        dfg_builder.finish_prelude_hugr_with_outputs([i1]).unwrap()
+        dfg_builder.finish_hugr_with_outputs([i1]).unwrap()
     }
 
     #[fixture]
@@ -284,7 +283,7 @@ pub(crate) mod test {
         let fn_builder =
             FunctionBuilder::new("test", Signature::new(vec![bool_t()], vec![bool_t()])).unwrap();
         let [i1] = fn_builder.input_wires_arr();
-        fn_builder.finish_prelude_hugr_with_outputs([i1]).unwrap()
+        fn_builder.finish_hugr_with_outputs([i1]).unwrap()
     }
 
     #[fixture]
@@ -292,7 +291,7 @@ pub(crate) mod test {
         let mut builder = ModuleBuilder::new();
         let sig = Signature::new(vec![bool_t()], vec![bool_t()]);
         builder.declare("test", sig.into()).unwrap();
-        builder.finish_prelude_hugr().unwrap()
+        builder.finish_hugr().unwrap()
     }
 
     #[fixture]
@@ -300,7 +299,7 @@ pub(crate) mod test {
         let mut cfg_builder =
             CFGBuilder::new(Signature::new(vec![usize_t()], vec![usize_t()])).unwrap();
         super::cfg::test::build_basic_cfg(&mut cfg_builder).unwrap();
-        cfg_builder.finish_prelude_hugr().unwrap()
+        cfg_builder.finish_hugr().unwrap()
     }
 
     /// A helper method which creates a DFG rooted hugr with Input and Output node

--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -4,9 +4,10 @@ use crate::hugr::views::HugrView;
 use crate::hugr::{NodeMetadata, ValidationError};
 use crate::ops::{self, OpTag, OpTrait, OpType, Tag, TailLoop};
 use crate::utils::collect_array;
-use crate::{IncomingPort, Node, OutgoingPort};
+use crate::{Extension, IncomingPort, Node, OutgoingPort};
 
 use std::iter;
+use std::sync::Arc;
 
 use super::{
     handle::{BuildHandle, Outputs},
@@ -19,7 +20,7 @@ use crate::{
     types::EdgeKind,
 };
 
-use crate::extension::{ExtensionRegistry, ExtensionSet, PRELUDE_REGISTRY, TO_BE_INFERRED};
+use crate::extension::{ExtensionRegistry, ExtensionSet, TO_BE_INFERRED};
 use crate::types::{PolyFuncType, Signature, Type, TypeArg, TypeRow};
 
 use itertools::Itertools;
@@ -45,7 +46,17 @@ pub trait Container {
     /// Immutable reference to HUGR being built
     fn hugr(&self) -> &Hugr;
     /// Add an [`OpType`] as the final child of the container.
+    ///
+    /// Adds the extensions required by the op to the HUGR, if they are not already present.
     fn add_child_node(&mut self, node: impl Into<OpType>) -> Node {
+        let node: OpType = node.into();
+
+        // Add the extension the operation is defined in to the HUGR.
+        let used_extensions = node
+            .used_extensions()
+            .unwrap_or_else(|e| panic!("Build-time signatures should have valid extensions. {e}"));
+        self.use_extensions(used_extensions);
+
         let parent = self.container_node();
         self.hugr_mut().add_node_with_parent(parent, node)
     }
@@ -60,6 +71,8 @@ pub trait Container {
     }
 
     /// Add a constant value to the container and return a handle to it.
+    ///
+    /// Adds the extensions required by the op to the HUGR, if they are not already present.
     ///
     /// # Errors
     ///
@@ -87,6 +100,13 @@ pub trait Container {
             name: name.into(),
             signature,
         });
+
+        // Add the extensions used by the function types.
+        self.use_extensions(
+            body.used_extensions().unwrap_or_else(|e| {
+                panic!("Build-time signatures should have valid extensions. {e}")
+            }),
+        );
 
         let db = DFGBuilder::create_with_io(self.hugr_mut(), f_node, body)?;
         Ok(FunctionBuilder::from_dfg_builder(db))
@@ -122,24 +142,26 @@ pub trait Container {
     ) {
         self.hugr_mut().set_metadata(child, key, meta);
     }
+
+    /// Add an extension to the set of extensions used by the hugr.
+    fn use_extension(&mut self, ext: impl Into<Arc<Extension>>) {
+        self.hugr_mut().use_extension(ext);
+    }
+
+    /// Extend the set of extensions used by the hugr with the extensions in the registry.
+    fn use_extensions<Reg>(&mut self, registry: impl IntoIterator<Item = Reg>)
+    where
+        ExtensionRegistry: Extend<Reg>,
+    {
+        self.hugr_mut().extensions_mut().extend(registry);
+    }
 }
 
 /// Types implementing this trait can be used to build complete HUGRs
 /// (with varying root node types)
 pub trait HugrBuilder: Container {
     /// Finish building the HUGR, perform any validation checks and return it.
-    fn finish_hugr(self, extension_registry: &ExtensionRegistry) -> Result<Hugr, ValidationError>;
-
-    /// Finish building the HUGR (as [HugrBuilder::finish_hugr]),
-    /// validating against the [prelude] extension only
-    ///
-    /// [prelude]: crate::extension::prelude
-    fn finish_prelude_hugr(self) -> Result<Hugr, ValidationError>
-    where
-        Self: Sized,
-    {
-        self.finish_hugr(&PRELUDE_REGISTRY)
-    }
+    fn finish_hugr(self) -> Result<Hugr, ValidationError>;
 }
 
 /// Types implementing this trait build a container graph region by borrowing a HUGR
@@ -178,6 +200,8 @@ pub trait Dataflow: Container {
     }
     /// Add a dataflow [`OpType`] to the sibling graph, wiring up the `input_wires` to the
     /// incoming ports of the resulting node.
+    ///
+    /// Adds the extensions required by the op to the HUGR, if they are not already present.
     ///
     /// # Errors
     ///
@@ -398,8 +422,6 @@ pub trait Dataflow: Container {
         &mut self,
         fid: &FuncID<DEFINED>,
         type_args: &[TypeArg],
-        // Sadly required as we substituting in type_args may result in recomputing bounds of types:
-        exts: &ExtensionRegistry,
     ) -> Result<Wire, BuildError> {
         let func_node = fid.node();
         let func_op = self.hugr().get_optype(func_node);
@@ -415,7 +437,7 @@ pub trait Dataflow: Container {
         };
 
         let load_n = self.add_dataflow_op(
-            ops::LoadFunction::try_new(func_sig, type_args, exts)?,
+            ops::LoadFunction::try_new(func_sig, type_args, self.hugr().extensions())?,
             // Static wire from the function node
             vec![Wire::new(func_node, func_op.static_output_port().unwrap())],
         )?;
@@ -664,8 +686,6 @@ pub trait Dataflow: Container {
         function: &FuncID<DEFINED>,
         type_args: &[TypeArg],
         input_wires: impl IntoIterator<Item = Wire>,
-        // Sadly required as we substituting in type_args may result in recomputing bounds of types:
-        exts: &ExtensionRegistry,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
         let hugr = self.hugr();
         let def_op = hugr.get_optype(function.node());
@@ -679,7 +699,8 @@ pub trait Dataflow: Container {
                 })
             }
         };
-        let op: OpType = ops::Call::try_new(type_scheme, type_args, exts)?.into();
+        let op: OpType =
+            ops::Call::try_new(type_scheme, type_args, self.hugr().extensions())?.into();
         let const_in_port = op.static_input_port().unwrap();
         let op_id = self.add_dataflow_op(op, input_wires)?;
         let src_port = self.hugr_mut().num_outputs(function.node()) - 1;
@@ -697,6 +718,8 @@ pub trait Dataflow: Container {
 }
 
 /// Add a node to the graph, wiring up the `inputs` to the input ports of the resulting node.
+///
+/// Adds the extensions required by the op to the HUGR, if they are not already present.
 ///
 /// # Errors
 ///
@@ -826,27 +849,12 @@ pub trait DataflowHugr: HugrBuilder + Dataflow {
     fn finish_hugr_with_outputs(
         mut self,
         outputs: impl IntoIterator<Item = Wire>,
-        extension_registry: &ExtensionRegistry,
     ) -> Result<Hugr, BuildError>
     where
         Self: Sized,
     {
         self.set_outputs(outputs)?;
-        Ok(self.finish_hugr(extension_registry)?)
-    }
-
-    /// Sets the outputs of a dataflow Hugr, validates against
-    /// the [prelude] extension only, and return the Hugr
-    ///
-    /// [prelude]: crate::extension::prelude
-    fn finish_prelude_hugr_with_outputs(
-        self,
-        outputs: impl IntoIterator<Item = Wire>,
-    ) -> Result<Hugr, BuildError>
-    where
-        Self: Sized,
-    {
-        self.finish_hugr_with_outputs(outputs, &PRELUDE_REGISTRY)
+        Ok(self.finish_hugr()?)
     }
 }
 

--- a/hugr-core/src/builder/circuit.rs
+++ b/hugr-core/src/builder/circuit.rs
@@ -346,7 +346,7 @@ mod test {
 
         let mut registry = test_quantum_extension::REG.clone();
         registry.register(my_ext).unwrap();
-        let build_res = module_builder.finish_hugr(&registry);
+        let build_res = module_builder.finish_hugr();
 
         assert_matches!(build_res, Ok(_));
     }

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -14,7 +14,6 @@ use crate::{Direction, IncomingPort, OutgoingPort, Wire};
 
 use crate::types::{PolyFuncType, Signature, Type};
 
-use crate::extension::ExtensionRegistry;
 use crate::Node;
 use crate::{hugr::HugrMut, Hugr};
 
@@ -83,11 +82,11 @@ impl DFGBuilder<Hugr> {
 }
 
 impl HugrBuilder for DFGBuilder<Hugr> {
-    fn finish_hugr(
-        mut self,
-        extension_registry: &ExtensionRegistry,
-    ) -> Result<Hugr, ValidationError> {
-        self.base.update_validate(extension_registry)?;
+    fn finish_hugr(mut self) -> Result<Hugr, ValidationError> {
+        if cfg!(feature = "extension_inference") {
+            self.base.infer_extensions(false)?;
+        }
+        self.base.validate()?;
         Ok(self.base)
     }
 }
@@ -299,8 +298,8 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>, T: From<BuildHandle<DfgID>>> SubContainer for
 }
 
 impl<T> HugrBuilder for DFGWrapper<Hugr, T> {
-    fn finish_hugr(self, extension_registry: &ExtensionRegistry) -> Result<Hugr, ValidationError> {
-        self.0.finish_hugr(extension_registry)
+    fn finish_hugr(self) -> Result<Hugr, ValidationError> {
+        self.0.finish_hugr()
     }
 }
 
@@ -317,7 +316,7 @@ pub(crate) mod test {
     };
     use crate::extension::prelude::{bool_t, qb_t, usize_t};
     use crate::extension::prelude::{Lift, Noop};
-    use crate::extension::{ExtensionId, SignatureError, EMPTY_REG, PRELUDE_REGISTRY};
+    use crate::extension::{ExtensionId, SignatureError, PRELUDE_REGISTRY};
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::ops::{handle::NodeHandle, OpTag};
     use crate::ops::{OpTrait, Value};
@@ -325,7 +324,7 @@ pub(crate) mod test {
     use crate::std_extensions::logic::test::and_op;
     use crate::types::type_param::TypeParam;
     use crate::types::{EdgeKind, FuncValueType, RowVariable, Signature, Type, TypeBound, TypeRV};
-    use crate::utils::test_quantum_extension::{self, h_gate};
+    use crate::utils::test_quantum_extension::h_gate;
     use crate::{builder::test::n_identity, type_row, Wire};
 
     use super::super::test::simple_dfg_hugr;
@@ -342,10 +341,7 @@ pub(crate) mod test {
             let inner_builder = outer_builder.dfg_builder_endo([(usize_t(), int)])?;
             let inner_id = n_identity(inner_builder)?;
 
-            outer_builder.finish_hugr_with_outputs(
-                inner_id.outputs().chain(q_out.outputs()),
-                &test_quantum_extension::REG,
-            )
+            outer_builder.finish_hugr_with_outputs(inner_id.outputs().chain(q_out.outputs()))
         };
 
         assert_eq!(build_result.err(), None);
@@ -363,7 +359,7 @@ pub(crate) mod test {
 
             f(&mut builder)?;
 
-            builder.finish_hugr(&test_quantum_extension::REG)
+            builder.finish_hugr()
         };
         assert_matches!(build_result, Ok(_), "Failed on example: {}", msg);
 
@@ -412,7 +408,7 @@ pub(crate) mod test {
             let [q1] = f_build.input_wires_arr();
             f_build.finish_with_outputs([q1, q1])?;
 
-            Ok(module_builder.finish_prelude_hugr()?)
+            Ok(module_builder.finish_hugr()?)
         };
 
         assert_matches!(
@@ -446,7 +442,7 @@ pub(crate) mod test {
 
             let nested = nested.finish_with_outputs([id.out_wire(0)])?;
 
-            f_build.finish_prelude_hugr_with_outputs([nested.out_wire(0)])
+            f_build.finish_hugr_with_outputs([nested.out_wire(0)])
         };
 
         assert_matches!(builder(), Ok(_));
@@ -473,8 +469,7 @@ pub(crate) mod test {
             let i1 = f_build.add_input(qb_t());
             let noop1 = f_build.add_dataflow_op(Noop(qb_t()), [i1])?;
 
-            let hugr =
-                f_build.finish_prelude_hugr_with_outputs([noop0.out_wire(0), noop1.out_wire(0)])?;
+            let hugr = f_build.finish_hugr_with_outputs([noop0.out_wire(0), noop1.out_wire(0)])?;
             Ok((hugr, f_node))
         };
 
@@ -527,7 +522,7 @@ pub(crate) mod test {
         let mut dfg_builder = DFGBuilder::new(Signature::new(vec![bool_t()], vec![bool_t()]))?;
         let [i1] = dfg_builder.input_wires_arr();
         dfg_builder.set_metadata("x", 42);
-        let dfg_hugr = dfg_builder.finish_hugr_with_outputs([i1], &EMPTY_REG)?;
+        let dfg_hugr = dfg_builder.finish_hugr_with_outputs([i1])?;
 
         // Create a module, and insert the DFG into it
         let mut module_builder = ModuleBuilder::new();
@@ -543,7 +538,7 @@ pub(crate) mod test {
             (dfg.node(), f.node())
         };
 
-        let hugr = module_builder.finish_hugr(&EMPTY_REG)?;
+        let hugr = module_builder.finish_hugr()?;
         assert_eq!(hugr.node_count(), 7);
 
         assert_eq!(hugr.get_metadata(hugr.root(), "x"), None);
@@ -585,7 +580,7 @@ pub(crate) mod test {
 
         let add_c = add_c.finish_with_outputs(wires)?;
         let [w] = add_c.outputs_arr();
-        parent.finish_hugr_with_outputs([w], &test_quantum_extension::REG)?;
+        parent.finish_hugr_with_outputs([w])?;
 
         Ok(())
     }
@@ -603,7 +598,7 @@ pub(crate) mod test {
         // CFGs
         let b_child_2_handle = b_child_2.finish_with_outputs([b_child_in_wire])?;
 
-        let res = b.finish_prelude_hugr_with_outputs([b_child_2_handle.out_wire(0)]);
+        let res = b.finish_hugr_with_outputs([b_child_2_handle.out_wire(0)]);
 
         assert_matches!(
             res,
@@ -685,17 +680,13 @@ pub(crate) mod test {
                     .unwrap();
                 let load_constant = builder.add_load_value(Value::true_val());
                 let [r] = builder
-                    .call(&func, &[], [load_constant], &EMPTY_REG)
+                    .call(&func, &[], [load_constant])
                     .unwrap()
                     .outputs_arr();
                 builder.finish_with_outputs([r]).unwrap();
                 (load_constant.node(), r.node())
             };
-            (
-                builder.finish_hugr(&EMPTY_REG).unwrap(),
-                load_constant,
-                call,
-            )
+            (builder.finish_hugr().unwrap(), load_constant, call)
         };
 
         let lc_optype = hugr.get_optype(load_constant);
@@ -712,6 +703,6 @@ pub(crate) mod test {
             call_optype.other_input_port().unwrap(),
         );
 
-        hugr.validate(&EMPTY_REG).unwrap();
+        hugr.validate().unwrap();
     }
 }

--- a/hugr-core/src/builder/tail_loop.rs
+++ b/hugr-core/src/builder/tail_loop.rs
@@ -127,7 +127,7 @@ mod test {
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
-            loop_b.finish_prelude_hugr()
+            loop_b.finish_hugr()
         };
 
         assert_matches!(build_result, Ok(_));
@@ -191,7 +191,7 @@ mod test {
                 };
                 fbuild.finish_with_outputs(loop_id.outputs())?
             };
-            module_builder.finish_prelude_hugr()
+            module_builder.finish_hugr()
         };
 
         assert_matches!(build_result, Ok(_));

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -670,7 +670,7 @@ pub(super) mod test {
                 .unwrap(),
             dfg.input_wires(),
         )?;
-        dfg.finish_hugr_with_outputs(rev.outputs(), &reg)?;
+        dfg.finish_hugr_with_outputs(rev.outputs())?;
 
         Ok(())
     }

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -958,9 +958,7 @@ impl MakeRegisteredOp for Lift {
 #[cfg(test)]
 mod test {
     use crate::builder::inout_sig;
-    use crate::std_extensions::arithmetic::float_ops::FLOAT_OPS_REGISTRY;
     use crate::std_extensions::arithmetic::float_types::{float64_type, ConstF64};
-    use crate::utils::test_quantum_extension;
     use crate::{
         builder::{endo_sig, DFGBuilder, Dataflow, DataflowHugr},
         utils::test_quantum_extension::cx_gate,
@@ -1049,7 +1047,7 @@ mod test {
 
         let out = b.add_dataflow_op(op, [q1, q2]).unwrap();
 
-        b.finish_prelude_hugr_with_outputs(out.outputs()).unwrap();
+        b.finish_hugr_with_outputs(out.outputs()).unwrap();
     }
 
     #[test]
@@ -1063,7 +1061,7 @@ mod test {
         let some = b.add_load_value(const_val1);
         let none = b.add_load_value(const_val2);
 
-        b.finish_prelude_hugr_with_outputs([some, none]).unwrap();
+        b.finish_hugr_with_outputs([some, none]).unwrap();
     }
 
     #[test]
@@ -1077,8 +1075,7 @@ mod test {
         let bool = b.add_load_value(const_bool);
         let float = b.add_load_value(const_float);
 
-        b.finish_hugr_with_outputs([bool, float], &FLOAT_OPS_REGISTRY)
-            .unwrap();
+        b.finish_hugr_with_outputs([bool, float]).unwrap();
     }
 
     #[test]
@@ -1121,7 +1118,7 @@ mod test {
 
         b.add_dataflow_op(op, [err]).unwrap();
 
-        b.finish_prelude_hugr_with_outputs([]).unwrap();
+        b.finish_hugr_with_outputs([]).unwrap();
     }
 
     #[test]
@@ -1151,8 +1148,7 @@ mod test {
             .add_dataflow_op(panic_op, [err, q0, q1])
             .unwrap()
             .outputs_arr();
-        b.finish_hugr_with_outputs([q0, q1], &test_quantum_extension::REG)
-            .unwrap();
+        b.finish_hugr_with_outputs([q0, q1]).unwrap();
     }
 
     #[test]
@@ -1186,7 +1182,7 @@ mod test {
             .instantiate_extension_op(&PRINT_OP_ID, [], &PRELUDE_REGISTRY)
             .unwrap();
         b.add_dataflow_op(print_op, [greeting_out]).unwrap();
-        b.finish_prelude_hugr_with_outputs([]).unwrap();
+        b.finish_hugr_with_outputs([]).unwrap();
     }
 
     #[test]

--- a/hugr-core/src/extension/prelude/array.rs
+++ b/hugr-core/src/extension/prelude/array.rs
@@ -764,7 +764,7 @@ mod tests {
 
         let out = b.add_dataflow_op(op, [q1, q2]).unwrap();
 
-        b.finish_prelude_hugr_with_outputs(out.outputs()).unwrap();
+        b.finish_hugr_with_outputs(out.outputs()).unwrap();
     }
 
     #[test]

--- a/hugr-core/src/extension/prelude/unwrap_builder.rs
+++ b/hugr-core/src/extension/prelude/unwrap_builder.rs
@@ -104,6 +104,6 @@ mod tests {
         let [res] = builder
             .build_unwrap_sum(&PRELUDE_REGISTRY, 1, option_type(bool_t()), opt)
             .unwrap();
-        builder.finish_prelude_hugr_with_outputs([res]).unwrap();
+        builder.finish_hugr_with_outputs([res]).unwrap();
     }
 }

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -15,7 +15,7 @@ use crate::extension::resolution::{
     resolve_op_extensions, resolve_op_types_extensions, ExtensionCollectionError,
 };
 use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet};
-use crate::ops::{CallIndirect, ExtensionOp, Input, OpType, Tag, Value};
+use crate::ops::{CallIndirect, ExtensionOp, Input, OpTrait, OpType, Tag, Value};
 use crate::std_extensions::arithmetic::float_types::float64_type;
 use crate::std_extensions::arithmetic::int_ops;
 use crate::std_extensions::arithmetic::int_types::{self, int_type};
@@ -222,12 +222,6 @@ fn resolve_hugr_extensions() {
 #[rstest]
 fn dropped_weak_extensions() {
     let (ext_a, op_a) = make_extension("dummy.a", "op_a");
-    let build_extensions = ExtensionRegistry::new([
-        PRELUDE.to_owned(),
-        ext_a.clone(),
-        float_types::EXTENSION.to_owned(),
-    ]);
-
     let mut func = FunctionBuilder::new(
         "dummy_fn",
         Signature::new(vec![float64_type(), bool_t()], vec![]).with_extension_delta(
@@ -241,7 +235,7 @@ fn dropped_weak_extensions() {
     let [_func_i0, func_i1] = func.input_wires_arr();
     func.add_dataflow_op(op_a, vec![func_i1]).unwrap();
 
-    let hugr = func.finish_hugr(&build_extensions).unwrap();
+    let hugr = func.finish_hugr().unwrap();
 
     // Do a serialization roundtrip to drop the references.
     let ser = serde_json::to_string(&hugr).unwrap();

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -14,9 +14,9 @@ use crate::extension::prelude::{bool_t, ConstUsize};
 use crate::extension::resolution::{
     resolve_op_extensions, resolve_op_types_extensions, ExtensionCollectionError,
 };
-use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE};
-use crate::ops::{CallIndirect, ExtensionOp, Input, OpTrait, OpType, Tag, Value};
-use crate::std_extensions::arithmetic::float_types::{self, float64_type};
+use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet};
+use crate::ops::{CallIndirect, ExtensionOp, Input, OpType, Tag, Value};
+use crate::std_extensions::arithmetic::float_types::float64_type;
 use crate::std_extensions::arithmetic::int_ops;
 use crate::std_extensions::arithmetic::int_types::{self, int_type};
 use crate::types::{Signature, Type};
@@ -88,17 +88,6 @@ fn resolve_hugr_extensions() {
     let (ext_d, op_d) = make_extension("dummy.d", "op_d");
     let (ext_e, op_e) = make_extension("dummy.e", "op_e");
 
-    let build_extensions = ExtensionRegistry::new([
-        PRELUDE.to_owned(),
-        ext_a.clone(),
-        ext_b.clone(),
-        ext_c.clone(),
-        ext_d.clone(),
-        ext_e.clone(),
-        float_types::EXTENSION.to_owned(),
-        int_types::EXTENSION.to_owned(),
-    ]);
-
     let mut module = ModuleBuilder::new();
 
     // A constant op using the prelude extension.
@@ -133,20 +122,8 @@ fn resolve_hugr_extensions() {
     let [func_i0, func_i1] = func.input_wires_arr();
 
     // Call the function declaration directly, and load & call indirectly.
-    func.call(
-        &decl,
-        &[],
-        vec![func_i0],
-        &ExtensionRegistry::new([float_types::EXTENSION.to_owned()]),
-    )
-    .unwrap();
-    let loaded_func = func
-        .load_func(
-            &decl,
-            &[],
-            &ExtensionRegistry::new([float_types::EXTENSION.to_owned()]),
-        )
-        .unwrap();
+    func.call(&decl, &[], vec![func_i0]).unwrap();
+    let loaded_func = func.load_func(&decl, &[]).unwrap();
     func.add_dataflow_op(
         CallIndirect {
             signature: Signature::new_endo(vec![float64_type()]),
@@ -212,9 +189,13 @@ fn resolve_hugr_extensions() {
 
     // Finally, finish the hugr and ensure it's using the right extensions.
     func.finish_with_outputs(vec![]).unwrap();
-    let mut hugr = module
-        .finish_hugr(&build_extensions)
-        .unwrap_or_else(|e| panic!("{e}"));
+    let mut hugr = module.finish_hugr().unwrap_or_else(|e| panic!("{e}"));
+
+    let build_extensions = hugr.extensions().clone();
+    assert!(build_extensions.contains(ext_a.name()));
+    assert!(build_extensions.contains(ext_b.name()));
+    assert!(build_extensions.contains(ext_c.name()));
+    assert!(build_extensions.contains(ext_d.name()));
 
     // Check that the read-only methods collect the same extensions.
     let mut collected_exts = ExtensionRegistry::default();
@@ -228,14 +209,12 @@ fn resolve_hugr_extensions() {
     );
 
     // Check that the mutable methods collect the same extensions.
-    assert_matches!(
-        hugr.resolve_extension_defs(&ExtensionRegistry::default()),
-        Err(_)
-    );
-    let resolved = hugr.resolve_extension_defs(&build_extensions).unwrap();
+    hugr.resolve_extension_defs(&build_extensions).unwrap();
     assert_eq!(
-        &resolved, &build_extensions,
-        "{resolved} != {build_extensions}"
+        hugr.extensions(),
+        &build_extensions,
+        "{} != {build_extensions}",
+        hugr.extensions()
     );
 }
 

--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -2,14 +2,16 @@
 
 use core::panic;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use portgraph::view::{NodeFilter, NodeFiltered};
 use portgraph::{LinkMut, NodeIndex, PortMut, PortView, SecondaryMap};
 
+use crate::extension::ExtensionRegistry;
 use crate::hugr::views::SiblingSubgraph;
 use crate::hugr::{HugrView, Node, OpType, RootTagged};
 use crate::hugr::{NodeMetadata, Rewrite};
-use crate::{Hugr, IncomingPort, OutgoingPort, Port, PortIndex};
+use crate::{Extension, Hugr, IncomingPort, OutgoingPort, Port, PortIndex};
 
 use super::internal::HugrMutInternals;
 use super::NodeMetadataMap;
@@ -245,6 +247,37 @@ pub trait HugrMut: HugrMutInternals {
     {
         rw.apply(self)
     }
+
+    /// Registers a new extension in the set used by the hugr, keeping the one
+    /// most up to date if the extension already exists.
+    ///
+    /// These can be queried using [`HugrView::extensions`].
+    ///
+    /// See [`ExtensionRegistry::register_updated`] for more information.
+    fn use_extension(&mut self, extension: impl Into<Arc<Extension>>) {
+        self.hugr_mut().extensions.register_updated(extension);
+    }
+
+    /// Extend the set of extensions used by the hugr with the extensions in the
+    /// registry.
+    ///
+    /// For each extension, keeps the one most up to date if the extension
+    /// already exists.
+    ///
+    /// These can be queried using [`HugrView::extensions`].
+    ///
+    /// See [`ExtensionRegistry::register_updated`] for more information.
+    fn use_extensions<Reg>(&mut self, registry: impl IntoIterator<Item = Reg>)
+    where
+        ExtensionRegistry: Extend<Reg>,
+    {
+        self.hugr_mut().extensions.extend(registry);
+    }
+
+    /// Returns a mutable reference to the extension registry for this hugr.
+    fn extensions_mut(&mut self) -> &mut ExtensionRegistry {
+        &mut self.hugr_mut().extensions
+    }
 }
 
 /// Records the result of inserting a Hugr or view
@@ -349,6 +382,8 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
     fn insert_hugr(&mut self, root: Node, mut other: Hugr) -> InsertionResult {
         let (new_root, node_map) = insert_hugr_internal(self.as_mut(), root, &other);
         // Update the optypes and metadata, taking them from the other graph.
+        //
+        // No need to compute each node's extensions here, as we merge `other.extensions` directly.
         for (&node, &new_node) in node_map.iter() {
             let optype = other.op_types.take(node);
             self.as_mut().op_types.set(new_node, optype);
@@ -368,6 +403,8 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
     fn insert_from_view(&mut self, root: Node, other: &impl HugrView) -> InsertionResult {
         let (new_root, node_map) = insert_hugr_internal(self.as_mut(), root, other);
         // Update the optypes and metadata, copying them from the other graph.
+        //
+        // No need to compute each node's extensions here, as we merge `other.extensions` directly.
         for (&node, &new_node) in node_map.iter() {
             let nodetype = other.get_optype(node.into());
             self.as_mut().op_types.set(new_node, nodetype.clone());
@@ -404,6 +441,10 @@ impl<T: RootTagged<RootHandle = Node> + AsMut<Hugr>> HugrMut for T {
             self.as_mut().op_types.set(new_node, nodetype.clone());
             let meta = other.base_hugr().metadata.get(node);
             self.as_mut().metadata.set(new_node, meta.clone());
+            // Add the required extensions to the registry.
+            if let Ok(exts) = nodetype.used_extensions() {
+                self.use_extensions(exts);
+            }
         }
         translate_indices(node_map)
     }
@@ -440,13 +481,8 @@ fn insert_hugr_internal(
         });
     }
 
-    // The root node didn't have any ports.
-    let root_optype = other.get_optype(other.root());
-    hugr.set_num_ports(
-        other_root.into(),
-        root_optype.input_count(),
-        root_optype.output_count(),
-    );
+    // Merge the extension sets.
+    hugr.extensions.extend(other.extensions());
 
     (other_root.into(), node_map)
 }
@@ -533,11 +569,9 @@ pub(super) fn panic_invalid_port<H: HugrView + ?Sized>(
 
 #[cfg(test)]
 mod test {
+    use crate::extension::PRELUDE;
     use crate::{
-        extension::{
-            prelude::{usize_t, Noop},
-            PRELUDE_REGISTRY,
-        },
+        extension::prelude::{usize_t, Noop},
         ops::{self, dataflow::IOTrait, FuncDefn, Input, Output},
         types::Signature,
     };
@@ -547,6 +581,7 @@ mod test {
     #[test]
     fn simple_function() -> Result<(), Box<dyn std::error::Error>> {
         let mut hugr = Hugr::default();
+        hugr.use_extension(PRELUDE.to_owned());
 
         // Create the root module definition
         let module: Node = hugr.root();
@@ -572,7 +607,7 @@ mod test {
             hugr.connect(noop, 0, f_out, 1);
         }
 
-        hugr.update_validate(&PRELUDE_REGISTRY)?;
+        hugr.validate()?;
 
         Ok(())
     }
@@ -599,6 +634,7 @@ mod test {
     #[test]
     fn remove_subtree() {
         let mut hugr = Hugr::default();
+        hugr.use_extension(PRELUDE.to_owned());
         let root = hugr.root();
         let [foo, bar] = ["foo", "bar"].map(|name| {
             let fd = hugr.add_node_with_parent(
@@ -613,15 +649,15 @@ mod test {
             hugr.connect(inp, 0, out, 0);
             fd
         });
-        hugr.validate(&PRELUDE_REGISTRY).unwrap();
+        hugr.validate().unwrap();
         assert_eq!(hugr.node_count(), 7);
 
         hugr.remove_subtree(foo);
-        hugr.validate(&PRELUDE_REGISTRY).unwrap();
+        hugr.validate().unwrap();
         assert_eq!(hugr.node_count(), 4);
 
         hugr.remove_subtree(bar);
-        hugr.validate(&PRELUDE_REGISTRY).unwrap();
+        hugr.validate().unwrap();
         assert_eq!(hugr.node_count(), 1);
     }
 }

--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -249,7 +249,7 @@ pub trait HugrMut: HugrMutInternals {
     }
 
     /// Registers a new extension in the set used by the hugr, keeping the one
-    /// most up to date if the extension already exists.
+    /// most recent one if the extension already exists.
     ///
     /// These can be queried using [`HugrView::extensions`].
     ///
@@ -261,8 +261,8 @@ pub trait HugrMut: HugrMutInternals {
     /// Extend the set of extensions used by the hugr with the extensions in the
     /// registry.
     ///
-    /// For each extension, keeps the one most up to date if the extension
-    /// already exists.
+    /// For each extension, keeps the most recent version if the id already
+    /// exists.
     ///
     /// These can be queried using [`HugrView::extensions`].
     ///

--- a/hugr-core/src/hugr/rewrite/consts.rs
+++ b/hugr-core/src/hugr/rewrite/consts.rs
@@ -117,7 +117,7 @@ mod test {
     use crate::extension::prelude::PRELUDE_ID;
     use crate::{
         builder::{Container, Dataflow, HugrBuilder, ModuleBuilder, SubContainer},
-        extension::{prelude::ConstUsize, PRELUDE_REGISTRY},
+        extension::prelude::ConstUsize,
         ops::{handle::NodeHandle, Value},
         type_row,
         types::Signature,
@@ -136,7 +136,7 @@ mod test {
         let tup = dfg_build.make_tuple([load_1, load_2])?;
         dfg_build.finish_sub_container()?;
 
-        let mut h = build.finish_prelude_hugr()?;
+        let mut h = build.finish_hugr()?;
         // nodes are Module, Function, Input, Output, Const, LoadConstant*2, MakeTuple
         assert_eq!(h.node_count(), 8);
         let tup_node = tup.node();
@@ -194,7 +194,7 @@ mod test {
         assert_eq!(h.apply_rewrite(remove_con)?, h.root());
 
         assert_eq!(h.node_count(), 4);
-        assert!(h.validate(&PRELUDE_REGISTRY).is_ok());
+        assert!(h.validate().is_ok());
         Ok(())
     }
 }

--- a/hugr-core/src/hugr/rewrite/inline_dfg.rs
+++ b/hugr-core/src/hugr/rewrite/inline_dfg.rs
@@ -137,7 +137,7 @@ mod test {
         SubContainer,
     };
     use crate::extension::prelude::qb_t;
-    use crate::extension::{ExtensionRegistry, ExtensionSet, PRELUDE};
+    use crate::extension::ExtensionSet;
     use crate::hugr::rewrite::inline_dfg::InlineDFGError;
     use crate::hugr::HugrMut;
     use crate::ops::handle::{DfgID, NodeHandle};
@@ -169,12 +169,6 @@ mod test {
     fn inline_add_load_const(#[case] nonlocal: bool) -> Result<(), Box<dyn std::error::Error>> {
         use crate::extension::prelude::Lift;
 
-        let reg = ExtensionRegistry::new([
-            PRELUDE.to_owned(),
-            int_ops::EXTENSION.to_owned(),
-            int_types::EXTENSION.to_owned(),
-        ]);
-        reg.validate()?;
         let int_ty = &int_types::INT_TYPES[6];
 
         let mut outer = DFGBuilder::new(inout_sig(vec![int_ty.clone(); 2], vec![int_ty.clone()]))?;
@@ -204,7 +198,7 @@ mod test {
         let [a1] = inner.outputs_arr();
 
         let a1_sub_b = outer.add_dataflow_op(IntOpDef::isub.with_log_width(6), [a1, b])?;
-        let mut outer = outer.finish_hugr_with_outputs(a1_sub_b.outputs(), &reg)?;
+        let mut outer = outer.finish_hugr_with_outputs(a1_sub_b.outputs())?;
 
         // Sanity checks
         assert_eq!(
@@ -229,7 +223,7 @@ mod test {
         }
 
         outer.apply_rewrite(InlineDFG(*inner.handle()))?;
-        outer.validate(&reg)?;
+        outer.validate()?;
         assert_eq!(outer.nodes().count(), 8);
         assert_eq!(find_dfgs(&outer), vec![outer.root()]);
         let [_lift, add, sub] = extension_ops(&outer).try_into().unwrap();
@@ -256,14 +250,8 @@ mod test {
         };
         let [q, p] = swap.outputs_arr();
         let cx = h.add_dataflow_op(test_quantum_extension::cx_gate(), [q, p])?;
-        let reg = ExtensionRegistry::new([
-            test_quantum_extension::EXTENSION.clone(),
-            PRELUDE.clone(),
-            float_types::EXTENSION.clone(),
-        ]);
-        reg.validate()?;
 
-        let mut h = h.finish_hugr_with_outputs(cx.outputs(), &reg)?;
+        let mut h = h.finish_hugr_with_outputs(cx.outputs())?;
         assert_eq!(find_dfgs(&h), vec![h.root(), swap.node()]);
         assert_eq!(h.nodes().count(), 8); // Dfg+I+O, H, CX, Dfg+I+O
                                           // No permutation outside the swap DFG:
@@ -333,12 +321,6 @@ mod test {
          *              CX
          */
         // Extension inference here relies on quantum ops not requiring their own test_quantum_extension
-        let reg = ExtensionRegistry::new([
-            test_quantum_extension::EXTENSION.to_owned(),
-            float_types::EXTENSION.to_owned(),
-            PRELUDE.to_owned(),
-        ]);
-        reg.validate()?;
         let mut outer = DFGBuilder::new(endo_sig(vec![qb_t(), qb_t()]))?;
         let [a, b] = outer.input_wires_arr();
         let h_a = outer.add_dataflow_op(test_quantum_extension::h_gate(), [a])?;
@@ -370,10 +352,10 @@ mod test {
             test_quantum_extension::cx_gate(),
             h_a2.outputs().chain(inner.outputs()),
         )?;
-        let mut outer = outer.finish_hugr_with_outputs(cx.outputs(), &reg)?;
+        let mut outer = outer.finish_hugr_with_outputs(cx.outputs())?;
 
         outer.apply_rewrite(InlineDFG(*inner.handle()))?;
-        outer.validate(&reg)?;
+        outer.validate()?;
         let order_neighbours = |n, d| {
             let p = outer.get_optype(n).other_port(d).unwrap();
             outer

--- a/hugr-core/src/hugr/rewrite/insert_identity.rs
+++ b/hugr-core/src/hugr/rewrite/insert_identity.rs
@@ -101,7 +101,6 @@ mod tests {
 
     use super::super::simple_replace::test::dfg_hugr;
     use super::*;
-    use crate::utils::test_quantum_extension;
     use crate::{extension::prelude::qb_t, Hugr};
 
     #[rstest]
@@ -127,6 +126,6 @@ mod tests {
 
         assert_eq!(noop, Noop(qb_t()));
 
-        h.update_validate(&test_quantum_extension::REG).unwrap();
+        h.validate().unwrap();
     }
 }

--- a/hugr-core/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr-core/src/hugr/rewrite/outline_cfg.rs
@@ -252,7 +252,6 @@ mod test {
         HugrBuilder, ModuleBuilder,
     };
     use crate::extension::prelude::usize_t;
-    use crate::extension::PRELUDE_REGISTRY;
     use crate::hugr::views::sibling::SiblingMut;
     use crate::hugr::HugrMut;
     use crate::ops::constant::Value;
@@ -319,7 +318,7 @@ mod test {
             let exit = cfg_builder.exit_block();
             cfg_builder.branch(&tail, 0, &exit)?;
 
-            let h = cfg_builder.finish_prelude_hugr()?;
+            let h = cfg_builder.finish_hugr()?;
             let (left, right) = (left.node(), right.node());
             let (merge, head, tail) = (merge.node(), head.node(), tail.node());
             Ok(Self {
@@ -446,7 +445,7 @@ mod test {
             .add_hugr_with_wires(cond_then_loop_cfg.h, [i1])
             .unwrap();
         fbuild.finish_with_outputs(cfg.outputs()).unwrap();
-        let mut h = module_builder.finish_prelude_hugr().unwrap();
+        let mut h = module_builder.finish_hugr().unwrap();
         // `add_hugr_with_wires` does not return an InsertionResult, so recover the nodes manually:
         let cfg = cfg.node();
         let exit_node = h.children(cfg).nth(1).unwrap();
@@ -463,7 +462,7 @@ mod test {
             cfg,
             vec![head, tail],
         );
-        h.update_validate(&PRELUDE_REGISTRY).unwrap();
+        h.validate().unwrap();
     }
 
     #[rstest]
@@ -486,7 +485,7 @@ mod test {
         let root = h.root();
         let (new_block, _, _) =
             outline_cfg_check_parents(&mut h, root, vec![entry, left, right, merge]);
-        h.update_validate(&PRELUDE_REGISTRY).unwrap();
+        h.validate().unwrap();
         assert_eq!(new_block, h.children(h.root()).next().unwrap());
         assert_eq!(h.output_neighbours(new_block).collect_vec(), [head]);
     }

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -491,7 +491,7 @@ mod test {
         cfg.branch(&entry, 0, &bb2)?;
         cfg.branch(&bb2, 0, &exit)?;
 
-        let mut h = cfg.finish_hugr(&reg).unwrap();
+        let mut h = cfg.finish_hugr().unwrap();
         {
             let pop = find_node(&h, "pop");
             let push = find_node(&h, "push");
@@ -571,7 +571,7 @@ mod test {
             }],
             mu_new: vec![],
         })?;
-        h.update_validate(&reg)?;
+        h.validate()?;
         {
             let pop = find_node(&h, "pop");
             let push = find_node(&h, "push");
@@ -684,9 +684,7 @@ mod test {
         let baz_dfg = baz_dfg.finish_with_outputs(baz.outputs()).unwrap();
         let case2 = case2.finish_with_outputs(baz_dfg.outputs()).unwrap().node();
         let cond = cond.finish_sub_container().unwrap();
-        let h = h
-            .finish_hugr_with_outputs(cond.outputs(), &registry)
-            .unwrap();
+        let h = h.finish_hugr_with_outputs(cond.outputs()).unwrap();
 
         let mut r_hugr = Hugr::new(h.get_optype(cond.node()).clone());
         let r1 = r_hugr.add_node_with_parent(

--- a/hugr-core/src/hugr/serialize/upgrade/test.rs
+++ b/hugr-core/src/hugr/serialize/upgrade/test.rs
@@ -4,7 +4,6 @@ use crate::{
     hugr::serialize::test::check_hugr_deserialize,
     std_extensions::logic::LogicOp,
     types::Signature,
-    utils::test_quantum_extension,
 };
 use lazy_static::lazy_static;
 use std::{
@@ -50,9 +49,7 @@ pub fn hugr_with_named_op() -> Hugr {
         DFGBuilder::new(Signature::new(vec![bool_t(), bool_t()], vec![bool_t()])).unwrap();
     let [a, b] = builder.input_wires_arr();
     let x = builder.add_dataflow_op(LogicOp::And, [a, b]).unwrap();
-    builder
-        .finish_hugr_with_outputs(x.outputs(), &test_quantum_extension::REG)
-        .unwrap()
+    builder.finish_hugr_with_outputs(x.outputs()).unwrap()
 }
 
 #[rstest]

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -40,8 +40,9 @@ impl Hugr {
     /// variables (see github issue #457)
     pub fn validate(&self) -> Result<(), ValidationError> {
         self.validate_no_extensions()?;
-        #[cfg(feature = "extension_inference")]
-        self.validate_extensions()?;
+        if cfg!(feature = "extension_inference") {
+            self.validate_extensions()?;
+        }
         Ok(())
     }
 

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -11,8 +11,10 @@ use crate::builder::{
     FunctionBuilder, HugrBuilder, ModuleBuilder, SubContainer,
 };
 use crate::extension::prelude::Noop;
-use crate::extension::prelude::{bool_t, qb_t, usize_t, PRELUDE, PRELUDE_ID};
-use crate::extension::{Extension, ExtensionSet, TypeDefBound, EMPTY_REG, PRELUDE_REGISTRY};
+use crate::extension::prelude::{bool_t, qb_t, usize_t, PRELUDE_ID};
+use crate::extension::{
+    Extension, ExtensionRegistry, ExtensionSet, TypeDefBound, PRELUDE, PRELUDE_REGISTRY,
+};
 use crate::hugr::internal::HugrMutInternals;
 use crate::hugr::HugrMut;
 use crate::ops::dataflow::IOTrait;
@@ -72,12 +74,12 @@ fn add_df_children(b: &mut Hugr, parent: Node, copies: usize) -> (Node, Node, No
 fn invalid_root() {
     let mut b = Hugr::new(LogicOp::Not);
     let root = b.root();
-    assert_eq!(b.validate(&PRELUDE_REGISTRY), Ok(()));
+    assert_eq!(b.validate(), Ok(()));
 
     // Change the number of ports in the root
     b.set_num_ports(root, 1, 0);
     assert_matches!(
-        b.validate(&PRELUDE_REGISTRY),
+        b.validate(),
         Err(ValidationError::WrongNumberOfPorts { node, .. }) => assert_eq!(node, root)
     );
     b.set_num_ports(root, 2, 2);
@@ -85,7 +87,7 @@ fn invalid_root() {
     // Connect it to itself
     b.connect(root, 0, root, 0);
     assert_matches!(
-        b.validate(&PRELUDE_REGISTRY),
+        b.validate(),
         Err(ValidationError::RootWithEdges { node, .. }) => assert_eq!(node, root)
     );
     b.disconnect(root, OutgoingPort::from(0));
@@ -93,21 +95,21 @@ fn invalid_root() {
     // Add another hierarchy root
     let module = b.add_node(ops::Module::new().into());
     assert_matches!(
-        b.validate(&PRELUDE_REGISTRY),
+        b.validate(),
         Err(ValidationError::NoParent { node }) => assert_eq!(node, module)
     );
 
     // Make the hugr root not a hierarchy root
     b.set_parent(root, module);
     assert_matches!(
-        b.validate(&PRELUDE_REGISTRY),
+        b.validate(),
         Err(ValidationError::RootNotRoot { node }) => assert_eq!(node, root)
     );
 
     // Fix the root
     b.root = module.pg_index();
     b.remove_node(root);
-    assert_eq!(b.validate(&PRELUDE_REGISTRY), Ok(()));
+    assert_eq!(b.validate(), Ok(()));
 }
 
 #[test]
@@ -115,7 +117,7 @@ fn leaf_root() {
     let leaf_op: OpType = Noop(usize_t()).into();
 
     let b = Hugr::new(leaf_op);
-    assert_eq!(b.validate(&PRELUDE_REGISTRY), Ok(()));
+    assert_eq!(b.validate(), Ok(()));
 }
 
 #[test]
@@ -128,13 +130,13 @@ fn dfg_root() {
     let mut b = Hugr::new(dfg_op);
     let root = b.root();
     add_df_children(&mut b, root, 1);
-    assert_eq!(b.update_validate(&test_quantum_extension::REG), Ok(()));
+    assert_eq!(b.validate(), Ok(()));
 }
 
 #[test]
 fn simple_hugr() {
-    let mut b = make_simple_hugr(2).0;
-    assert_eq!(b.update_validate(&test_quantum_extension::REG), Ok(()));
+    let b = make_simple_hugr(2).0;
+    assert_eq!(b.validate(), Ok(()));
 }
 
 #[test]
@@ -159,7 +161,7 @@ fn children_restrictions() {
         },
     );
     assert_matches!(
-        b.update_validate(&test_quantum_extension::REG),
+        b.validate(),
         Err(ValidationError::ContainerWithoutChildren { node, .. }) => assert_eq!(node, new_def)
     );
 
@@ -167,7 +169,7 @@ fn children_restrictions() {
     add_df_children(&mut b, new_def, 2);
     b.set_parent(new_def, copy);
     assert_matches!(
-        b.update_validate(&test_quantum_extension::REG),
+        b.validate(),
         Err(ValidationError::NonContainerWithChildren { node, .. }) => assert_eq!(node, copy)
     );
     b.set_parent(new_def, root);
@@ -176,7 +178,7 @@ fn children_restrictions() {
     // add an input node to the module subgraph
     let new_input = b.add_node_with_parent(root, ops::Input::new(type_row![]));
     assert_matches!(
-        b.validate(&test_quantum_extension::REG),
+        b.validate(),
         Err(ValidationError::InvalidParentOp { parent, child, .. }) => {assert_eq!(parent, root); assert_eq!(child, new_input)}
     );
 }
@@ -195,7 +197,7 @@ fn df_children_restrictions() {
     // Replace the output operation of the df subgraph with a copy
     b.replace_op(output, Noop(usize_t())).unwrap();
     assert_matches!(
-        b.validate(&test_quantum_extension::REG),
+        b.validate(),
         Err(ValidationError::InvalidInitialChild { parent, .. }) => assert_eq!(parent, def)
     );
 
@@ -203,7 +205,7 @@ fn df_children_restrictions() {
     b.replace_op(output, ops::Output::new(vec![bool_t()]))
         .unwrap();
     assert_matches!(
-        b.validate(&test_quantum_extension::REG),
+        b.validate(),
         Err(ValidationError::InvalidChildren { parent, source: ChildrenValidationError::IOSignatureMismatch { child, .. }, .. })
             => {assert_eq!(parent, def); assert_eq!(child, output.pg_index())}
     );
@@ -214,7 +216,7 @@ fn df_children_restrictions() {
     b.replace_op(copy, ops::Output::new(vec![bool_t(), bool_t()]))
         .unwrap();
     assert_matches!(
-        b.validate(&test_quantum_extension::REG),
+        b.validate(),
         Err(ValidationError::InvalidChildren { parent, source: ChildrenValidationError::InternalIOChildren { child, .. }, .. })
             => {assert_eq!(parent, def); assert_eq!(child, copy.pg_index())}
     );
@@ -248,21 +250,19 @@ fn test_ext_edge() {
     h.connect(input, 0, sub_dfg, 0);
     h.connect(sub_dfg, 0, output, 0);
 
-    assert_matches!(
-        h.update_validate(&test_quantum_extension::REG),
-        Err(ValidationError::UnconnectedPort { .. })
-    );
+    assert_matches!(h.validate(), Err(ValidationError::UnconnectedPort { .. }));
 
     h.connect(input, 1, sub_op, 1);
     assert_matches!(
-        h.update_validate(&test_quantum_extension::REG),
+        h.validate(),
         Err(ValidationError::InterGraphEdgeError(
             InterGraphEdgeError::MissingOrderEdge { .. }
         ))
     );
     //Order edge. This will need metadata indicating its purpose.
     h.add_other_edge(input, sub_dfg);
-    h.update_validate(&test_quantum_extension::REG).unwrap();
+    h.infer_extensions(false).unwrap();
+    h.validate().unwrap();
 }
 
 #[test]
@@ -276,9 +276,9 @@ fn no_ext_edge_into_func() -> Result<(), Box<dyn std::error::Error>> {
     let [fn_input] = func.input_wires_arr();
     let and_op = func.add_dataflow_op(and_op(), [fn_input, input])?; // 'ext' edge
     let func = func.finish_with_outputs(and_op.outputs())?;
-    let loadfn = dfg.load_func(func.handle(), &[], &EMPTY_REG)?;
+    let loadfn = dfg.load_func(func.handle(), &[])?;
     let dfg = dfg.finish_with_outputs([loadfn])?;
-    let res = h.finish_hugr_with_outputs(dfg.outputs(), &test_quantum_extension::REG);
+    let res = h.finish_hugr_with_outputs(dfg.outputs());
     assert_eq!(
         res,
         Err(BuildError::InvalidHUGR(
@@ -303,7 +303,7 @@ fn test_local_const() {
     h.connect(input, 0, and, 0);
     h.connect(and, 0, output, 0);
     assert_eq!(
-        h.update_validate(&test_quantum_extension::REG),
+        h.validate(),
         Err(ValidationError::UnconnectedPort {
             node: and,
             port: IncomingPort::from(1).into(),
@@ -324,7 +324,8 @@ fn test_local_const() {
     h.connect(lcst, 0, and, 1);
     assert_eq!(h.static_source(lcst), Some(cst));
     // There is no edge from Input to LoadConstant, but that's OK:
-    h.update_validate(&test_quantum_extension::REG).unwrap();
+    h.infer_extensions(false).unwrap();
+    h.validate().unwrap();
 }
 
 #[test]
@@ -340,12 +341,11 @@ fn dfg_with_cycles() {
     h.connect(input, 1, not2, 0);
     h.connect(not2, 0, output, 0);
     // The graph contains a cycle:
-    assert_matches!(
-        h.validate(&test_quantum_extension::REG),
-        Err(ValidationError::NotADag { .. })
-    );
+    assert_matches!(h.validate(), Err(ValidationError::NotADag { .. }));
 }
 
+/// An identity hugr. Note that extensions must be updated before validation,
+/// as `hugr.extensions` is empty.
 fn identity_hugr_with_type(t: Type) -> (Hugr, Node) {
     let mut b = Hugr::default();
     let row: TypeRow = vec![t].into();
@@ -366,11 +366,10 @@ fn identity_hugr_with_type(t: Type) -> (Hugr, Node) {
 #[test]
 fn unregistered_extension() {
     let (mut h, _def) = identity_hugr_with_type(usize_t());
-    assert_matches!(
-        h.validate(&EMPTY_REG),
-        Err(ValidationError::SignatureError { .. })
-    );
-    h.update_validate(&test_quantum_extension::REG).unwrap();
+    assert!(h.validate().is_err(),);
+    h.resolve_extension_defs(&test_quantum_extension::REG)
+        .unwrap();
+    h.validate().unwrap();
 }
 
 const_extension_ids! {
@@ -388,21 +387,20 @@ fn invalid_types() {
         )
         .unwrap();
     });
-    let reg = ExtensionRegistry::new([ext.clone(), PRELUDE.clone()]);
+    let reg = ExtensionRegistry::new([ext.clone(), PRELUDE.to_owned()]);
     reg.validate().unwrap();
 
-    let validate_to_sig_error = |t: CustomType| {
-        let (h, def) = identity_hugr_with_type(Type::new_extension(t));
-        match h.validate(&reg) {
-            Err(ValidationError::SignatureError { node, cause, .. }) if node == def => cause,
-            e => panic!(
-                "Expected SignatureError at def node, got {}",
-                match e {
-                    Ok(()) => "Ok".to_owned(),
-                    Err(e) => format!("{}", e),
-                }
-            ),
-        }
+    let validate_to_sig_error = |t: CustomType| -> SignatureError {
+        let (mut h, def) = identity_hugr_with_type(Type::new_extension(t));
+        h.resolve_extension_defs(&reg).unwrap();
+
+        let e = h.validate().unwrap_err();
+        let (node, cause) = assert_matches!(
+            e,
+            ValidationError::SignatureError{ node, cause, .. } => (node, cause)
+        );
+        assert_eq!(node, def);
+        cause
     };
 
     let valid = Type::new_extension(CustomType::new(
@@ -412,12 +410,9 @@ fn invalid_types() {
         TypeBound::Any,
         &Arc::downgrade(&ext),
     ));
-    assert_eq!(
-        identity_hugr_with_type(valid.clone())
-            .0
-            .update_validate(&reg),
-        Ok(())
-    );
+    let mut hugr = identity_hugr_with_type(valid.clone()).0;
+    hugr.resolve_extension_defs(&reg).unwrap();
+    assert_eq!(hugr.validate(), Ok(()));
 
     // valid is Any, so is not allowed as an element of an outer MyContainer.
     let element_outside_bound = CustomType::new(
@@ -495,7 +490,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
         ),
     )?;
     let [w] = f.input_wires_arr();
-    f.finish_prelude_hugr_with_outputs([w])?;
+    f.finish_hugr_with_outputs([w])?;
     // Type refers to undeclared variable
     let f = FunctionBuilder::new(
         "myfunc",
@@ -505,7 +500,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
         ),
     )?;
     let [w] = f.input_wires_arr();
-    assert!(f.finish_prelude_hugr_with_outputs([w]).is_err());
+    assert!(f.finish_hugr_with_outputs([w]).is_err());
     // Variable declaration incorrectly copied to use site
     let f = FunctionBuilder::new(
         "myfunc",
@@ -515,7 +510,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
         ),
     )?;
     let [w] = f.input_wires_arr();
-    assert!(f.finish_prelude_hugr_with_outputs([w]).is_err());
+    assert!(f.finish_hugr_with_outputs([w]).is_err());
     Ok(())
 }
 
@@ -539,7 +534,7 @@ fn nested_typevars() -> Result<(), Box<dyn std::error::Error>> {
         let [w] = inner.input_wires_arr();
         inner.finish_with_outputs([w])?;
         let [w] = outer.input_wires_arr();
-        outer.finish_prelude_hugr_with_outputs([w])
+        outer.finish_hugr_with_outputs([w])
     }
     assert!(build(Type::new_var_use(0, INNER_BOUND)).is_ok());
     assert_matches!(
@@ -585,7 +580,7 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
         TypeBound::Copyable,
     )));
     let cst = def.add_load_const(empty_list);
-    let res = def.finish_hugr_with_outputs([cst], &reg);
+    let res = def.finish_hugr_with_outputs([cst]);
     assert_matches!(
         res.unwrap_err(),
         BuildError::InvalidHUGR(ValidationError::SignatureError {
@@ -653,10 +648,7 @@ fn instantiate_row_variables() -> Result<(), Box<dyn std::error::Error>> {
     let eval2 =
         e.instantiate_extension_op("eval", [uint_seq(2), uint_seq(4)], &PRELUDE_REGISTRY)?;
     let eval2 = dfb.add_dataflow_op(eval2, [par_func, a, b])?;
-    dfb.finish_hugr_with_outputs(
-        eval2.outputs(),
-        &ExtensionRegistry::new([PRELUDE.clone(), e]),
-    )?;
+    dfb.finish_hugr_with_outputs(eval2.outputs())?;
     Ok(())
 }
 
@@ -685,7 +677,7 @@ fn row_variables() -> Result<(), Box<dyn std::error::Error>> {
         let bldr = fb.define_function("id_usz", Signature::new_endo(usize_t()))?;
         let vals = bldr.input_wires();
         let inner_def = bldr.finish_with_outputs(vals)?;
-        fb.load_func(inner_def.handle(), &[], &PRELUDE_REGISTRY)?
+        fb.load_func(inner_def.handle(), &[])?
     };
     let par = e.instantiate_extension_op(
         "parallel",
@@ -693,10 +685,7 @@ fn row_variables() -> Result<(), Box<dyn std::error::Error>> {
         &PRELUDE_REGISTRY,
     )?;
     let par_func = fb.add_dataflow_op(par, [func_arg, id_usz])?;
-    fb.finish_hugr_with_outputs(
-        par_func.outputs(),
-        &ExtensionRegistry::new([PRELUDE.clone(), e]),
-    )?;
+    fb.finish_hugr_with_outputs(par_func.outputs())?;
     Ok(())
 }
 
@@ -782,8 +771,6 @@ fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
         f.finish_with_outputs([tup])?
     };
 
-    let reg = ExtensionRegistry::new([e, PRELUDE.clone()]);
-    reg.validate()?;
     let [func, tup] = d.input_wires_arr();
     let call = d.call(
         f.handle(),
@@ -791,9 +778,8 @@ fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
             es: ExtensionSet::singleton(PRELUDE_ID),
         }],
         [func, tup],
-        &reg,
     )?;
-    let h = d.finish_hugr_with_outputs(call.outputs(), &reg)?;
+    let h = d.finish_hugr_with_outputs(call.outputs())?;
     let call_ty = h.get_optype(call.node()).dataflow_signature().unwrap();
     let exp_fun_ty = Signature::new(vec![utou(PRELUDE_ID), int_pair.clone()], int_pair)
         .with_extension_delta(EXT_ID)
@@ -817,9 +803,9 @@ fn test_polymorphic_load() -> Result<(), Box<dyn std::error::Error>> {
         vec![Type::new_function(Signature::new_endo(vec![usize_t()]))],
     );
     let mut f = m.define_function("main", sig)?;
-    let l = f.load_func(&id, &[usize_t().into()], &PRELUDE_REGISTRY)?;
+    let l = f.load_func(&id, &[usize_t().into()])?;
     f.finish_with_outputs([l])?;
-    let _ = m.finish_prelude_hugr()?;
+    let _ = m.finish_hugr()?;
     Ok(())
 }
 
@@ -835,7 +821,7 @@ fn cfg_children_restrictions() {
         .unwrap();
     // Write Extension annotations into the Hugr while it's still well-formed
     // enough for us to compute them
-    b.validate(&test_quantum_extension::REG).unwrap();
+    b.validate().unwrap();
     b.replace_op(
         copy,
         ops::CFG {
@@ -844,7 +830,7 @@ fn cfg_children_restrictions() {
     )
     .unwrap();
     assert_matches!(
-        b.validate(&test_quantum_extension::REG),
+        b.validate(),
         Err(ValidationError::ContainerWithoutChildren { .. })
     );
     let cfg = copy;
@@ -880,7 +866,7 @@ fn cfg_children_restrictions() {
         },
     );
     b.add_other_edge(block, exit);
-    assert_eq!(b.update_validate(&test_quantum_extension::REG), Ok(()));
+    assert_eq!(b.validate(), Ok(()));
 
     // Test malformed errors
 
@@ -892,7 +878,7 @@ fn cfg_children_restrictions() {
         },
     );
     assert_matches!(
-        b.validate(&test_quantum_extension::REG),
+        b.validate(),
         Err(ValidationError::InvalidChildren { parent, source: ChildrenValidationError::InternalExitChildren { child, .. }, .. })
             => {assert_eq!(parent, cfg); assert_eq!(child, exit2.pg_index())}
     );
@@ -927,7 +913,7 @@ fn cfg_children_restrictions() {
     )
     .unwrap();
     assert_matches!(
-        b.validate(&test_quantum_extension::REG),
+        b.validate(),
         Err(ValidationError::InvalidEdges { parent, source: EdgeValidationError::CFGEdgeSignatureMismatch { .. }, .. })
             => assert_eq!(parent, cfg)
     );
@@ -956,11 +942,11 @@ fn cfg_connections() -> Result<(), Box<dyn std::error::Error>> {
     let exit = hugr.exit_block();
     hugr.branch(&entry, 0, &middle)?;
     hugr.branch(&middle, 0, &exit)?;
-    let mut h = hugr.finish_hugr(&PRELUDE_REGISTRY)?;
+    let mut h = hugr.finish_hugr()?;
 
     h.connect(middle.node(), 0, middle.node(), 0);
     assert_eq!(
-        h.validate(&PRELUDE_REGISTRY),
+        h.validate(),
         Err(ValidationError::TooManyConnections {
             node: middle.node(),
             port: Port::new(Direction::Outgoing, 0),
@@ -975,12 +961,12 @@ fn cfg_connections() -> Result<(), Box<dyn std::error::Error>> {
 fn cfg_entry_io_bug() -> Result<(), Box<dyn std::error::Error>> {
     // load test file where input node of entry block has types in reversed
     // order compared to parent CFG node.
-    let mut hugr: Hugr = serde_json::from_reader(BufReader::new(
+    let hugr: Hugr = serde_json::from_reader(BufReader::new(
         File::open(test_file!("issue-1189.json")).unwrap(),
     ))
     .unwrap();
     assert_matches!(
-        hugr.update_validate(&PRELUDE_REGISTRY),
+        hugr.validate(),
         Err(ValidationError::InvalidChildren { parent, source: ChildrenValidationError::IOSignatureMismatch{..}, .. })
             => assert_eq!(parent, hugr.root())
     );
@@ -1039,7 +1025,7 @@ mod extension_tests {
         hugr.connect(input, 0, lift, 0);
         hugr.connect(lift, 0, output, 0);
 
-        let result = hugr.validate(&PRELUDE_REGISTRY);
+        let result = hugr.validate();
         assert_eq!(
             result,
             Err(ValidationError::ExtensionError(ExtensionError {
@@ -1069,7 +1055,7 @@ mod extension_tests {
         let exit = cfg.exit_block();
         cfg.branch(&blk, 0, &exit)?;
         let root = cfg.hugr().root();
-        let res = cfg.finish_prelude_hugr();
+        let res = cfg.finish_hugr();
         if success {
             assert!(res.is_ok())
         } else {
@@ -1143,7 +1129,7 @@ mod extension_tests {
             case
         });
         // case is the last-assigned child, i.e. the one that requires 'XB'
-        let result = hugr.validate(&PRELUDE_REGISTRY);
+        let result = hugr.validate();
         let expected = if success {
             Ok(())
         } else {
@@ -1171,7 +1157,7 @@ mod extension_tests {
         let lift = dfg.add_dataflow_op(Lift::new(usize_t().into(), XB), dfg.input_wires())?;
         let pred = make_pred(&mut dfg, lift.outputs())?;
         let root = dfg.hugr().root();
-        let res = dfg.finish_prelude_hugr_with_outputs([pred]);
+        let res = dfg.finish_hugr_with_outputs([pred]);
         if success {
             assert!(res.is_ok())
         } else {

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -434,16 +434,30 @@ pub trait HugrView: HugrInternals {
             .map(|(p, t)| (p.as_outgoing().unwrap(), t))
     }
 
+    /// Returns the set of extensions used by the HUGR.
+    ///
+    /// This set may contain extensions that are no longer required by the HUGR.
+    fn extensions(&self) -> &ExtensionRegistry {
+        &self.base_hugr().extensions
+    }
+
     /// Check the validity of the underlying HUGR.
-    fn validate(&self, reg: &ExtensionRegistry) -> Result<(), ValidationError> {
-        self.base_hugr().validate(reg)
+    ///
+    /// This includes checking consistency of extension requirements between
+    /// connected nodes and between parents and children.
+    /// See [`HugrView::validate_no_extensions`] for a version that doesn't check
+    /// extension requirements.
+    fn validate(&self) -> Result<(), ValidationError> {
+        self.base_hugr().validate()
     }
 
     /// Check the validity of the underlying HUGR, but don't check consistency
     /// of extension requirements between connected nodes or between parents and
     /// children.
-    fn validate_no_extensions(&self, reg: &ExtensionRegistry) -> Result<(), ValidationError> {
-        self.base_hugr().validate_no_extensions(reg)
+    ///
+    /// For a more thorough check, use [`HugrView::validate`].
+    fn validate_no_extensions(&self) -> Result<(), ValidationError> {
+        self.base_hugr().validate_no_extensions()
     }
 }
 

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -176,7 +176,6 @@ pub(super) mod test {
     use rstest::rstest;
 
     use crate::extension::prelude::{qb_t, usize_t};
-    use crate::utils::test_quantum_extension;
     use crate::IncomingPort;
     use crate::{
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
@@ -214,7 +213,7 @@ pub(super) mod test {
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?;
             (f_id, inner_id)
         };
-        let hugr = module_builder.finish_hugr(&test_quantum_extension::REG)?;
+        let hugr = module_builder.finish_hugr()?;
         Ok((hugr, f_id.handle().node(), inner_id.handle().node()))
     }
 
@@ -291,7 +290,7 @@ pub(super) mod test {
 
         let region: DescendantsGraph = DescendantsGraph::try_new(&hugr, def)?;
         let extracted = region.extract_hugr();
-        extracted.validate(&test_quantum_extension::REG)?;
+        extracted.validate()?;
 
         let region: DescendantsGraph = DescendantsGraph::try_new(&hugr, def)?;
 

--- a/hugr-core/src/hugr/views/sibling.rs
+++ b/hugr-core/src/hugr/views/sibling.rs
@@ -341,7 +341,7 @@ mod test {
     use crate::ops::{dataflow::IOTrait, Input, OpTag, Output};
     use crate::ops::{OpTrait, OpType};
     use crate::types::Signature;
-    use crate::utils::test_quantum_extension::{self, EXTENSION_ID};
+    use crate::utils::test_quantum_extension::EXTENSION_ID;
     use crate::IncomingPort;
 
     use super::super::descendants::test::make_module_hgr;
@@ -456,7 +456,7 @@ mod test {
         let ins = dfg.input_wires();
         let sub_dfg = dfg.finish_with_outputs(ins)?;
         let fun = fbuild.finish_with_outputs(sub_dfg.outputs())?;
-        let h = module_builder.finish_hugr(&test_quantum_extension::REG)?;
+        let h = module_builder.finish_hugr()?;
         let sub_dfg = sub_dfg.node();
 
         // We can create a view from a child or grandchild of a hugr:
@@ -485,9 +485,7 @@ mod test {
     /// Mutate a SiblingMut wrapper
     #[rstest]
     fn flat_mut(mut simple_dfg_hugr: Hugr) {
-        simple_dfg_hugr
-            .update_validate(&test_quantum_extension::REG)
-            .unwrap();
+        simple_dfg_hugr.validate().unwrap();
         let root = simple_dfg_hugr.root();
         let signature = simple_dfg_hugr.inner_function_type().unwrap().clone();
 
@@ -512,9 +510,7 @@ mod test {
 
         // In contrast, performing this on the Hugr (where the allowed root type is 'Any') is only detected by validation
         simple_dfg_hugr.replace_op(root, bad_nodetype).unwrap();
-        assert!(simple_dfg_hugr
-            .validate(&test_quantum_extension::REG)
-            .is_err());
+        assert!(simple_dfg_hugr.validate().is_err());
     }
 
     #[rstest]
@@ -543,7 +539,7 @@ mod test {
 
         let region: SiblingGraph = SiblingGraph::try_new(&hugr, inner)?;
         let extracted = region.extract_hugr();
-        extracted.validate(&test_quantum_extension::REG)?;
+        extracted.validate()?;
 
         let region: SiblingGraph = SiblingGraph::try_new(&hugr, inner)?;
 

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -785,7 +785,6 @@ mod tests {
     use cool_asserts::assert_matches;
 
     use crate::builder::inout_sig;
-    use crate::extension::{prelude, ExtensionRegistry};
     use crate::ops::Const;
     use crate::std_extensions::arithmetic::float_types::{self, ConstF64};
     use crate::std_extensions::logic::{self, LogicOp};
@@ -849,11 +848,7 @@ mod tests {
             dfg.finish_with_outputs([w0, w1, w2])?
         };
         let hugr = mod_builder
-            .finish_hugr(&ExtensionRegistry::new([
-                prelude::PRELUDE.to_owned(),
-                test_quantum_extension::EXTENSION.to_owned(),
-                float_types::EXTENSION.to_owned(),
-            ]))
+            .finish_hugr()
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -875,7 +870,7 @@ mod tests {
             dfg.finish_with_outputs(outs3.outputs())?
         };
         let hugr = mod_builder
-            .finish_hugr(&test_quantum_extension::REG)
+            .finish_hugr()
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -897,7 +892,7 @@ mod tests {
             dfg.finish_with_outputs([b1, b2])?
         };
         let hugr = mod_builder
-            .finish_hugr(&test_quantum_extension::REG)
+            .finish_hugr()
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -918,7 +913,7 @@ mod tests {
             dfg.finish_with_outputs(outs.outputs())?
         };
         let hugr = mod_builder
-            .finish_hugr(&test_quantum_extension::REG)
+            .finish_hugr()
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -951,7 +946,7 @@ mod tests {
             let builder =
                 DFGBuilder::new(Signature::new_endo(vec![qb_t(), qb_t(), qb_t()])).unwrap();
             let inputs = builder.input_wires();
-            builder.finish_prelude_hugr_with_outputs(inputs).unwrap()
+            builder.finish_hugr_with_outputs(inputs).unwrap()
         };
 
         let rep = sub.create_simple_replacement(&func, empty_dfg).unwrap();
@@ -991,7 +986,7 @@ mod tests {
         let empty_dfg = {
             let builder = DFGBuilder::new(Signature::new_endo(vec![qb_t()])).unwrap();
             let inputs = builder.input_wires();
-            builder.finish_prelude_hugr_with_outputs(inputs).unwrap()
+            builder.finish_hugr_with_outputs(inputs).unwrap()
         };
 
         assert_matches!(
@@ -1135,13 +1130,7 @@ mod tests {
         let subgraph = SiblingSubgraph::try_new_dataflow_subgraph(&func_graph).unwrap();
         let extracted = subgraph.extract_subgraph(&hugr, "region");
 
-        extracted
-            .validate(&ExtensionRegistry::new([
-                prelude::PRELUDE.to_owned(),
-                test_quantum_extension::EXTENSION.to_owned(),
-                float_types::EXTENSION.to_owned(),
-            ]))
-            .unwrap();
+        extracted.validate().unwrap();
     }
 
     #[test]
@@ -1161,9 +1150,7 @@ mod tests {
             .unwrap()
             .outputs();
         let outw = [outw1].into_iter().chain(outw2);
-        let h = builder
-            .finish_hugr_with_outputs(outw, &test_quantum_extension::REG)
-            .unwrap();
+        let h = builder.finish_hugr_with_outputs(outw).unwrap();
         let view = SiblingGraph::<DfgID>::try_new(&h, h.root()).unwrap();
         let subg = SiblingSubgraph::try_new_dataflow_subgraph(&view).unwrap();
         assert_eq!(subg.nodes().len(), 2);

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -566,14 +566,15 @@ mod test {
     use crate::builder::inout_sig;
     use crate::builder::test::simple_dfg_hugr;
     use crate::extension::prelude::{bool_t, usize_custom_t};
+    use crate::extension::PRELUDE;
     use crate::std_extensions::arithmetic::int_types::ConstInt;
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
         extension::{
             prelude::{usize_t, ConstUsize},
-            ExtensionId, ExtensionRegistry, PRELUDE,
+            ExtensionId,
         },
-        std_extensions::arithmetic::float_types::{self, float64_type, ConstF64},
+        std_extensions::arithmetic::float_types::{float64_type, ConstF64},
         type_row,
         types::type_param::TypeArg,
         types::{Type, TypeBound, TypeRow},
@@ -613,10 +614,6 @@ mod test {
             .into()
     }
 
-    fn test_registry() -> ExtensionRegistry {
-        ExtensionRegistry::new([PRELUDE.to_owned(), float_types::EXTENSION.to_owned()])
-    }
-
     /// Constructs a DFG hugr defining a sum constant, and returning the loaded value.
     #[test]
     fn test_sum() -> Result<(), BuildError> {
@@ -638,7 +635,7 @@ mod test {
             pred_ty.clone(),
         )?);
         let w = b.load_const(&c);
-        b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
+        b.finish_hugr_with_outputs([w]).unwrap();
 
         let mut b = DFGBuilder::new(Signature::new(
             type_row![],
@@ -646,7 +643,7 @@ mod test {
         ))?;
         let c = b.add_constant(Value::sum(1, [], pred_ty.clone())?);
         let w = b.load_const(&c);
-        b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
+        b.finish_hugr_with_outputs([w]).unwrap();
 
         Ok(())
     }

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -302,6 +302,9 @@ pub enum OpaqueOpError {
     /// Unresolved operation encountered during validation.
     #[error("Unexpected unresolved opaque operation '{1}' in {0}, from Extension {2}.")]
     UnresolvedOp(Node, OpName, ExtensionId),
+    /// Error updating the extension registry in the Hugr while resolving opaque ops.
+    #[error("Error updating extension registry: {0}")]
+    ExtensionRegistryError(#[from] crate::extension::ExtensionRegistryError),
 }
 
 #[cfg(test)]

--- a/hugr-core/src/ops/validate.rs
+++ b/hugr-core/src/ops/validate.rs
@@ -215,18 +215,21 @@ impl ChildrenValidationError {
 #[non_exhaustive]
 pub enum EdgeValidationError {
     /// The dataflow signature of two connected basic blocks does not match.
-    #[error("The dataflow signature of two connected basic blocks does not match. Output signature: {source_op}, input signature: {target_op}",
-        source_op = edge.source_op,
-        target_op = edge.target_op
+    #[error("The dataflow signature of two connected basic blocks does not match. The source type was {source_ty} but the target had type {target_types}",
+        source_ty = source_types.clone().unwrap_or_default(),
     )]
-    CFGEdgeSignatureMismatch { edge: ChildrenEdgeData },
+    CFGEdgeSignatureMismatch {
+        edge: ChildrenEdgeData,
+        source_types: Option<TypeRow>,
+        target_types: TypeRow,
+    },
 }
 
 impl EdgeValidationError {
     /// Returns information on the edge that caused the error.
     pub fn edge(&self) -> &ChildrenEdgeData {
         match self {
-            EdgeValidationError::CFGEdgeSignatureMismatch { edge } => edge,
+            EdgeValidationError::CFGEdgeSignatureMismatch { edge, .. } => edge,
         }
     }
 }
@@ -342,8 +345,14 @@ fn validate_cfg_edge(edge: ChildrenEdgeData) -> Result<(), EdgeValidationError> 
         _ => panic!("CFG sibling graphs can only contain basic block operations."),
     };
 
-    if source.successor_input(edge.source_port.index()).as_ref() != Some(target_input) {
-        return Err(EdgeValidationError::CFGEdgeSignatureMismatch { edge });
+    let source_types = source.successor_input(edge.source_port.index());
+    if source_types.as_ref() != Some(target_input) {
+        let target_types = target_input.clone();
+        return Err(EdgeValidationError::CFGEdgeSignatureMismatch {
+            edge,
+            source_types,
+            target_types,
+        });
     }
 
     Ok(())

--- a/hugr-core/src/std_extensions/ptr.rs
+++ b/hugr-core/src/std_extensions/ptr.rs
@@ -235,9 +235,7 @@ pub(crate) mod test {
     use strum::IntoEnumIterator;
 
     use super::*;
-    use crate::std_extensions::arithmetic::float_types::{
-        float64_type, EXTENSION as FLOAT_EXTENSION,
-    };
+    use crate::std_extensions::arithmetic::float_types::float64_type;
     fn get_opdef(op: impl NamedOp) -> Option<&'static Arc<OpDef>> {
         EXTENSION.get_op(&op.name())
     }
@@ -271,7 +269,6 @@ pub(crate) mod test {
     fn test_build() {
         let in_row = vec![bool_t(), float64_type()];
 
-        let reg = ExtensionRegistry::new([EXTENSION.to_owned(), FLOAT_EXTENSION.to_owned()]);
         let hugr = {
             let mut builder = DFGBuilder::new(
                 Signature::new(in_row.clone(), type_row![]).with_extension_delta(EXTENSION_ID),
@@ -285,8 +282,8 @@ pub(crate) mod test {
                 builder.add_write_ptr(new_ptr, read).unwrap();
             }
 
-            builder.finish_hugr_with_outputs([], &reg).unwrap()
+            builder.finish_hugr_with_outputs([]).unwrap()
         };
-        assert_matches!(hugr.validate(&reg), Ok(_));
+        assert_matches!(hugr.validate(), Ok(_));
     }
 }

--- a/hugr-llvm/src/emit/test.rs
+++ b/hugr-llvm/src/emit/test.rs
@@ -165,7 +165,7 @@ impl SimpleHugrConfig {
         // unvalidated.
         // println!("{}", mod_b.hugr().mermaid_string());
 
-        mod_b.finish_hugr(&self.extensions).unwrap()
+        mod_b.finish_hugr().unwrap()
     }
 }
 
@@ -251,7 +251,7 @@ mod test_fns {
     use hugr_core::builder::DataflowSubContainer;
     use hugr_core::builder::{Container, Dataflow, HugrBuilder, ModuleBuilder, SubContainer};
     use hugr_core::extension::prelude::{bool_t, usize_t, ConstUsize};
-    use hugr_core::extension::{EMPTY_REG, PRELUDE_REGISTRY};
+    use hugr_core::extension::PRELUDE_REGISTRY;
     use hugr_core::ops::constant::CustomConst;
 
     use hugr_core::ops::{CallIndirect, Tag, Value};
@@ -370,9 +370,7 @@ mod test_fns {
                 .declare(name, HugrFuncType::new_endo(io).into())
                 .unwrap();
             let mut func_b = mod_b.define_declaration(&f_id).unwrap();
-            let call = func_b
-                .call(&f_id, &[], func_b.input_wires(), &EMPTY_REG)
-                .unwrap();
+            let call = func_b.call(&f_id, &[], func_b.input_wires()).unwrap();
             func_b.finish_with_outputs(call.outputs()).unwrap();
         }
 
@@ -380,7 +378,7 @@ mod test_fns {
         build_recursive(&mut mod_b, "main_void", type_row![]);
         build_recursive(&mut mod_b, "main_unary", vec![bool_t()].into());
         build_recursive(&mut mod_b, "main_binary", vec![bool_t(), bool_t()].into());
-        let hugr = mod_b.finish_hugr(&EMPTY_REG).unwrap();
+        let hugr = mod_b.finish_hugr().unwrap();
         check_emission!(hugr, llvm_ctx);
     }
 
@@ -390,7 +388,7 @@ mod test_fns {
             let signature = HugrFuncType::new_endo(io);
             let f_id = mod_b.declare(name, signature.clone().into()).unwrap();
             let mut func_b = mod_b.define_declaration(&f_id).unwrap();
-            let func = func_b.load_func(&f_id, &[], &EMPTY_REG).unwrap();
+            let func = func_b.load_func(&f_id, &[]).unwrap();
             let inputs = iter::once(func).chain(func_b.input_wires());
             let call_indirect = func_b
                 .add_dataflow_op(CallIndirect { signature }, inputs)
@@ -402,7 +400,7 @@ mod test_fns {
         build_recursive(&mut mod_b, "main_void", type_row![]);
         build_recursive(&mut mod_b, "main_unary", vec![bool_t()].into());
         build_recursive(&mut mod_b, "main_binary", vec![bool_t(), bool_t()].into());
-        let hugr = mod_b.finish_hugr(&EMPTY_REG).unwrap();
+        let hugr = mod_b.finish_hugr().unwrap();
         check_emission!(hugr, llvm_ctx);
     }
 
@@ -459,7 +457,7 @@ mod test_fns {
             let _ = builder
                 .declare("decl", HugrFuncType::new_endo(type_row![]).into())
                 .unwrap();
-            builder.finish_hugr(&EMPTY_REG).unwrap()
+            builder.finish_hugr().unwrap()
         };
         check_emission!(hugr, llvm_ctx);
     }
@@ -484,10 +482,7 @@ mod test_fns {
                         let w = builder.load_const(&konst);
                         builder.finish_with_outputs([w]).unwrap()
                     };
-                    let [r] = builder
-                        .call(func.handle(), &[], [], &EMPTY_REG)
-                        .unwrap()
-                        .outputs_arr();
+                    let [r] = builder.call(func.handle(), &[], []).unwrap().outputs_arr();
                     builder.finish_with_outputs([r]).unwrap().outputs_arr()
                 };
                 builder.finish_with_outputs([r]).unwrap()
@@ -518,10 +513,7 @@ mod test_fns {
                             .entry_builder([type_row![]], vec![bool_t()].into())
                             .unwrap();
                         let control = builder.add_load_value(Value::unary_unit_sum());
-                        let [r] = builder
-                            .call(func.handle(), &[], [], &EMPTY_REG)
-                            .unwrap()
-                            .outputs_arr();
+                        let [r] = builder.call(func.handle(), &[], []).unwrap().outputs_arr();
                         builder.finish_with_outputs(control, [r]).unwrap()
                     };
                     let exit = builder.exit_block();
@@ -548,10 +540,10 @@ mod test_fns {
                         Signature::new(type_row![], Type::new_function(target_sig)),
                     )
                     .unwrap();
-                let r = builder.load_func(&target_func, &[], &EMPTY_REG).unwrap();
+                let r = builder.load_func(&target_func, &[]).unwrap();
                 builder.finish_with_outputs([r]).unwrap()
             };
-            builder.finish_hugr(&EMPTY_REG).unwrap()
+            builder.finish_hugr().unwrap()
         };
 
         check_emission!(hugr, llvm_ctx);

--- a/hugr-llvm/src/extension/prelude/array.rs
+++ b/hugr-llvm/src/extension/prelude/array.rs
@@ -969,9 +969,7 @@ mod test {
                     .unwrap();
                 let v = func.add_load_value(ConstInt::new_u(6, value).unwrap());
                 let func_id = func.finish_with_outputs(vec![v]).unwrap();
-                let func_v = builder
-                    .load_func(func_id.handle(), &[], &exec_registry())
-                    .unwrap();
+                let func_v = builder.load_func(func_id.handle(), &[]).unwrap();
                 let repeat = ArrayRepeat::new(int_ty.clone(), size, exec_extension_set());
                 let arr = builder
                     .add_dataflow_op(repeat, vec![func_v])
@@ -1023,9 +1021,7 @@ mod test {
                 let delta = func.add_load_value(ConstInt::new_u(6, inc).unwrap());
                 let out = func.add_iadd(6, elem, delta).unwrap();
                 let func_id = func.finish_with_outputs(vec![out]).unwrap();
-                let func_v = builder
-                    .load_func(func_id.handle(), &[], &exec_registry())
-                    .unwrap();
+                let func_v = builder.load_func(func_id.handle(), &[]).unwrap();
                 let scan = ArrayScan::new(
                     int_ty.clone(),
                     int_ty.clone(),
@@ -1102,9 +1098,7 @@ mod test {
                     .unwrap()
                     .out_wire(0);
                 let func_id = func.finish_with_outputs(vec![unit, acc]).unwrap();
-                let func_v = builder
-                    .load_func(func_id.handle(), &[], &exec_registry())
-                    .unwrap();
+                let func_v = builder.load_func(func_id.handle(), &[]).unwrap();
                 let scan = ArrayScan::new(
                     int_ty.clone(),
                     Type::UNIT,

--- a/hugr-llvm/src/utils/array_op_builder.rs
+++ b/hugr-llvm/src/utils/array_op_builder.rs
@@ -200,6 +200,6 @@ pub mod test {
 
     #[rstest]
     fn build_all_ops(all_array_ops: DFGBuilder<Hugr>) {
-        all_array_ops.finish_hugr(&PRELUDE_REGISTRY).unwrap();
+        all_array_ops.finish_hugr().unwrap();
     }
 }

--- a/hugr-llvm/src/utils/inline_constant_functions.rs
+++ b/hugr-llvm/src/utils/inline_constant_functions.rs
@@ -106,9 +106,7 @@ mod test {
         Value::function({
             let mut builder = DFGBuilder::new(Signature::new_endo(qb_t())).unwrap();
             let r = go(&mut builder);
-            builder
-                .finish_hugr_with_outputs([r], &PRELUDE_REGISTRY)
-                .unwrap()
+            builder.finish_hugr_with_outputs([r]).unwrap()
         })
         .unwrap()
         .into()
@@ -138,7 +136,7 @@ mod test {
                     .outputs_arr();
                 builder.finish_with_outputs([r]).unwrap();
             };
-            builder.finish_hugr(&PRELUDE_REGISTRY).unwrap()
+            builder.finish_hugr().unwrap()
         };
 
         inline_constant_functions(&mut hugr, &PRELUDE_REGISTRY).unwrap();
@@ -187,7 +185,7 @@ mod test {
                     .outputs_arr();
                 builder.finish_with_outputs([r]).unwrap();
             };
-            builder.finish_hugr(&PRELUDE_REGISTRY).unwrap()
+            builder.finish_hugr().unwrap()
         };
 
         inline_constant_functions(&mut hugr, &PRELUDE_REGISTRY).unwrap();

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -11,7 +11,7 @@ use hugr_core::types::SumType;
 use hugr_core::Direction;
 use hugr_core::{
     builder::{DFGBuilder, Dataflow, DataflowHugr},
-    extension::{fold_out_row, ConstFoldResult, ExtensionRegistry},
+    extension::{fold_out_row, ConstFoldResult},
     hugr::{
         hugrmut::HugrMut,
         rewrite::consts::{RemoveConst, RemoveLoadConstant},
@@ -51,40 +51,34 @@ impl ConstantFoldPass {
     }
 
     /// Run the Constant Folding pass.
-    pub fn run<H: HugrMut>(
-        &self,
-        hugr: &mut H,
-        reg: &ExtensionRegistry,
-    ) -> Result<(), ConstFoldError> {
-        self.validation
-            .run_validated_pass(hugr, reg, |hugr: &mut H, _| {
-                loop {
-                    // We can only safely apply a single replacement. Applying a
-                    // replacement removes nodes and edges which may be referenced by
-                    // further replacements returned by find_consts. Even worse, if we
-                    // attempted to apply those replacements, expecting them to fail if
-                    // the nodes and edges they reference had been deleted,  they may
-                    // succeed because new nodes and edges reused the ids.
-                    //
-                    // We could be a lot smarter here, keeping track of `LoadConstant`
-                    // nodes and only looking at their out neighbours.
-                    let Some((replace, removes)) = find_consts(hugr, hugr.nodes(), reg).next()
-                    else {
-                        break Ok(());
-                    };
-                    hugr.apply_rewrite(replace)?;
-                    for rem in removes {
-                        // We are optimistically applying these [RemoveLoadConstant] and
-                        // [RemoveConst] rewrites without checking whether the nodes
-                        // they attempt to remove have remaining uses. If they do, then
-                        // the rewrite fails and we move on.
-                        if let Ok(const_node) = hugr.apply_rewrite(rem) {
-                            // if the LoadConst was removed, try removing the Const too.
-                            let _ = hugr.apply_rewrite(RemoveConst(const_node));
-                        }
+    pub fn run<H: HugrMut>(&self, hugr: &mut H) -> Result<(), ConstFoldError> {
+        self.validation.run_validated_pass(hugr, |hugr: &mut H, _| {
+            loop {
+                // We can only safely apply a single replacement. Applying a
+                // replacement removes nodes and edges which may be referenced by
+                // further replacements returned by find_consts. Even worse, if we
+                // attempted to apply those replacements, expecting them to fail if
+                // the nodes and edges they reference had been deleted,  they may
+                // succeed because new nodes and edges reused the ids.
+                //
+                // We could be a lot smarter here, keeping track of `LoadConstant`
+                // nodes and only looking at their out neighbours.
+                let Some((replace, removes)) = find_consts(hugr, hugr.nodes()).next() else {
+                    break Ok(());
+                };
+                hugr.apply_rewrite(replace)?;
+                for rem in removes {
+                    // We are optimistically applying these [RemoveLoadConstant] and
+                    // [RemoveConst] rewrites without checking whether the nodes
+                    // they attempt to remove have remaining uses. If they do, then
+                    // the rewrite fails and we move on.
+                    if let Ok(const_node) = hugr.apply_rewrite(rem) {
+                        // if the LoadConst was removed, try removing the Const too.
+                        let _ = hugr.apply_rewrite(RemoveConst(const_node));
                     }
                 }
-            })
+            }
+        })
     }
 }
 
@@ -107,7 +101,7 @@ pub fn fold_leaf_op(op: &OpType, consts: &[(IncomingPort, Value)]) -> ConstFoldR
 
 /// Generate a graph that loads and outputs `consts` in order, validating
 /// against `reg`.
-fn const_graph(consts: Vec<Value>, reg: &ExtensionRegistry) -> Hugr {
+fn const_graph(consts: Vec<Value>) -> Hugr {
     let const_types = consts.iter().map(Value::get_type).collect_vec();
     let mut b = DFGBuilder::new(inout_sig(type_row![], const_types)).unwrap();
 
@@ -116,7 +110,7 @@ fn const_graph(consts: Vec<Value>, reg: &ExtensionRegistry) -> Hugr {
         .map(|c| b.add_load_const(c))
         .collect_vec();
 
-    b.finish_hugr_with_outputs(outputs, reg).unwrap()
+    b.finish_hugr_with_outputs(outputs).unwrap()
 }
 
 /// Given some `candidate_nodes` to search for LoadConstant operations in `hugr`,
@@ -130,7 +124,6 @@ fn const_graph(consts: Vec<Value>, reg: &ExtensionRegistry) -> Hugr {
 pub fn find_consts<'a, 'r: 'a>(
     hugr: &'a impl HugrView,
     candidate_nodes: impl IntoIterator<Item = Node> + 'a,
-    reg: &'r ExtensionRegistry,
 ) -> impl Iterator<Item = (SimpleReplacement, Vec<RemoveLoadConstant>)> + 'a {
     // track nodes for operations that have already been considered for folding
     let mut used_neighbours = BTreeSet::new();
@@ -152,7 +145,7 @@ pub fn find_consts<'a, 'r: 'a>(
             }
             let fold_iter = neighbours
                 .into_iter()
-                .filter_map(|(neighbour, _)| fold_op(hugr, neighbour, reg));
+                .filter_map(|(neighbour, _)| fold_op(hugr, neighbour));
             Some(fold_iter)
         })
         .flatten()
@@ -162,7 +155,6 @@ pub fn find_consts<'a, 'r: 'a>(
 fn fold_op(
     hugr: &impl HugrView,
     op_node: Node,
-    reg: &ExtensionRegistry,
 ) -> Option<(SimpleReplacement, Vec<RemoveLoadConstant>)> {
     // only support leaf folding for now.
     let neighbour_op = hugr.get_optype(op_node);
@@ -184,7 +176,7 @@ fn fold_op(
                 .map(|np| ((np, i.into()), konst))
         })
         .unzip();
-    let replacement = const_graph(consts, reg);
+    let replacement = const_graph(consts);
     let sibling_graph = SiblingSubgraph::try_from_nodes([op_node], hugr)
         .expect("Operation should form valid subgraph.");
 
@@ -213,8 +205,8 @@ fn get_const(hugr: &impl HugrView, op_node: Node, in_p: IncomingPort) -> Option<
 }
 
 /// Exhaustively apply constant folding to a HUGR.
-pub fn constant_fold_pass<H: HugrMut>(h: &mut H, reg: &ExtensionRegistry) {
-    ConstantFoldPass::default().run(h, reg).unwrap()
+pub fn constant_fold_pass<H: HugrMut>(h: &mut H) {
+    ConstantFoldPass::default().run(h).unwrap()
 }
 
 #[cfg(test)]

--- a/hugr-passes/src/force_order.rs
+++ b/hugr-passes/src/force_order.rs
@@ -205,11 +205,10 @@ mod test {
 
     use super::*;
     use hugr_core::builder::{endo_sig, BuildHandle, Dataflow, DataflowHugr};
-    use hugr_core::extension::EMPTY_REG;
     use hugr_core::ops::handle::{DataflowOpID, NodeHandle};
 
     use hugr_core::ops::Value;
-    use hugr_core::std_extensions::arithmetic::int_ops::{self, IntOpDef};
+    use hugr_core::std_extensions::arithmetic::int_ops::IntOpDef;
     use hugr_core::std_extensions::arithmetic::int_types::INT_TYPES;
     use hugr_core::types::{Signature, Type};
     use hugr_core::{builder::DFGBuilder, hugr::Hugr};
@@ -261,10 +260,7 @@ mod test {
             .unwrap();
         (
             builder
-                .finish_hugr_with_outputs(
-                    [v2.out_wire(0), v3.out_wire(0)],
-                    &int_ops::INT_OPS_REGISTRY,
-                )
+                .finish_hugr_with_outputs([v2.out_wire(0), v3.out_wire(0)])
                 .unwrap(),
             nodes,
         )
@@ -279,8 +275,7 @@ mod test {
             .iter(&hugr.as_petgraph())
             .filter(|n| rank_map.contains_key(n))
             .collect_vec();
-        hugr.validate_no_extensions(&int_ops::INT_OPS_REGISTRY)
-            .unwrap();
+        hugr.validate_no_extensions().unwrap();
 
         topo_sorted
     }
@@ -326,9 +321,7 @@ mod test {
             let mut builder =
                 DFGBuilder::new(Signature::new(Type::EMPTY_TYPEROW, Type::UNIT)).unwrap();
             let unit = builder.add_load_value(Value::unary_unit_sum());
-            builder
-                .finish_hugr_with_outputs([unit], &EMPTY_REG)
-                .unwrap()
+            builder.finish_hugr_with_outputs([unit]).unwrap()
         };
         let root = hugr.root();
         force_order(&mut hugr, root, |_, _| 0).unwrap();

--- a/hugr-passes/src/lower.rs
+++ b/hugr-passes/src/lower.rs
@@ -96,14 +96,14 @@ mod test {
             .add_dataflow_op(Noop::new(bool_t()), [b.input_wires().next().unwrap()])
             .unwrap()
             .out_wire(0);
-        b.finish_prelude_hugr_with_outputs([out]).unwrap()
+        b.finish_hugr_with_outputs([out]).unwrap()
     }
 
     #[fixture]
     fn identity_hugr() -> Hugr {
         let b = DFGBuilder::new(Signature::new_endo(bool_t())).unwrap();
         let out = b.input_wires().next().unwrap();
-        b.finish_prelude_hugr_with_outputs([out]).unwrap()
+        b.finish_hugr_with_outputs([out]).unwrap()
     }
 
     #[rstest]

--- a/hugr-passes/src/nest_cfgs.rs
+++ b/hugr-passes/src/nest_cfgs.rs
@@ -570,7 +570,6 @@ pub(crate) mod test {
     use hugr_core::builder::{
         endo_sig, BuildError, CFGBuilder, Container, DataflowSubContainer, HugrBuilder,
     };
-    use hugr_core::extension::PRELUDE_REGISTRY;
     use hugr_core::extension::{prelude::usize_t, ExtensionSet};
 
     use hugr_core::hugr::rewrite::insert_identity::{IdentityInsertion, IdentityInsertionError};
@@ -628,7 +627,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let mut h = cfg_builder.finish_prelude_hugr()?;
+        let mut h = cfg_builder.finish_hugr()?;
         let rc = RootChecked::<_, CfgID>::try_new(&mut h).unwrap();
         let (entry, exit) = (entry.node(), exit.node());
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
@@ -654,7 +653,7 @@ pub(crate) mod test {
             ])
         );
         transform_cfg_to_nested(&mut IdentityCfgMap::new(rc));
-        h.update_validate(&PRELUDE_REGISTRY).unwrap();
+        h.validate().unwrap();
         assert_eq!(1, depth(&h, entry));
         assert_eq!(1, depth(&h, exit));
         for n in [split, left, right, merge, head, tail] {
@@ -758,7 +757,7 @@ pub(crate) mod test {
         let root = h.root();
         let m = SiblingMut::<CfgID>::try_new(&mut h, root).unwrap();
         transform_cfg_to_nested(&mut IdentityCfgMap::new(m));
-        h.update_validate(&PRELUDE_REGISTRY).unwrap();
+        h.validate().unwrap();
         assert_eq!(1, depth(&h, entry));
         assert_eq!(3, depth(&h, head));
         for n in [split, left, right, merge] {
@@ -902,7 +901,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_prelude_hugr()?;
+        let h = cfg_builder.finish_hugr()?;
         Ok((h, merge, tail))
     }
 
@@ -912,7 +911,7 @@ pub(crate) mod test {
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(Signature::new_endo(usize_t()))?;
         let (head, tail) = build_conditional_in_loop(&mut cfg_builder, separate_headers)?;
-        let h = cfg_builder.finish_prelude_hugr()?;
+        let h = cfg_builder.finish_hugr()?;
         Ok((h, head, tail))
     }
 

--- a/hugr-passes/src/non_local.rs
+++ b/hugr-passes/src/non_local.rs
@@ -48,8 +48,6 @@ mod test {
         types::Signature,
     };
 
-    use crate::test::TEST_REG;
-
     use super::*;
 
     #[test]
@@ -62,9 +60,7 @@ mod test {
                 .add_dataflow_op(Noop::new(bool_t()), [in_w])
                 .unwrap()
                 .outputs_arr();
-            builder
-                .finish_hugr_with_outputs([out_w], &TEST_REG)
-                .unwrap()
+            builder.finish_hugr_with_outputs([out_w]).unwrap()
         };
         ensure_no_nonlocal_edges(&hugr).unwrap();
     }
@@ -91,12 +87,7 @@ mod test {
                     noop_edge,
                 )
             };
-            (
-                builder
-                    .finish_hugr_with_outputs([out_w], &TEST_REG)
-                    .unwrap(),
-                edge,
-            )
+            (builder.finish_hugr_with_outputs([out_w]).unwrap(), edge)
         };
         assert_eq!(
             ensure_no_nonlocal_edges(&hugr).unwrap_err(),

--- a/hugr/benches/benchmarks/hugr/examples.rs
+++ b/hugr/benches/benchmarks/hugr/examples.rs
@@ -9,7 +9,6 @@ use hugr::builder::{
 use hugr::extension::prelude::{bool_t, qb_t, usize_t};
 use hugr::extension::PRELUDE_REGISTRY;
 use hugr::ops::OpName;
-use hugr::std_extensions::arithmetic::float_ops::FLOAT_OPS_REGISTRY;
 use hugr::std_extensions::arithmetic::float_types::float64_type;
 use hugr::types::Signature;
 use hugr::{type_row, Extension, Hugr, Node};
@@ -18,7 +17,7 @@ use lazy_static::lazy_static;
 pub fn simple_dfg_hugr() -> Hugr {
     let dfg_builder = DFGBuilder::new(Signature::new(vec![bool_t()], vec![bool_t()])).unwrap();
     let [i1] = dfg_builder.input_wires_arr();
-    dfg_builder.finish_prelude_hugr_with_outputs([i1]).unwrap()
+    dfg_builder.finish_hugr_with_outputs([i1]).unwrap()
 }
 
 pub fn simple_cfg_builder<T: AsMut<Hugr> + AsRef<Hugr>>(
@@ -50,7 +49,7 @@ pub fn simple_cfg_hugr() -> Hugr {
     let mut cfg_builder =
         CFGBuilder::new(Signature::new(vec![usize_t()], vec![usize_t()])).unwrap();
     simple_cfg_builder(&mut cfg_builder).unwrap();
-    cfg_builder.finish_prelude_hugr().unwrap()
+    cfg_builder.finish_hugr().unwrap()
 }
 
 lazy_static! {
@@ -137,8 +136,5 @@ pub fn circuit(layers: usize) -> (Hugr, Vec<CircuitLayer>) {
     let outs = linear.finish();
     f_build.finish_with_outputs(outs).unwrap();
 
-    (
-        module_builder.finish_hugr(&FLOAT_OPS_REGISTRY).unwrap(),
-        layer_ids,
-    )
+    (module_builder.finish_hugr().unwrap(), layer_ids)
 }

--- a/hugr/src/hugr.rs
+++ b/hugr/src/hugr.rs
@@ -3,6 +3,6 @@
 // Exports everything except the `internal` module.
 pub use hugr_core::hugr::{
     hugrmut, rewrite, serialize, validate, views, Hugr, HugrError, HugrView, IdentList,
-    InvalidIdentifier, NodeMetadata, NodeMetadataMap, OpType, Rewrite, RootTagged,
+    InvalidIdentifier, LoadHugrError, NodeMetadata, NodeMetadataMap, OpType, Rewrite, RootTagged,
     SimpleReplacement, SimpleReplacementError, ValidationError, DEFAULT_OPTYPE,
 };

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -102,7 +102,7 @@
 //!     }
 //! }
 //!
-//! use mini_quantum_extension::{cx_gate, h_gate, measure, REG};
+//! use mini_quantum_extension::{cx_gate, h_gate, measure};
 //!
 //! //      ┌───┐
 //! // q_0: ┤ H ├──■─────
@@ -120,7 +120,7 @@
 //!     let h1 = dfg_builder.add_dataflow_op(h_gate(), vec![wire1])?;
 //!     let cx = dfg_builder.add_dataflow_op(cx_gate(), h0.outputs().chain(h1.outputs()))?;
 //!     let measure = dfg_builder.add_dataflow_op(measure(), cx.outputs().last())?;
-//!     dfg_builder.finish_hugr_with_outputs(cx.outputs().take(1).chain(measure.outputs()), &REG)
+//!     dfg_builder.finish_hugr_with_outputs(cx.outputs().take(1).chain(measure.outputs()))
 //! }
 //!
 //! let h: Hugr = make_dfg_hugr().unwrap();


### PR DESCRIPTION
Closes #1613. Depends on #1739.

Hugrs now keep an `Extensions` registry that is automatically computed when using the builder or deserializing from json (using the new `Hugr::load_json`).
This set can contain unneeded extensions, but it should always be sufficient to validate the HUGR definition. Note that this is **not** runtime extensions (see #426, #1734).

A big chunk of the diff is removing the extension registry when finishing building a hugr. The extension tracking is now done automatically while adding operations. 

drive-by: Remove unneeded `set_num_ports` call in `insert_hugr_internal`.

BREAKING CHANGE: Removed `update_validate`. The hugr extensions should be resolved at load time, so we can use `validate` instead.
BREAKING CHANGE: The builder `finish_hugr` function family no longer takes a registry as parameter, and the `_prelude` variants have been removed.