### PR TITLE
feat: add ArrayValue to python, rust and lowering

### DIFF
--- a/hugr-core/src/std_extensions/collections/list.rs
+++ b/hugr-core/src/std_extensions/collections/list.rs
@@ -49,7 +49,7 @@ pub struct ListValue(Vec<Value>, Type);
 
 impl ListValue {
     /// Create a new [CustomConst] for a list of values of type `typ`.
-    /// That all values ore of type `typ` is not checked here.
+    /// That all values are of type `typ` is not checked here.
     pub fn new(typ: Type, contents: impl IntoIterator<Item = Value>) -> Self {
         Self(contents.into_iter().collect_vec(), typ)
     }

--- a/hugr-llvm/src/extension/collections/snapshots/hugr_llvm__extension__collections__array__test__emit_array_value@llvm14.snap
+++ b/hugr-llvm/src/extension/collections/snapshots/hugr_llvm__extension__collections__array__test__emit_array_value@llvm14.snap
@@ -1,0 +1,14 @@
+---
+source: hugr-llvm/src/extension/collections/array.rs
+expression: mod_str
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define [2 x i64] @_hl.main.1() {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  ret [2 x i64] [i64 1, i64 2]
+}

--- a/hugr-llvm/src/extension/collections/snapshots/hugr_llvm__extension__collections__array__test__emit_array_value@pre-mem2reg@llvm14.snap
+++ b/hugr-llvm/src/extension/collections/snapshots/hugr_llvm__extension__collections__array__test__emit_array_value@pre-mem2reg@llvm14.snap
@@ -1,0 +1,20 @@
+---
+source: hugr-llvm/src/extension/collections/array.rs
+expression: mod_str
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define [2 x i64] @_hl.main.1() {
+alloca_block:
+  %"0" = alloca [2 x i64], align 8
+  %"5_0" = alloca [2 x i64], align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store [2 x i64] [i64 1, i64 2], [2 x i64]* %"5_0", align 4
+  %"5_01" = load [2 x i64], [2 x i64]* %"5_0", align 4
+  store [2 x i64] %"5_01", [2 x i64]* %"0", align 4
+  %"02" = load [2 x i64], [2 x i64]* %"0", align 4
+  ret [2 x i64] %"02"
+}

--- a/hugr-py/tests/test_tys.py
+++ b/hugr-py/tests/test_tys.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from hugr import val
-from hugr.std.collections.array import Array
+from hugr.std.collections.array import Array, ArrayVal
 from hugr.std.collections.list import List, ListVal
 from hugr.std.float import FLOAT_T
 from hugr.std.int import INT_T, _int_tv
@@ -170,3 +170,7 @@ def test_array():
     ls = Array(ty_var, len_var)
     assert ls.ty == ty_var
     assert ls.size is None
+
+    ar_val = ArrayVal([val.TRUE, val.FALSE], Bool)
+    assert ar_val.v == [val.TRUE, val.FALSE]
+    assert ar_val.ty == Array(Bool, 2)

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "hugr"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "hugr-py" }
 dependencies = [
     { name = "graphviz" },


### PR DESCRIPTION
drive-by: fix Array type annotation

Closes #1771 

TODO:
 - [x] Rust ArrayValue
 - [x] LLVM lowering