### PR TITLE
feat: (WIP) Static evaluation via constant folding

### DIFF
--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -61,7 +61,7 @@ pub struct Replacement {
     /// and there would be no possible [Self::mu_inp], [Self::mu_out] or [Self::adoptions].
     pub removal: Vec<Node>,
     /// A hugr (not necessarily valid, as it may be missing edges and/or nodes), whose root
-    /// is the same type as the root of [Self::replacement].  "G" in the spec.
+    /// is the same type as the common parent of all the nodes in [Self::removal].  "G" in the spec.
     pub replacement: Hugr,
     /// Describes how parts of the Hugr that would otherwise be removed should instead be preserved but
     /// with new parents amongst the newly-inserted nodes.  This is a Map from container nodes in

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -155,7 +155,7 @@ impl ConstantFoldPass {
                 continue;
             };
 
-            if h.get_optype(n).is_cfg() {
+            if h.get_optype(n).is_cfg() || h.get_optype(n).is_conditional() {
                 for bb in h.children(n) {
                     //if results.bb_reachable(bb).unwrap() { // no, we'd need to patch up predicates
                     q.push_back(bb);

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -27,6 +27,8 @@ pub use monomorphize::monomorphize;
 pub use monomorphize::{MonomorphizeError, MonomorphizePass};
 pub mod nest_cfgs;
 pub mod non_local;
+mod static_eval;
+pub use static_eval::static_eval;
 pub mod validation;
 pub use force_order::{force_order, force_order_by_key};
 pub use lower::{lower_ops, replace_many_ops};

--- a/hugr-passes/src/static_eval.rs
+++ b/hugr-passes/src/static_eval.rs
@@ -195,3 +195,26 @@ fn peel_tailloop(h: &mut impl HugrMut, tl: Node) -> Option<()> {
     // Some(())
     None
 }
+
+#[cfg(test)]
+mod test {
+    use std::{fs::File, io::BufReader};
+
+    use hugr_core::std_extensions::{arithmetic::int_types::ConstInt, STD_REG};
+    use hugr_core::{ops::Value, Hugr};
+
+    use super::static_eval;
+
+    #[test]
+    fn recursive_fibonacci() {
+        let h = Hugr::load_json(
+            BufReader::new(File::open("/Users/alanlawrence/fibonacci_hugr.json").unwrap()),
+            &STD_REG,
+        )
+        .unwrap();
+        assert_eq!(
+            static_eval(h),
+            Some(vec![Value::extension(ConstInt::new_u(5, 8).unwrap())])
+        );
+    }
+}

--- a/hugr-passes/src/static_eval.rs
+++ b/hugr-passes/src/static_eval.rs
@@ -1,0 +1,93 @@
+//! Static evaluation of Hugrs, i.e. down to a [Value] (given inputs).
+//! Some of this logic might be generalizable to cases where we cannot deduce a
+//! unique [Value], and thus integrated into [constant folding](super::const_fold),
+//! but the API is useful, and it seems likely that some of the transforms
+//! will not be worth performing if a single-[Value] is not wanted and/or achievable.
+
+use hugr_core::hugr::hugrmut::HugrMut;
+use hugr_core::hugr::rewrite::inline_dfg::InlineDFG;
+use hugr_core::ops::{OpType, Value};
+use hugr_core::{Hugr, HugrView};
+
+use super::const_fold::constant_fold_pass;
+
+pub fn static_eval(mut h: Hugr) -> Option<Vec<Value>> {
+    // TODO: allow inputs to be specified
+    loop {
+        constant_fold_pass(&mut h);
+        let mut precision_improved = false;
+        loop {
+            let mut need_scan = false;
+            for n in h.children(h.root()).collect::<Vec<_>>() {
+                match h.get_optype(n) {
+                    OpType::Conditional(_) => {
+                        let (pred, _) = h.single_linked_output(n, 0).unwrap();
+                        if h.get_optype(pred).is_load_constant() {
+                            // TODO: replace conditional with DFG containing that case,
+                            // and constant with element constants.
+                            need_scan = true; // will inline on next iter. PERF: inline it now
+                        }
+                    }
+                    OpType::DFG(_) => {
+                        h.apply_rewrite(InlineDFG(n.into())).unwrap();
+                        need_scan = true;
+                    }
+                    OpType::TailLoop(_) => {
+                        let (pred, _) = h.single_linked_output(n, 0).unwrap();
+                        if h.get_optype(pred).is_load_constant() {
+                            // TODO: copy body of loop into DFG (dup loop, change container type, output Sum)
+                            // TODO: change constant into elements
+                            // TODO: nest existing loop inside conditional testing output of DFG.
+                            precision_improved = true;
+                        }
+                    }
+                    OpType::CallIndirect(_) => {
+                        let (called, _) = h.single_linked_output(n, 0).unwrap();
+                        match h.get_optype(called) {
+                            OpType::LoadConstant(_) => {
+                                // TODO: Inline called Hugr into DFG
+                                precision_improved = true;
+                            }
+                            OpType::LoadFunction(_) => {
+                                // TODO: Convert to Call
+                                precision_improved = true
+                            }
+                            _ => (),
+                        }
+                    }
+                    OpType::Call(_) => {
+                        // Even if no inputs are constants (e.g. they are partial sums with multiple tags),
+                        // this *could* (maybe) be beneficial.
+                        // Note we are only doing this at the top level of the Hugr!
+                        // TODO: Copy body of called-function into DFG, wire in remaining inputs (unchanged).
+                        precision_improved = true;
+                    }
+                    OpType::CFG(_) => {
+                        // TODO: if entry node has in-edges (i.e. from other blocks) -> peel, set precision_improved=True
+                        // else if entry node is exit block, elide CFG;
+                        // else if entry-node predicate is constant -> move contents of entry node outside CFG, make selected successor be the new entry block, set need_scan=True
+                    }
+                    _ => (),
+                }
+            }
+            if precision_improved || !need_scan {
+                break;
+            };
+        }
+        if !precision_improved {
+            break;
+        };
+    }
+
+    let [_, out] = h.get_io(h.root()).unwrap();
+    h.signature(out)
+        .unwrap()
+        .input_ports()
+        .map(|p| {
+            let (src_node, _) = h.single_linked_output(out, p)?;
+            h.get_optype(src_node).as_load_constant()?;
+            let cst = h.get_optype(h.static_source(src_node)?).as_const()?;
+            Some(cst.value().clone())
+        })
+        .collect()
+}

--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -106,3 +106,73 @@ class _DivModDef(RegisteredOp):
 
 #: DivMod operation.
 DivMod = _DivModDef()
+
+
+@dataclass(frozen=True)
+class _ILtUDef(RegisteredOp):
+    """Integer less than (unsigned)."""
+
+    width: int = 5
+    const_op_def: ClassVar[ext.OpDef] = INT_OPS_EXTENSION.operations["ilt_u"]
+
+    def type_args(self) -> list[tys.TypeArg]:
+        return [tys.BoundedNatArg(n=self.width)]
+
+    def cached_signature(self) -> tys.FunctionType | None:
+        row: list[tys.Type] = [int_t(self.width)] * 2
+        return tys.FunctionType(row, [tys.Bool], runtime_reqs=[INT_OPS_EXTENSION.name])
+
+    def __call__(self, a: ComWire) -> Command:
+        return DataflowOp.__call__(self, a)
+
+
+#: IntLessThan (unsigned) operation
+ILtU = _ILtUDef()
+
+
+@dataclass(frozen=True)
+class _ISubDef(RegisteredOp):
+    """Integer subtract."""
+
+    width: int = 5
+    const_op_def: ClassVar[ext.OpDef] = INT_OPS_EXTENSION.operations["isub"]
+
+    def type_args(self) -> list[tys.TypeArg]:
+        return [tys.BoundedNatArg(n=self.width)]
+
+    def cached_signature(self) -> tys.FunctionType | None:
+        row: list[tys.Type] = [int_t(self.width)] * 2
+        return tys.FunctionType(
+            row, [int_t(self.width)], runtime_reqs=[INT_OPS_EXTENSION.name]
+        )
+
+    def __call__(self, a: ComWire) -> Command:
+        return DataflowOp.__call__(self, a)
+
+
+#: ISub operation
+ISub = _ISubDef()
+
+
+@dataclass(frozen=True)
+class _IAddDef(RegisteredOp):
+    """Integer add."""
+
+    width: int = 5
+    const_op_def: ClassVar[ext.OpDef] = INT_OPS_EXTENSION.operations["iadd"]
+
+    def type_args(self) -> list[tys.TypeArg]:
+        return [tys.BoundedNatArg(n=self.width)]
+
+    def cached_signature(self) -> tys.FunctionType | None:
+        row: list[tys.Type] = [int_t(self.width)] * 2
+        return tys.FunctionType(
+            row, [int_t(self.width)], runtime_reqs=[INT_OPS_EXTENSION.name]
+        )
+
+    def __call__(self, a: ComWire) -> Command:
+        return DataflowOp.__call__(self, a)
+
+
+#: IAdd operation
+IAdd = _IAddDef()

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -318,6 +318,9 @@ def test_recursive_fibonacci() -> None:
 
     validate(mod.hugr)
 
+    with open("/Users/alanlawrence/fibonacci_hugr.json", "w") as f:
+        f.write(mod.hugr.to_json())
+
 
 def test_higher_order() -> None:
     noop_fn = Dfg(tys.Qubit)

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -10,7 +10,7 @@ from hugr.build.function import Module
 from hugr.hugr import Hugr
 from hugr.hugr.node_port import Node, _SubPort
 from hugr.ops import NoConcreteFunc
-from hugr.std.int import INT_T, DivMod, IntVal
+from hugr.std.int import INT_T, DivMod, IAdd, ILtU, IntVal, ISub
 from hugr.std.logic import Not
 
 from .conftest import validate
@@ -295,6 +295,28 @@ def test_invalid_recursive_function() -> None:
 
     with pytest.raises(ValueError, match="The function has fixed output type"):
         f_recursive.set_outputs(f_recursive.input_node[0])
+
+
+def test_recursive_fibonacci() -> None:
+    mod = Module()
+
+    fib = mod.define_function("fibonacci", [INT_T], [INT_T])
+    one = fib.load(IntVal(1))
+    two = fib.load(IntVal(2))
+    pred = fib.add_op(ILtU, fib.input_node[0], two)
+    cond = fib.add_conditional(pred)
+    with cond.add_case(0) as f:
+        r1 = f.call(fib, f.add_op(ISub, fib.input_node[0], one))
+        r2 = f.call(fib, f.add_op(ISub, fib.input_node[0], two))
+        f.set_outputs(f.add_op(IAdd, r1, r2))
+    with cond.add_case(1) as t:
+        t.set_outputs(t.load(IntVal(1)))
+    fib.set_outputs(*cond.outputs())
+
+    main = mod.define_function("main", [], [INT_T])
+    main.set_outputs(main.call(fib, main.load(IntVal(5))))
+
+    validate(mod.hugr)
 
 
 def test_higher_order() -> None:


### PR DESCRIPTION
So far:
* Inlining of direct `Call`s, `Conditional`s and (trivially) `DFG`s
* ...sufficient to evaluate a doubly-recursive `fibonacci`
* Hacky extension of constant-folding to allow specifying entry points
* Fix constant-folding not to eliminate unused Cases
* And simplify `find_needed_nodes`

TODO:
* TailLoop
* CallIndirect
* CFG
* Handle incoming nonlocal edges - see #1833 