### PR TITLE
feat: Update extension pointers in customConsts

### DIFF
--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -25,6 +25,7 @@ use crate::{type_row, Extension};
 
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
+use super::resolution::{resolve_type_extensions, ExtensionResolutionError};
 use super::ExtensionRegistry;
 
 mod unwrap_builder;
@@ -502,6 +503,13 @@ impl CustomConst for ConstExternalSymbol {
     }
     fn get_type(&self) -> Type {
         self.typ.clone()
+    }
+
+    fn update_extensions(
+        &mut self,
+        extensions: &ExtensionRegistry,
+    ) -> Result<(), ExtensionResolutionError> {
+        resolve_type_extensions(&mut self.typ, extensions)
     }
 
     fn validate(&self) -> Result<(), CustomCheckFailure> {

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -26,15 +26,52 @@ mod types_mut;
 pub(crate) use ops::{collect_op_extension, resolve_op_extensions};
 pub(crate) use types::{collect_op_types_extensions, collect_signature_exts};
 pub(crate) use types_mut::resolve_op_types_extensions;
+use types_mut::{resolve_type_exts, resolve_typearg_exts, resolve_value_exts};
 
 use derive_more::{Display, Error, From};
 
 use super::{Extension, ExtensionId, ExtensionRegistry, ExtensionSet};
 use crate::ops::constant::ValueName;
 use crate::ops::custom::OpaqueOpError;
-use crate::ops::{NamedOp, OpName, OpType};
-use crate::types::{FuncTypeBase, MaybeRV, TypeName};
+use crate::ops::{NamedOp, OpName, OpType, Value};
+use crate::types::{FuncTypeBase, MaybeRV, TypeArg, TypeBase, TypeName};
 use crate::Node;
+
+/// Update all weak Extension pointers inside a type.
+pub fn resolve_type_extensions<RV: MaybeRV>(
+    typ: &mut TypeBase<RV>,
+    extensions: &ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    // This public export is used for implementing `CustomConst::update_extensions`, so we don't need the full internal API here.
+    // TODO: Make `node` optional in `ExtensionResolutionError`
+    let node: Node = portgraph::NodeIndex::new(0).into();
+    let mut used_extensions = ExtensionRegistry::default();
+    resolve_type_exts(node, typ, extensions, &mut used_extensions)
+}
+
+/// Update all weak Extension pointers inside a type argument.
+pub fn resolve_typearg_extensions(
+    arg: &mut TypeArg,
+    extensions: &ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    // This public export is used for implementing `CustomConst::update_extensions`, so we don't need the full internal API here.
+    // TODO: Make `node` optional in `ExtensionResolutionError`
+    let node: Node = portgraph::NodeIndex::new(0).into();
+    let mut used_extensions = ExtensionRegistry::default();
+    resolve_typearg_exts(node, arg, extensions, &mut used_extensions)
+}
+
+/// Update all weak Extension pointers inside a constant value.
+pub fn resolve_value_extensions(
+    value: &mut Value,
+    extensions: &ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    // This public export is used for implementing `CustomConst::update_extensions`, so we don't need the full internal API here.
+    // TODO: Make `node` optional in `ExtensionResolutionError`
+    let node: Node = portgraph::NodeIndex::new(0).into();
+    let mut used_extensions = ExtensionRegistry::default();
+    resolve_value_exts(node, value, extensions, &mut used_extensions)
+}
 
 /// Errors that can occur during extension resolution.
 #[derive(Debug, Display, Clone, Error, From, PartialEq)]

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -26,7 +26,9 @@ mod types_mut;
 pub(crate) use ops::{collect_op_extension, resolve_op_extensions};
 pub(crate) use types::{collect_op_types_extensions, collect_signature_exts};
 pub(crate) use types_mut::resolve_op_types_extensions;
-use types_mut::{resolve_type_exts, resolve_typearg_exts, resolve_value_exts};
+use types_mut::{
+    resolve_custom_type_exts, resolve_type_exts, resolve_typearg_exts, resolve_value_exts,
+};
 
 use derive_more::{Display, Error, From};
 
@@ -34,7 +36,7 @@ use super::{Extension, ExtensionId, ExtensionRegistry, ExtensionSet};
 use crate::ops::constant::ValueName;
 use crate::ops::custom::OpaqueOpError;
 use crate::ops::{NamedOp, OpName, OpType, Value};
-use crate::types::{FuncTypeBase, MaybeRV, TypeArg, TypeBase, TypeName};
+use crate::types::{CustomType, FuncTypeBase, MaybeRV, TypeArg, TypeBase, TypeName};
 use crate::Node;
 
 /// Update all weak Extension pointers inside a type.
@@ -47,6 +49,18 @@ pub fn resolve_type_extensions<RV: MaybeRV>(
     let node: Node = portgraph::NodeIndex::new(0).into();
     let mut used_extensions = ExtensionRegistry::default();
     resolve_type_exts(node, typ, extensions, &mut used_extensions)
+}
+
+/// Update all weak Extension pointers in a custom type.
+pub fn resolve_custom_type_extensions(
+    typ: &mut CustomType,
+    extensions: &ExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    // This public export is used for implementing `CustomConst::update_extensions`, so we don't need the full internal API here.
+    // TODO: Make `node` optional in `ExtensionResolutionError`
+    let node: Node = portgraph::NodeIndex::new(0).into();
+    let mut used_extensions = ExtensionRegistry::default();
+    resolve_custom_type_exts(node, typ, extensions, &mut used_extensions)
 }
 
 /// Update all weak Extension pointers inside a type argument.

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -143,7 +143,7 @@ fn resolve_type_row_exts<RV: MaybeRV>(
 /// Update all weak Extension pointers in the [`CustomType`]s inside a type.
 ///
 /// Adds the extensions used in the type to the `used_extensions` registry.
-fn resolve_type_exts<RV: MaybeRV>(
+pub(super) fn resolve_type_exts<RV: MaybeRV>(
     node: Node,
     typ: &mut TypeBase<RV>,
     extensions: &ExtensionRegistry,
@@ -191,7 +191,7 @@ fn resolve_type_exts<RV: MaybeRV>(
 /// Update all weak Extension pointers in the [`CustomType`]s inside a type arg.
 ///
 /// Adds the extensions used in the type to the `used_extensions` registry.
-fn resolve_typearg_exts(
+pub(super) fn resolve_typearg_exts(
     node: Node,
     arg: &mut TypeArg,
     extensions: &ExtensionRegistry,
@@ -212,7 +212,7 @@ fn resolve_typearg_exts(
 /// Update all weak Extension pointers in the [`CustomType`]s inside a [`Value`].
 ///
 /// Adds the extensions used in the row to the `used_extensions` registry.
-fn resolve_value_exts(
+pub(super) fn resolve_value_exts(
     node: Node,
     value: &mut Value,
     extensions: &ExtensionRegistry,
@@ -220,9 +220,10 @@ fn resolve_value_exts(
 ) -> Result<(), ExtensionResolutionError> {
     match value {
         Value::Extension { e } => {
-            // We expect that the `CustomConst::get_type` binary calls always
-            // return types with valid extensions.
-            // So here we just collect the used extensions.
+            e.value_mut().update_extensions(extensions)?;
+
+            // We expect that the `CustomConst::get_type` binary calls
+            // return types with valid extensions after we call `update_extensions`.
             let typ = e.get_type();
             let mut missing = ExtensionSet::new();
             collect_type_exts(&typ, used_extensions, &mut missing);

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -569,7 +569,7 @@ pub type ValueName = SmolStr;
 pub type ValueNameRef = str;
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use std::collections::HashSet;
     use std::sync::{Arc, Weak};
 
@@ -577,7 +577,9 @@ mod test {
     use crate::builder::inout_sig;
     use crate::builder::test::simple_dfg_hugr;
     use crate::extension::prelude::{bool_t, usize_custom_t};
-    use crate::extension::resolution::{resolve_typearg_extensions, ExtensionResolutionError};
+    use crate::extension::resolution::{
+        resolve_custom_type_extensions, resolve_typearg_extensions, ExtensionResolutionError,
+    };
     use crate::extension::{ExtensionRegistry, PRELUDE};
     use crate::std_extensions::arithmetic::int_types::ConstInt;
     use crate::{
@@ -614,6 +616,9 @@ mod test {
             &mut self,
             extensions: &ExtensionRegistry,
         ) -> Result<(), ExtensionResolutionError> {
+            resolve_custom_type_extensions(&mut self.0, extensions)?;
+            // This loop is redundant, but we use it to test the public
+            // function.
             for arg in self.0.args_mut() {
                 resolve_typearg_extensions(arg, extensions)?;
             }

--- a/hugr-core/src/std_extensions/collections/list.rs
+++ b/hugr-core/src/std_extensions/collections/list.rs
@@ -13,6 +13,9 @@ use serde::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 use crate::extension::prelude::{either_type, option_type, usize_t};
+use crate::extension::resolution::{
+    resolve_type_extensions, resolve_value_extensions, ExtensionResolutionError,
+};
 use crate::extension::simple_op::{MakeOpDef, MakeRegisteredOp};
 use crate::extension::{ExtensionBuildError, OpDef, SignatureFunc, PRELUDE};
 use crate::ops::constant::{maybe_hash_values, TryHash, ValueName};
@@ -125,6 +128,16 @@ impl CustomConst for ListValue {
     fn extension_reqs(&self) -> ExtensionSet {
         ExtensionSet::union_over(self.0.iter().map(Value::extension_reqs))
             .union(EXTENSION_ID.into())
+    }
+
+    fn update_extensions(
+        &mut self,
+        extensions: &ExtensionRegistry,
+    ) -> Result<(), ExtensionResolutionError> {
+        for val in &mut self.0 {
+            resolve_value_extensions(val, extensions)?;
+        }
+        resolve_type_extensions(&mut self.1, extensions)
     }
 }
 


### PR DESCRIPTION
Closes #1742.

Adds a (default defined) `update_extensions` call to `CustomConst` so it can update its internal extension `Weak` pointers after loading a serialized hugr.