### PR TITLE
chore: Drop `viz_hugr` test utils.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,6 @@ strum = "0.26.1"
 strum_macros = "0.26.1"
 thiserror = "2.0.6"
 typetag = "0.2.7"
-urlencoding = "2.1.2"
-webbrowser = "1.0.0"
 clap = { version = "4.5.4" }
 clio = "0.3.5"
 clap-verbosity-flag = "3.0.1"

--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -21,8 +21,6 @@ clap-verbosity-flag.workspace = true
 derive_more = { workspace = true, features = ["display", "error", "from"] }
 hugr = { path = "../hugr", version = "0.14.0" }
 serde_json.workspace = true
-serde.workspace = true
-thiserror.workspace = true
 clio = { workspace = true, features = ["clap-parse"] }
 
 [lints]

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -60,8 +60,6 @@ bumpalo = { workspace = true, features = ["collections"] }
 
 [dev-dependencies]
 rstest = { workspace = true }
-webbrowser = { workspace = true }
-urlencoding = { workspace = true }
 cool_asserts = { workspace = true }
 insta = { workspace = true, features = ["yaml"] }
 jsonschema = { workspace = true }

--- a/hugr-core/src/utils.rs
+++ b/hugr-core/src/utils.rs
@@ -266,22 +266,6 @@ pub(crate) mod test {
         Hugr,
     };
 
-    /// Open a browser page to render a dot string graph.
-    ///
-    /// This can be used directly on the output of `Hugr::dot_string`
-    #[cfg(not(ci_run))]
-    pub(crate) fn viz_dotstr(dotstr: impl AsRef<str>) {
-        let mut base: String = "https://dreampuf.github.io/GraphvizOnline/#".into();
-        base.push_str(&urlencoding::encode(dotstr.as_ref()));
-        webbrowser::open(&base).unwrap();
-    }
-
-    /// Open a browser page to render a HugrView's dot string graph.
-    #[cfg(not(ci_run))]
-    pub(crate) fn viz_hugr(hugr: &impl HugrView) {
-        viz_dotstr(hugr.dot_string());
-    }
-
     /// Check that a hugr just loads and returns a single expected constant.
     pub(crate) fn assert_fully_folded(h: &Hugr, expected_value: &Value) {
         assert_fully_folded_with(h, |v| v == expected_value)

--- a/hugr-llvm/Cargo.toml
+++ b/hugr-llvm/Cargo.toml
@@ -16,15 +16,7 @@ keywords = ["Quantum", "Quantinuum"]
 categories = ["compilers"]
 
 [features]
-test-utils = [
-    "insta",
-    "rstest",
-    "portgraph",
-    "pathsearch",
-    "serde_json",
-    "serde",
-    "typetag",
-]
+test-utils = ["insta", "rstest", "pathsearch"]
 
 default = ["llvm14-0"]
 llvm14-0 = ["inkwell/llvm14-0"]
@@ -38,16 +30,11 @@ itertools.workspace = true
 delegate.workspace = true
 petgraph.workspace = true
 lazy_static.workspace = true
-downcast-rs.workspace = true
 strum.workspace = true
 
 insta = { workspace = true, optional = true }
 rstest = { workspace = true, optional = true }
-portgraph = { workspace = true, optional = true }
 pathsearch = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-typetag = { workspace = true, optional = true }
 
 [dev-dependencies]
-hugr-llvm = {"path" = ".", features = ["test-utils"]}
+hugr-llvm = { "path" = ".", features = ["test-utils"] }

--- a/hugr-passes/Cargo.toml
+++ b/hugr-passes/Cargo.toml
@@ -21,7 +21,6 @@ portgraph = { workspace = true }
 ascent = { version = "0.7.0" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-paste = { workspace = true }
 thiserror = { workspace = true }
 petgraph = { workspace = true }
 
@@ -31,5 +30,4 @@ extension_inference = ["hugr-core/extension_inference"]
 [dev-dependencies]
 rstest = { workspace = true }
 proptest = { workspace = true }
-proptest-derive = { workspace = true }
 proptest-recurse = { version = "0.5.0" }


### PR DESCRIPTION
The method is not used that much, and its dependency `webbrowser` caused a transitive dependency on `home` for linux targets, which started requiring `rust 1.81` recently.

This fixes the errors seen on CI: https://github.com/CQCL/hugr/actions/runs/12371264488/job/34526993767?pr=1788#step:7:308

drive-by: Use `cargo-machete` to find and cleanup other unused dependencies