### PR TITLE
fix: `Call` ops not tracking their parameter extensions

### DIFF
--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -355,24 +355,34 @@ fn resolve_call() {
         Signature::new(vec![], vec![bool_t()]),
     );
 
-    let generic_type = TypeArg::Type { ty: float64_type() };
-    let expected_ext = float_types::EXTENSION_ID.to_owned();
+    let generic_type_1 = TypeArg::Type { ty: float64_type() };
+    let generic_type_2 = TypeArg::Type { ty: int_type(6) };
+    let expected_exts = [
+        float_types::EXTENSION_ID.to_owned(),
+        int_types::EXTENSION_ID.to_owned(),
+    ]
+    .into_iter()
+    .collect::<ExtensionSet>();
 
     let mut module = ModuleBuilder::new();
     let dummy_fn = module.declare("called_fn", dummy_fn_sig).unwrap();
+
     let mut func = module
         .define_function(
             "caller_fn",
             Signature::new(vec![], vec![bool_t()])
-                .with_extension_delta(ExtensionSet::from_iter([expected_ext.clone()])),
+                .with_extension_delta(ExtensionSet::from_iter(expected_exts.clone())),
         )
         .unwrap();
-    let call = func.call(&dummy_fn, &[generic_type], vec![]).unwrap();
+    let _load_func = func.load_func(&dummy_fn, &[generic_type_1]).unwrap();
+    let call = func.call(&dummy_fn, &[generic_type_2], vec![]).unwrap();
     func.finish_with_outputs(call.outputs()).unwrap();
 
-    let hugr = module.finish_hugr().unwrap_or_else(|e| panic!("{e}"));
+    let hugr = module.finish_hugr().unwrap();
 
-    assert!(hugr.extensions().contains(&expected_ext));
+    for ext in expected_exts {
+        assert!(hugr.extensions().contains(&ext));
+    }
 
     check_extension_resolution(hugr);
 }

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -50,12 +50,18 @@ pub(crate) fn collect_op_types_extensions(
         OpType::Call(c) => {
             collect_signature_exts(c.func_sig.body(), &mut used, &mut missing);
             collect_signature_exts(&c.instantiation, &mut used, &mut missing);
+            for arg in &c.type_args {
+                collect_typearg_exts(arg, &mut used, &mut missing);
+            }
         }
         OpType::CallIndirect(c) => collect_signature_exts(&c.signature, &mut used, &mut missing),
         OpType::LoadConstant(lc) => collect_type_exts(&lc.datatype, &mut used, &mut missing),
         OpType::LoadFunction(lf) => {
             collect_signature_exts(lf.func_sig.body(), &mut used, &mut missing);
             collect_signature_exts(&lf.instantiation, &mut used, &mut missing);
+            for arg in &lf.type_args {
+                collect_typearg_exts(arg, &mut used, &mut missing);
+            }
         }
         OpType::DFG(dfg) => collect_signature_exts(&dfg.signature, &mut used, &mut missing),
         OpType::OpaqueOp(op) => {
@@ -203,7 +209,7 @@ pub(super) fn collect_type_exts<RV: MaybeRV>(
 /// - `used_extensions`: A The registry where to store the used extensions.
 /// - `missing_extensions`: A set of `ExtensionId`s of which the
 ///   `Weak<Extension>` pointer has been invalidated.
-fn collect_typearg_exts(
+pub(super) fn collect_typearg_exts(
     arg: &TypeArg,
     used_extensions: &mut WeakExtensionRegistry,
     missing_extensions: &mut ExtensionSet,

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -50,6 +50,9 @@ pub fn resolve_op_types_extensions(
         OpType::Call(c) => {
             resolve_signature_exts(node, c.func_sig.body_mut(), extensions, used_extensions)?;
             resolve_signature_exts(node, &mut c.instantiation, extensions, used_extensions)?;
+            for arg in &mut c.type_args {
+                resolve_typearg_exts(node, arg, extensions, used_extensions)?;
+            }
         }
         OpType::CallIndirect(c) => {
             resolve_signature_exts(node, &mut c.signature, extensions, used_extensions)?
@@ -60,6 +63,9 @@ pub fn resolve_op_types_extensions(
         OpType::LoadFunction(lf) => {
             resolve_signature_exts(node, lf.func_sig.body_mut(), extensions, used_extensions)?;
             resolve_signature_exts(node, &mut lf.instantiation, extensions, used_extensions)?;
+            for arg in &mut lf.type_args {
+                resolve_typearg_exts(node, arg, extensions, used_extensions)?;
+            }
         }
         OpType::DFG(dfg) => {
             resolve_signature_exts(node, &mut dfg.signature, extensions, used_extensions)?

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -587,6 +587,8 @@ impl From<Type> for TypeRV {
 
 /// Details a replacement of type variables with a finite list of known values.
 /// (Variables out of the range of the list will result in a panic)
+#[derive(Clone, Debug, derive_more::Display)]
+#[display("[{}]", _0.iter().map(|ta| ta.to_string()).join(", "))]
 pub struct Substitution<'a>(&'a [TypeArg]);
 
 impl<'a> Substitution<'a> {


### PR DESCRIPTION
Fixes #1795 

I forgot to track the `type_args` of `Call` and `LoadFunction` when doing extension resolution

drive-by: Add derives to `types::Substitution`