### PR TITLE
feat!: Use registries of `Weak<Extension>`s when doing resolution 

### DIFF
--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -25,7 +25,7 @@ use crate::{type_row, Extension};
 
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
-use super::resolution::{resolve_type_extensions, ExtensionResolutionError};
+use super::resolution::{resolve_type_extensions, ExtensionResolutionError, WeakExtensionRegistry};
 use super::ExtensionRegistry;
 
 mod unwrap_builder;
@@ -507,7 +507,7 @@ impl CustomConst for ConstExternalSymbol {
 
     fn update_extensions(
         &mut self,
-        extensions: &ExtensionRegistry,
+        extensions: &WeakExtensionRegistry,
     ) -> Result<(), ExtensionResolutionError> {
         resolve_type_extensions(&mut self.typ, extensions)
     }

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -22,6 +22,9 @@
 mod ops;
 mod types;
 mod types_mut;
+mod weak_registry;
+
+pub use weak_registry::WeakExtensionRegistry;
 
 pub(crate) use ops::{collect_op_extension, resolve_op_extensions};
 pub(crate) use types::{collect_op_types_extensions, collect_signature_exts};
@@ -42,36 +45,36 @@ use crate::Node;
 /// Update all weak Extension pointers inside a type.
 pub fn resolve_type_extensions<RV: MaybeRV>(
     typ: &mut TypeBase<RV>,
-    extensions: &ExtensionRegistry,
+    extensions: &WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    let mut used_extensions = ExtensionRegistry::default();
+    let mut used_extensions = WeakExtensionRegistry::default();
     resolve_type_exts(None, typ, extensions, &mut used_extensions)
 }
 
 /// Update all weak Extension pointers in a custom type.
 pub fn resolve_custom_type_extensions(
     typ: &mut CustomType,
-    extensions: &ExtensionRegistry,
+    extensions: &WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    let mut used_extensions = ExtensionRegistry::default();
+    let mut used_extensions = WeakExtensionRegistry::default();
     resolve_custom_type_exts(None, typ, extensions, &mut used_extensions)
 }
 
 /// Update all weak Extension pointers inside a type argument.
 pub fn resolve_typearg_extensions(
     arg: &mut TypeArg,
-    extensions: &ExtensionRegistry,
+    extensions: &WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    let mut used_extensions = ExtensionRegistry::default();
+    let mut used_extensions = WeakExtensionRegistry::default();
     resolve_typearg_exts(None, arg, extensions, &mut used_extensions)
 }
 
 /// Update all weak Extension pointers inside a constant value.
 pub fn resolve_value_extensions(
     value: &mut Value,
-    extensions: &ExtensionRegistry,
+    extensions: &WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    let mut used_extensions = ExtensionRegistry::default();
+    let mut used_extensions = WeakExtensionRegistry::default();
     resolve_value_exts(None, value, extensions, &mut used_extensions)
 }
 
@@ -146,7 +149,7 @@ impl ExtensionResolutionError {
         node: Option<Node>,
         ty: &TypeName,
         missing_extension: &ExtensionId,
-        extensions: &ExtensionRegistry,
+        extensions: &WeakExtensionRegistry,
     ) -> Self {
         Self::MissingTypeExtension {
             node,

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -124,7 +124,10 @@ fn operation_extension<'e>(
     match extensions.get(ext) {
         Some(e) => Ok(Some(e)),
         None => Err(ExtensionResolutionError::missing_op_extension(
-            node, op, ext, extensions,
+            Some(node),
+            op,
+            ext,
+            extensions,
         )),
     }
 }

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -7,7 +7,8 @@
 
 use std::sync::Arc;
 
-use super::{Extension, ExtensionCollectionError, ExtensionRegistry, ExtensionResolutionError};
+use super::{Extension, ExtensionCollectionError, ExtensionResolutionError};
+use crate::extension::ExtensionRegistry;
 use crate::ops::custom::OpaqueOpError;
 use crate::ops::{DataflowOpTrait, ExtensionOp, NamedOp, OpType};
 use crate::Node;

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -54,7 +54,8 @@ fn resolve_type_extensions(#[case] op: impl Into<OpType>, #[case] extensions: Ex
 
     let mut used_exts = ExtensionRegistry::default();
     resolve_op_extensions(dummy_node, &mut deser_op, &extensions).unwrap();
-    resolve_op_types_extensions(dummy_node, &mut deser_op, &extensions, &mut used_exts).unwrap();
+    resolve_op_types_extensions(Some(dummy_node), &mut deser_op, &extensions, &mut used_exts)
+        .unwrap();
 
     let deser_extensions = deser_op.used_extensions().unwrap();
 

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -11,6 +11,7 @@ use crate::builder::{
     Container, Dataflow, DataflowSubContainer, FunctionBuilder, HugrBuilder, ModuleBuilder,
 };
 use crate::extension::prelude::{bool_t, usize_custom_t, ConstUsize};
+use crate::extension::resolution::WeakExtensionRegistry;
 use crate::extension::resolution::{
     resolve_op_extensions, resolve_op_types_extensions, ExtensionCollectionError,
 };
@@ -52,10 +53,12 @@ fn resolve_type_extensions(#[case] op: impl Into<OpType>, #[case] extensions: Ex
 
     let dummy_node = portgraph::NodeIndex::new(0).into();
 
-    let mut used_exts = ExtensionRegistry::default();
     resolve_op_extensions(dummy_node, &mut deser_op, &extensions).unwrap();
-    resolve_op_types_extensions(Some(dummy_node), &mut deser_op, &extensions, &mut used_exts)
-        .unwrap();
+
+    let weak_extensions: WeakExtensionRegistry = (&extensions).into();
+    resolve_op_types_extensions(Some(dummy_node), &mut deser_op, &weak_extensions)
+        .unwrap()
+        .for_each(|_| ());
 
     let deser_extensions = deser_op.used_extensions().unwrap();
 

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -22,7 +22,7 @@ use crate::Node;
 ///
 /// This is a helper function used right after deserializing a Hugr.
 pub fn resolve_op_types_extensions(
-    node: Node,
+    node: Option<Node>,
     op: &mut OpType,
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,
@@ -113,7 +113,7 @@ pub fn resolve_op_types_extensions(
 ///
 /// Adds the extensions used in the signature to the `used_extensions` registry.
 fn resolve_signature_exts(
-    node: Node,
+    node: Option<Node>,
     signature: &mut Signature,
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,
@@ -129,7 +129,7 @@ fn resolve_signature_exts(
 ///
 /// Adds the extensions used in the row to the `used_extensions` registry.
 fn resolve_type_row_exts<RV: MaybeRV>(
-    node: Node,
+    node: Option<Node>,
     row: &mut TypeRowBase<RV>,
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,
@@ -144,7 +144,7 @@ fn resolve_type_row_exts<RV: MaybeRV>(
 ///
 /// Adds the extensions used in the type to the `used_extensions` registry.
 pub(super) fn resolve_type_exts<RV: MaybeRV>(
-    node: Node,
+    node: Option<Node>,
     typ: &mut TypeBase<RV>,
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,
@@ -175,7 +175,7 @@ pub(super) fn resolve_type_exts<RV: MaybeRV>(
 ///
 /// Adds the extensions used in the type to the `used_extensions` registry.
 pub(super) fn resolve_custom_type_exts(
-    node: Node,
+    node: Option<Node>,
     custom: &mut CustomType,
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,
@@ -201,7 +201,7 @@ pub(super) fn resolve_custom_type_exts(
 ///
 /// Adds the extensions used in the type to the `used_extensions` registry.
 pub(super) fn resolve_typearg_exts(
-    node: Node,
+    node: Option<Node>,
     arg: &mut TypeArg,
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,
@@ -222,7 +222,7 @@ pub(super) fn resolve_typearg_exts(
 ///
 /// Adds the extensions used in the row to the `used_extensions` registry.
 pub(super) fn resolve_value_exts(
-    node: Node,
+    node: Option<Node>,
     value: &mut Value,
     extensions: &ExtensionRegistry,
     used_extensions: &mut ExtensionRegistry,

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -17,10 +17,7 @@ use crate::{Extension, Node};
 /// optype with a valid pointer to the extension in the `extensions`
 /// registry.
 ///
-/// When a pointer is replaced, the extension is added to the
-/// `used_extensions` registry.
-///
-/// Returns
+/// Returns an iterator over the used extensions.
 ///
 /// This is a helper function used right after deserializing a Hugr.
 pub fn resolve_op_types_extensions(

--- a/hugr-core/src/extension/resolution/weak_registry.rs
+++ b/hugr-core/src/extension/resolution/weak_registry.rs
@@ -1,0 +1,88 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Weak};
+
+use itertools::Itertools;
+
+use derive_more::Display;
+
+use crate::extension::{ExtensionId, ExtensionRegistry};
+use crate::Extension;
+
+/// The equivalent to an [`ExtensionRegistry`] that only contains weak references.
+///
+/// This is used to resolve extensions pointers while
+#[derive(Debug, Display, Default)]
+#[display("WeakExtensionRegistry[{}]", exts.keys().join(", "))]
+pub struct WeakExtensionRegistry {
+    /// The extensions in the registry.
+    exts: BTreeMap<ExtensionId, Weak<Extension>>,
+}
+
+impl WeakExtensionRegistry {
+    /// Gets the Extension with the given name
+    pub fn get(&self, name: &str) -> Option<&Weak<Extension>> {
+        self.exts.get(name)
+    }
+
+    /// Returns `true` if the registry contains an extension with the given name.
+    pub fn contains(&self, name: &str) -> bool {
+        self.exts.contains_key(name)
+    }
+
+    /// Register a new extension in the registry.
+    ///
+    /// Returns `true` if the extension was added, `false` if it was already present.
+    pub fn register(&mut self, id: ExtensionId, ext: impl Into<Weak<Extension>>) -> bool {
+        self.exts.insert(id, ext.into()).is_none()
+    }
+
+    /// Returns an iterator over the weak references in the registry.
+    pub fn iter(&self) -> impl Iterator<Item = &Weak<Extension>> {
+        self.exts.values()
+    }
+
+    /// Returns an iterator over the extensions ids in the registry.
+    pub fn ids(&self) -> impl Iterator<Item = &ExtensionId> {
+        self.exts.keys()
+    }
+}
+
+impl IntoIterator for WeakExtensionRegistry {
+    type Item = Weak<Extension>;
+    type IntoIter = std::collections::btree_map::IntoValues<ExtensionId, Weak<Extension>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.exts.into_values()
+    }
+}
+
+impl<'a> TryFrom<&'a WeakExtensionRegistry> for ExtensionRegistry {
+    type Error = ();
+
+    fn try_from(weak: &'a WeakExtensionRegistry) -> Result<Self, Self::Error> {
+        let exts: Vec<Arc<Extension>> = weak.iter().map(|w| w.upgrade().ok_or(())).try_collect()?;
+        Ok(ExtensionRegistry::new(exts))
+    }
+}
+
+impl TryFrom<WeakExtensionRegistry> for ExtensionRegistry {
+    type Error = ();
+
+    fn try_from(weak: WeakExtensionRegistry) -> Result<Self, Self::Error> {
+        let exts: Vec<Arc<Extension>> = weak
+            .into_iter()
+            .map(|w| w.upgrade().ok_or(()))
+            .try_collect()?;
+        Ok(ExtensionRegistry::new(exts))
+    }
+}
+
+impl<'a> From<&'a ExtensionRegistry> for WeakExtensionRegistry {
+    fn from(reg: &'a ExtensionRegistry) -> Self {
+        let exts = reg
+            .iter()
+            .map(|ext| (ext.name().clone(), Arc::downgrade(ext)))
+            .collect();
+        Self { exts }
+    }
+}

--- a/hugr-core/src/extension/resolution/weak_registry.rs
+++ b/hugr-core/src/extension/resolution/weak_registry.rs
@@ -8,10 +8,12 @@ use derive_more::Display;
 use crate::extension::{ExtensionId, ExtensionRegistry};
 use crate::Extension;
 
-/// The equivalent to an [`ExtensionRegistry`] that only contains weak references.
+/// The equivalent to an [`ExtensionRegistry`] that only contains weak
+/// references.
 ///
-/// This is used to resolve extensions pointers while
-#[derive(Debug, Display, Default)]
+/// This is used to resolve extensions pointers while the extensions themselves
+/// (and the [`Arc`] that contains them) are being initialized.
+#[derive(Debug, Display, Default, Clone)]
 #[display("WeakExtensionRegistry[{}]", exts.keys().join(", "))]
 pub struct WeakExtensionRegistry {
     /// The extensions in the registry.
@@ -41,7 +43,7 @@ impl WeakExtensionRegistry {
         self.exts.values()
     }
 
-    /// Returns an iterator over the extensions ids in the registry.
+    /// Returns an iterator over the extension ids in the registry.
     pub fn ids(&self) -> impl Iterator<Item = &ExtensionId> {
         self.exts.keys()
     }

--- a/hugr-core/src/extension/resolution/weak_registry.rs
+++ b/hugr-core/src/extension/resolution/weak_registry.rs
@@ -21,7 +21,7 @@ pub struct WeakExtensionRegistry {
 }
 
 impl WeakExtensionRegistry {
-    /// Create a new empty extension registry.
+    /// Create a new weak registry from a list of extensions and their ids.
     pub fn new(extensions: impl IntoIterator<Item = (ExtensionId, Weak<Extension>)>) -> Self {
         let mut res = Self::default();
         for (id, ext) in extensions.into_iter() {

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -27,6 +27,7 @@ pub use self::views::{HugrView, RootTagged};
 use crate::core::NodeIndex;
 use crate::extension::resolution::{
     resolve_op_extensions, resolve_op_types_extensions, ExtensionResolutionError,
+    WeakExtensionRegistry,
 };
 use crate::extension::{ExtensionRegistry, ExtensionSet, TO_BE_INFERRED};
 use crate::ops::{OpTag, OpTrait};
@@ -231,6 +232,7 @@ impl Hugr {
         // Since we don't have a non-borrowing iterator over all the possible
         // NodeIds, we have to simulate it by iterating over all possible
         // indices and checking if the node exists.
+        let weak_extensions: WeakExtensionRegistry = extensions.into();
         for n in 0..self.graph.node_capacity() {
             let pg_node = portgraph::NodeIndex::new(n);
             let node: Node = pg_node.into();
@@ -243,7 +245,12 @@ impl Hugr {
             if let Some(extension) = resolve_op_extensions(node, op, extensions)? {
                 used_extensions.register_updated_ref(extension);
             }
-            resolve_op_types_extensions(Some(node), op, extensions, &mut used_extensions)?;
+            used_extensions.extend(
+                resolve_op_types_extensions(Some(node), op, &weak_extensions)?.map(|weak| {
+                    weak.upgrade()
+                        .expect("Extension comes from a valid registry")
+                }),
+            );
         }
 
         self.extensions = used_extensions;

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -243,7 +243,7 @@ impl Hugr {
             if let Some(extension) = resolve_op_extensions(node, op, extensions)? {
                 used_extensions.register_updated_ref(extension);
             }
-            resolve_op_types_extensions(node, op, extensions, &mut used_extensions)?;
+            resolve_op_types_extensions(Some(node), op, extensions, &mut used_extensions)?;
         }
 
         self.extensions = used_extensions;

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -579,8 +579,9 @@ pub(crate) mod test {
     use crate::extension::prelude::{bool_t, usize_custom_t};
     use crate::extension::resolution::{
         resolve_custom_type_extensions, resolve_typearg_extensions, ExtensionResolutionError,
+        WeakExtensionRegistry,
     };
-    use crate::extension::{ExtensionRegistry, PRELUDE};
+    use crate::extension::PRELUDE;
     use crate::std_extensions::arithmetic::int_types::ConstInt;
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
@@ -614,7 +615,7 @@ pub(crate) mod test {
 
         fn update_extensions(
             &mut self,
-            extensions: &ExtensionRegistry,
+            extensions: &WeakExtensionRegistry,
         ) -> Result<(), ExtensionResolutionError> {
             resolve_custom_type_extensions(&mut self.0, extensions)?;
             // This loop is redundant, but we use it to test the public

--- a/hugr-core/src/ops/constant/custom.rs
+++ b/hugr-core/src/ops/constant/custom.rs
@@ -10,8 +10,10 @@ use std::hash::{Hash, Hasher};
 use downcast_rs::{impl_downcast, Downcast};
 use thiserror::Error;
 
-use crate::extension::resolution::{resolve_type_extensions, ExtensionResolutionError};
-use crate::extension::{ExtensionRegistry, ExtensionSet};
+use crate::extension::resolution::{
+    resolve_type_extensions, ExtensionResolutionError, WeakExtensionRegistry,
+};
+use crate::extension::ExtensionSet;
 use crate::macros::impl_box_clone;
 use crate::types::{CustomCheckFailure, Type};
 use crate::IncomingPort;
@@ -93,7 +95,7 @@ pub trait CustomConst:
     /// See the helper methods in [`crate::extension::resolution`].
     fn update_extensions(
         &mut self,
-        _extensions: &ExtensionRegistry,
+        _extensions: &WeakExtensionRegistry,
     ) -> Result<(), ExtensionResolutionError> {
         Ok(())
     }
@@ -316,7 +318,7 @@ impl CustomConst for CustomSerialized {
     }
     fn update_extensions(
         &mut self,
-        extensions: &ExtensionRegistry,
+        extensions: &WeakExtensionRegistry,
     ) -> Result<(), ExtensionResolutionError> {
         resolve_type_extensions(&mut self.typ, extensions)
     }

--- a/hugr-core/src/std_extensions/collections/list.rs
+++ b/hugr-core/src/std_extensions/collections/list.rs
@@ -15,6 +15,7 @@ use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 use crate::extension::prelude::{either_type, option_type, usize_t};
 use crate::extension::resolution::{
     resolve_type_extensions, resolve_value_extensions, ExtensionResolutionError,
+    WeakExtensionRegistry,
 };
 use crate::extension::simple_op::{MakeOpDef, MakeRegisteredOp};
 use crate::extension::{ExtensionBuildError, OpDef, SignatureFunc, PRELUDE};
@@ -132,7 +133,7 @@ impl CustomConst for ListValue {
 
     fn update_extensions(
         &mut self,
-        extensions: &ExtensionRegistry,
+        extensions: &WeakExtensionRegistry,
     ) -> Result<(), ExtensionResolutionError> {
         for val in &mut self.0 {
             resolve_value_extensions(val, extensions)?;


### PR DESCRIPTION
We'll need this to resolve extension references inside an extension that's being created.

drive-by: Make "node" optional in resolution errors.

BREAKING CHANGE: `::extension::resolve` operations now use `WeakExtensionRegistry`es. 