### PR TITLE
feat!: Remove ExtensionRegistry args in UnwrapBuilder and ListOp

### DIFF
--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -471,11 +471,11 @@ mod test {
         let listy = list::list_type(usize_t());
         let pop: ExtensionOp = list::ListOp::pop
             .with_type(usize_t())
-            .to_extension_op(&reg)
+            .to_extension_op()
             .unwrap();
         let push: ExtensionOp = list::ListOp::push
             .with_type(usize_t())
-            .to_extension_op(&reg)
+            .to_extension_op()
             .unwrap();
         let just_list = TypeRow::from(vec![listy.clone()]);
         let intermed = TypeRow::from(vec![listy.clone(), usize_t()]);

--- a/hugr-llvm/src/extension/collections/array.rs
+++ b/hugr-llvm/src/extension/collections/array.rs
@@ -831,7 +831,7 @@ mod test {
         let hugr = SimpleHugrConfig::new()
             .with_outs(usize_t())
             .with_extensions(exec_registry())
-            .finish_with_exts(|mut builder, reg| {
+            .finish(|mut builder| {
                 let us0 = builder.add_load_value(ConstUsize::new(0));
                 let us1 = builder.add_load_value(ConstUsize::new(1));
                 let i1 = builder.add_load_value(ConstInt::new_u(3, 1).unwrap());
@@ -872,13 +872,13 @@ mod test {
                         let [arr_0] = {
                             let r = builder.add_array_get(int_ty.clone(), 2, arr, us0).unwrap();
                             builder
-                                .build_unwrap_sum(reg, 1, option_type(int_ty.clone()), r)
+                                .build_unwrap_sum(1, option_type(int_ty.clone()), r)
                                 .unwrap()
                         };
                         let [arr_1] = {
                             let r = builder.add_array_get(int_ty.clone(), 2, arr, us1).unwrap();
                             builder
-                                .build_unwrap_sum(reg, 1, option_type(int_ty.clone()), r)
+                                .build_unwrap_sum(1, option_type(int_ty.clone()), r)
                                 .unwrap()
                         };
                         let elem_eq = builder.add_ieq(3, elem, expected_elem).unwrap();
@@ -943,7 +943,7 @@ mod test {
         let hugr = SimpleHugrConfig::new()
             .with_outs(usize_t())
             .with_extensions(exec_registry())
-            .finish_with_exts(|mut builder, reg| {
+            .finish(|mut builder| {
                 let us0 = builder.add_load_value(ConstUsize::new(0));
                 let us1 = builder.add_load_value(ConstUsize::new(1));
                 let i1 = builder.add_load_value(ConstInt::new_u(3, 1).unwrap());
@@ -983,13 +983,13 @@ mod test {
                 let elem_0 = {
                     let r = builder.add_array_get(int_ty.clone(), 2, arr, us0).unwrap();
                     builder
-                        .build_unwrap_sum::<1>(reg, 1, option_type(int_ty.clone()), r)
+                        .build_unwrap_sum::<1>(1, option_type(int_ty.clone()), r)
                         .unwrap()[0]
                 };
                 let elem_1 = {
                     let r = builder.add_array_get(int_ty.clone(), 2, arr, us1).unwrap();
                     builder
-                        .build_unwrap_sum::<1>(reg, 1, option_type(int_ty), r)
+                        .build_unwrap_sum::<1>(1, option_type(int_ty), r)
                         .unwrap()[0]
                 };
                 let expected_elem_0 =
@@ -1052,7 +1052,7 @@ mod test {
         let hugr = SimpleHugrConfig::new()
             .with_outs(int_ty.clone())
             .with_extensions(exec_registry())
-            .finish_with_exts(|mut builder, reg| {
+            .finish(|mut builder| {
                 let mut r = builder.add_load_value(ConstInt::new_u(6, 0).unwrap());
                 let new_array_args = array_contents
                     .iter()
@@ -1074,7 +1074,6 @@ mod test {
                     };
                     let [elem, new_arr] = builder
                         .build_unwrap_sum(
-                            reg,
                             1,
                             option_type(vec![
                                 int_ty.clone(),
@@ -1117,7 +1116,7 @@ mod test {
         let hugr = SimpleHugrConfig::new()
             .with_outs(int_ty.clone())
             .with_extensions(exec_registry())
-            .finish_with_exts(|mut builder, reg| {
+            .finish(|mut builder| {
                 let mut func = builder
                     .define_function(
                         "foo",
@@ -1138,7 +1137,7 @@ mod test {
                     .add_array_get(int_ty.clone(), size, arr, idx_v)
                     .unwrap();
                 let [elem] = builder
-                    .build_unwrap_sum(reg, 1, option_type(vec![int_ty.clone()]), get_res)
+                    .build_unwrap_sum(1, option_type(vec![int_ty.clone()]), get_res)
                     .unwrap();
                 builder.finish_with_outputs([elem]).unwrap()
             });
@@ -1164,7 +1163,7 @@ mod test {
         let hugr = SimpleHugrConfig::new()
             .with_outs(int_ty.clone())
             .with_extensions(exec_registry())
-            .finish_with_exts(|mut builder, reg| {
+            .finish(|mut builder| {
                 let mut r = builder.add_load_value(ConstInt::new_u(6, 0).unwrap());
                 let new_array_args = (0..size)
                     .map(|i| builder.add_load_value(ConstInt::new_u(6, i).unwrap()))
@@ -1204,7 +1203,6 @@ mod test {
                         .unwrap();
                     let [elem, new_arr] = builder
                         .build_unwrap_sum(
-                            reg,
                             1,
                             option_type(vec![
                                 int_ty.clone(),
@@ -1240,7 +1238,7 @@ mod test {
         let hugr = SimpleHugrConfig::new()
             .with_outs(int_ty.clone())
             .with_extensions(exec_registry())
-            .finish_with_exts(|mut builder, _reg| {
+            .finish(|mut builder| {
                 let new_array_args = (0..size)
                     .map(|i| builder.add_load_value(ConstInt::new_u(6, i).unwrap()))
                     .collect_vec();

--- a/hugr-llvm/src/utils/array_op_builder.rs
+++ b/hugr-llvm/src/utils/array_op_builder.rs
@@ -118,10 +118,7 @@ pub mod test {
     use hugr_core::std_extensions::collections::array::{self, array_type};
     use hugr_core::{
         builder::{DFGBuilder, HugrBuilder},
-        extension::{
-            prelude::{either_type, option_type, usize_t, ConstUsize, UnwrapBuilder as _},
-            PRELUDE_REGISTRY,
-        },
+        extension::prelude::{either_type, option_type, usize_t, ConstUsize, UnwrapBuilder as _},
         types::Signature,
         Hugr,
     };
@@ -149,15 +146,13 @@ pub mod test {
                 let array_type = array_type(2, usize_t());
                 either_type(array_type.clone(), array_type)
             };
-            builder
-                .build_unwrap_sum(&PRELUDE_REGISTRY, 1, res_sum_ty, r)
-                .unwrap()
+            builder.build_unwrap_sum(1, res_sum_ty, r).unwrap()
         };
 
         let [elem_0] = {
             let r = builder.add_array_get(usize_t(), 2, arr, us0).unwrap();
             builder
-                .build_unwrap_sum(&PRELUDE_REGISTRY, 1, option_type(usize_t()), r)
+                .build_unwrap_sum(1, option_type(usize_t()), r)
                 .unwrap()
         };
 
@@ -169,31 +164,19 @@ pub mod test {
                 let row = vec![usize_t(), array_type(2, usize_t())];
                 either_type(row.clone(), row)
             };
-            builder
-                .build_unwrap_sum(&PRELUDE_REGISTRY, 1, res_sum_ty, r)
-                .unwrap()
+            builder.build_unwrap_sum(1, res_sum_ty, r).unwrap()
         };
 
         let [_elem_left, arr] = {
             let r = builder.add_array_pop_left(usize_t(), 2, arr).unwrap();
             builder
-                .build_unwrap_sum(
-                    &PRELUDE_REGISTRY,
-                    1,
-                    option_type(vec![usize_t(), array_type(1, usize_t())]),
-                    r,
-                )
+                .build_unwrap_sum(1, option_type(vec![usize_t(), array_type(1, usize_t())]), r)
                 .unwrap()
         };
         let [_elem_right, arr] = {
             let r = builder.add_array_pop_right(usize_t(), 1, arr).unwrap();
             builder
-                .build_unwrap_sum(
-                    &PRELUDE_REGISTRY,
-                    1,
-                    option_type(vec![usize_t(), array_type(0, usize_t())]),
-                    r,
-                )
+                .build_unwrap_sum(1, option_type(vec![usize_t(), array_type(0, usize_t())]), r)
                 .unwrap()
         };
 

--- a/hugr-passes/src/const_fold/test.rs
+++ b/hugr-passes/src/const_fold/test.rs
@@ -1,7 +1,6 @@
 use std::collections::hash_map::RandomState;
 use std::collections::HashSet;
 
-use hugr_core::std_extensions::STD_REG;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use rstest::rstest;
@@ -184,10 +183,7 @@ fn test_list_ops() -> Result<(), Box<dyn std::error::Error>> {
 
     let [list, maybe_elem] = build
         .add_dataflow_op(
-            ListOp::pop
-                .with_type(bool_t())
-                .to_extension_op(&STD_REG)
-                .unwrap(),
+            ListOp::pop.with_type(bool_t()).to_extension_op().unwrap(),
             [list],
         )?
         .outputs_arr();
@@ -197,10 +193,7 @@ fn test_list_ops() -> Result<(), Box<dyn std::error::Error>> {
 
     let [list] = build
         .add_dataflow_op(
-            ListOp::push
-                .with_type(bool_t())
-                .to_extension_op(&STD_REG)
-                .unwrap(),
+            ListOp::push.with_type(bool_t()).to_extension_op().unwrap(),
             [list, elem],
         )?
         .outputs_arr();

--- a/hugr-passes/src/monomorphize.rs
+++ b/hugr-passes/src/monomorphize.rs
@@ -300,8 +300,8 @@ mod test {
     use std::iter;
 
     use hugr_core::extension::simple_op::MakeRegisteredOp as _;
+    use hugr_core::std_extensions::collections;
     use hugr_core::std_extensions::collections::array::{array_type_parametric, ArrayOpDef};
-    use hugr_core::std_extensions::{collections, STD_REG};
     use hugr_core::types::type_param::TypeParam;
     use itertools::Itertools;
 
@@ -491,7 +491,7 @@ mod test {
                 .unwrap();
             let [get] = pf2.add_dataflow_op(op, [inw, idx]).unwrap().outputs_arr();
             let [got] = pf2
-                .build_unwrap_sum(&STD_REG, 1, SumType::new([vec![], vec![tv(1)]]), get)
+                .build_unwrap_sum(1, SumType::new([vec![], vec![tv(1)]]), get)
                 .unwrap();
             pf2.finish_with_outputs([got]).unwrap()
         };
@@ -521,7 +521,7 @@ mod test {
             panic!()
         };
         let [_, ar2_unwrapped] = outer
-            .build_unwrap_sum(&STD_REG, 1, st.clone(), ar2.out_wire(0))
+            .build_unwrap_sum(1, st.clone(), ar2.out_wire(0))
             .unwrap();
         let [e2] = outer
             .call(pf1.handle(), &[sa(n - 1)], [ar2_unwrapped])


### PR DESCRIPTION
Last two remaining usages of `ExtensionRegistry` as redundant parameters. These should have been included in #1784.

BREAKING CHANGE: `UnwrapBuilder` no longer requires an `ExtensionRegistry` as argument.
BREAKING CHANGE: `ListOpInst` no longer requires an `ExtensionRegistry` to produce an `ExtensionOp`.