### PR TITLE
feat!: Resolve extension references inside the extension themselves

### DIFF
--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -257,15 +257,16 @@ impl ExtensionRegistry {
     {
         let extensions = extensions.into_iter().collect_vec();
 
-        // Unsafe internally-mutable wrapper around an extension.
-        // Important: The layout is identical to A
+        // Unsafe internally-mutable wrapper around an extension. Important:
+        // `repr(transparent)` ensures the layout is identical to `Extension`,
+        // so it can be safely transmuted.
         #[repr(transparent)]
         struct ExtensionCell {
             ext: UnsafeCell<Extension>,
         }
 
         // Create the arcs with internal mutability, and collect weak references
-        // over non-mutable references.
+        // over immutable references.
         //
         // This is safe as long as the cell mutation happens when we can guarantee
         // that the weak references are not used.
@@ -778,10 +779,10 @@ pub enum ExtensionRegistryError {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ExtensionRegistryLoadError {
-    /// Extension already defined.
+    /// Deserialization error.
     #[error(transparent)]
     SerdeError(#[from] serde_json::Error),
-    /// A registered extension has invalid signatures.
+    /// Error when resolving internal extension references.
     #[error(transparent)]
     ExtensionResolutionError(#[from] ExtensionResolutionError),
 }

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -287,7 +287,7 @@ impl ExtensionRegistry {
                 let weak_arc: Weak<Extension> = unsafe { mem::transmute(Arc::downgrade(&arc)) };
                 (arc, weak_arc)
             })
-            .collect();
+            .unzip();
 
         let mut weak_registry = WeakExtensionRegistry::default();
         for (ext, weak) in extensions.iter().zip(weaks) {

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -998,6 +998,7 @@ pub mod test {
         assert!(reg.remove_extension(&ext_1_id).unwrap().version() == &Version::new(1, 1, 0));
         assert_eq!(reg.len(), 1);
     }
+
     mod proptest {
 
         use ::proptest::{collection::hash_set, prelude::*};

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -136,6 +136,11 @@ impl CustomValidator {
             validate: Box::new(validate),
         }
     }
+
+    /// Return a mutable reference to the PolyFuncType.
+    pub(super) fn poly_func_mut(&mut self) -> &mut PolyFuncTypeRV {
+        &mut self.poly_func
+    }
 }
 
 /// The ways in which an OpDef may compute the Signature of each operation node.
@@ -407,6 +412,11 @@ impl OpDef {
         self.extension_ref.clone()
     }
 
+    /// Returns a mutable reference to the weak extension pointer in the operation definition.
+    pub(super) fn extension_mut(&mut self) -> &mut Weak<Extension> {
+        &mut self.extension_ref
+    }
+
     /// Returns a reference to the description of this [`OpDef`].
     pub fn description(&self) -> &str {
         self.description.as_ref()
@@ -468,6 +478,11 @@ impl OpDef {
     /// Returns a reference to the signature function of this [`OpDef`].
     pub fn signature_func(&self) -> &SignatureFunc {
         &self.signature_func
+    }
+
+    /// Returns a mutable reference to the signature function of this [`OpDef`].
+    pub(super) fn signature_func_mut(&mut self) -> &mut SignatureFunc {
+        &mut self.signature_func
     }
 }
 

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -19,6 +19,7 @@
 //! (will) automatically resolve extensions as the operations are created,
 //! we will no longer require this post-facto resolution step.
 
+mod extension;
 mod ops;
 mod types;
 mod types_mut;
@@ -102,12 +103,12 @@ pub enum ExtensionResolutionError {
         /// A list of available extensions.
         available_extensions: Vec<ExtensionId>,
     },
+    /// A type references an extension that is not in the given registry.
     #[display(
         "Type {ty}{} requires extension {missing_extension}, but it could not be found in the extension list used during resolution. The available extensions are: {}",
         node.map(|n| format!(" in {}", n)).unwrap_or_default(),
         available_extensions.join(", ")
     )]
-    /// A type references an extension that is not in the given registry.
     MissingTypeExtension {
         /// The node that requires the extension.
         node: Option<Node>,
@@ -117,6 +118,30 @@ pub enum ExtensionResolutionError {
         missing_extension: ExtensionId,
         /// A list of available extensions.
         available_extensions: Vec<ExtensionId>,
+    },
+    /// A type definition's `extension_id` does not match the extension it is in.
+    #[display(
+        "Type definition {def} in extension {extension} declares it was defined in {wrong_extension} instead."
+    )]
+    WrongTypeDefExtension {
+        /// The extension that defines the type.
+        extension: ExtensionId,
+        /// The type definition name.
+        def: TypeName,
+        /// The extension declared in the type definition's `extension_id`.
+        wrong_extension: ExtensionId,
+    },
+    /// An operation definition's `extension_id` does not match the extension it is in.
+    #[display(
+        "Operation definition {def} in extension {extension} declares it was defined in {wrong_extension} instead."
+    )]
+    WrongOpDefExtension {
+        /// The extension that defines the op.
+        extension: ExtensionId,
+        /// The op definition name.
+        def: OpName,
+        /// The extension declared in the op definition's `extension_id`.
+        wrong_extension: ExtensionId,
     },
     /// The type of an `OpaqueValue` has types which do not reference their defining extensions.
     #[display("The type of the opaque value '{value}' requires extensions {missing_extensions}, but does not reference their definition.")]

--- a/hugr-core/src/extension/resolution/extension.rs
+++ b/hugr-core/src/extension/resolution/extension.rs
@@ -26,10 +26,15 @@ impl ExtensionRegistry {
     ///   registry.
     pub fn new_with_extension_resolution(
         extensions: impl IntoIterator<Item = Extension>,
+        other_extensions: &WeakExtensionRegistry,
     ) -> Result<ExtensionRegistry, ExtensionResolutionError> {
         Self::new_cyclic(extensions, |mut exts, weak_registry| {
+            let mut weak_registry = weak_registry.clone();
+            for (other_id, other) in other_extensions.iter() {
+                weak_registry.register(other_id.clone(), other.clone());
+            }
             for ext in &mut exts {
-                ext.resolve_references(weak_registry)?;
+                ext.resolve_references(&weak_registry)?;
             }
             Ok(exts)
         })

--- a/hugr-core/src/extension/resolution/extension.rs
+++ b/hugr-core/src/extension/resolution/extension.rs
@@ -1,0 +1,161 @@
+//! Resolve weak links inside `CustomType`s in an extension definition.
+//!
+//! This module is used when loading serialized extensions, to ensure that all
+//! weak links are resolved.
+#![allow(dead_code, unused_variables)]
+
+use std::mem;
+use std::sync::Arc;
+
+use crate::extension::{Extension, ExtensionId, ExtensionRegistry, OpDef, SignatureFunc, TypeDef};
+
+use super::types_mut::{resolve_signature_exts, resolve_value_exts};
+use super::{ExtensionResolutionError, WeakExtensionRegistry};
+
+impl ExtensionRegistry {
+    /// Given a list of extensions that has been deserialized, create a new
+    /// registry while updating any internal `Weak<Extension>` reference to
+    /// point to the newly created [`Arc`]s in the registry.
+    ///
+    /// # Errors
+    ///
+    /// - If an opaque operation cannot be resolved to an extension operation.
+    /// - If an extension operation references an extension that is missing from
+    ///   the registry.
+    /// - If a custom type references an extension that is missing from the
+    ///   registry.
+    pub fn new_with_extension_resolution(
+        extensions: impl IntoIterator<Item = Extension>,
+    ) -> Result<ExtensionRegistry, ExtensionResolutionError> {
+        Self::new_cyclic(extensions, |mut exts, weak_registry| {
+            for ext in &mut exts {
+                ext.resolve_references(weak_registry)?;
+            }
+            Ok(exts)
+        })
+    }
+}
+
+impl Extension {
+    /// Resolve all extension references inside the extension.
+    ///
+    /// This is internally called when after deserializing an extension, to
+    /// update all `Weak` references that were dropped from the types.
+    ///
+    /// This method will clone all opdef `Arc`s in the extension, so it should
+    /// not be called on locally defined extensions to prevent unnecessary
+    /// cloning.
+    fn resolve_references(
+        &mut self,
+        extensions: &WeakExtensionRegistry,
+    ) -> Result<(), ExtensionResolutionError> {
+        let mut used_extensions = WeakExtensionRegistry::default();
+
+        for type_def in self.types.values_mut() {
+            resolve_typedef_exts(&self.name, type_def, extensions, &mut used_extensions)?;
+        }
+        for val in self.values.values_mut() {
+            resolve_value_exts(
+                None,
+                val.typed_value_mut(),
+                extensions,
+                &mut used_extensions,
+            )?;
+        }
+        let ops = mem::take(&mut self.operations);
+        for (op_id, mut op_def) in ops {
+            // TODO: We should be able to clone the definition if needed by using `make_mut`,
+            // but `OpDef` does not implement clone -.-
+            let op_ref = Arc::<OpDef>::get_mut(&mut op_def).expect("OpDef is not unique");
+            resolve_opdef_exts(&self.name, op_ref, extensions, &mut used_extensions)?;
+            self.operations.insert(op_id, op_def);
+        }
+
+        Ok(())
+    }
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside a type
+/// definition.
+///
+/// Adds the extensions used in the type to the `used_extensions` registry.
+pub(super) fn resolve_typedef_exts(
+    extension: &ExtensionId,
+    def: &mut TypeDef,
+    extensions: &WeakExtensionRegistry,
+    used_extensions: &mut WeakExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    match extensions.get(def.extension_id()) {
+        Some(ext) => {
+            *def.extension_mut() = ext.clone();
+        }
+        None => {
+            return Err(ExtensionResolutionError::WrongTypeDefExtension {
+                extension: extension.clone(),
+                def: def.name().clone(),
+                wrong_extension: def.extension_id().clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside an
+/// operation definition.
+///
+/// Adds the extensions used in the type to the `used_extensions` registry.
+pub(super) fn resolve_opdef_exts(
+    extension: &ExtensionId,
+    def: &mut OpDef,
+    extensions: &WeakExtensionRegistry,
+    used_extensions: &mut WeakExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    match extensions.get(def.extension_id()) {
+        Some(ext) => {
+            *def.extension_mut() = ext.clone();
+        }
+        None => {
+            return Err(ExtensionResolutionError::WrongOpDefExtension {
+                extension: extension.clone(),
+                def: def.name().clone(),
+                wrong_extension: def.extension_id().clone(),
+            });
+        }
+    }
+
+    resolve_signature_func_exts(
+        extension,
+        def.signature_func_mut(),
+        extensions,
+        used_extensions,
+    )?;
+
+    // We ignore the lowering functions in the operation definition.
+    // They may contain an unresolved hugr, but it's the responsibility of the
+    // lowering call to resolve it, is it may use a different set of extensions.
+
+    Ok(())
+}
+
+/// Update all weak Extension pointers in the [`CustomType`]s inside a
+/// signature computation function.
+///
+/// Adds the extensions used in the type to the `used_extensions` registry.
+pub(super) fn resolve_signature_func_exts(
+    extension: &ExtensionId,
+    signature: &mut SignatureFunc,
+    extensions: &WeakExtensionRegistry,
+    used_extensions: &mut WeakExtensionRegistry,
+) -> Result<(), ExtensionResolutionError> {
+    let signature_body = match signature {
+        SignatureFunc::PolyFuncType(p) => p.body_mut(),
+        SignatureFunc::CustomValidator(v) => v.poly_func_mut().body_mut(),
+        SignatureFunc::MissingValidateFunc(p) => p.body_mut(),
+        // Binary computation functions should always return valid types.
+        SignatureFunc::CustomFunc(_) | SignatureFunc::MissingComputeFunc => {
+            return Ok(());
+        }
+    };
+    resolve_signature_exts(None, signature_body, extensions, used_extensions)
+}

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -90,7 +90,7 @@ fn make_extension(name: &str, op_name: &str) -> (Arc<Extension>, OpType) {
 
 /// Create a new test extension with a type and an op using that type
 ///
-/// Returns an instance of the defined op.
+/// Returns the defined extension.
 fn make_extension_self_referencing(name: &str, op_name: &str, type_name: &str) -> Arc<Extension> {
     let ext = Extension::new_test_arc(ExtensionId::new_unchecked(name), |ext, extension_ref| {
         let type_def = ext

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -10,7 +10,7 @@ use super::{ExtensionResolutionError, WeakExtensionRegistry};
 use crate::extension::ExtensionSet;
 use crate::ops::{OpType, Value};
 use crate::types::type_row::TypeRowBase;
-use crate::types::{CustomType, MaybeRV, Signature, SumType, TypeArg, TypeBase, TypeEnum};
+use crate::types::{CustomType, FuncTypeBase, MaybeRV, SumType, TypeArg, TypeBase, TypeEnum};
 use crate::{Extension, Node};
 
 /// Replace the dangling extension pointer in the [`CustomType`]s inside an
@@ -112,9 +112,9 @@ pub fn resolve_op_types_extensions(
 /// Update all weak Extension pointers in the [`CustomType`]s inside a signature.
 ///
 /// Adds the extensions used in the signature to the `used_extensions` registry.
-fn resolve_signature_exts(
+pub(super) fn resolve_signature_exts<RV: MaybeRV>(
     node: Option<Node>,
-    signature: &mut Signature,
+    signature: &mut FuncTypeBase<RV>,
     extensions: &WeakExtensionRegistry,
     used_extensions: &mut WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
@@ -128,7 +128,7 @@ fn resolve_signature_exts(
 /// Update all weak Extension pointers in the [`CustomType`]s inside a type row.
 ///
 /// Adds the extensions used in the row to the `used_extensions` registry.
-fn resolve_type_row_exts<RV: MaybeRV>(
+pub(super) fn resolve_type_row_exts<RV: MaybeRV>(
     node: Option<Node>,
     row: &mut TypeRowBase<RV>,
     extensions: &WeakExtensionRegistry,

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -157,7 +157,8 @@ impl TypeDef {
         &self.params
     }
 
-    fn name(&self) -> &TypeName {
+    /// The type name of the definition.
+    pub fn name(&self) -> &TypeName {
         &self.name
     }
 
@@ -169,6 +170,11 @@ impl TypeDef {
     /// Returns a weak reference to the extension defining this type.
     pub fn extension(&self) -> Weak<Extension> {
         self.extension_ref.clone()
+    }
+
+    /// Returns a mutable reference to the weak extension pointer in the type def.
+    pub(super) fn extension_mut(&mut self) -> &mut Weak<Extension> {
+        &mut self.extension_ref
     }
 }
 


### PR DESCRIPTION
When deserializing an `ExtensionRegistry`, traverses the extension definitions to update any `Weak<Extension>` so they point to valid extensions (including to extensions in the registry being deserialized!).

This needed a bit of `unsafe` trickery to mimic [`Arc::new_cyclic`](https://doc.rust-lang.org/std/sync/struct.Arc.html#method.new_cyclic) but for vectors of extensions.

As with `Package`, I left the `serde::Deserialize` implementation available but now extension registries have a `load_json` method that should be used when possible, as it runs the required pointer updates.

BREAKING CHANGE: Marked `ExtensionBuildError` and `ExtensionRegistryError` as non-exhaustive.