### PR TITLE
feat!: `used_extensions` calls for both ops and signatures

### DIFF
--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -705,7 +705,7 @@ impl ExtensionSet {
     }
 
     /// Adds a extension to the set.
-    pub fn insert(&mut self, extension: &ExtensionId) {
+    pub fn insert(&mut self, extension: ExtensionId) {
         self.0.insert(extension.clone());
     }
 
@@ -733,7 +733,7 @@ impl ExtensionSet {
     }
 
     /// Create a extension set with a single element.
-    pub fn singleton(extension: &ExtensionId) -> Self {
+    pub fn singleton(extension: ExtensionId) -> Self {
         let mut set = Self::new();
         set.insert(extension);
         set
@@ -797,7 +797,25 @@ impl ExtensionSet {
 
 impl From<ExtensionId> for ExtensionSet {
     fn from(id: ExtensionId) -> Self {
-        Self::singleton(&id)
+        Self::singleton(id)
+    }
+}
+
+impl IntoIterator for ExtensionSet {
+    type Item = ExtensionId;
+    type IntoIter = std::collections::btree_set::IntoIter<ExtensionId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a ExtensionSet {
+    type Item = &'a ExtensionId;
+    type IntoIter = std::collections::btree_set::Iter<'a, ExtensionId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
     }
 }
 

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -52,8 +52,9 @@ pub struct ExtensionRegistry {
     /// A flag indicating whether the current set of extensions has been
     /// validated.
     ///
-    /// This is used to avoid re-validating the extensions every time they are
-    /// used, and is set to `false` whenever a new extension is added.
+    /// This is used to avoid re-validating the extensions every time the
+    /// registry is validated, and is set to `false` whenever a new extension is
+    /// added.
     valid: AtomicBool,
 }
 

--- a/hugr-core/src/extension/declarative.rs
+++ b/hugr-core/src/extension/declarative.rs
@@ -127,7 +127,7 @@ impl ExtensionSetDeclaration {
             registry.register(PRELUDE.clone())?;
         }
         if !scope.contains(&PRELUDE_ID) {
-            scope.insert(&PRELUDE_ID);
+            scope.insert(PRELUDE_ID);
         }
 
         // Registers extensions sequentially, adding them to the current scope.
@@ -137,7 +137,7 @@ impl ExtensionSetDeclaration {
                 registry,
             };
             let ext = decl.make_extension(&self.imports, ctx)?;
-            scope.insert(ext.name());
+            scope.insert(ext.name().clone());
             registry.register(ext)?;
         }
 

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -658,7 +658,8 @@ pub(super) mod test {
             Ok(())
         })?;
 
-        let reg = ExtensionRegistry::try_new([PRELUDE.clone(), EXTENSION.clone(), ext]).unwrap();
+        let reg = ExtensionRegistry::new([PRELUDE.clone(), EXTENSION.clone(), ext]);
+        reg.validate()?;
         let e = reg.get(&EXT_ID).unwrap();
 
         let list_usize =

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -245,7 +245,7 @@ impl SignatureFunc {
             SignatureFunc::MissingValidateFunc(ts) => (ts, args),
         };
         let mut res = pf.instantiate(args, exts)?;
-        res.extension_reqs.insert(&def.extension);
+        res.extension_reqs.insert(def.extension.clone());
 
         // If there are any row variables left, this will fail with an error:
         res.try_into()
@@ -823,7 +823,7 @@ pub(super) mod test {
             )?;
 
             // Concrete extension set
-            let es = ExtensionSet::singleton(&EXT_ID);
+            let es = ExtensionSet::singleton(EXT_ID);
             let exp_fun_ty = Signature::new_endo(bool_t()).with_extension_delta(es.clone());
             let args = [TypeArg::Extensions { es }];
 

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -127,8 +127,7 @@ lazy_static! {
     };
 
     /// An extension registry containing only the prelude
-    pub static ref PRELUDE_REGISTRY: ExtensionRegistry =
-        ExtensionRegistry::try_new([PRELUDE.clone()]).unwrap();
+    pub static ref PRELUDE_REGISTRY: ExtensionRegistry = ExtensionRegistry::new([PRELUDE.clone()]);
 }
 
 pub(crate) fn usize_custom_t(extension_ref: &Weak<Extension>) -> CustomType {

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -223,7 +223,7 @@ impl CustomConst for ConstString {
     }
 
     fn extension_reqs(&self) -> ExtensionSet {
-        ExtensionSet::singleton(&PRELUDE_ID)
+        ExtensionSet::singleton(PRELUDE_ID)
     }
 
     fn get_type(&self) -> Type {
@@ -416,7 +416,7 @@ impl CustomConst for ConstUsize {
     }
 
     fn extension_reqs(&self) -> ExtensionSet {
-        ExtensionSet::singleton(&PRELUDE_ID)
+        ExtensionSet::singleton(PRELUDE_ID)
     }
 
     fn get_type(&self) -> Type {
@@ -462,7 +462,7 @@ impl CustomConst for ConstError {
     }
 
     fn extension_reqs(&self) -> ExtensionSet {
-        ExtensionSet::singleton(&PRELUDE_ID)
+        ExtensionSet::singleton(PRELUDE_ID)
     }
     fn get_type(&self) -> Type {
         error_type()
@@ -508,7 +508,7 @@ impl CustomConst for ConstExternalSymbol {
     }
 
     fn extension_reqs(&self) -> ExtensionSet {
-        ExtensionSet::singleton(&PRELUDE_ID)
+        ExtensionSet::singleton(PRELUDE_ID)
     }
     fn get_type(&self) -> Type {
         self.typ.clone()
@@ -1020,7 +1020,7 @@ mod test {
     #[test]
     fn test_lift() {
         const XA: ExtensionId = ExtensionId::new_unchecked("xa");
-        let op = Lift::new(type_row![Type::UNIT], ExtensionSet::singleton(&XA));
+        let op = Lift::new(type_row![Type::UNIT], ExtensionSet::singleton(XA));
         let optype: OpType = op.clone().into();
         assert_eq!(
             optype.dataflow_signature().unwrap(),
@@ -1100,7 +1100,7 @@ mod test {
 
         assert_eq!(
             error_val.extension_reqs(),
-            ExtensionSet::singleton(&PRELUDE_ID)
+            ExtensionSet::singleton(PRELUDE_ID)
         );
         assert!(error_val.equal_consts(&ConstError::new(2, "my message")));
         assert!(!error_val.equal_consts(&ConstError::new(3, "my message")));
@@ -1169,7 +1169,7 @@ mod test {
         assert!(string_const.validate().is_ok());
         assert_eq!(
             string_const.extension_reqs(),
-            ExtensionSet::singleton(&PRELUDE_ID)
+            ExtensionSet::singleton(PRELUDE_ID)
         );
         assert!(string_const.equal_consts(&ConstString::new("Lorem ipsum".into())));
         assert!(!string_const.equal_consts(&ConstString::new("Lorem ispum".into())));
@@ -1196,7 +1196,7 @@ mod test {
         assert!(subject.validate().is_ok());
         assert_eq!(
             subject.extension_reqs(),
-            ExtensionSet::singleton(&PRELUDE_ID)
+            ExtensionSet::singleton(PRELUDE_ID)
         );
         assert!(subject.equal_consts(&ConstExternalSymbol::new("foo", Type::UNIT, false)));
         assert!(!subject.equal_consts(&ConstExternalSymbol::new("bar", Type::UNIT, false)));

--- a/hugr-core/src/extension/prelude/array.rs
+++ b/hugr-core/src/extension/prelude/array.rs
@@ -871,7 +871,7 @@ mod tests {
 
     #[test]
     fn test_repeat_def() {
-        let op = ArrayRepeat::new(qb_t(), 2, ExtensionSet::singleton(&PRELUDE_ID));
+        let op = ArrayRepeat::new(qb_t(), 2, ExtensionSet::singleton(PRELUDE_ID));
         let optype: OpType = op.clone().into();
         let new_op: ArrayRepeat = optype.cast().unwrap();
         assert_eq!(new_op, op);
@@ -881,7 +881,7 @@ mod tests {
     fn test_repeat() {
         let size = 2;
         let element_ty = qb_t();
-        let es = ExtensionSet::singleton(&PRELUDE_ID);
+        let es = ExtensionSet::singleton(PRELUDE_ID);
         let op = ArrayRepeat::new(element_ty.clone(), size, es.clone());
 
         let optype: OpType = op.into();
@@ -907,7 +907,7 @@ mod tests {
             qb_t(),
             vec![usize_t()],
             2,
-            ExtensionSet::singleton(&PRELUDE_ID),
+            ExtensionSet::singleton(PRELUDE_ID),
         );
         let optype: OpType = op.clone().into();
         let new_op: ArrayScan = optype.cast().unwrap();
@@ -919,7 +919,7 @@ mod tests {
         let size = 2;
         let src_ty = qb_t();
         let tgt_ty = bool_t();
-        let es = ExtensionSet::singleton(&PRELUDE_ID);
+        let es = ExtensionSet::singleton(PRELUDE_ID);
 
         let op = ArrayScan::new(src_ty.clone(), tgt_ty.clone(), vec![], size, es.clone());
         let optype: OpType = op.into();
@@ -947,7 +947,7 @@ mod tests {
         let tgt_ty = bool_t();
         let acc_ty1 = usize_t();
         let acc_ty2 = qb_t();
-        let es = ExtensionSet::singleton(&PRELUDE_ID);
+        let es = ExtensionSet::singleton(PRELUDE_ID);
 
         let op = ArrayScan::new(
             src_ty.clone(),

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -16,8 +16,8 @@
 //! Note: These procedures are only temporary until `hugr-model` is stabilized.
 //! Once that happens, hugrs will no longer be directly deserialized using serde
 //! but instead will be created by the methods in `crate::import`. As these
-//! (will) automatically resolve extensions as the operations are created, we
-//! will no longer require this post-facto resolution step.
+//! (will) automatically resolve extensions as the operations are created,
+//! we will no longer require this post-facto resolution step.
 
 mod ops;
 mod types;

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -1,5 +1,8 @@
 //! Utilities for resolving operations and types present in a HUGR, and updating
-//! the list of used extensions. See [`crate::Hugr::resolve_extension_defs`].
+//! the list of used extensions. The functionalities of this module can be
+//! called from the type methods [`crate::Hugr::resolve_extension_defs`],
+//! [`crate::ops::OpType::used_extensions`], and
+//! [`crate::types::Signature::used_extensions`].
 //!
 //! When listing "used extensions" we only care about _definitional_ extension
 //! requirements, i.e., the operations and types that are required to define the
@@ -13,21 +16,23 @@
 //! Note: These procedures are only temporary until `hugr-model` is stabilized.
 //! Once that happens, hugrs will no longer be directly deserialized using serde
 //! but instead will be created by the methods in `crate::import`. As these
-//! (will) automatically resolve extensions as the operations are created,
-//! we will no longer require this post-facto resolution step.
+//! (will) automatically resolve extensions as the operations are created, we
+//! will no longer require this post-facto resolution step.
 
 mod ops;
 mod types;
+mod types_mut;
 
-pub(crate) use ops::update_op_extensions;
-pub(crate) use types::update_op_types_extensions;
+pub(crate) use ops::{collect_op_extensions, update_op_extensions};
+pub(crate) use types::{collect_op_types_extensions, collect_signature_exts};
+pub(crate) use types_mut::update_op_types_extensions;
 
 use derive_more::{Display, Error, From};
 
 use super::{Extension, ExtensionId, ExtensionRegistry};
 use crate::ops::custom::OpaqueOpError;
 use crate::ops::{NamedOp, OpName, OpType};
-use crate::types::TypeName;
+use crate::types::{FuncTypeBase, MaybeRV, TypeName};
 use crate::Node;
 
 /// Errors that can occur during extension resolution.
@@ -98,6 +103,63 @@ impl ExtensionResolutionError {
             ty: ty.clone(),
             missing_extension: missing_extension.clone(),
             available_extensions: extensions.ids().cloned().collect(),
+        }
+    }
+}
+
+/// Errors that can occur when collecting extension requirements.
+#[derive(Debug, Display, Clone, Error, From, PartialEq)]
+#[non_exhaustive]
+pub enum ExtensionCollectionError {
+    /// An operation requires an extension that is not in the given registry.
+    #[display(
+        "{op}{} contains custom types for which have lost the reference to their defining extensions. Dropped extensions: {}",
+        if let Some(node) = node { format!(" ({})", node) } else { "".to_string() },
+        missing_extensions.join(", ")
+    )]
+    DroppedOpExtensions {
+        /// The node that is missing extensions.
+        node: Option<Node>,
+        /// The operation that is missing extensions.
+        op: OpName,
+        /// The missing extensions.
+        missing_extensions: Vec<ExtensionId>,
+    },
+    /// A signature requires an extension that is not in the given registry.
+    #[display(
+        "Signature {signature} contains custom types for which have lost the reference to their defining extensions. Dropped extensions: {}",
+        missing_extensions.join(", ")
+    )]
+    DroppedSignatureExtensions {
+        /// The signature that is missing extensions.
+        signature: String,
+        /// The missing extensions.
+        missing_extensions: Vec<ExtensionId>,
+    },
+}
+
+impl ExtensionCollectionError {
+    /// Create a new error when operation extensions have been dropped.
+    pub fn dropped_op_extension(
+        node: Option<Node>,
+        op: &OpType,
+        missing_extension: impl IntoIterator<Item = ExtensionId>,
+    ) -> Self {
+        Self::DroppedOpExtensions {
+            node,
+            op: NamedOp::name(op),
+            missing_extensions: missing_extension.into_iter().collect(),
+        }
+    }
+
+    /// Create a new error when signature extensions have been dropped.
+    pub fn dropped_signature<RV: MaybeRV>(
+        signature: &FuncTypeBase<RV>,
+        missing_extension: impl IntoIterator<Item = ExtensionId>,
+    ) -> Self {
+        Self::DroppedSignatureExtensions {
+            signature: format!("{signature}"),
+            missing_extensions: missing_extension.into_iter().collect(),
         }
     }
 }

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -23,7 +23,7 @@ mod ops;
 mod types;
 mod types_mut;
 
-pub(crate) use ops::{collect_op_extensions, resolve_op_extensions};
+pub(crate) use ops::{collect_op_extension, resolve_op_extensions};
 pub(crate) use types::{collect_op_types_extensions, collect_signature_exts};
 pub(crate) use types_mut::resolve_op_types_extensions;
 

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -23,9 +23,9 @@ mod ops;
 mod types;
 mod types_mut;
 
-pub(crate) use ops::{collect_op_extensions, update_op_extensions};
+pub(crate) use ops::{collect_op_extensions, resolve_op_extensions};
 pub(crate) use types::{collect_op_types_extensions, collect_signature_exts};
-pub(crate) use types_mut::update_op_types_extensions;
+pub(crate) use types_mut::resolve_op_types_extensions;
 
 use derive_more::{Display, Error, From};
 

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -163,3 +163,6 @@ impl ExtensionCollectionError {
         }
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -1,7 +1,7 @@
 //! Resolve `OpaqueOp`s into `ExtensionOp`s and return an operation's required
 //! extension.
 //!
-//! Contains both mutable ([`update_op_extensions`]) and immutable
+//! Contains both mutable ([`resolve_op_extensions`]) and immutable
 //! ([`collect_operation_extension`]) methods to resolve operations and collect
 //! the required extensions respectively.
 
@@ -58,7 +58,7 @@ pub(crate) fn collect_op_extensions(
 ///
 /// If the serialized opaque resolves to a definition that conflicts with what
 /// was serialized. Or if the operation is not found in the registry.
-pub(crate) fn update_op_extensions<'e>(
+pub(crate) fn resolve_op_extensions<'e>(
     node: Node,
     op: &mut OpType,
     extensions: &'e ExtensionRegistry,

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -30,6 +30,8 @@ pub(crate) fn collect_op_extensions(
     op: &OpType,
 ) -> Result<Option<Arc<Extension>>, ExtensionCollectionError> {
     let OpType::ExtensionOp(ext_op) = op else {
+        // TODO: Extract the extension when the operation is a `Const`.
+        // https://github.com/CQCL/hugr/issues/1742
         return Ok(None);
     };
     let ext = ext_op.def().extension();

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -20,12 +20,12 @@ use crate::Node;
 /// invalidated if the original `Arc<Extension>` is dropped. On such cases, we
 /// return an error with the missing extension names.
 ///
-/// # Attributes
+/// # Parameters
 ///
 /// - `node`: The node where the operation is located, if available. This is
 ///   used to provide context in the error message.
 /// - `op`: The operation to collect the extensions from.
-pub(crate) fn collect_op_extensions(
+pub(crate) fn collect_op_extension(
     node: Option<Node>,
     op: &OpType,
 ) -> Result<Option<Arc<Extension>>, ExtensionCollectionError> {

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -1,0 +1,49 @@
+//! Tests for extension resolution.
+
+use rstest::rstest;
+
+use crate::extension::resolution::{update_op_extensions, update_op_types_extensions};
+use crate::extension::ExtensionRegistry;
+use crate::ops::{Input, OpType};
+use crate::std_extensions::arithmetic::int_ops;
+use crate::std_extensions::arithmetic::int_types;
+use crate::type_row;
+
+#[rstest]
+#[case::empty(Input { types: type_row![]}, ExtensionRegistry::default())]
+// A type with extra extensions in its instantiated type arguments.
+#[case::parametric_op(int_ops::IntOpDef::ieq.with_log_width(4),
+    ExtensionRegistry::new([int_ops::EXTENSION.to_owned(), int_types::EXTENSION.to_owned()]
+))]
+fn collect_type_extensions(#[case] op: impl Into<OpType>, #[case] extensions: ExtensionRegistry) {
+    let op = op.into();
+    let resolved = op.used_extensions().unwrap();
+    assert_eq!(resolved, extensions);
+}
+
+#[rstest]
+#[case::empty(Input { types: type_row![]}, ExtensionRegistry::default())]
+// A type with extra extensions in its instantiated type arguments.
+#[case::parametric_op(int_ops::IntOpDef::ieq.with_log_width(4),
+    ExtensionRegistry::new([int_ops::EXTENSION.to_owned(), int_types::EXTENSION.to_owned()]
+))]
+fn resolve_type_extensions(#[case] op: impl Into<OpType>, #[case] extensions: ExtensionRegistry) {
+    let op = op.into();
+
+    // Ensure that all the `Weak` pointers get invalidated by round-tripping via serialization.
+    let ser = serde_json::to_string(&op).unwrap();
+    let mut deser_op: OpType = serde_json::from_str(&ser).unwrap();
+
+    let dummy_node = portgraph::NodeIndex::new(0).into();
+
+    let mut used_exts = ExtensionRegistry::default();
+    update_op_extensions(dummy_node, &mut deser_op, &extensions).unwrap();
+    update_op_types_extensions(dummy_node, &mut deser_op, &extensions, &mut used_exts).unwrap();
+
+    let deser_extensions = deser_op.used_extensions().unwrap();
+
+    assert_eq!(
+        deser_extensions, extensions,
+        "{deser_extensions} != {extensions}"
+    );
+}

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -12,8 +12,7 @@ use crate::builder::{
 };
 use crate::extension::prelude::{bool_t, ConstUsize};
 use crate::extension::resolution::{
-    collect_op_extensions, collect_op_types_extensions, resolve_op_extensions,
-    resolve_op_types_extensions, ExtensionCollectionError,
+    resolve_op_extensions, resolve_op_types_extensions, ExtensionCollectionError,
 };
 use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE};
 use crate::ops::{CallIndirect, ExtensionOp, Input, OpTrait, OpType, Tag, Value};
@@ -221,8 +220,7 @@ fn resolve_hugr_extensions() {
     let mut collected_exts = ExtensionRegistry::default();
     for node in hugr.nodes() {
         let op = hugr.get_optype(node);
-        collected_exts.extend(collect_op_extensions(Some(node), op).unwrap());
-        collected_exts.extend(collect_op_types_extensions(Some(node), op).unwrap());
+        collected_exts.extend(op.used_extensions().unwrap());
     }
     assert_eq!(
         collected_exts, build_extensions,

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -12,8 +12,8 @@ use crate::builder::{
 };
 use crate::extension::prelude::{bool_t, ConstUsize};
 use crate::extension::resolution::{
-    collect_op_extensions, collect_op_types_extensions, update_op_extensions,
-    update_op_types_extensions, ExtensionCollectionError,
+    collect_op_extensions, collect_op_types_extensions, resolve_op_extensions,
+    resolve_op_types_extensions, ExtensionCollectionError,
 };
 use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE};
 use crate::ops::{CallIndirect, ExtensionOp, Input, OpTrait, OpType, Tag, Value};
@@ -51,8 +51,8 @@ fn resolve_type_extensions(#[case] op: impl Into<OpType>, #[case] extensions: Ex
     let dummy_node = portgraph::NodeIndex::new(0).into();
 
     let mut used_exts = ExtensionRegistry::default();
-    update_op_extensions(dummy_node, &mut deser_op, &extensions).unwrap();
-    update_op_types_extensions(dummy_node, &mut deser_op, &extensions, &mut used_exts).unwrap();
+    resolve_op_extensions(dummy_node, &mut deser_op, &extensions).unwrap();
+    resolve_op_types_extensions(dummy_node, &mut deser_op, &extensions, &mut used_exts).unwrap();
 
     let deser_extensions = deser_op.used_extensions().unwrap();
 

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -1,13 +1,24 @@
 //! Tests for extension resolution.
 
+use core::panic;
+use std::sync::Arc;
+
+use itertools::Itertools;
 use rstest::rstest;
 
-use crate::extension::resolution::{update_op_extensions, update_op_types_extensions};
-use crate::extension::ExtensionRegistry;
-use crate::ops::{Input, OpType};
+use crate::builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder};
+use crate::extension::prelude::{bool_t, ConstUsize};
+use crate::extension::resolution::{
+    collect_op_extensions, collect_op_types_extensions, update_op_extensions,
+    update_op_types_extensions,
+};
+use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet};
+use crate::ops::{CallIndirect, ExtensionOp, Input, OpType, Tag, Value};
+use crate::std_extensions::arithmetic::float_types::float64_type;
 use crate::std_extensions::arithmetic::int_ops;
-use crate::std_extensions::arithmetic::int_types;
-use crate::type_row;
+use crate::std_extensions::arithmetic::int_types::{self, int_type};
+use crate::types::{Signature, Type};
+use crate::{type_row, Extension, HugrView};
 
 #[rstest]
 #[case::empty(Input { types: type_row![]}, ExtensionRegistry::default())]
@@ -45,5 +56,147 @@ fn resolve_type_extensions(#[case] op: impl Into<OpType>, #[case] extensions: Ex
     assert_eq!(
         deser_extensions, extensions,
         "{deser_extensions} != {extensions}"
+    );
+}
+
+/// Create a new test extension with a single operation.
+///
+/// Returns an instance of the defined op.
+fn make_extension(name: &str, op_name: &str) -> (Arc<Extension>, OpType) {
+    let ext = Extension::new_test_arc(ExtensionId::new_unchecked(name), |ext, extension_ref| {
+        ext.add_op(
+            op_name.into(),
+            "".to_string(),
+            Signature::new_endo(vec![bool_t()]),
+            extension_ref,
+        )
+        .unwrap();
+    });
+    let op_def = ext.get_op(op_name).unwrap();
+    let op = ExtensionOp::new(op_def.clone(), vec![], &ExtensionRegistry::default()).unwrap();
+    (ext, op.into())
+}
+
+/// Build a hugr with all possible op nodes and resolve the extensions.
+#[rstest]
+fn resolve_hugr_extensions() {
+    let (ext_a, op_a) = make_extension("dummy.a", "op_a");
+    let (ext_b, op_b) = make_extension("dummy.b", "op_b");
+    let (ext_c, op_c) = make_extension("dummy.c", "op_c");
+    let (ext_d, op_d) = make_extension("dummy.d", "op_d");
+
+    let mut module = ModuleBuilder::new();
+
+    // A constant op using the prelude extension.
+    module.add_constant(Value::extension(ConstUsize::new(42)));
+
+    // A function declaration using the floats extension in its signature.
+    let decl = module
+        .declare(
+            "dummy_declaration",
+            Signature::new_endo(vec![float64_type()]).into(),
+        )
+        .unwrap();
+
+    // A function definition using the int_types and float_types extension in its body.
+    let mut func = module
+        .define_function(
+            "dummy_fn",
+            Signature::new(vec![float64_type(), bool_t()], vec![]).with_extension_delta(
+                [ext_a.name(), ext_b.name(), ext_c.name(), ext_d.name()]
+                    .into_iter()
+                    .cloned()
+                    .collect::<ExtensionSet>(),
+            ),
+        )
+        .unwrap();
+    let [func_i0, func_i1] = func.input_wires_arr();
+
+    // Call the function declaration directly, and load & call indirectly.
+    func.call(&decl, &[], vec![func_i0]).unwrap();
+    let loaded_func = func.load_func(&decl, &[]).unwrap();
+    func.add_dataflow_op(
+        CallIndirect {
+            signature: Signature::new_endo(vec![float64_type()]),
+        },
+        vec![loaded_func, func_i0],
+    )
+    .unwrap();
+
+    // Add one of the custom ops.
+    func.add_dataflow_op(op_a, vec![func_i1]).unwrap();
+
+    // A nested dataflow region.
+    let mut dfg = func.dfg_builder_endo([(bool_t(), func_i1)]).unwrap();
+    let dfg_inputs = dfg.input_wires().collect_vec();
+    dfg.add_dataflow_op(op_b, dfg_inputs.clone()).unwrap();
+    dfg.finish_with_outputs(dfg_inputs).unwrap();
+
+    // A tag
+    func.add_dataflow_op(
+        Tag::new(0, vec![vec![bool_t()].into(), vec![int_type(4)].into()]),
+        vec![func_i1],
+    )
+    .unwrap();
+
+    // Dfg control flow.
+    let mut tail_loop = func
+        .tail_loop_builder([(bool_t(), func_i1)], [], vec![].into())
+        .unwrap();
+    let tl_inputs = tail_loop.input_wires().collect_vec();
+    tail_loop.add_dataflow_op(op_c, tl_inputs).unwrap();
+    let tl_tag = tail_loop.add_load_const(Value::true_val());
+    let tl_tag = tail_loop
+        .add_dataflow_op(
+            Tag::new(0, vec![vec![Type::new_unit_sum(2)].into(), vec![].into()]),
+            vec![tl_tag],
+        )
+        .unwrap()
+        .out_wire(0);
+    tail_loop.finish_with_outputs(tl_tag, vec![]).unwrap();
+
+    // Cfg control flow.
+    let mut cfg = func
+        .cfg_builder([(bool_t(), func_i1)], vec![].into())
+        .unwrap();
+    let mut cfg_entry = cfg.entry_builder([type_row![]], type_row![]).unwrap();
+    let [cfg_i0] = cfg_entry.input_wires_arr();
+    cfg_entry.add_dataflow_op(op_d, [cfg_i0]).unwrap();
+    let cfg_tag = cfg_entry.add_load_const(Value::unary_unit_sum());
+    let cfg_entry_wire = cfg_entry.finish_with_outputs(cfg_tag, []).unwrap();
+    let cfg_exit = cfg.exit_block();
+    cfg.branch(&cfg_entry_wire, 0, &cfg_exit).unwrap();
+
+    // --------------------------------------------------
+
+    // Finally, finish the hugr and ensure it's using the right extensions.
+    func.finish_with_outputs(vec![]).unwrap();
+    let mut hugr = module.finish_hugr().unwrap_or_else(|e| panic!("{e}"));
+
+    let build_extensions = hugr.extensions().clone();
+    assert!(build_extensions.contains(ext_a.name()));
+    assert!(build_extensions.contains(ext_b.name()));
+    assert!(build_extensions.contains(ext_c.name()));
+    assert!(build_extensions.contains(ext_d.name()));
+
+    // Check that the read-only methods collect the same extensions.
+    let mut collected_exts = ExtensionRegistry::default();
+    for node in hugr.nodes() {
+        let op = hugr.get_optype(node);
+        collected_exts.extend(collect_op_extensions(Some(node), op).unwrap());
+        collected_exts.extend(collect_op_types_extensions(Some(node), op).unwrap());
+    }
+    assert_eq!(
+        collected_exts, build_extensions,
+        "{collected_exts} != {build_extensions}"
+    );
+
+    // Check that the mutable methods collect the same extensions.
+    hugr.resolve_extension_defs(&build_extensions).unwrap();
+    assert_eq!(
+        hugr.extensions(),
+        &build_extensions,
+        "{} != {build_extensions}",
+        hugr.extensions()
     );
 }

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -3,7 +3,7 @@
 //!
 //! Fails if any of the weak extension pointers have been invalidated.
 //!
-//! See [`super::update_op_types_extensions`] for a mutating version that
+//! See [`super::resolve_op_types_extensions`] for a mutating version that
 //! updates the weak links to point to the correct extensions.
 
 use super::ExtensionCollectionError;

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -211,6 +211,8 @@ fn collect_typearg_exts(
                 collect_typearg_exts(elem, used_extensions, missing_extensions);
             }
         }
+        // We ignore the `TypeArg::Extension` case, as it is not required to
+        // **define** the hugr.
         _ => {}
     }
 }

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -20,7 +20,7 @@ use crate::Node;
 /// happens when deserializing a HUGR. On such cases, we return an error with
 /// the missing extension names.
 ///
-/// Use [`collect_op_types_extensions`] instead to update the weak references and
+/// Use [`super::resolve_op_types_extensions`] instead to update the weak references and
 /// ensure they point to valid extensions.
 ///
 /// # Attributes

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -37,6 +37,9 @@ pub fn collect_op_types_extensions(
 
     match op {
         OpType::ExtensionOp(ext) => {
+            for arg in ext.args() {
+                collect_typearg_exts(arg, &mut used, &mut missing);
+            }
             collect_signature_exts(&ext.signature(), &mut used, &mut missing)
         }
         OpType::FuncDefn(f) => collect_signature_exts(f.signature.body(), &mut used, &mut missing),
@@ -58,7 +61,12 @@ pub fn collect_op_types_extensions(
             collect_signature_exts(&lf.signature, &mut used, &mut missing);
         }
         OpType::DFG(dfg) => collect_signature_exts(&dfg.signature, &mut used, &mut missing),
-        OpType::OpaqueOp(op) => collect_signature_exts(&op.signature(), &mut used, &mut missing),
+        OpType::OpaqueOp(op) => {
+            for arg in op.args() {
+                collect_typearg_exts(arg, &mut used, &mut missing);
+            }
+            collect_signature_exts(&op.signature(), &mut used, &mut missing)
+        }
         OpType::Tag(t) => {
             for variant in t.variants.iter() {
                 collect_type_row_exts(variant, &mut used, &mut missing)

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -43,8 +43,9 @@ pub fn collect_op_types_extensions(
         }
         OpType::FuncDefn(f) => collect_signature_exts(f.signature.body(), &mut used, &mut missing),
         OpType::FuncDecl(f) => collect_signature_exts(f.signature.body(), &mut used, &mut missing),
-        OpType::Const(_c) => {
-            // TODO: Is it OK to assume that `Value::get_type` returns a well-resolved value
+        OpType::Const(c) => {
+            let typ = c.get_type();
+            collect_type_exts(&typ, &mut used, &mut missing);
         }
         OpType::Input(inp) => collect_type_row_exts(&inp.types, &mut used, &mut missing),
         OpType::Output(out) => collect_type_row_exts(&out.types, &mut used, &mut missing),
@@ -153,7 +154,7 @@ fn collect_type_row_exts<RV: MaybeRV>(
 /// - `used_extensions`: A The registry where to store the used extensions.
 /// - `missing_extensions`: A set of `ExtensionId`s of which the
 ///   `Weak<Extension>` pointer has been invalidated.
-fn collect_type_exts<RV: MaybeRV>(
+pub(super) fn collect_type_exts<RV: MaybeRV>(
     typ: &TypeBase<RV>,
     used_extensions: &mut ExtensionRegistry,
     missing_extensions: &mut HashSet<ExtensionId>,

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -188,7 +188,11 @@ pub(super) fn collect_type_exts<RV: MaybeRV>(
                 collect_type_row_exts(row, used_extensions, missing_extensions);
             }
         }
-        _ => {}
+        // Other types do not store extensions.
+        TypeEnum::Alias(_)
+        | TypeEnum::RowVar(_)
+        | TypeEnum::Variable(_, _)
+        | TypeEnum::Sum(SumType::Unit { .. }) => {}
     }
 }
 

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -6,10 +6,8 @@
 //! See [`super::update_op_types_extensions`] for a mutating version that
 //! updates the weak links to point to the correct extensions.
 
-use std::collections::HashSet;
-
 use super::ExtensionCollectionError;
-use crate::extension::{ExtensionId, ExtensionRegistry};
+use crate::extension::{ExtensionRegistry, ExtensionSet};
 use crate::ops::{DataflowOpTrait, OpType};
 use crate::types::type_row::TypeRowBase;
 use crate::types::{FuncTypeBase, MaybeRV, SumType, TypeArg, TypeBase, TypeEnum};
@@ -35,7 +33,7 @@ pub fn collect_op_types_extensions(
     op: &OpType,
 ) -> Result<ExtensionRegistry, ExtensionCollectionError> {
     let mut used = ExtensionRegistry::default();
-    let mut missing = HashSet::<ExtensionId>::new();
+    let mut missing = ExtensionSet::new();
 
     match op {
         OpType::ExtensionOp(ext) => {
@@ -118,7 +116,7 @@ pub fn collect_op_types_extensions(
 pub(crate) fn collect_signature_exts<RV: MaybeRV>(
     signature: &FuncTypeBase<RV>,
     used_extensions: &mut ExtensionRegistry,
-    missing_extensions: &mut HashSet<ExtensionId>,
+    missing_extensions: &mut ExtensionSet,
 ) {
     // Note that we do not include the signature's `extension_reqs` here, as those refer
     // to _runtime_ requirements that may not be currently present.
@@ -139,7 +137,7 @@ pub(crate) fn collect_signature_exts<RV: MaybeRV>(
 fn collect_type_row_exts<RV: MaybeRV>(
     row: &TypeRowBase<RV>,
     used_extensions: &mut ExtensionRegistry,
-    missing_extensions: &mut HashSet<ExtensionId>,
+    missing_extensions: &mut ExtensionSet,
 ) {
     for ty in row.iter() {
         collect_type_exts(ty, used_extensions, missing_extensions);
@@ -157,7 +155,7 @@ fn collect_type_row_exts<RV: MaybeRV>(
 pub(super) fn collect_type_exts<RV: MaybeRV>(
     typ: &TypeBase<RV>,
     used_extensions: &mut ExtensionRegistry,
-    missing_extensions: &mut HashSet<ExtensionId>,
+    missing_extensions: &mut ExtensionSet,
 ) {
     match typ.as_type_enum() {
         TypeEnum::Extension(custom) => {
@@ -200,7 +198,7 @@ pub(super) fn collect_type_exts<RV: MaybeRV>(
 fn collect_typearg_exts(
     arg: &TypeArg,
     used_extensions: &mut ExtensionRegistry,
-    missing_extensions: &mut HashSet<ExtensionId>,
+    missing_extensions: &mut ExtensionSet,
 ) {
     match arg {
         TypeArg::Type { ty } => collect_type_exts(ty, used_extensions, missing_extensions),

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -171,12 +171,9 @@ pub(super) fn collect_type_exts<RV: MaybeRV>(
             }
             match custom.extension_ref().upgrade() {
                 Some(ext) => {
-                    // The extension pointer is still valid.
                     used_extensions.register_updated(ext);
                 }
                 None => {
-                    // The extension has been dropped.
-                    // Register it in the missing set.
                     missing_extensions.insert(custom.extension().clone());
                 }
             }

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -126,7 +126,8 @@ pub(crate) fn collect_signature_exts<RV: MaybeRV>(
     missing_extensions: &mut ExtensionSet,
 ) {
     // Note that we do not include the signature's `extension_reqs` here, as those refer
-    // to _runtime_ requirements that may not be currently present.
+    // to _runtime_ requirements that we do not be require to be defined.
+    //
     // See https://github.com/CQCL/hugr/issues/1734
     // TODO: Update comment once that issue gets implemented.
     collect_type_row_exts(&signature.input, used_extensions, missing_extensions);

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -28,7 +28,7 @@ use crate::Node;
 /// - `node`: The node where the operation is located, if available.
 ///   This is used to provide context in the error message.
 /// - `op`: The operation to collect the extensions from.
-pub fn collect_op_types_extensions(
+pub(crate) fn collect_op_types_extensions(
     node: Option<Node>,
     op: &OpType,
 ) -> Result<ExtensionRegistry, ExtensionCollectionError> {

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -101,7 +101,7 @@ pub fn collect_op_types_extensions(
             collect_signature_exts(&case.signature, &mut used, &mut missing);
         }
         // Ignore optypes that do not store a signature.
-        _ => {}
+        OpType::Module(_) | OpType::AliasDecl(_) | OpType::AliasDefn(_) => {}
     };
 
     missing

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -104,13 +104,12 @@ pub fn collect_op_types_extensions(
         _ => {}
     };
 
-    if missing.is_empty() {
-        Ok(used)
-    } else {
-        Err(ExtensionCollectionError::dropped_op_extension(
+    missing
+        .is_empty()
+        .then_some(used)
+        .ok_or(ExtensionCollectionError::dropped_op_extension(
             node, op, missing,
         ))
-    }
 }
 
 /// Collect the Extension pointers in the [`CustomType`]s inside a signature.

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -191,7 +191,11 @@ fn resolve_type_exts<RV: MaybeRV>(
                 resolve_type_row_exts(node, row, extensions, used_extensions)?;
             }
         }
-        _ => {}
+        // Other types do not store extensions.
+        TypeEnum::Alias(_)
+        | TypeEnum::RowVar(_)
+        | TypeEnum::Variable(_, _)
+        | TypeEnum::Sum(SumType::Unit { .. }) => {}
     }
     Ok(())
 }

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -3,11 +3,11 @@
 //!
 //! For a non-mutating option see [`super::collect_op_types_extensions`].
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use super::types::collect_type_exts;
 use super::{ExtensionRegistry, ExtensionResolutionError};
+use crate::extension::ExtensionSet;
 use crate::ops::OpType;
 use crate::types::type_row::TypeRowBase;
 use crate::types::{MaybeRV, Signature, SumType, TypeArg, TypeBase, TypeEnum};
@@ -39,7 +39,7 @@ pub fn update_op_types_extensions(
         }
         OpType::Const(c) => {
             let typ = c.get_type();
-            let mut missing = HashSet::new();
+            let mut missing = ExtensionSet::new();
             collect_type_exts(&typ, used_extensions, &mut missing);
             // We expect that the `CustomConst::get_type` binary calls always return valid extensions.
             // As we cannot update the `CustomConst` type, we ignore the result.

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -13,12 +13,12 @@ use crate::types::type_row::TypeRowBase;
 use crate::types::{MaybeRV, Signature, SumType, TypeArg, TypeBase, TypeEnum};
 use crate::Node;
 
-/// Replace the dangling extension pointer in the [`CustomType`]s inside a
-/// signature with a valid pointer to the extension in the `extensions`
+/// Replace the dangling extension pointer in the [`CustomType`]s inside an
+/// optype with a valid pointer to the extension in the `extensions`
 /// registry.
 ///
 /// When a pointer is replaced, the extension is added to the
-/// `used_extensions` registry and the new type definition is returned.
+/// `used_extensions` registry.
 ///
 /// This is a helper function used right after deserializing a Hugr.
 pub fn resolve_op_types_extensions(

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -114,7 +114,7 @@ pub fn update_op_types_extensions(
             update_signature_exts(node, &mut case.signature, extensions, used_extensions)?;
         }
         // Ignore optypes that do not store a signature.
-        _ => {}
+        OpType::Module(_) | OpType::AliasDecl(_) | OpType::AliasDefn(_) => {}
     }
     Ok(())
 }

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -1,0 +1,202 @@
+//! Resolve weak links inside `CustomType`s in an optype's signature, while
+//! collecting all used extensions.
+//!
+//! For a non-mutating option see [`super::collect_op_types_extensions`].
+
+use std::sync::Arc;
+
+use super::{ExtensionRegistry, ExtensionResolutionError};
+use crate::ops::OpType;
+use crate::types::type_row::TypeRowBase;
+use crate::types::{MaybeRV, Signature, SumType, TypeArg, TypeBase, TypeEnum};
+use crate::Node;
+
+/// Replace the dangling extension pointer in the [`CustomType`]s inside a
+/// signature with a valid pointer to the extension in the `extensions`
+/// registry.
+///
+/// When a pointer is replaced, the extension is added to the
+/// `used_extensions` registry and the new type definition is returned.
+///
+/// This is a helper function used right after deserializing a Hugr.
+pub fn update_op_types_extensions(
+    node: Node,
+    op: &mut OpType,
+    extensions: &ExtensionRegistry,
+    used_extensions: &mut ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    match op {
+        OpType::ExtensionOp(ext) => {
+            update_signature_exts(node, ext.signature_mut(), extensions, used_extensions)?
+        }
+        OpType::FuncDefn(f) => {
+            update_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?
+        }
+        OpType::FuncDecl(f) => {
+            update_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?
+        }
+        OpType::Const(_c) => {
+            // TODO: Is it OK to assume that `Value::get_type` returns a well-resolved value?
+        }
+        OpType::Input(inp) => {
+            update_type_row_exts(node, &mut inp.types, extensions, used_extensions)?
+        }
+        OpType::Output(out) => {
+            update_type_row_exts(node, &mut out.types, extensions, used_extensions)?
+        }
+        OpType::Call(c) => {
+            update_signature_exts(node, c.func_sig.body_mut(), extensions, used_extensions)?;
+            update_signature_exts(node, &mut c.instantiation, extensions, used_extensions)?;
+        }
+        OpType::CallIndirect(c) => {
+            update_signature_exts(node, &mut c.signature, extensions, used_extensions)?
+        }
+        OpType::LoadConstant(lc) => {
+            update_type_exts(node, &mut lc.datatype, extensions, used_extensions)?
+        }
+        OpType::LoadFunction(lf) => {
+            update_signature_exts(node, lf.func_sig.body_mut(), extensions, used_extensions)?;
+            update_signature_exts(node, &mut lf.signature, extensions, used_extensions)?;
+        }
+        OpType::DFG(dfg) => {
+            update_signature_exts(node, &mut dfg.signature, extensions, used_extensions)?
+        }
+        OpType::OpaqueOp(op) => {
+            update_signature_exts(node, op.signature_mut(), extensions, used_extensions)?
+        }
+        OpType::Tag(t) => {
+            for variant in t.variants.iter_mut() {
+                update_type_row_exts(node, variant, extensions, used_extensions)?
+            }
+        }
+        OpType::DataflowBlock(db) => {
+            update_type_row_exts(node, &mut db.inputs, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut db.other_outputs, extensions, used_extensions)?;
+            for row in db.sum_rows.iter_mut() {
+                update_type_row_exts(node, row, extensions, used_extensions)?;
+            }
+        }
+        OpType::ExitBlock(e) => {
+            update_type_row_exts(node, &mut e.cfg_outputs, extensions, used_extensions)?;
+        }
+        OpType::TailLoop(tl) => {
+            update_type_row_exts(node, &mut tl.just_inputs, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut tl.just_outputs, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut tl.rest, extensions, used_extensions)?;
+        }
+        OpType::CFG(cfg) => {
+            update_signature_exts(node, &mut cfg.signature, extensions, used_extensions)?;
+        }
+        OpType::Conditional(cond) => {
+            for row in cond.sum_rows.iter_mut() {
+                update_type_row_exts(node, row, extensions, used_extensions)?;
+            }
+            update_type_row_exts(node, &mut cond.other_inputs, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut cond.outputs, extensions, used_extensions)?;
+        }
+        OpType::Case(case) => {
+            update_signature_exts(node, &mut case.signature, extensions, used_extensions)?;
+        }
+        // Ignore optypes that do not store a signature.
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside a signature.
+///
+/// Adds the extensions used in the signature to the `used_extensions` registry.
+fn update_signature_exts(
+    node: Node,
+    signature: &mut Signature,
+    extensions: &ExtensionRegistry,
+    used_extensions: &mut ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    // Note that we do not include the signature's `extension_reqs` here, as those refer
+    // to _runtime_ requirements that may not be currently present.
+    // See https://github.com/CQCL/hugr/issues/1734
+    // TODO: Update comment once that issue gets implemented.
+    update_type_row_exts(node, &mut signature.input, extensions, used_extensions)?;
+    update_type_row_exts(node, &mut signature.output, extensions, used_extensions)?;
+    Ok(())
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside a type row.
+///
+/// Adds the extensions used in the row to the `used_extensions` registry.
+fn update_type_row_exts<RV: MaybeRV>(
+    node: Node,
+    row: &mut TypeRowBase<RV>,
+    extensions: &ExtensionRegistry,
+    used_extensions: &mut ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    for ty in row.iter_mut() {
+        update_type_exts(node, ty, extensions, used_extensions)?;
+    }
+    Ok(())
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside a type.
+///
+/// Adds the extensions used in the type to the `used_extensions` registry.
+fn update_type_exts<RV: MaybeRV>(
+    node: Node,
+    typ: &mut TypeBase<RV>,
+    extensions: &ExtensionRegistry,
+    used_extensions: &mut ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    match typ.as_type_enum_mut() {
+        TypeEnum::Extension(custom) => {
+            for arg in custom.args_mut() {
+                update_typearg_exts(node, arg, extensions, used_extensions)?;
+            }
+
+            let ext_id = custom.extension();
+            let ext = extensions.get(ext_id).ok_or_else(|| {
+                ExtensionResolutionError::missing_type_extension(
+                    node,
+                    custom.name(),
+                    ext_id,
+                    extensions,
+                )
+            })?;
+
+            // Add the extension to the used extensions registry,
+            // and update the CustomType with the valid pointer.
+            used_extensions.register_updated_ref(ext);
+            custom.update_extension(Arc::downgrade(ext));
+        }
+        TypeEnum::Function(f) => {
+            update_type_row_exts(node, &mut f.input, extensions, used_extensions)?;
+            update_type_row_exts(node, &mut f.output, extensions, used_extensions)?;
+        }
+        TypeEnum::Sum(SumType::General { rows }) => {
+            for row in rows.iter_mut() {
+                update_type_row_exts(node, row, extensions, used_extensions)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside a type arg.
+///
+/// Adds the extensions used in the type to the `used_extensions` registry.
+fn update_typearg_exts(
+    node: Node,
+    arg: &mut TypeArg,
+    extensions: &ExtensionRegistry,
+    used_extensions: &mut ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    match arg {
+        TypeArg::Type { ty } => update_type_exts(node, ty, extensions, used_extensions)?,
+        TypeArg::Sequence { elems } => {
+            for elem in elems.iter_mut() {
+                update_typearg_exts(node, elem, extensions, used_extensions)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -29,6 +29,9 @@ pub fn update_op_types_extensions(
 ) -> Result<(), ExtensionResolutionError> {
     match op {
         OpType::ExtensionOp(ext) => {
+            for arg in ext.args_mut() {
+                update_typearg_exts(node, arg, extensions, used_extensions)?;
+            }
             update_signature_exts(node, ext.signature_mut(), extensions, used_extensions)?
         }
         OpType::FuncDefn(f) => {
@@ -72,6 +75,9 @@ pub fn update_op_types_extensions(
             update_signature_exts(node, &mut dfg.signature, extensions, used_extensions)?
         }
         OpType::OpaqueOp(op) => {
+            for arg in op.args_mut() {
+                update_typearg_exts(node, arg, extensions, used_extensions)?;
+            }
             update_signature_exts(node, op.signature_mut(), extensions, used_extensions)?
         }
         OpType::Tag(t) => {

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -21,7 +21,7 @@ use crate::Node;
 /// `used_extensions` registry and the new type definition is returned.
 ///
 /// This is a helper function used right after deserializing a Hugr.
-pub fn update_op_types_extensions(
+pub fn resolve_op_types_extensions(
     node: Node,
     op: &mut OpType,
     extensions: &ExtensionRegistry,
@@ -30,15 +30,15 @@ pub fn update_op_types_extensions(
     match op {
         OpType::ExtensionOp(ext) => {
             for arg in ext.args_mut() {
-                update_typearg_exts(node, arg, extensions, used_extensions)?;
+                resolve_typearg_exts(node, arg, extensions, used_extensions)?;
             }
-            update_signature_exts(node, ext.signature_mut(), extensions, used_extensions)?
+            resolve_signature_exts(node, ext.signature_mut(), extensions, used_extensions)?
         }
         OpType::FuncDefn(f) => {
-            update_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?
+            resolve_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?
         }
         OpType::FuncDecl(f) => {
-            update_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?
+            resolve_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?
         }
         OpType::Const(c) => {
             let typ = c.get_type();
@@ -52,66 +52,66 @@ pub fn update_op_types_extensions(
             //assert!(missing.is_empty());
         }
         OpType::Input(inp) => {
-            update_type_row_exts(node, &mut inp.types, extensions, used_extensions)?
+            resolve_type_row_exts(node, &mut inp.types, extensions, used_extensions)?
         }
         OpType::Output(out) => {
-            update_type_row_exts(node, &mut out.types, extensions, used_extensions)?
+            resolve_type_row_exts(node, &mut out.types, extensions, used_extensions)?
         }
         OpType::Call(c) => {
-            update_signature_exts(node, c.func_sig.body_mut(), extensions, used_extensions)?;
-            update_signature_exts(node, &mut c.instantiation, extensions, used_extensions)?;
+            resolve_signature_exts(node, c.func_sig.body_mut(), extensions, used_extensions)?;
+            resolve_signature_exts(node, &mut c.instantiation, extensions, used_extensions)?;
         }
         OpType::CallIndirect(c) => {
-            update_signature_exts(node, &mut c.signature, extensions, used_extensions)?
+            resolve_signature_exts(node, &mut c.signature, extensions, used_extensions)?
         }
         OpType::LoadConstant(lc) => {
-            update_type_exts(node, &mut lc.datatype, extensions, used_extensions)?
+            resolve_type_exts(node, &mut lc.datatype, extensions, used_extensions)?
         }
         OpType::LoadFunction(lf) => {
-            update_signature_exts(node, lf.func_sig.body_mut(), extensions, used_extensions)?;
-            update_signature_exts(node, &mut lf.signature, extensions, used_extensions)?;
+            resolve_signature_exts(node, lf.func_sig.body_mut(), extensions, used_extensions)?;
+            resolve_signature_exts(node, &mut lf.signature, extensions, used_extensions)?;
         }
         OpType::DFG(dfg) => {
-            update_signature_exts(node, &mut dfg.signature, extensions, used_extensions)?
+            resolve_signature_exts(node, &mut dfg.signature, extensions, used_extensions)?
         }
         OpType::OpaqueOp(op) => {
             for arg in op.args_mut() {
-                update_typearg_exts(node, arg, extensions, used_extensions)?;
+                resolve_typearg_exts(node, arg, extensions, used_extensions)?;
             }
-            update_signature_exts(node, op.signature_mut(), extensions, used_extensions)?
+            resolve_signature_exts(node, op.signature_mut(), extensions, used_extensions)?
         }
         OpType::Tag(t) => {
             for variant in t.variants.iter_mut() {
-                update_type_row_exts(node, variant, extensions, used_extensions)?
+                resolve_type_row_exts(node, variant, extensions, used_extensions)?
             }
         }
         OpType::DataflowBlock(db) => {
-            update_type_row_exts(node, &mut db.inputs, extensions, used_extensions)?;
-            update_type_row_exts(node, &mut db.other_outputs, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut db.inputs, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut db.other_outputs, extensions, used_extensions)?;
             for row in db.sum_rows.iter_mut() {
-                update_type_row_exts(node, row, extensions, used_extensions)?;
+                resolve_type_row_exts(node, row, extensions, used_extensions)?;
             }
         }
         OpType::ExitBlock(e) => {
-            update_type_row_exts(node, &mut e.cfg_outputs, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut e.cfg_outputs, extensions, used_extensions)?;
         }
         OpType::TailLoop(tl) => {
-            update_type_row_exts(node, &mut tl.just_inputs, extensions, used_extensions)?;
-            update_type_row_exts(node, &mut tl.just_outputs, extensions, used_extensions)?;
-            update_type_row_exts(node, &mut tl.rest, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut tl.just_inputs, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut tl.just_outputs, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut tl.rest, extensions, used_extensions)?;
         }
         OpType::CFG(cfg) => {
-            update_signature_exts(node, &mut cfg.signature, extensions, used_extensions)?;
+            resolve_signature_exts(node, &mut cfg.signature, extensions, used_extensions)?;
         }
         OpType::Conditional(cond) => {
             for row in cond.sum_rows.iter_mut() {
-                update_type_row_exts(node, row, extensions, used_extensions)?;
+                resolve_type_row_exts(node, row, extensions, used_extensions)?;
             }
-            update_type_row_exts(node, &mut cond.other_inputs, extensions, used_extensions)?;
-            update_type_row_exts(node, &mut cond.outputs, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut cond.other_inputs, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut cond.outputs, extensions, used_extensions)?;
         }
         OpType::Case(case) => {
-            update_signature_exts(node, &mut case.signature, extensions, used_extensions)?;
+            resolve_signature_exts(node, &mut case.signature, extensions, used_extensions)?;
         }
         // Ignore optypes that do not store a signature.
         OpType::Module(_) | OpType::AliasDecl(_) | OpType::AliasDefn(_) => {}
@@ -122,7 +122,7 @@ pub fn update_op_types_extensions(
 /// Update all weak Extension pointers in the [`CustomType`]s inside a signature.
 ///
 /// Adds the extensions used in the signature to the `used_extensions` registry.
-fn update_signature_exts(
+fn resolve_signature_exts(
     node: Node,
     signature: &mut Signature,
     extensions: &ExtensionRegistry,
@@ -132,22 +132,22 @@ fn update_signature_exts(
     // to _runtime_ requirements that may not be currently present.
     // See https://github.com/CQCL/hugr/issues/1734
     // TODO: Update comment once that issue gets implemented.
-    update_type_row_exts(node, &mut signature.input, extensions, used_extensions)?;
-    update_type_row_exts(node, &mut signature.output, extensions, used_extensions)?;
+    resolve_type_row_exts(node, &mut signature.input, extensions, used_extensions)?;
+    resolve_type_row_exts(node, &mut signature.output, extensions, used_extensions)?;
     Ok(())
 }
 
 /// Update all weak Extension pointers in the [`CustomType`]s inside a type row.
 ///
 /// Adds the extensions used in the row to the `used_extensions` registry.
-fn update_type_row_exts<RV: MaybeRV>(
+fn resolve_type_row_exts<RV: MaybeRV>(
     node: Node,
     row: &mut TypeRowBase<RV>,
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
     for ty in row.iter_mut() {
-        update_type_exts(node, ty, extensions, used_extensions)?;
+        resolve_type_exts(node, ty, extensions, used_extensions)?;
     }
     Ok(())
 }
@@ -155,7 +155,7 @@ fn update_type_row_exts<RV: MaybeRV>(
 /// Update all weak Extension pointers in the [`CustomType`]s inside a type.
 ///
 /// Adds the extensions used in the type to the `used_extensions` registry.
-fn update_type_exts<RV: MaybeRV>(
+fn resolve_type_exts<RV: MaybeRV>(
     node: Node,
     typ: &mut TypeBase<RV>,
     extensions: &ExtensionRegistry,
@@ -164,7 +164,7 @@ fn update_type_exts<RV: MaybeRV>(
     match typ.as_type_enum_mut() {
         TypeEnum::Extension(custom) => {
             for arg in custom.args_mut() {
-                update_typearg_exts(node, arg, extensions, used_extensions)?;
+                resolve_typearg_exts(node, arg, extensions, used_extensions)?;
             }
 
             let ext_id = custom.extension();
@@ -183,12 +183,12 @@ fn update_type_exts<RV: MaybeRV>(
             custom.update_extension(Arc::downgrade(ext));
         }
         TypeEnum::Function(f) => {
-            update_type_row_exts(node, &mut f.input, extensions, used_extensions)?;
-            update_type_row_exts(node, &mut f.output, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut f.input, extensions, used_extensions)?;
+            resolve_type_row_exts(node, &mut f.output, extensions, used_extensions)?;
         }
         TypeEnum::Sum(SumType::General { rows }) => {
             for row in rows.iter_mut() {
-                update_type_row_exts(node, row, extensions, used_extensions)?;
+                resolve_type_row_exts(node, row, extensions, used_extensions)?;
             }
         }
         _ => {}
@@ -199,17 +199,17 @@ fn update_type_exts<RV: MaybeRV>(
 /// Update all weak Extension pointers in the [`CustomType`]s inside a type arg.
 ///
 /// Adds the extensions used in the type to the `used_extensions` registry.
-fn update_typearg_exts(
+fn resolve_typearg_exts(
     node: Node,
     arg: &mut TypeArg,
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
     match arg {
-        TypeArg::Type { ty } => update_type_exts(node, ty, extensions, used_extensions)?,
+        TypeArg::Type { ty } => resolve_type_exts(node, ty, extensions, used_extensions)?,
         TypeArg::Sequence { elems } => {
             for elem in elems.iter_mut() {
-                update_typearg_exts(node, elem, extensions, used_extensions)?;
+                resolve_typearg_exts(node, elem, extensions, used_extensions)?;
             }
         }
         _ => {}

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -358,8 +358,7 @@ mod test {
                     .unwrap();
             })
         };
-        static ref DUMMY_REG: ExtensionRegistry =
-            ExtensionRegistry::try_new([EXT.clone()]).unwrap();
+        static ref DUMMY_REG: ExtensionRegistry = ExtensionRegistry::new([EXT.clone()]);
     }
     impl MakeRegisteredOp for DummyEnum {
         fn extension_id(&self) -> ExtensionId {

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -213,6 +213,10 @@ impl Hugr {
         //
         // This is not something we want to expose it the API, so we manually
         // iterate instead of writing it as a method.
+        //
+        // Since we don't have a non-borrowing iterator over all the possible
+        // NodeIds, we have to simulate it by iterating over all possible
+        // indices and checking if the node exists.
         for n in 0..self.graph.node_capacity() {
             let pg_node = portgraph::NodeIndex::new(n);
             let node: Node = pg_node.into();

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 pub use self::views::{HugrView, RootTagged};
 use crate::core::NodeIndex;
 use crate::extension::resolution::{
-    update_op_extensions, update_op_types_extensions, ExtensionResolutionError,
+    resolve_op_extensions, resolve_op_types_extensions, ExtensionResolutionError,
 };
 use crate::extension::{ExtensionRegistry, ExtensionSet, TO_BE_INFERRED};
 use crate::ops::{OpTag, OpTrait};
@@ -222,10 +222,10 @@ impl Hugr {
 
             let op = &mut self.op_types[pg_node];
 
-            if let Some(extension) = update_op_extensions(node, op, extensions)? {
+            if let Some(extension) = resolve_op_extensions(node, op, extensions)? {
                 used_extensions.register_updated_ref(extension);
             }
-            update_op_types_extensions(node, op, extensions, &mut used_extensions)?;
+            resolve_op_types_extensions(node, op, extensions, &mut used_extensions)?;
         }
 
         Ok(used_extensions)

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -162,7 +162,7 @@ impl Hugr {
                 return Ok(es.clone()); // Can't neither add nor remove, so nothing to do
             }
             let merged = ExtensionSet::union_over(child_sets.into_iter().map(|(_, e)| e));
-            *es = ExtensionSet::singleton(&TO_BE_INFERRED).missing_from(&merged);
+            *es = ExtensionSet::singleton(TO_BE_INFERRED).missing_from(&merged);
 
             Ok(es.clone())
         }

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -19,7 +19,7 @@ pub use ident::{IdentList, InvalidIdentifier};
 pub use rewrite::{Rewrite, SimpleReplacement, SimpleReplacementError};
 
 use portgraph::multiportgraph::MultiPortGraph;
-use portgraph::{Hierarchy, PortMut, UnmanagedDenseMap};
+use portgraph::{Hierarchy, PortMut, PortView, UnmanagedDenseMap};
 use thiserror::Error;
 
 pub use self::views::{HugrView, RootTagged};
@@ -213,7 +213,7 @@ impl Hugr {
         //
         // This is not something we want to expose it the API, so we manually
         // iterate instead of writing it as a method.
-        for n in 0..self.node_count() {
+        for n in 0..self.graph.node_capacity() {
             let pg_node = portgraph::NodeIndex::new(n);
             let node: Node = pg_node.into();
             if !self.contains_node(node) {

--- a/hugr-core/src/hugr/rewrite/inline_dfg.rs
+++ b/hugr-core/src/hugr/rewrite/inline_dfg.rs
@@ -169,12 +169,12 @@ mod test {
     fn inline_add_load_const(#[case] nonlocal: bool) -> Result<(), Box<dyn std::error::Error>> {
         use crate::extension::prelude::Lift;
 
-        let reg = ExtensionRegistry::try_new([
+        let reg = ExtensionRegistry::new([
             PRELUDE.to_owned(),
             int_ops::EXTENSION.to_owned(),
             int_types::EXTENSION.to_owned(),
-        ])
-        .unwrap();
+        ]);
+        reg.validate()?;
         let int_ty = &int_types::INT_TYPES[6];
 
         let mut outer = DFGBuilder::new(inout_sig(vec![int_ty.clone(); 2], vec![int_ty.clone()]))?;
@@ -256,12 +256,12 @@ mod test {
         };
         let [q, p] = swap.outputs_arr();
         let cx = h.add_dataflow_op(test_quantum_extension::cx_gate(), [q, p])?;
-        let reg = ExtensionRegistry::try_new([
+        let reg = ExtensionRegistry::new([
             test_quantum_extension::EXTENSION.clone(),
             PRELUDE.clone(),
             float_types::EXTENSION.clone(),
-        ])
-        .unwrap();
+        ]);
+        reg.validate()?;
 
         let mut h = h.finish_hugr_with_outputs(cx.outputs(), &reg)?;
         assert_eq!(find_dfgs(&h), vec![h.root(), swap.node()]);
@@ -333,12 +333,12 @@ mod test {
          *              CX
          */
         // Extension inference here relies on quantum ops not requiring their own test_quantum_extension
-        let reg = ExtensionRegistry::try_new([
+        let reg = ExtensionRegistry::new([
             test_quantum_extension::EXTENSION.to_owned(),
             float_types::EXTENSION.to_owned(),
             PRELUDE.to_owned(),
-        ])
-        .unwrap();
+        ]);
+        reg.validate()?;
         let mut outer = DFGBuilder::new(endo_sig(vec![qb_t(), qb_t()]))?;
         let [a, b] = outer.input_wires_arr();
         let h_a = outer.add_dataflow_op(test_quantum_extension::h_gate(), [a])?;

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -470,9 +470,8 @@ mod test {
     #[test]
     #[ignore] // FIXME: This needs a rewrite now that `pop` returns an optional value -.-'
     fn cfg() -> Result<(), Box<dyn std::error::Error>> {
-        let reg =
-            ExtensionRegistry::try_new([PRELUDE.to_owned(), collections::EXTENSION.to_owned()])
-                .unwrap();
+        let reg = ExtensionRegistry::new([PRELUDE.to_owned(), collections::EXTENSION.to_owned()]);
+        reg.validate()?;
         let listy = list_type(usize_t());
         let pop: ExtensionOp = ListOp::pop
             .with_type(usize_t())

--- a/hugr-core/src/hugr/rewrite/simple_replace.rs
+++ b/hugr-core/src/hugr/rewrite/simple_replace.rs
@@ -793,7 +793,7 @@ pub(in crate::hugr::rewrite) mod test {
         };
         rewrite.apply(&mut hugr).unwrap_or_else(|e| panic!("{e}"));
 
-        assert_eq!(hugr.update_validate(&PRELUDE_REGISTRY), Ok(()));
+        assert_eq!(hugr.update_validate(&test_quantum_extension::REG), Ok(()));
         assert_eq!(hugr.node_count(), 4);
     }
 

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -548,7 +548,7 @@ fn roundtrip_polyfunctype_varlen(#[case] poly_func_type: PolyFuncTypeRV) {
 #[case(ops::Const::new(Value::function(crate::builder::test::simple_dfg_hugr()).unwrap()))]
 #[case(ops::Input::new(vec![Type::new_var_use(3,TypeBound::Copyable)]))]
 #[case(ops::Output::new(vec![Type::new_function(FuncValueType::new_endo(type_row![]))]))]
-#[case(ops::Call::try_new(polyfunctype1(), [TypeArg::BoundedNat{n: 1}, TypeArg::Extensions{ es: ExtensionSet::singleton(&PRELUDE_ID)} ], &EMPTY_REG).unwrap())]
+#[case(ops::Call::try_new(polyfunctype1(), [TypeArg::BoundedNat{n: 1}, TypeArg::Extensions{ es: ExtensionSet::singleton(PRELUDE_ID)} ], &EMPTY_REG).unwrap())]
 #[case(ops::CallIndirect { signature : Signature::new_endo(vec![bool_t()]) })]
 fn roundtrip_optype(#[case] optype: impl Into<OpType> + std::fmt::Debug) {
     check_testing_roundtrip(NodeSer {

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -388,7 +388,8 @@ fn invalid_types() {
         )
         .unwrap();
     });
-    let reg = ExtensionRegistry::try_new([ext.clone(), PRELUDE.clone()]).unwrap();
+    let reg = ExtensionRegistry::new([ext.clone(), PRELUDE.clone()]);
+    reg.validate().unwrap();
 
     let validate_to_sig_error = |t: CustomType| {
         let (h, def) = identity_hugr_with_type(Type::new_extension(t));
@@ -569,7 +570,8 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap()
             .instantiate(vec![TypeArg::new_var_use(0, BOUND)])?,
     );
-    let reg = ExtensionRegistry::try_new([collections::EXTENSION.to_owned()]).unwrap();
+    let reg = ExtensionRegistry::new([collections::EXTENSION.to_owned()]);
+    reg.validate()?;
     let mut def = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
@@ -653,7 +655,7 @@ fn instantiate_row_variables() -> Result<(), Box<dyn std::error::Error>> {
     let eval2 = dfb.add_dataflow_op(eval2, [par_func, a, b])?;
     dfb.finish_hugr_with_outputs(
         eval2.outputs(),
-        &ExtensionRegistry::try_new([PRELUDE.clone(), e]).unwrap(),
+        &ExtensionRegistry::new([PRELUDE.clone(), e]),
     )?;
     Ok(())
 }
@@ -693,7 +695,7 @@ fn row_variables() -> Result<(), Box<dyn std::error::Error>> {
     let par_func = fb.add_dataflow_op(par, [func_arg, id_usz])?;
     fb.finish_hugr_with_outputs(
         par_func.outputs(),
-        &ExtensionRegistry::try_new([PRELUDE.clone(), e]).unwrap(),
+        &ExtensionRegistry::new([PRELUDE.clone(), e]),
     )?;
     Ok(())
 }
@@ -780,7 +782,8 @@ fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
         f.finish_with_outputs([tup])?
     };
 
-    let reg = ExtensionRegistry::try_new([e, PRELUDE.clone()])?;
+    let reg = ExtensionRegistry::new([e, PRELUDE.clone()]);
+    reg.validate()?;
     let [func, tup] = d.input_wires_arr();
     let call = d.call(
         f.handle(),

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -788,7 +788,7 @@ fn test_polymorphic_call() -> Result<(), Box<dyn std::error::Error>> {
     let call = d.call(
         f.handle(),
         &[TypeArg::Extensions {
-            es: ExtensionSet::singleton(&PRELUDE_ID),
+            es: ExtensionSet::singleton(PRELUDE_ID),
         }],
         [func, tup],
         &reg,

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -849,14 +849,11 @@ mod tests {
             dfg.finish_with_outputs([w0, w1, w2])?
         };
         let hugr = mod_builder
-            .finish_hugr(
-                &ExtensionRegistry::try_new([
-                    prelude::PRELUDE.to_owned(),
-                    test_quantum_extension::EXTENSION.to_owned(),
-                    float_types::EXTENSION.to_owned(),
-                ])
-                .unwrap(),
-            )
+            .finish_hugr(&ExtensionRegistry::new([
+                prelude::PRELUDE.to_owned(),
+                test_quantum_extension::EXTENSION.to_owned(),
+                float_types::EXTENSION.to_owned(),
+            ]))
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -1139,14 +1136,11 @@ mod tests {
         let extracted = subgraph.extract_subgraph(&hugr, "region");
 
         extracted
-            .validate(
-                &ExtensionRegistry::try_new([
-                    prelude::PRELUDE.to_owned(),
-                    test_quantum_extension::EXTENSION.to_owned(),
-                    float_types::EXTENSION.to_owned(),
-                ])
-                .unwrap(),
-            )
+            .validate(&ExtensionRegistry::new([
+                prelude::PRELUDE.to_owned(),
+                test_quantum_extension::EXTENSION.to_owned(),
+                float_types::EXTENSION.to_owned(),
+            ]))
             .unwrap();
     }
 

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -1068,7 +1068,7 @@ impl<'a> Context<'a> {
                                 let ext_ident = IdentList::new(*ext).map_err(|_| {
                                     model::ModelError::MalformedName(ext.to_smolstr())
                                 })?;
-                                es.insert(&ext_ident);
+                                es.insert(ext_ident);
                             }
                             model::ExtSetPart::Splice(term_id) => {
                                 // The order in an extension set does not matter.

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -10,7 +10,7 @@ pub mod sum;
 pub mod tag;
 pub mod validate;
 use crate::extension::resolution::{
-    collect_op_extensions, collect_op_types_extensions, ExtensionCollectionError,
+    collect_op_extension, collect_op_types_extensions, ExtensionCollectionError,
 };
 use crate::extension::simple_op::MakeExtensionOp;
 use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet};
@@ -313,7 +313,7 @@ impl OpType {
         }
     }
 
-    /// Returns a register with all the extensions required by the operation.
+    /// Returns a registry with all the extensions required by the operation.
     ///
     /// This includes the operation extension in [`OpType::extension_id`], and any
     /// extension required by the operation's signature types.
@@ -321,7 +321,7 @@ impl OpType {
         // Collect extensions on the types.
         let mut reg = collect_op_types_extensions(None, self)?;
         // And on the operation definition itself.
-        if let Some(ext) = collect_op_extensions(None, self)? {
+        if let Some(ext) = collect_op_extension(None, self)? {
             reg.register_updated(ext);
         }
         Ok(reg)

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -594,7 +594,7 @@ mod test {
         }
 
         fn extension_reqs(&self) -> ExtensionSet {
-            ExtensionSet::singleton(self.0.extension())
+            ExtensionSet::singleton(self.0.extension().clone())
         }
 
         fn get_type(&self) -> Type {

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -614,7 +614,7 @@ mod test {
     }
 
     fn test_registry() -> ExtensionRegistry {
-        ExtensionRegistry::try_new([PRELUDE.to_owned(), float_types::EXTENSION.to_owned()]).unwrap()
+        ExtensionRegistry::new([PRELUDE.to_owned(), float_types::EXTENSION.to_owned()])
     }
 
     /// Constructs a DFG hugr defining a sum constant, and returning the loaded value.

--- a/hugr-core/src/ops/constant/custom.rs
+++ b/hugr-core/src/ops/constant/custom.rs
@@ -41,7 +41,7 @@ use super::{Value, ValueName};
 /// #[typetag::serde]
 /// impl CustomConst for CC {
 ///   fn name(&self) -> ValueName { "CC".into() }
-///   fn extension_reqs(&self) -> ExtensionSet { ExtensionSet::singleton(&int_types::EXTENSION_ID) }
+///   fn extension_reqs(&self) -> ExtensionSet { ExtensionSet::singleton(int_types::EXTENSION_ID) }
 ///   fn get_type(&self) -> Type { int_types::INT_TYPES[5].clone() }
 /// }
 ///

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -116,6 +116,11 @@ impl ExtensionOp {
     pub fn signature_mut(&mut self) -> &mut Signature {
         &mut self.signature
     }
+
+    /// Returns a mutable reference to the type arguments of the operation.
+    pub(crate) fn args_mut(&mut self) -> &mut [TypeArg] {
+        self.args.as_mut_slice()
+    }
 }
 
 impl From<ExtensionOp> for OpaqueOp {
@@ -234,6 +239,11 @@ impl OpaqueOp {
     /// Parent extension.
     pub fn extension(&self) -> &ExtensionId {
         &self.extension
+    }
+
+    /// Returns a mutable reference to the type arguments of the operation.
+    pub(crate) fn args_mut(&mut self) -> &mut [TypeArg] {
+        self.args.as_mut_slice()
     }
 }
 

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -383,7 +383,8 @@ mod test {
         });
         let ext_id = ext.name().clone();
 
-        let registry = ExtensionRegistry::try_new([ext]).unwrap();
+        let registry = ExtensionRegistry::new([ext]);
+        registry.validate().unwrap();
         let opaque_val = OpaqueOp::new(
             ext_id.clone(),
             val_name,

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -309,7 +309,7 @@ mod test {
 
     use ops::OpType;
 
-    use crate::extension::resolution::update_op_extensions;
+    use crate::extension::resolution::resolve_op_extensions;
     use crate::std_extensions::arithmetic::conversions::{self, CONVERT_OPS_REGISTRY};
     use crate::{
         extension::{
@@ -359,7 +359,7 @@ mod test {
             Signature::new(i0.clone(), bool_t()),
         );
         let mut resolved = opaque.into();
-        update_op_extensions(
+        resolve_op_extensions(
             Node::from(portgraph::NodeIndex::new(1)),
             &mut resolved,
             registry,
@@ -404,7 +404,7 @@ mod test {
         );
         let opaque_comp = OpaqueOp::new(ext_id.clone(), comp_name, "".into(), vec![], endo_sig);
         let mut resolved_val = opaque_val.into();
-        update_op_extensions(
+        resolve_op_extensions(
             Node::from(portgraph::NodeIndex::new(1)),
             &mut resolved_val,
             &registry,
@@ -413,7 +413,7 @@ mod test {
         assert_eq!(resolve_res_definition(&resolved_val).name(), val_name);
 
         let mut resolved_comp = opaque_comp.into();
-        update_op_extensions(
+        resolve_op_extensions(
             Node::from(portgraph::NodeIndex::new(2)),
             &mut resolved_comp,
             &registry,

--- a/hugr-core/src/ops/validate.rs
+++ b/hugr-core/src/ops/validate.rs
@@ -215,18 +215,21 @@ impl ChildrenValidationError {
 #[non_exhaustive]
 pub enum EdgeValidationError {
     /// The dataflow signature of two connected basic blocks does not match.
-    #[error("The dataflow signature of two connected basic blocks does not match. Output signature: {source_op}, input signature: {target_op}",
-        source_op = edge.source_op,
-        target_op = edge.target_op
+    #[error("The dataflow signature of two connected basic blocks does not match. The source type was {source_ty} but the target had type {target_types}",
+        source_ty = source_types.clone().unwrap_or_default(),
     )]
-    CFGEdgeSignatureMismatch { edge: ChildrenEdgeData },
+    CFGEdgeSignatureMismatch {
+        edge: ChildrenEdgeData,
+        source_types: Option<TypeRow>,
+        target_types: TypeRow,
+    },
 }
 
 impl EdgeValidationError {
     /// Returns information on the edge that caused the error.
     pub fn edge(&self) -> &ChildrenEdgeData {
         match self {
-            EdgeValidationError::CFGEdgeSignatureMismatch { edge } => edge,
+            EdgeValidationError::CFGEdgeSignatureMismatch { edge, .. } => edge,
         }
     }
 }
@@ -342,8 +345,14 @@ fn validate_cfg_edge(edge: ChildrenEdgeData) -> Result<(), EdgeValidationError> 
         _ => panic!("CFG sibling graphs can only contain basic block operations."),
     };
 
-    if source.successor_input(edge.source_port.index()).as_ref() != Some(target_input) {
-        return Err(EdgeValidationError::CFGEdgeSignatureMismatch { edge });
+    let source_types = source.successor_input(edge.source_port.index());
+    if source_types.as_ref() != Some(target_input) {
+        let target_types = target_input.clone();
+        return Err(EdgeValidationError::CFGEdgeSignatureMismatch {
+            edge,
+            source_types,
+            target_types,
+        });
     }
 
     Ok(())

--- a/hugr-core/src/std_extensions.rs
+++ b/hugr-core/src/std_extensions.rs
@@ -11,7 +11,7 @@ pub mod ptr;
 
 /// Extension registry with all standard extensions and prelude.
 pub fn std_reg() -> ExtensionRegistry {
-    ExtensionRegistry::try_new([
+    let reg = ExtensionRegistry::new([
         crate::extension::prelude::PRELUDE.clone(),
         arithmetic::int_ops::EXTENSION.to_owned(),
         arithmetic::int_types::EXTENSION.to_owned(),
@@ -21,8 +21,10 @@ pub fn std_reg() -> ExtensionRegistry {
         collections::EXTENSION.to_owned(),
         logic::EXTENSION.to_owned(),
         ptr::EXTENSION.to_owned(),
-    ])
-    .unwrap()
+    ]);
+    reg.validate()
+        .expect("Standard extension registry is valid");
+    reg
 }
 
 lazy_static::lazy_static! {

--- a/hugr-core/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions.rs
@@ -170,13 +170,12 @@ lazy_static! {
     };
 
     /// Registry of extensions required to validate integer operations.
-    pub static ref CONVERT_OPS_REGISTRY: ExtensionRegistry  = ExtensionRegistry::try_new([
+    pub static ref CONVERT_OPS_REGISTRY: ExtensionRegistry  = ExtensionRegistry::new([
         PRELUDE.clone(),
         super::int_types::EXTENSION.clone(),
         super::float_types::EXTENSION.clone(),
         EXTENSION.clone(),
-    ])
-    .unwrap();
+    ]);
 }
 
 impl MakeRegisteredOp for ConvertOpType {

--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -117,12 +117,11 @@ lazy_static! {
     };
 
     /// Registry of extensions required to validate float operations.
-    pub static ref FLOAT_OPS_REGISTRY: ExtensionRegistry  = ExtensionRegistry::try_new([
+    pub static ref FLOAT_OPS_REGISTRY: ExtensionRegistry = ExtensionRegistry::new([
         PRELUDE.clone(),
         super::float_types::EXTENSION.clone(),
         EXTENSION.clone(),
-    ])
-    .unwrap();
+    ]);
 }
 
 impl MakeRegisteredOp for FloatOps {

--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -111,7 +111,7 @@ lazy_static! {
     /// Extension for basic float operations.
     pub static ref EXTENSION: Arc<Extension> = {
         Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
-            extension.add_requirements(ExtensionSet::singleton(&super::int_types::EXTENSION_ID));
+            extension.add_requirements(ExtensionSet::singleton(super::int_types::EXTENSION_ID));
             FloatOps::load_all_ops(extension, extension_ref).unwrap();
         })
     };

--- a/hugr-core/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_types.rs
@@ -84,7 +84,7 @@ impl CustomConst for ConstF64 {
     }
 
     fn extension_reqs(&self) -> ExtensionSet {
-        ExtensionSet::singleton(&EXTENSION_ID)
+        ExtensionSet::singleton(EXTENSION_ID)
     }
 }
 

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -260,12 +260,11 @@ lazy_static! {
     };
 
     /// Registry of extensions required to validate integer operations.
-    pub static ref INT_OPS_REGISTRY: ExtensionRegistry  = ExtensionRegistry::try_new([
+    pub static ref INT_OPS_REGISTRY: ExtensionRegistry = ExtensionRegistry::new([
         PRELUDE.clone(),
         super::int_types::EXTENSION.clone(),
         EXTENSION.clone(),
-    ])
-    .unwrap();
+    ]);
 }
 
 impl HasConcrete for IntOpDef {

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -254,7 +254,7 @@ lazy_static! {
     /// Extension for basic integer operations.
     pub static ref EXTENSION: Arc<Extension> = {
         Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
-            extension.add_requirements(ExtensionSet::singleton(&super::int_types::EXTENSION_ID));
+            extension.add_requirements(ExtensionSet::singleton(super::int_types::EXTENSION_ID));
             IntOpDef::load_all_ops(extension, extension_ref).unwrap();
         })
     };

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -182,7 +182,7 @@ impl CustomConst for ConstInt {
     }
 
     fn extension_reqs(&self) -> ExtensionSet {
-        ExtensionSet::singleton(&EXTENSION_ID)
+        ExtensionSet::singleton(EXTENSION_ID)
     }
 
     fn get_type(&self) -> Type {

--- a/hugr-core/src/std_extensions/collections.rs
+++ b/hugr-core/src/std_extensions/collections.rs
@@ -287,11 +287,10 @@ lazy_static! {
     };
 
     /// Registry of extensions required to validate list operations.
-    pub static ref COLLECTIONS_REGISTRY: ExtensionRegistry  = ExtensionRegistry::try_new([
+    pub static ref COLLECTIONS_REGISTRY: ExtensionRegistry  = ExtensionRegistry::new([
         PRELUDE.clone(),
         EXTENSION.clone(),
-    ])
-    .unwrap();
+    ]);
 }
 
 impl MakeRegisteredOp for ListOp {
@@ -367,15 +366,14 @@ impl ListOpInst {
     /// Convert this list operation to an [`ExtensionOp`] by providing a
     /// registry to validate the element type against.
     pub fn to_extension_op(self, elem_type_registry: &ExtensionRegistry) -> Option<ExtensionOp> {
-        let registry = ExtensionRegistry::try_new(
+        let registry = ExtensionRegistry::new(
             elem_type_registry
                 .clone()
                 .into_iter()
                 // ignore self if already in registry
                 .filter(|ext| ext.name() != EXTENSION.name())
                 .chain(std::iter::once(EXTENSION.to_owned())),
-        )
-        .unwrap();
+        );
         ExtensionOp::new(
             registry.get(&EXTENSION_ID)?.get_op(&self.name())?.clone(),
             self.type_args(),
@@ -438,9 +436,7 @@ mod test {
 
     #[test]
     fn test_list_ops() {
-        let reg =
-            ExtensionRegistry::try_new([PRELUDE.to_owned(), float_types::EXTENSION.to_owned()])
-                .unwrap();
+        let reg = ExtensionRegistry::new([PRELUDE.to_owned(), float_types::EXTENSION.to_owned()]);
         let pop_op = ListOp::pop.with_type(qb_t());
         let pop_ext = pop_op.clone().to_extension_op(&reg).unwrap();
         assert_eq!(ListOpInst::from_extension_op(&pop_ext).unwrap(), pop_op);

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -130,8 +130,7 @@ lazy_static! {
     /// Reference to the logic Extension.
     pub static ref EXTENSION: Arc<Extension> = extension();
     /// Registry required to validate logic extension.
-    pub static ref LOGIC_REG: ExtensionRegistry =
-        ExtensionRegistry::try_new([EXTENSION.clone()]).unwrap();
+    pub static ref LOGIC_REG: ExtensionRegistry = ExtensionRegistry::new([EXTENSION.clone()]);
 }
 
 impl MakeRegisteredOp for LogicOp {

--- a/hugr-core/src/std_extensions/ptr.rs
+++ b/hugr-core/src/std_extensions/ptr.rs
@@ -110,8 +110,7 @@ lazy_static! {
     /// Reference to the pointer Extension.
     pub static ref EXTENSION: Arc<Extension> = extension();
     /// Registry required to validate pointer extension.
-    pub static ref PTR_REG: ExtensionRegistry =
-        ExtensionRegistry::try_new([EXTENSION.clone()]).unwrap();
+    pub static ref PTR_REG: ExtensionRegistry = ExtensionRegistry::new([EXTENSION.clone()]);
 }
 
 /// Integer type of a given bit width (specified by the TypeArg).  Depending on
@@ -272,8 +271,7 @@ pub(crate) mod test {
     fn test_build() {
         let in_row = vec![bool_t(), float64_type()];
 
-        let reg =
-            ExtensionRegistry::try_new([EXTENSION.to_owned(), FLOAT_EXTENSION.to_owned()]).unwrap();
+        let reg = ExtensionRegistry::new([EXTENSION.to_owned(), FLOAT_EXTENSION.to_owned()]);
         let hugr = {
             let mut builder = DFGBuilder::new(
                 Signature::new(in_row.clone(), type_row![]).with_extension_delta(EXTENSION_ID),

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -17,7 +17,7 @@ use crate::utils::display_list_with_separator;
 pub use check::SumTypeError;
 pub use custom::CustomType;
 pub use poly_func::{PolyFuncType, PolyFuncTypeRV};
-pub use signature::{FuncValueType, Signature};
+pub use signature::{FuncTypeBase, FuncValueType, Signature};
 use smol_str::SmolStr;
 pub use type_param::TypeArg;
 pub use type_row::{TypeRow, TypeRowRV};
@@ -25,8 +25,6 @@ pub use type_row::{TypeRow, TypeRowRV};
 // Unused in --no-features
 #[allow(unused_imports)]
 pub(crate) use poly_func::PolyFuncTypeBase;
-#[allow(unused_imports)]
-pub(crate) use signature::FuncTypeBase;
 
 use itertools::FoldWhile::{Continue, Done};
 use itertools::{repeat_n, Itertools};

--- a/hugr-core/src/types/custom.rs
+++ b/hugr-core/src/types/custom.rs
@@ -137,6 +137,11 @@ impl CustomType {
         &self.args
     }
 
+    /// Returns a mutable reference to the type arguments.
+    pub(crate) fn args_mut(&mut self) -> &mut Vec<TypeArg> {
+        &mut self.args
+    }
+
     /// Parent extension.
     pub fn extension(&self) -> &ExtensionId {
         &self.extension

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -177,7 +177,7 @@ pub(crate) mod test {
 
     lazy_static! {
         static ref REGISTRY: ExtensionRegistry =
-            ExtensionRegistry::try_new([PRELUDE.to_owned(), EXTENSION.to_owned()]).unwrap();
+            ExtensionRegistry::new([PRELUDE.to_owned(), EXTENSION.to_owned()]);
     }
 
     impl<RV: MaybeRV> PolyFuncTypeBase<RV> {
@@ -345,7 +345,8 @@ pub(crate) mod test {
             .unwrap();
         });
 
-        let reg = ExtensionRegistry::try_new([ext.clone()]).unwrap();
+        let reg = ExtensionRegistry::new([ext.clone()]);
+        reg.validate().unwrap();
 
         let make_scheme = |tp: TypeParam| {
             PolyFuncTypeBase::new_validated(

--- a/hugr-core/src/types/signature.rs
+++ b/hugr-core/src/types/signature.rs
@@ -2,7 +2,6 @@
 
 use itertools::Either;
 
-use std::collections::HashSet;
 use std::fmt::{self, Display, Write};
 
 use super::type_param::TypeParam;
@@ -11,7 +10,7 @@ use super::{MaybeRV, NoRV, RowVariable, Substitution, Type, TypeRow};
 
 use crate::core::PortIndex;
 use crate::extension::resolution::{collect_signature_exts, ExtensionCollectionError};
-use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet, SignatureError};
+use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
 use crate::{Direction, IncomingPort, OutgoingPort, Port};
 
 #[cfg(test)]
@@ -132,7 +131,7 @@ impl<RV: MaybeRV> FuncTypeBase<RV> {
     /// manipulate a HUGR.
     pub fn used_extensions(&self) -> Result<ExtensionRegistry, ExtensionCollectionError> {
         let mut used = ExtensionRegistry::default();
-        let mut missing = HashSet::<ExtensionId>::new();
+        let mut missing = ExtensionSet::new();
 
         collect_signature_exts(self, &mut used, &mut missing);
 

--- a/hugr-core/src/types/signature.rs
+++ b/hugr-core/src/types/signature.rs
@@ -2,6 +2,7 @@
 
 use itertools::Either;
 
+use std::collections::HashSet;
 use std::fmt::{self, Display, Write};
 
 use super::type_param::TypeParam;
@@ -9,7 +10,8 @@ use super::type_row::TypeRowBase;
 use super::{MaybeRV, NoRV, RowVariable, Substitution, Type, TypeRow};
 
 use crate::core::PortIndex;
-use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
+use crate::extension::resolution::{collect_signature_exts, ExtensionCollectionError};
+use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet, SignatureError};
 use crate::{Direction, IncomingPort, OutgoingPort, Port};
 
 #[cfg(test)]
@@ -117,6 +119,28 @@ impl<RV: MaybeRV> FuncTypeBase<RV> {
         self.input.validate(extension_registry, var_decls)?;
         self.output.validate(extension_registry, var_decls)?;
         self.extension_reqs.validate(var_decls)
+    }
+
+    /// Returns a registry with the concrete extensions used by this signature.
+    ///
+    /// Note that extension type parameters are not included, as they have not
+    /// been instantiated yet.
+    ///
+    /// This method only returns extensions actually used by the types in the
+    /// signature. The extension deltas added via [`Self::with_extension_delta`]
+    /// refer to _runtime_ extensions, which may not be in all places that
+    /// manipulate a HUGR.
+    pub fn used_extensions(&self) -> Result<ExtensionRegistry, ExtensionCollectionError> {
+        let mut used = ExtensionRegistry::default();
+        let mut missing = HashSet::<ExtensionId>::new();
+
+        collect_signature_exts(self, &mut used, &mut missing);
+
+        if missing.is_empty() {
+            Ok(used)
+        } else {
+            Err(ExtensionCollectionError::dropped_signature(self, missing))
+        }
     }
 }
 

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -194,13 +194,13 @@ pub(crate) mod test_quantum_extension {
         pub static ref EXTENSION: Arc<Extension> = extension();
 
         /// A registry with all necessary extensions to run tests internally, including the test quantum extension.
-        pub static ref REG: ExtensionRegistry = ExtensionRegistry::try_new([
+        pub static ref REG: ExtensionRegistry = ExtensionRegistry::new([
             EXTENSION.clone(),
             PRELUDE.clone(),
             float_types::EXTENSION.clone(),
             float_ops::EXTENSION.clone(),
             logic::EXTENSION.clone()
-        ]).unwrap();
+        ]);
 
     }
 

--- a/hugr-llvm/src/emit/ops/cfg.rs
+++ b/hugr-llvm/src/emit/ops/cfg.rs
@@ -244,13 +244,10 @@ mod test {
         let hugr = SimpleHugrConfig::new()
             .with_ins(vec![t1.clone(), t2.clone()])
             .with_outs(t2.clone())
-            .with_extensions(
-                ExtensionRegistry::try_new([
-                    int_types::EXTENSION.to_owned(),
-                    prelude::PRELUDE.to_owned(),
-                ])
-                .unwrap(),
-            )
+            .with_extensions(ExtensionRegistry::new([
+                int_types::EXTENSION.to_owned(),
+                prelude::PRELUDE.to_owned(),
+            ]))
             .finish(|mut builder| {
                 let [in1, in2] = builder.input_wires_arr();
                 let mut cfg_builder = builder

--- a/hugr-llvm/src/emit/test.rs
+++ b/hugr-llvm/src/emit/test.rs
@@ -5,7 +5,7 @@ use hugr_core::builder::{
     BuildHandle, Container, DFGWrapper, HugrBuilder, ModuleBuilder, SubContainer,
 };
 use hugr_core::extension::prelude::PRELUDE_ID;
-use hugr_core::extension::{ExtensionRegistry, ExtensionSet, EMPTY_REG};
+use hugr_core::extension::{ExtensionRegistry, ExtensionSet};
 use hugr_core::ops::handle::FuncID;
 use hugr_core::std_extensions::arithmetic::{
     conversions, float_ops, float_types, int_ops, int_types,
@@ -108,7 +108,7 @@ impl SimpleHugrConfig {
         Self {
             ins: Default::default(),
             outs: Default::default(),
-            extensions: EMPTY_REG,
+            extensions: Default::default(),
         }
     }
 

--- a/hugr-llvm/src/extension/collections.rs
+++ b/hugr-llvm/src/extension/collections.rs
@@ -398,11 +398,11 @@ mod test {
                 &collections::COLLECTIONS_REGISTRY,
             )
             .unwrap();
-        let es = ExtensionRegistry::try_new([
+        let es = ExtensionRegistry::new([
             collections::EXTENSION.to_owned(),
             prelude::PRELUDE.to_owned(),
-        ])
-        .unwrap();
+        ]);
+        es.validate().unwrap();
         let hugr = SimpleHugrConfig::new()
             .with_ins(ext_op.signature().input().clone())
             .with_outs(ext_op.signature().output().clone())
@@ -423,11 +423,11 @@ mod test {
     fn test_const_list_emmission(mut llvm_ctx: TestContext) {
         let elem_ty = usize_t();
         let contents = (1..4).map(|i| Value::extension(ConstUsize::new(i)));
-        let es = ExtensionRegistry::try_new([
+        let es = ExtensionRegistry::new([
             collections::EXTENSION.to_owned(),
             prelude::PRELUDE.to_owned(),
-        ])
-        .unwrap();
+        ]);
+        es.validate().unwrap();
 
         let hugr = SimpleHugrConfig::new()
             .with_ins(vec![])

--- a/hugr-llvm/src/extension/logic.rs
+++ b/hugr-llvm/src/extension/logic.rs
@@ -110,7 +110,7 @@ mod test {
         SimpleHugrConfig::new()
             .with_ins(vec![bool_t(); arity])
             .with_outs(vec![bool_t()])
-            .with_extensions(ExtensionRegistry::try_new(vec![logic::EXTENSION.to_owned()]).unwrap())
+            .with_extensions(ExtensionRegistry::new(vec![logic::EXTENSION.to_owned()]))
             .finish(|mut builder| {
                 let outputs = builder
                     .add_dataflow_op(op, builder.input_wires())

--- a/hugr-llvm/src/extension/prelude/array.rs
+++ b/hugr-llvm/src/extension/prelude/array.rs
@@ -445,13 +445,12 @@ mod test {
     }
 
     fn exec_registry() -> ExtensionRegistry {
-        ExtensionRegistry::try_new([
+        ExtensionRegistry::new([
             int_types::EXTENSION.to_owned(),
             int_ops::EXTENSION.to_owned(),
             logic::EXTENSION.to_owned(),
             prelude::PRELUDE.to_owned(),
         ])
-        .unwrap()
     }
 
     #[rstest]

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -24,7 +24,7 @@ pub(crate) mod test {
 
     lazy_static! {
         /// A registry containing various extensions for testing.
-        pub(crate) static ref TEST_REG: ExtensionRegistry = ExtensionRegistry::try_new([
+        pub(crate) static ref TEST_REG: ExtensionRegistry = ExtensionRegistry::new([
             PRELUDE.to_owned(),
             arithmetic::int_ops::EXTENSION.to_owned(),
             arithmetic::int_types::EXTENSION.to_owned(),
@@ -33,7 +33,6 @@ pub(crate) mod test {
             logic::EXTENSION.to_owned(),
             arithmetic::conversions::EXTENSION.to_owned(),
             collections::EXTENSION.to_owned(),
-        ])
-        .unwrap();
+        ]);
     }
 }

--- a/hugr-passes/src/merge_bbs.rs
+++ b/hugr-passes/src/merge_bbs.rs
@@ -231,7 +231,8 @@ mod test {
         let exit_types: TypeRow = vec![usize_t()].into();
         let e = extension();
         let tst_op = e.instantiate_extension_op("Test", [], &PRELUDE_REGISTRY)?;
-        let reg = ExtensionRegistry::try_new([PRELUDE.clone(), e])?;
+        let reg = ExtensionRegistry::new([PRELUDE.clone(), e]);
+        reg.validate()?;
         let mut h = CFGBuilder::new(inout_sig(loop_variants.clone(), exit_types.clone()))?;
         let mut no_b1 = h.simple_entry_builder_exts(loop_variants.clone(), 1, PRELUDE_ID)?;
         let n = no_b1.add_dataflow_op(Noop::new(qb_t()), no_b1.input_wires())?;
@@ -358,7 +359,8 @@ mod test {
         h.branch(&bb2, 0, &bb3)?;
         h.branch(&bb3, 0, &h.exit_block())?;
 
-        let reg = ExtensionRegistry::try_new([e, PRELUDE.clone()])?;
+        let reg = ExtensionRegistry::new([e, PRELUDE.clone()]);
+        reg.validate()?;
         let mut h = h.finish_hugr(&reg)?;
         let root = h.root();
         merge_basic_blocks(&mut SiblingMut::try_new(&mut h, root)?);

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -81,8 +81,7 @@
 //!     lazy_static! {
 //!         /// Quantum extension definition.
 //!         pub static ref EXTENSION: Arc<Extension> = extension();
-//!         pub static ref REG: ExtensionRegistry =
-//!             ExtensionRegistry::try_new([EXTENSION.clone(), PRELUDE.clone()]).unwrap();
+//!         pub static ref REG: ExtensionRegistry = ExtensionRegistry::new([EXTENSION.clone(), PRELUDE.clone()]);
 //!     }
 //!     fn get_gate(gate_name: impl Into<OpName>) -> ExtensionOp {
 //!         EXTENSION


### PR DESCRIPTION
Adds methods
- `OpType::used_extensions(&self) -> Result<ExtensionRegistry, _>`
- `Signature::used_extensions(&self) -> Result<ExtensionRegistry, _>`
and tests these along with the code merged in #1735.

Moves the code from #1735 into `resolution::types_mut`, and adds a (quite-similar) non-mutable version in `::types` that only collects the extensions without modifying the `OpType`. 

Fixes the resolution not exploring types inside a `CustomType` type arguments.

drive-by: Implement `Display`, `Serialize`, and `::new` for `ExtensionRegistry`.
drive-by: `ExtensionSet` should take ids by value when inserting.
drive-by: Fix `Hugr::resolve_extension_defs` not scanning all the ops.

These changes were extracted from #1738.

BREAKING CHANGE: Removed `ExtensionRegistry::try_new`. Use `new` instead, and call `ExtensionRegistry::validate` to validate.
BREAKING CHANGE: `ExtensionSet::insert` and `singleton` take extension ids by value instead of cloning internally.