### PR TITLE
feat: Scoping rules and utilities for symbols, links and variables

### DIFF
--- a/hugr-core/tests/snapshots/model__roundtrip_add.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_add.snap
@@ -1,8 +1,12 @@
 ---
 source: hugr-core/tests/model.rs
-expression: "roundtrip(include_str!(\"fixtures/model-add.edn\"))"
+expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-add.edn\"))"
 ---
 (hugr 0)
+
+(import arithmetic.int.iadd)
+
+(import arithmetic.int.types.int)
 
 (define-func example.add
   [(@ arithmetic.int.types.int) (@ arithmetic.int.types.int)]

--- a/hugr-core/tests/snapshots/model__roundtrip_alias.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_alias.snap
@@ -1,8 +1,10 @@
 ---
 source: hugr-core/tests/model.rs
-expression: "roundtrip(include_str!(\"fixtures/model-alias.edn\"))"
+expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-alias.edn\"))"
 ---
 (hugr 0)
+
+(import arithmetic.int.types.int)
 
 (declare-alias local.float type)
 

--- a/hugr-core/tests/snapshots/model__roundtrip_call.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_call.snap
@@ -4,6 +4,10 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-call
 ---
 (hugr 0)
 
+(import prelude.json)
+
+(import arithmetic.int.types.int)
+
 (declare-func example.callee
   (forall ?0 ext-set)
   [(@ arithmetic.int.types.int)]

--- a/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
@@ -13,14 +13,14 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cfg.
     (cfg [%0] [%1]
       (signature (fn [?0] [?0] (ext)))
       (cfg
-        [%2] [%8]
+        [%4] [%8]
         (signature (fn [?0] [?0] (ext)))
-        (block [%2] [%5]
+        (block [%4] [%5]
           (signature (fn [(ctrl [?0])] [(ctrl [?0])] (ext)))
           (dfg
-            [%3] [%4]
+            [%2] [%3]
             (signature (fn [?0] [(adt [[?0]])] (ext)))
-            (tag 0 [%3] [%4] (signature (fn [?0] [(adt [[?0]])] (ext))))))
+            (tag 0 [%2] [%3] (signature (fn [?0] [(adt [[?0]])] (ext))))))
         (block [%5] [%8]
           (signature (fn [(ctrl [?0])] [(ctrl [?0])] (ext)))
           (dfg

--- a/hugr-core/tests/snapshots/model__roundtrip_cond.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_cond.snap
@@ -1,8 +1,12 @@
 ---
 source: hugr-core/tests/model.rs
-expression: "roundtrip(include_str!(\"fixtures/model-cond.edn\"))"
+expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cond.edn\"))"
 ---
 (hugr 0)
+
+(import arithmetic.int.types.int)
+
+(import arithmetic.int.ineg)
 
 (define-func example.cond
   [(adt [[] []]) (@ arithmetic.int.types.int)]

--- a/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
@@ -4,6 +4,8 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
 ---
 (hugr 0)
 
+(import prelude.Array)
+
 (declare-func array.replicate
   (forall ?0 type)
   (forall ?1 nat)

--- a/hugr-model/capnp/hugr-v0.capnp
+++ b/hugr-model/capnp/hugr-v0.capnp
@@ -15,6 +15,9 @@ using NodeId = UInt32;
 # The id of a `Link`.
 using LinkId = UInt32;
 
+# The index of a `Link`.
+using LinkIndex = UInt32;
+
 struct Module {
     root @0 :RegionId;
     nodes @1 :List(Node);
@@ -24,8 +27,8 @@ struct Module {
 
 struct Node {
     operation @0 :Operation;
-    inputs @1 :List(LinkRef);
-    outputs @2 :List(LinkRef);
+    inputs @1 :List(LinkIndex);
+    outputs @2 :List(LinkIndex);
     params @3 :List(TermId);
     regions @4 :List(RegionId);
     meta @5 :List(MetaItem);
@@ -42,8 +45,8 @@ struct Operation {
         funcDecl @5 :FuncDecl;
         aliasDefn @6 :AliasDefn;
         aliasDecl @7 :AliasDecl;
-        custom @8 :GlobalRef;
-        customFull @9 :GlobalRef;
+        custom @8 :NodeId;
+        customFull @9 :NodeId;
         tag @10 :UInt16;
         tailLoop @11 :Void;
         conditional @12 :Void;
@@ -51,6 +54,7 @@ struct Operation {
         loadFunc @14 :TermId;
         constructorDecl @15 :ConstructorDecl;
         operationDecl @16 :OperationDecl;
+        import @17 :Text;
     }
 
     struct FuncDefn {
@@ -97,12 +101,21 @@ struct Operation {
 
 struct Region {
     kind @0 :RegionKind;
-    sources @1 :List(LinkRef);
-    targets @2 :List(LinkRef);
+    sources @1 :List(LinkIndex);
+    targets @2 :List(LinkIndex);
     children @3 :List(NodeId);
     meta @4 :List(MetaItem);
     signature @5 :OptionalTermId;
+    scope @6 :RegionScope;
 }
+
+struct RegionScope {
+    links @0 :UInt32;
+    ports @1 :UInt32;
+}
+
+# Either `0` for an open scope, or the number of links in the closed scope incremented by `1`.
+using LinkScope = UInt32;
 
 enum RegionKind {
     dataFlow @0;
@@ -115,37 +128,16 @@ struct MetaItem {
     value @1 :UInt32;
 }
 
-struct LinkRef {
-    union {
-        id @0 :LinkId;
-        named @1 :Text;
-    }
-}
-
-struct GlobalRef {
-    union {
-        node @0 :NodeId;
-        named @1 :Text;
-    }
-}
-
-struct LocalRef {
-    union {
-        direct :group {
-            index @0 :UInt16;
-            node @1 :NodeId;
-        }
-        named @2 :Text;
-    }
-}
-
 struct Term {
     union {
         wildcard @0 :Void;
         runtimeType @1 :Void;
         staticType @2 :Void;
         constraint @3 :Void;
-        variable @4 :LocalRef;
+        variable :group {
+            variableNode @4 :NodeId;
+            variableIndex @21 :UInt16;
+        }
         apply @5 :Apply;
         applyFull @6 :ApplyFull;
         quote @7 :TermId;
@@ -165,12 +157,12 @@ struct Term {
     }
 
     struct Apply {
-        global @0 :GlobalRef;
+        symbol @0 :NodeId;
         args @1 :List(TermId);
     }
 
     struct ApplyFull {
-        global @0 :GlobalRef;
+        symbol @0 :NodeId;
         args @1 :List(TermId);
     }
 

--- a/hugr-model/src/v0/scope/link.rs
+++ b/hugr-model/src/v0/scope/link.rs
@@ -37,7 +37,13 @@ type FxIndexSet<K> = IndexSet<K, BuildHasherDefault<FxHasher>>;
 /// ```
 #[derive(Debug, Clone)]
 pub struct LinkTable<K> {
+    /// The set of links in the currently active region and all parent regions.
+    ///
+    /// The order in this index set is the order in which links were added to the table.
+    /// This is used to efficiently remove all links from the current region when exiting a scope.
     links: FxIndexSet<(RegionId, K)>,
+
+    /// The stack of scopes that are currently open.
     scopes: Vec<LinkScope>,
 }
 

--- a/hugr-model/src/v0/scope/link.rs
+++ b/hugr-model/src/v0/scope/link.rs
@@ -1,0 +1,119 @@
+use std::hash::{BuildHasherDefault, Hash};
+
+use fxhash::FxHasher;
+use indexmap::IndexSet;
+
+use crate::v0::{LinkIndex, RegionId};
+
+type FxIndexSet<K> = IndexSet<K, BuildHasherDefault<FxHasher>>;
+
+/// Table for tracking links between ports.
+///
+/// Two ports are connected when they share the same link. Links are named and
+/// scoped via closed regions. Links from one closed region are not visible
+/// in another. Open regions are considered to form the same scope as their
+/// parent region. Links do not have a unique point of declaration.
+///
+/// The link table keeps track of an association between a key of type `K` and
+/// the link indices within each closed region. When resolving links from a text format,
+/// `K` is the name of the link as a string slice. However the link table might
+/// is also useful in other contexts where the key is not a string when constructing
+/// a module from a different representation.
+///
+/// # Examples
+///
+/// ```
+/// # pub use hugr_model::v0::RegionId;
+/// # pub use hugr_model::v0::scope::LinkTable;
+/// let mut links = LinkTable::new();
+/// links.enter(RegionId(0));
+/// let foo_0 = links.use_link("foo");
+/// let bar_0 = links.use_link("bar");
+/// assert_eq!(foo_0, links.use_link("foo"));
+/// assert_eq!(bar_0, links.use_link("bar"));
+/// let (num_links, num_ports) = links.exit();
+/// assert_eq!(num_links, 2);
+/// assert_eq!(num_ports, 4);
+/// ```
+#[derive(Debug, Clone)]
+pub struct LinkTable<K> {
+    links: FxIndexSet<(RegionId, K)>,
+    scopes: Vec<LinkScope>,
+}
+
+impl<K> LinkTable<K>
+where
+    K: Copy + Eq + Hash,
+{
+    /// Create a new empty link table.
+    pub fn new() -> Self {
+        Self {
+            links: FxIndexSet::default(),
+            scopes: Vec::new(),
+        }
+    }
+
+    /// Enter a new scope for the given closed region.
+    pub fn enter(&mut self, region: RegionId) {
+        self.scopes.push(LinkScope {
+            link_stack: self.links.len(),
+            link_count: 0,
+            port_count: 0,
+            region,
+        });
+    }
+
+    /// Exit a previously entered scope, returning the number of links and ports in the scope.
+    pub fn exit(&mut self) -> (u32, u32) {
+        let scope = self.scopes.pop().unwrap();
+        self.links.drain(scope.link_stack..);
+        debug_assert_eq!(self.links.len(), scope.link_stack);
+        (scope.link_count, scope.port_count)
+    }
+
+    /// Resolve a link key to a link index, adding one more port to the current scope.
+    ///
+    /// If the key has not been used in the current scope before, it will be added to the link table.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no open scopes.
+    pub fn use_link(&mut self, key: K) -> LinkIndex {
+        let scope = self.scopes.last_mut().unwrap();
+        let (map_index, inserted) = self.links.insert_full((scope.region, key));
+
+        if inserted {
+            scope.link_count += 1;
+        }
+
+        scope.port_count += 1;
+        LinkIndex::new(map_index - scope.link_stack)
+    }
+
+    /// Reset the link table to an empty state while preserving allocated memory.
+    pub fn clear(&mut self) {
+        self.links.clear();
+        self.scopes.clear();
+    }
+}
+
+impl<K> Default for LinkTable<K>
+where
+    K: Copy + Eq + Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LinkScope {
+    /// The length of `LinkTable::links` when the scope was opened.
+    link_stack: usize,
+    /// The number of links in this scope.
+    link_count: u32,
+    /// The number of ports in this scope.
+    port_count: u32,
+    /// The region that introduces this scope.
+    region: RegionId,
+}

--- a/hugr-model/src/v0/scope/mod.rs
+++ b/hugr-model/src/v0/scope/mod.rs
@@ -1,0 +1,8 @@
+//! Utilities for working with scoped symbols, variables and links.
+mod link;
+mod symbol;
+mod vars;
+
+pub use link::LinkTable;
+pub use symbol::{DuplicateSymbolError, SymbolTable, UnknownSymbolError};
+pub use vars::{DuplicateVarError, UnknownVarError, VarTable};

--- a/hugr-model/src/v0/scope/symbol.rs
+++ b/hugr-model/src/v0/scope/symbol.rs
@@ -1,0 +1,198 @@
+use std::{borrow::Cow, hash::BuildHasherDefault};
+
+use fxhash::FxHasher;
+use indexmap::IndexMap;
+use thiserror::Error;
+
+use crate::v0::{NodeId, RegionId};
+
+type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+
+/// Symbol binding table that keeps track of symbol resolution and scoping.
+///
+/// Nodes may introduce a symbol so that other parts of the IR can refer to the
+/// node. Symbols have an associated name and are scoped via regions. A symbol
+/// can shadow another symbol with the same name from an outer region, but
+/// within any single region each symbol name must be unique.
+///
+/// When a symbol is referred to directly by the id of the node, the symbol must
+/// be in scope at the point of reference as if the reference was by name. This
+/// guarantees that transformations between directly indexed and named formats
+/// are always valid.
+///
+/// # Examples
+///
+/// ```
+/// # pub use hugr_model::v0::{NodeId, RegionId};
+/// # pub use hugr_model::v0::scope::SymbolTable;
+/// let mut symbols = SymbolTable::new();
+/// symbols.enter(RegionId(0));
+/// symbols.insert("foo", NodeId(0)).unwrap();
+/// assert_eq!(symbols.resolve("foo").unwrap(), NodeId(0));
+/// symbols.enter(RegionId(1));
+/// assert_eq!(symbols.resolve("foo").unwrap(), NodeId(0));
+/// symbols.insert("foo", NodeId(1)).unwrap();
+/// assert_eq!(symbols.resolve("foo").unwrap(), NodeId(1));
+/// assert!(!symbols.is_visible(NodeId(0)));
+/// symbols.exit();
+/// assert_eq!(symbols.resolve("foo").unwrap(), NodeId(0));
+/// assert!(symbols.is_visible(NodeId(0)));
+/// assert!(!symbols.is_visible(NodeId(1)));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct SymbolTable<'a> {
+    symbols: FxIndexMap<&'a str, BindingIndex>,
+    bindings: FxIndexMap<NodeId, Binding>,
+    scopes: FxIndexMap<RegionId, Scope>,
+}
+
+impl<'a> SymbolTable<'a> {
+    /// Create a new symbol table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enter a new scope for the given region.
+    pub fn enter(&mut self, region: RegionId) {
+        self.scopes.insert(
+            region,
+            Scope {
+                binding_stack: self.bindings.len(),
+            },
+        );
+    }
+
+    /// Exit a previously entered scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no remaining open scopes.
+    pub fn exit(&mut self) {
+        let (_, scope) = self.scopes.pop().unwrap();
+
+        for _ in scope.binding_stack..self.bindings.len() {
+            let (_, binding) = self.bindings.pop().unwrap();
+
+            if let Some(shadows) = binding.shadows {
+                self.symbols[binding.symbol_index] = shadows;
+            } else {
+                let last = self.symbols.pop();
+                debug_assert_eq!(last.unwrap().1, self.bindings.len());
+            }
+        }
+    }
+
+    /// Insert a new symbol into the current scope.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the symbol is already defined in the current scope.
+    /// In the case of an error the table remains unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is no current scope.
+    pub fn insert(&mut self, name: &'a str, node: NodeId) -> Result<(), DuplicateSymbolError> {
+        let scope_depth = self.scopes.len() as u16 - 1;
+        let (symbol_index, shadowed) = self.symbols.insert_full(name, self.bindings.len());
+
+        if let Some(shadowed) = shadowed {
+            let (shadowed_node, shadowed_binding) = self.bindings.get_index(shadowed).unwrap();
+            if shadowed_binding.scope_depth == scope_depth {
+                self.symbols.insert(name, shadowed);
+                return Err(DuplicateSymbolError(name.into(), node, *shadowed_node));
+            }
+        }
+
+        self.bindings.insert(
+            node,
+            Binding {
+                scope_depth,
+                shadows: shadowed,
+                symbol_index,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Check whether a symbol is currently visible in the current scope.
+    pub fn is_visible(&self, node: NodeId) -> bool {
+        let Some(binding) = self.bindings.get(&node) else {
+            return false;
+        };
+
+        // Check that the symbol has not been shadowed at this point.
+        self.symbols[binding.symbol_index] == binding.symbol_index
+    }
+
+    /// Tries to resolve a symbol name in the current scope.
+    pub fn resolve(&self, name: &'a str) -> Result<NodeId, UnknownSymbolError> {
+        let index = *self
+            .symbols
+            .get(name)
+            .ok_or(UnknownSymbolError(name.into()))?;
+
+        // NOTE: The unwrap is safe because the `symbols` map
+        // points to valid indices in the `bindings` map.
+        let (node, _) = self.bindings.get_index(index).unwrap();
+        Ok(*node)
+    }
+
+    /// Returns the depth of the given region, if it corresponds to a currently open scope.
+    pub fn region_to_depth(&self, region: RegionId) -> Option<ScopeDepth> {
+        Some(self.scopes.get_index_of(&region)? as _)
+    }
+
+    /// Returns the region corresponding to the scope at the given depth.
+    pub fn depth_to_region(&self, depth: ScopeDepth) -> Option<RegionId> {
+        let (region, _) = self.scopes.get_index(depth as _)?;
+        Some(*region)
+    }
+
+    /// Resets the symbol table to its initial state while maintaining its
+    /// allocated memory.
+    pub fn clear(&mut self) {
+        self.symbols.clear();
+        self.bindings.clear();
+        self.scopes.clear();
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Binding {
+    /// The depth of the scope in which this binding is defined.
+    scope_depth: ScopeDepth,
+
+    /// The index of the binding that is shadowed by this one, if any.
+    shadows: Option<BindingIndex>,
+
+    /// The index of this binding's symbol in the symbol table.
+    ///
+    /// The symbol table always points to the currently visible binding for a
+    /// symbol. Therefore this index is only valid if this binding is not shadowed.
+    /// In particular, we detect shadowing by checking if the entry in the symbol
+    /// table at this index does indeed point to this binding.
+    symbol_index: SymbolIndex,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Scope {
+    /// The length of the `bindings` stack when this scope was entered.
+    binding_stack: usize,
+}
+
+type BindingIndex = usize;
+type SymbolIndex = usize;
+
+pub type ScopeDepth = u16;
+
+/// Error that occurs when trying to resolve an unknown symbol.
+#[derive(Debug, Clone, Error)]
+#[error("symbol name `{0}` not found in this scope")]
+pub struct UnknownSymbolError<'a>(pub Cow<'a, str>);
+
+/// Error that occurs when trying to introduce a symbol that is already defined in the current scope.
+#[derive(Debug, Clone, Error)]
+#[error("symbol `{0}` is already defined in this scope")]
+pub struct DuplicateSymbolError<'a>(pub Cow<'a, str>, pub NodeId, pub NodeId);

--- a/hugr-model/src/v0/scope/vars.rs
+++ b/hugr-model/src/v0/scope/vars.rs
@@ -38,7 +38,12 @@ type FxIndexSet<K> = IndexSet<K, BuildHasherDefault<FxHasher>>;
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct VarTable<'a> {
+    /// The set of variables in the currently active node and all its parent nodes.
+    ///
+    /// The order in this index set is the order in which variables were added to the table.
+    /// This is used to efficiently remove all variables from the current node when exiting a scope.
     vars: FxIndexSet<(NodeId, &'a str)>,
+    /// The stack of scopes that are currently open.
     scopes: Vec<VarScope>,
 }
 

--- a/hugr-model/src/v0/scope/vars.rs
+++ b/hugr-model/src/v0/scope/vars.rs
@@ -1,0 +1,146 @@
+use fxhash::FxHasher;
+use indexmap::IndexSet;
+use std::hash::BuildHasherDefault;
+use thiserror::Error;
+
+use crate::v0::{NodeId, VarId};
+
+type FxIndexSet<K> = IndexSet<K, BuildHasherDefault<FxHasher>>;
+
+/// Table for keeping track of node parameters.
+///
+/// Variables refer to the parameters of a node which introduces a symbol.
+/// Variables have an associated name and are scoped via nodes. The types of
+/// parameters of a node may only refer to earlier parameters in the same node
+/// in the order they are defined. A variable name must be unique within a
+/// single node. Each node that introduces a symbol introduces a new isolated
+/// scope for variables.
+///
+/// # Examples
+///
+/// ```
+/// # pub use hugr_model::v0::{NodeId, VarId};
+/// # pub use hugr_model::v0::scope::VarTable;
+/// let mut vars = VarTable::new();
+/// vars.enter(NodeId(0));
+/// vars.insert("foo").unwrap();
+/// assert_eq!(vars.resolve("foo").unwrap(), VarId(NodeId(0), 0));
+/// assert!(!vars.is_visible(VarId(NodeId(0), 1)));
+/// vars.insert("bar").unwrap();
+/// assert!(vars.is_visible(VarId(NodeId(0), 1)));
+/// assert_eq!(vars.resolve("bar").unwrap(), VarId(NodeId(0), 1));
+/// vars.enter(NodeId(1));
+/// assert!(vars.resolve("foo").is_err());
+/// assert!(!vars.is_visible(VarId(NodeId(0), 0)));
+/// vars.exit();
+/// assert_eq!(vars.resolve("foo").unwrap(), VarId(NodeId(0), 0));
+/// assert!(vars.is_visible(VarId(NodeId(0), 0)));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct VarTable<'a> {
+    vars: FxIndexSet<(NodeId, &'a str)>,
+    scopes: Vec<VarScope>,
+}
+
+impl<'a> VarTable<'a> {
+    /// Create a new empty variable table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enter a new scope for the given node.
+    pub fn enter(&mut self, node: NodeId) {
+        self.scopes.push(VarScope {
+            node,
+            var_count: 0,
+            var_stack: self.vars.len(),
+        })
+    }
+
+    /// Exit a previously entered scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no open scopes.
+    pub fn exit(&mut self) {
+        let scope = self.scopes.pop().unwrap();
+        self.vars.drain(scope.var_stack..);
+    }
+
+    /// Resolve a variable name to a node and variable index.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the variable is not defined in the current scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no open scopes.
+    pub fn resolve(&self, name: &'a str) -> Result<VarId, UnknownVarError<'a>> {
+        let scope = self.scopes.last().unwrap();
+        let set_index = self
+            .vars
+            .get_index_of(&(scope.node, name))
+            .ok_or(UnknownVarError(scope.node, name))?;
+        let var_index = (set_index - scope.var_stack) as u16;
+        Ok(VarId(scope.node, var_index))
+    }
+
+    /// Check if a variable is visible in the current scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no open scopes.
+    pub fn is_visible(&self, var: VarId) -> bool {
+        let scope = self.scopes.last().unwrap();
+        scope.node == var.0 && var.1 < scope.var_count
+    }
+
+    /// Insert a new variable into the current scope.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the variable is already defined in the current scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no open scopes.
+    pub fn insert(&mut self, name: &'a str) -> Result<VarId, DuplicateVarError<'a>> {
+        let scope = self.scopes.last_mut().unwrap();
+        let inserted = self.vars.insert((scope.node, name));
+
+        if !inserted {
+            return Err(DuplicateVarError(scope.node, name));
+        }
+
+        let var_index = scope.var_count;
+        scope.var_count += 1;
+        Ok(VarId(scope.node, var_index))
+    }
+
+    /// Reset the variable table to an empty state while preserving the allocations.
+    pub fn clear(&mut self) {
+        self.vars.clear();
+        self.scopes.clear();
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VarScope {
+    /// The node that introduces this scope.
+    node: NodeId,
+    /// The number of variables in this scope.
+    var_count: u16,
+    /// The length of `VarTable::vars` when the scope was opened.
+    var_stack: usize,
+}
+
+/// Error that occurs when a node defines two parameters with the same name.
+#[derive(Debug, Clone, Error)]
+#[error("node {0} already has a variable named `{1}`")]
+pub struct DuplicateVarError<'a>(NodeId, &'a str);
+
+/// Error that occurs when a variable is not defined in the current scope.
+#[derive(Debug, Clone, Error)]
+#[error("can not resolve variable `{1}` in node {0}")]
+pub struct UnknownVarError<'a>(NodeId, &'a str);

--- a/hugr-model/src/v0/text/hugr.pest
+++ b/hugr-model/src/v0/text/hugr.pest
@@ -34,6 +34,7 @@ node = {
   | node_tail_loop
   | node_cond
   | node_tag
+  | node_import
   | node_custom
 }
 
@@ -51,6 +52,7 @@ node_declare_operation = { "(" ~ "declare-operation" ~ operation_header ~ meta* 
 node_tail_loop         = { "(" ~ "tail-loop" ~ port_lists? ~ signature? ~ meta* ~ region* ~ ")" }
 node_cond              = { "(" ~ "cond" ~ port_lists? ~ signature? ~ meta* ~ region* ~ ")" }
 node_tag               = { "(" ~ "tag" ~ tag ~ port_lists? ~ signature? ~ meta* ~ region* ~ ")" }
+node_import            = { "(" ~ "import" ~ symbol ~ meta* ~ ")" }
 node_custom            = { "(" ~ (term_apply | term_apply_full) ~ port_lists? ~ signature? ~ meta* ~ region* ~ ")" }
 
 signature        = { "(" ~ "signature" ~ term ~ ")" }

--- a/hugr-model/src/v0/text/parse.rs
+++ b/hugr-model/src/v0/text/parse.rs
@@ -1,4 +1,5 @@
 use bumpalo::{collections::String as BumpString, collections::Vec as BumpVec, Bump};
+use fxhash::FxHashMap;
 use pest::{
     iterators::{Pair, Pairs},
     Parser, RuleType,
@@ -6,9 +7,10 @@ use pest::{
 use thiserror::Error;
 
 use crate::v0::{
-    AliasDecl, ConstructorDecl, ExtSetPart, FuncDecl, GlobalRef, LinkRef, ListPart, LocalRef,
-    MetaItem, Module, Node, NodeId, Operation, OperationDecl, Param, ParamSort, Region, RegionId,
-    RegionKind, Term, TermId,
+    scope::{LinkTable, SymbolTable, UnknownSymbolError, VarTable},
+    AliasDecl, ConstructorDecl, ExtSetPart, FuncDecl, LinkIndex, ListPart, MetaItem, Module, Node,
+    NodeId, Operation, OperationDecl, Param, ParamSort, Region, RegionId, RegionKind, RegionScope,
+    ScopeClosure, Term, TermId,
 };
 
 mod pest_parser {
@@ -50,12 +52,20 @@ pub fn parse<'a>(input: &'a str, bump: &'a Bump) -> Result<ParsedModule<'a>, Par
 struct ParseContext<'a> {
     module: Module<'a>,
     bump: &'a Bump,
+    vars: VarTable<'a>,
+    links: LinkTable<&'a str>,
+    symbols: SymbolTable<'a>,
+    implicit_imports: FxHashMap<&'a str, NodeId>,
 }
 
 impl<'a> ParseContext<'a> {
     fn new(bump: &'a Bump) -> Self {
         Self {
             module: Module::default(),
+            symbols: SymbolTable::default(),
+            links: LinkTable::default(),
+            vars: VarTable::default(),
+            implicit_imports: FxHashMap::default(),
             bump,
         }
     }
@@ -63,20 +73,38 @@ impl<'a> ParseContext<'a> {
     fn parse_module(&mut self, pair: Pair<'a, Rule>) -> ParseResult<()> {
         debug_assert_eq!(pair.as_rule(), Rule::module);
         let mut inner = pair.into_inner();
+
+        self.module.root = self.module.insert_region(Region::default());
+        self.symbols.enter(self.module.root);
+        self.links.enter(self.module.root);
+
+        // TODO: What scope does the metadata live in?
         let meta = self.parse_meta(&mut inner)?;
+        let explicit_children = self.parse_nodes(&mut inner)?;
 
-        let children = self.parse_nodes(&mut inner)?;
+        let mut children = BumpVec::with_capacity_in(
+            explicit_children.len() + self.implicit_imports.len(),
+            self.bump,
+        );
+        children.extend(explicit_children);
+        children.extend(self.implicit_imports.drain().map(|(_, node)| node));
+        let children = children.into_bump_slice();
 
-        let root_region = self.module.insert_region(Region {
+        let (link_count, port_count) = self.links.exit();
+        self.symbols.exit();
+
+        self.module.regions[self.module.root.index()] = Region {
             kind: RegionKind::Module,
             sources: &[],
             targets: &[],
             children,
             meta,
             signature: None,
-        });
-
-        self.module.root = root_region;
+            scope: Some(RegionScope {
+                links: link_count,
+                ports: port_count,
+            }),
+        };
 
         Ok(())
     }
@@ -87,143 +115,195 @@ impl<'a> ParseContext<'a> {
         let rule = pair.as_rule();
         let mut inner = pair.into_inner();
 
-        let term = match rule {
-            Rule::term_wildcard => Term::Wildcard,
-            Rule::term_type => Term::Type,
-            Rule::term_static => Term::StaticType,
-            Rule::term_constraint => Term::Constraint,
-            Rule::term_str_type => Term::StrType,
-            Rule::term_nat_type => Term::NatType,
-            Rule::term_ctrl_type => Term::ControlType,
-            Rule::term_ext_set_type => Term::ExtSetType,
+        let term =
+            match rule {
+                Rule::term_wildcard => Term::Wildcard,
+                Rule::term_type => Term::Type,
+                Rule::term_static => Term::StaticType,
+                Rule::term_constraint => Term::Constraint,
+                Rule::term_str_type => Term::StrType,
+                Rule::term_nat_type => Term::NatType,
+                Rule::term_ctrl_type => Term::ControlType,
+                Rule::term_ext_set_type => Term::ExtSetType,
 
-            Rule::term_var => {
-                let name_token = inner.next().unwrap();
-                let name = name_token.as_str();
-                Term::Var(LocalRef::Named(name))
-            }
+                Rule::term_var => {
+                    let name_token = inner.next().unwrap();
+                    let name = name_token.as_str();
 
-            Rule::term_apply => {
-                let name = GlobalRef::Named(self.parse_symbol(&mut inner)?);
-                let mut args = Vec::new();
+                    let var = self.vars.resolve(name).map_err(|err| {
+                        ParseError::custom(&err.to_string(), name_token.as_span())
+                    })?;
 
-                for token in inner {
-                    args.push(self.parse_term(token)?);
+                    Term::Var(var)
                 }
 
-                Term::Apply {
-                    global: name,
-                    args: self.bump.alloc_slice_copy(&args),
-                }
-            }
+                Rule::term_apply => {
+                    let symbol = self.parse_symbol_use(&mut inner)?;
+                    let mut args = Vec::new();
 
-            Rule::term_apply_full => {
-                let name = GlobalRef::Named(self.parse_symbol(&mut inner)?);
-                let mut args = Vec::new();
+                    for token in inner {
+                        args.push(self.parse_term(token)?);
+                    }
 
-                for token in inner {
-                    args.push(self.parse_term(token)?);
-                }
-
-                Term::ApplyFull {
-                    global: name,
-                    args: self.bump.alloc_slice_copy(&args),
-                }
-            }
-
-            Rule::term_quote => {
-                let r#type = self.parse_term(inner.next().unwrap())?;
-                Term::Quote { r#type }
-            }
-
-            Rule::term_list => {
-                let mut parts = BumpVec::with_capacity_in(inner.len(), self.bump);
-
-                for token in inner {
-                    match token.as_rule() {
-                        Rule::term => parts.push(ListPart::Item(self.parse_term(token)?)),
-                        Rule::spliced_term => {
-                            let term_token = token.into_inner().next().unwrap();
-                            parts.push(ListPart::Splice(self.parse_term(term_token)?))
-                        }
-                        _ => unreachable!(),
+                    Term::Apply {
+                        symbol,
+                        args: self.bump.alloc_slice_copy(&args),
                     }
                 }
 
-                Term::List {
-                    parts: parts.into_bump_slice(),
-                }
-            }
+                Rule::term_apply_full => {
+                    let symbol = self.parse_symbol_use(&mut inner)?;
+                    let mut args = Vec::new();
 
-            Rule::term_list_type => {
-                let item_type = self.parse_term(inner.next().unwrap())?;
-                Term::ListType { item_type }
-            }
+                    for token in inner {
+                        args.push(self.parse_term(token)?);
+                    }
 
-            Rule::term_str => {
-                let value = self.parse_string(inner.next().unwrap())?;
-                Term::Str(value)
-            }
-
-            Rule::term_nat => {
-                let value = inner.next().unwrap().as_str().parse().unwrap();
-                Term::Nat(value)
-            }
-
-            Rule::term_ext_set => {
-                let mut parts = BumpVec::with_capacity_in(inner.len(), self.bump);
-
-                for token in inner {
-                    match token.as_rule() {
-                        Rule::ext_name => {
-                            parts.push(ExtSetPart::Extension(self.bump.alloc_str(token.as_str())))
-                        }
-                        Rule::spliced_term => {
-                            let term_token = token.into_inner().next().unwrap();
-                            parts.push(ExtSetPart::Splice(self.parse_term(term_token)?))
-                        }
-                        _ => unreachable!(),
+                    Term::ApplyFull {
+                        symbol,
+                        args: self.bump.alloc_slice_copy(&args),
                     }
                 }
 
-                Term::ExtSet {
-                    parts: parts.into_bump_slice(),
+                Rule::term_quote => {
+                    let r#type = self.parse_term(inner.next().unwrap())?;
+                    Term::Quote { r#type }
                 }
-            }
 
-            Rule::term_adt => {
-                let variants = self.parse_term(inner.next().unwrap())?;
-                Term::Adt { variants }
-            }
+                Rule::term_list => {
+                    let mut parts = BumpVec::with_capacity_in(inner.len(), self.bump);
 
-            Rule::term_func_type => {
-                let inputs = self.parse_term(inner.next().unwrap())?;
-                let outputs = self.parse_term(inner.next().unwrap())?;
-                let extensions = self.parse_term(inner.next().unwrap())?;
-                Term::FuncType {
-                    inputs,
-                    outputs,
-                    extensions,
+                    for token in inner {
+                        match token.as_rule() {
+                            Rule::term => parts.push(ListPart::Item(self.parse_term(token)?)),
+                            Rule::spliced_term => {
+                                let term_token = token.into_inner().next().unwrap();
+                                parts.push(ListPart::Splice(self.parse_term(term_token)?))
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+
+                    Term::List {
+                        parts: parts.into_bump_slice(),
+                    }
                 }
-            }
 
-            Rule::term_ctrl => {
-                let values = self.parse_term(inner.next().unwrap())?;
-                Term::Control { values }
-            }
+                Rule::term_list_type => {
+                    let item_type = self.parse_term(inner.next().unwrap())?;
+                    Term::ListType { item_type }
+                }
 
-            Rule::term_non_linear => {
-                let term = self.parse_term(inner.next().unwrap())?;
-                Term::NonLinearConstraint { term }
-            }
+                Rule::term_str => {
+                    let value = self.parse_string(inner.next().unwrap())?;
+                    Term::Str(value)
+                }
 
-            r => unreachable!("term: {:?}", r),
-        };
+                Rule::term_nat => {
+                    let value = inner.next().unwrap().as_str().parse().unwrap();
+                    Term::Nat(value)
+                }
+
+                Rule::term_ext_set => {
+                    let mut parts = BumpVec::with_capacity_in(inner.len(), self.bump);
+
+                    for token in inner {
+                        match token.as_rule() {
+                            Rule::ext_name => parts
+                                .push(ExtSetPart::Extension(self.bump.alloc_str(token.as_str()))),
+                            Rule::spliced_term => {
+                                let term_token = token.into_inner().next().unwrap();
+                                parts.push(ExtSetPart::Splice(self.parse_term(term_token)?))
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+
+                    Term::ExtSet {
+                        parts: parts.into_bump_slice(),
+                    }
+                }
+
+                Rule::term_adt => {
+                    let variants = self.parse_term(inner.next().unwrap())?;
+                    Term::Adt { variants }
+                }
+
+                Rule::term_func_type => {
+                    let inputs = self.parse_term(inner.next().unwrap())?;
+                    let outputs = self.parse_term(inner.next().unwrap())?;
+                    let extensions = self.parse_term(inner.next().unwrap())?;
+                    Term::FuncType {
+                        inputs,
+                        outputs,
+                        extensions,
+                    }
+                }
+
+                Rule::term_ctrl => {
+                    let values = self.parse_term(inner.next().unwrap())?;
+                    Term::Control { values }
+                }
+
+                Rule::term_non_linear => {
+                    let term = self.parse_term(inner.next().unwrap())?;
+                    Term::NonLinearConstraint { term }
+                }
+
+                r => unreachable!("term: {:?}", r),
+            };
 
         Ok(self.module.insert_term(term))
     }
 
-    fn parse_node(&mut self, pair: Pair<'a, Rule>) -> ParseResult<NodeId> {
+    fn parse_node_shallow(&mut self, pair: Pair<'a, Rule>) -> ParseResult<NodeId> {
+        debug_assert_eq!(pair.as_rule(), Rule::node);
+        let pair = pair.into_inner().next().unwrap();
+        let span = pair.as_span();
+        let rule = pair.as_rule();
+        let mut inner = pair.into_inner();
+
+        let symbol = match rule {
+            Rule::node_define_func => {
+                let mut func_header = inner.next().unwrap().into_inner();
+                Some(self.parse_symbol(&mut func_header)?)
+            }
+            Rule::node_declare_func => {
+                let mut func_header = inner.next().unwrap().into_inner();
+                Some(self.parse_symbol(&mut func_header)?)
+            }
+            Rule::node_define_alias => {
+                let mut alias_header = inner.next().unwrap().into_inner();
+                Some(self.parse_symbol(&mut alias_header)?)
+            }
+            Rule::node_declare_alias => {
+                let mut alias_header = inner.next().unwrap().into_inner();
+                Some(self.parse_symbol(&mut alias_header)?)
+            }
+            Rule::node_declare_ctr => {
+                let mut ctr_header = inner.next().unwrap().into_inner();
+                Some(self.parse_symbol(&mut ctr_header)?)
+            }
+            Rule::node_declare_operation => {
+                let mut op_header = inner.next().unwrap().into_inner();
+                Some(self.parse_symbol(&mut op_header)?)
+            }
+            Rule::node_import => Some(self.parse_symbol(&mut inner)?),
+            _ => None,
+        };
+
+        let node = self.module.insert_node(Node::default());
+
+        if let Some(symbol) = symbol {
+            self.symbols
+                .insert(symbol, node)
+                .map_err(|err| ParseError::custom(&err.to_string(), span))?;
+        }
+
+        Ok(node)
+    }
+
+    fn parse_node_deep(&mut self, pair: Pair<'a, Rule>, node: NodeId) -> ParseResult<Node<'a>> {
         debug_assert_eq!(pair.as_rule(), Rule::node);
         let pair = pair.into_inner().next().unwrap();
         let rule = pair.as_rule();
@@ -236,7 +316,7 @@ impl<'a> ParseContext<'a> {
                 let outputs = self.parse_port_list(&mut inner)?;
                 let signature = self.parse_signature(&mut inner)?;
                 let meta = self.parse_meta(&mut inner)?;
-                let regions = self.parse_regions(&mut inner)?;
+                let regions = self.parse_regions(&mut inner, ScopeClosure::Open)?;
                 Node {
                     operation: Operation::Dfg,
                     inputs,
@@ -253,7 +333,7 @@ impl<'a> ParseContext<'a> {
                 let outputs = self.parse_port_list(&mut inner)?;
                 let signature = self.parse_signature(&mut inner)?;
                 let meta = self.parse_meta(&mut inner)?;
-                let regions = self.parse_regions(&mut inner)?;
+                let regions = self.parse_regions(&mut inner, ScopeClosure::Open)?;
                 Node {
                     operation: Operation::Cfg,
                     inputs,
@@ -270,7 +350,7 @@ impl<'a> ParseContext<'a> {
                 let outputs = self.parse_port_list(&mut inner)?;
                 let signature = self.parse_signature(&mut inner)?;
                 let meta = self.parse_meta(&mut inner)?;
-                let regions = self.parse_regions(&mut inner)?;
+                let regions = self.parse_regions(&mut inner, ScopeClosure::Open)?;
                 Node {
                     operation: Operation::Block,
                     inputs,
@@ -283,9 +363,11 @@ impl<'a> ParseContext<'a> {
             }
 
             Rule::node_define_func => {
+                self.vars.enter(node);
                 let decl = self.parse_func_header(inner.next().unwrap())?;
                 let meta = self.parse_meta(&mut inner)?;
-                let regions = self.parse_regions(&mut inner)?;
+                let regions = self.parse_regions(&mut inner, ScopeClosure::Closed)?;
+                self.vars.exit();
                 Node {
                     operation: Operation::DefineFunc { decl },
                     inputs: &[],
@@ -298,8 +380,10 @@ impl<'a> ParseContext<'a> {
             }
 
             Rule::node_declare_func => {
+                self.vars.enter(node);
                 let decl = self.parse_func_header(inner.next().unwrap())?;
                 let meta = self.parse_meta(&mut inner)?;
+                self.vars.exit();
                 Node {
                     operation: Operation::DeclareFunc { decl },
                     inputs: &[],
@@ -346,9 +430,11 @@ impl<'a> ParseContext<'a> {
             }
 
             Rule::node_define_alias => {
+                self.vars.enter(node);
                 let decl = self.parse_alias_header(inner.next().unwrap())?;
                 let value = self.parse_term(inner.next().unwrap())?;
                 let meta = self.parse_meta(&mut inner)?;
+                self.vars.exit();
                 Node {
                     operation: Operation::DefineAlias { decl, value },
                     inputs: &[],
@@ -361,8 +447,10 @@ impl<'a> ParseContext<'a> {
             }
 
             Rule::node_declare_alias => {
+                self.vars.enter(node);
                 let decl = self.parse_alias_header(inner.next().unwrap())?;
                 let meta = self.parse_meta(&mut inner)?;
+                self.vars.exit();
                 Node {
                     operation: Operation::DeclareAlias { decl },
                     inputs: &[],
@@ -383,7 +471,7 @@ impl<'a> ParseContext<'a> {
                 let op_rule = op.as_rule();
                 let mut op_inner = op.into_inner();
 
-                let name = GlobalRef::Named(self.parse_symbol(&mut op_inner)?);
+                let operation = self.parse_symbol_use(&mut op_inner)?;
 
                 let mut params = Vec::new();
 
@@ -392,8 +480,8 @@ impl<'a> ParseContext<'a> {
                 }
 
                 let operation = match op_rule {
-                    Rule::term_apply_full => Operation::CustomFull { operation: name },
-                    Rule::term_apply => Operation::Custom { operation: name },
+                    Rule::term_apply_full => Operation::CustomFull { operation },
+                    Rule::term_apply => Operation::Custom { operation },
                     _ => unreachable!(),
                 };
 
@@ -401,7 +489,7 @@ impl<'a> ParseContext<'a> {
                 let outputs = self.parse_port_list(&mut inner)?;
                 let signature = self.parse_signature(&mut inner)?;
                 let meta = self.parse_meta(&mut inner)?;
-                let regions = self.parse_regions(&mut inner)?;
+                let regions = self.parse_regions(&mut inner, ScopeClosure::Closed)?;
                 Node {
                     operation,
                     inputs,
@@ -418,7 +506,7 @@ impl<'a> ParseContext<'a> {
                 let outputs = self.parse_port_list(&mut inner)?;
                 let signature = self.parse_signature(&mut inner)?;
                 let meta = self.parse_meta(&mut inner)?;
-                let regions = self.parse_regions(&mut inner)?;
+                let regions = self.parse_regions(&mut inner, ScopeClosure::Open)?;
                 Node {
                     operation: Operation::TailLoop,
                     inputs,
@@ -435,7 +523,7 @@ impl<'a> ParseContext<'a> {
                 let outputs = self.parse_port_list(&mut inner)?;
                 let signature = self.parse_signature(&mut inner)?;
                 let meta = self.parse_meta(&mut inner)?;
-                let regions = self.parse_regions(&mut inner)?;
+                let regions = self.parse_regions(&mut inner, ScopeClosure::Open)?;
                 Node {
                     operation: Operation::Conditional,
                     inputs,
@@ -465,8 +553,10 @@ impl<'a> ParseContext<'a> {
             }
 
             Rule::node_declare_ctr => {
+                self.vars.enter(node);
                 let decl = self.parse_ctr_header(inner.next().unwrap())?;
                 let meta = self.parse_meta(&mut inner)?;
+                self.vars.exit();
                 Node {
                     operation: Operation::DeclareConstructor { decl },
                     inputs: &[],
@@ -479,8 +569,10 @@ impl<'a> ParseContext<'a> {
             }
 
             Rule::node_declare_operation => {
+                self.vars.enter(node);
                 let decl = self.parse_op_header(inner.next().unwrap())?;
                 let meta = self.parse_meta(&mut inner)?;
+                self.vars.exit();
                 Node {
                     operation: Operation::DeclareOperation { decl },
                     inputs: &[],
@@ -495,24 +587,37 @@ impl<'a> ParseContext<'a> {
             _ => unreachable!(),
         };
 
-        let node_id = self.module.insert_node(node);
-
-        Ok(node_id)
+        Ok(node)
     }
 
-    fn parse_regions(&mut self, pairs: &mut Pairs<'a, Rule>) -> ParseResult<&'a [RegionId]> {
+    fn parse_regions(
+        &mut self,
+        pairs: &mut Pairs<'a, Rule>,
+        closure: ScopeClosure,
+    ) -> ParseResult<&'a [RegionId]> {
         let mut regions = Vec::new();
         for pair in filter_rule(pairs, Rule::region) {
-            regions.push(self.parse_region(pair)?);
+            regions.push(self.parse_region(pair, closure)?);
         }
         Ok(self.bump.alloc_slice_copy(&regions))
     }
 
-    fn parse_region(&mut self, pair: Pair<'a, Rule>) -> ParseResult<RegionId> {
+    fn parse_region(
+        &mut self,
+        pair: Pair<'a, Rule>,
+        closure: ScopeClosure,
+    ) -> ParseResult<RegionId> {
         debug_assert_eq!(pair.as_rule(), Rule::region);
         let pair = pair.into_inner().next().unwrap();
         let rule = pair.as_rule();
         let mut inner = pair.into_inner();
+
+        let region = self.module.insert_region(Region::default());
+        self.symbols.enter(region);
+
+        if closure == ScopeClosure::Closed {
+            self.links.enter(region);
+        }
 
         let kind = match rule {
             Rule::region_cfg => RegionKind::ControlFlow,
@@ -526,24 +631,48 @@ impl<'a> ParseContext<'a> {
         let meta = self.parse_meta(&mut inner)?;
         let children = self.parse_nodes(&mut inner)?;
 
-        Ok(self.module.insert_region(Region {
+        let scope = match closure {
+            ScopeClosure::Closed => {
+                let (links, ports) = self.links.exit();
+                Some(RegionScope { links, ports })
+            }
+            ScopeClosure::Open => None,
+        };
+
+        self.symbols.exit();
+
+        self.module.regions[region.index()] = Region {
             kind,
             sources,
             targets,
             children,
             meta,
             signature,
-        }))
+            scope,
+        };
+
+        Ok(region)
     }
 
     fn parse_nodes(&mut self, pairs: &mut Pairs<'a, Rule>) -> ParseResult<&'a [NodeId]> {
-        let mut nodes = Vec::new();
+        let nodes = {
+            let mut pairs = pairs.clone();
+            let mut nodes = BumpVec::with_capacity_in(pairs.len(), self.bump);
 
-        for pair in filter_rule(pairs, Rule::node) {
-            nodes.push(self.parse_node(pair)?);
+            for pair in filter_rule(&mut pairs, Rule::node) {
+                nodes.push(self.parse_node_shallow(pair)?);
+            }
+
+            nodes.into_bump_slice()
+        };
+
+        for (i, pair) in filter_rule(pairs, Rule::node).enumerate() {
+            let node = nodes[i];
+            let node_data = self.parse_node_deep(pair, node)?;
+            self.module.nodes[node.index()] = node_data;
         }
 
-        Ok(self.bump.alloc_slice_copy(&nodes))
+        Ok(nodes)
     }
 
     fn parse_func_header(&mut self, pair: Pair<'a, Rule>) -> ParseResult<&'a FuncDecl<'a>> {
@@ -627,6 +756,7 @@ impl<'a> ParseContext<'a> {
 
         for pair in filter_rule(pairs, Rule::param) {
             let param = pair.into_inner().next().unwrap();
+            let param_span = param.as_span();
 
             let param = match param.as_rule() {
                 Rule::param_implicit => {
@@ -651,6 +781,10 @@ impl<'a> ParseContext<'a> {
                 }
                 _ => unreachable!(),
             };
+
+            self.vars
+                .insert(param.name)
+                .map_err(|err| ParseError::custom(&err.to_string(), param_span))?;
 
             params.push(param);
         }
@@ -679,27 +813,27 @@ impl<'a> ParseContext<'a> {
         Ok(Some(signature))
     }
 
-    fn parse_port_list(&mut self, pairs: &mut Pairs<'a, Rule>) -> ParseResult<&'a [LinkRef<'a>]> {
+    fn parse_port_list(&mut self, pairs: &mut Pairs<'a, Rule>) -> ParseResult<&'a [LinkIndex]> {
         let Some(Rule::port_list) = pairs.peek().map(|p| p.as_rule()) else {
             return Ok(&[]);
         };
 
         let pair = pairs.next().unwrap();
         let inner = pair.into_inner();
-        let mut links = Vec::new();
+        let mut links = BumpVec::with_capacity_in(inner.len(), self.bump);
 
         for token in inner {
             links.push(self.parse_port(token)?);
         }
 
-        Ok(self.bump.alloc_slice_copy(&links))
+        Ok(links.into_bump_slice())
     }
 
-    fn parse_port(&mut self, pair: Pair<'a, Rule>) -> ParseResult<LinkRef<'a>> {
+    fn parse_port(&mut self, pair: Pair<'a, Rule>) -> ParseResult<LinkIndex> {
         debug_assert_eq!(pair.as_rule(), Rule::port);
         let mut inner = pair.into_inner();
-        let link = LinkRef::Named(&inner.next().unwrap().as_str()[1..]);
-        Ok(link)
+        let name = &inner.next().unwrap().as_str()[1..];
+        Ok(self.links.use_link(name))
     }
 
     fn parse_meta(&mut self, pairs: &mut Pairs<'a, Rule>) -> ParseResult<&'a [MetaItem<'a>]> {
@@ -713,6 +847,21 @@ impl<'a> ParseContext<'a> {
         }
 
         Ok(self.bump.alloc_slice_copy(&items))
+    }
+
+    fn parse_symbol_use(&mut self, pairs: &mut Pairs<'a, Rule>) -> ParseResult<NodeId> {
+        let name = self.parse_symbol(pairs)?;
+        let resolved = self.symbols.resolve(name);
+
+        Ok(match resolved {
+            Ok(node) => node,
+            Err(UnknownSymbolError(_)) => *self.implicit_imports.entry(name).or_insert_with(|| {
+                self.module.insert_node(Node {
+                    operation: Operation::Import { name },
+                    ..Node::default()
+                })
+            }),
+        })
     }
 
     fn parse_symbol(&mut self, pairs: &mut Pairs<'a, Rule>) -> ParseResult<&'a str> {


### PR DESCRIPTION
This PR introduces scoping for symbols, links and variables. It comes with utilities that can be used to resolve names appropriately. Moreover the model data structures are changed so that they always use direct references by indices instead of names in order to streamline the serialisation format.