### PR TITLE
fix: allow disconnected outputs in SiblingSubgraph::from_node

### DIFF
--- a/hugr-llvm/src/emit/test.rs
+++ b/hugr-llvm/src/emit/test.rs
@@ -659,11 +659,9 @@ mod test_fns {
                             .conditional_builder(
                                 ([type_row![], type_row![]], eq_0),
                                 vec![(just_input.clone(), loop_int_w)],
-                                vec![HugrSumType::new(vec![
-                                    vec![just_input.clone()].into(),
-                                    vec![],
-                                ])
-                                .into()]
+                                vec![
+                                    HugrSumType::new(vec![vec![just_input.clone()], vec![]]).into()
+                                ]
                                 .into(),
                             )
                             .unwrap();
@@ -732,7 +730,7 @@ mod test_fns {
     ) {
         exec_ctx.add_extensions(add_int_extensions);
         assert_eq!(
-            input * 1 << (iters + 1),
+            input << (iters + 1),
             exec_ctx.exec_hugr_u64(terminal_loop, "main")
         );
     }

--- a/hugr-passes/src/lower.rs
+++ b/hugr-passes/src/lower.rs
@@ -67,7 +67,7 @@ pub fn lower_ops(
     replacements
         .into_iter()
         .map(|(node, replacement)| {
-            let subcirc = SiblingSubgraph::try_from_nodes([node], hugr)?;
+            let subcirc = SiblingSubgraph::from_node(node, hugr);
             let rw = subcirc.create_simple_replacement(hugr, replacement)?;
             let mut repls = hugr.apply_rewrite(rw)?;
             debug_assert_eq!(repls.len(), 1);

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -44,4 +44,3 @@ bumpalo = { workspace = true, features = ["collections"] }
 [[bench]]
 name = "bench_main"
 harness = false
-


### PR DESCRIPTION
Uses `from_node` in lowering code to take advantage of this


Closes #1746