### PR TITLE
tests: [Very WIP] Better proptests for Type

### DIFF
--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -998,5 +998,28 @@ pub(crate) mod test {
             }
             s
         }
+
+        struct MakePair<S, T>(S, T);
+
+        impl<A, B, S: VarEnvState<A>, T: VarEnvState<B> + Clone> VarEnvState<(A, B)> for MakePair<S, T>
+        where
+            A: std::fmt::Debug + Clone,
+            B: std::fmt::Debug,
+        {
+            fn with_env(
+                self,
+                env: Vec<TypeParam>,
+                reg: Arc<ExtensionRegistry>,
+            ) -> impl Strategy<Value = ((A, B), Vec<TypeParam>)> + Clone {
+                self.0
+                    .with_env(env, reg.clone())
+                    .prop_flat_map(move |(v1, env)| {
+                        self.1
+                            .clone()
+                            .with_env(env, reg.clone())
+                            .prop_map(move |(v2, env)| ((v1.clone(), v2), env))
+                    })
+            }
+        }
     }
 }

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -108,7 +108,7 @@ impl TypeParam {
         }
     }
 
-    fn contains(&self, other: &TypeParam) -> bool {
+    pub(super) fn contains(&self, other: &TypeParam) -> bool {
         match (self, other) {
             (TypeParam::Type { b: b1 }, TypeParam::Type { b: b2 }) => b1.contains(*b2),
             (TypeParam::BoundedNat { bound: b1 }, TypeParam::BoundedNat { bound: b2 }) => {


### PR DESCRIPTION
* Produce Type/etc. containing variables, plus an appropriate `Vec<TypeParam>` declaring all variables that are used
* Goal is for the type to validate with that environment....
* ...and to be able to produce a list of TypeArg's "fitting" the declared TypeParams, such that substitution also succeeds

but not there yet!