### PR TITLE
feat(hugr-llvm): Emit more int ops

### DIFF
--- a/hugr-llvm/src/emit/test.rs
+++ b/hugr-llvm/src/emit/test.rs
@@ -80,6 +80,15 @@ impl<'c> Emission<'c> {
 
     /// JIT and execute the function named `entry` in the inner module.
     ///
+    /// That function must take no arguments and return an `i64`.
+    pub fn exec_i64(&self, entry: impl AsRef<str>) -> Result<i64> {
+        let gv = self.exec_impl(entry)?;
+        let x: u64 = gv.as_int(true).try_into().unwrap();
+        Ok(x as i64)
+    }
+
+    /// JIT and execute the function named `entry` in the inner module.
+    ///
     /// That function must take no arguments and return an `f64`.
     pub fn exec_f64(&self, entry: impl AsRef<str>) -> Result<f64> {
         let gv = self.exec_impl(entry)?;

--- a/hugr-llvm/src/extension/int.rs
+++ b/hugr-llvm/src/extension/int.rs
@@ -278,7 +278,6 @@ impl<'a, H: HugrView + 'a> CodegenExtsBuilder<'a, H> {
 
 #[cfg(test)]
 mod test {
-    use hugr_core::builder::Container;
     use hugr_core::std_extensions::STD_REG;
     use hugr_core::{
         builder::{Dataflow, DataflowSubContainer},
@@ -301,51 +300,41 @@ mod test {
 
     fn test_binary_int_op(name: impl AsRef<str>, log_width: u8) -> Hugr {
         let ty = &INT_TYPES[log_width as usize];
-        test_binary_int_op_with_results(name, log_width, vec![ty.clone()])
+        test_binary_int_op_with_results(name, log_width, None, vec![ty.clone()])
     }
 
     fn test_binary_icmp_op(name: impl AsRef<str>, log_width: u8) -> Hugr {
-        test_binary_int_op_with_results(name, log_width, vec![bool_t()])
+        test_binary_int_op_with_results(name, log_width, None, vec![bool_t()])
     }
+
     fn test_binary_int_op_with_results(
         name: impl AsRef<str>,
         log_width: u8,
+        inputs: Option<[ConstInt; 2]>, // If inputs are provided, they'll be wired into the op, otherwise the inputs to the hugr will be wired into the op
         output_types: impl Into<TypeRow>,
     ) -> Hugr {
         let ty = &INT_TYPES[log_width as usize];
+        let input_tys = if inputs.is_some() {
+            vec![]
+        } else {
+            vec![ty.clone(), ty.clone()]
+        };
         SimpleHugrConfig::new()
-            .with_ins(vec![ty.clone(), ty.clone()])
+            .with_ins(input_tys)
             .with_outs(output_types.into())
             .with_extensions(STD_REG.clone())
             .finish(|mut hugr_builder| {
-                let [in1, in2] = hugr_builder.input_wires_arr();
-                let ext_op = int_ops::EXTENSION
-                    .instantiate_extension_op(name.as_ref(), [(log_width as u64).into()])
-                    .unwrap();
-                let outputs = hugr_builder
-                    .add_dataflow_op(ext_op, [in1, in2])
-                    .unwrap()
-                    .outputs();
-                hugr_builder.finish_with_outputs(outputs).unwrap()
-            })
-    }
-
-    fn test_binary_int_op_with_results_inputs(
-        name: impl AsRef<str>,
-        log_width: u8,
-        inputs: Vec<ConstInt>,
-        output_types: impl Into<TypeRow>,
-    ) -> Hugr {
-        SimpleHugrConfig::new()
-            .with_ins(vec![])
-            .with_outs(output_types.into())
-            .with_extensions(STD_REG.clone())
-            .finish(|mut hugr_builder| {
-                let mut input_wires = Vec::new();
-                inputs.into_iter().for_each(|i| {
-                    let w = hugr_builder.add_load_value(i);
-                    input_wires.push(w);
-                });
+                let input_wires = match inputs {
+                    None => hugr_builder.input_wires_arr::<2>().to_vec(),
+                    Some(inputs) => {
+                        let mut input_wires = Vec::new();
+                        inputs.into_iter().for_each(|i| {
+                            let w = hugr_builder.add_load_value(i);
+                            input_wires.push(w);
+                        });
+                        input_wires
+                    }
+                };
                 let ext_op = int_ops::EXTENSION
                     .instantiate_extension_op(name.as_ref(), [(log_width as u64).into()])
                     .unwrap();
@@ -357,19 +346,27 @@ mod test {
             })
     }
 
-    fn test_unary_int_op(name: impl AsRef<str>, log_width: u8) -> Hugr {
+    fn test_unary_int_op(name: impl AsRef<str>, log_width: u8, input: Option<ConstInt>) -> Hugr {
         let ty = &INT_TYPES[log_width as usize];
+        let hugr_input_tys = if input.is_some() {
+            vec![]
+        } else {
+            vec![ty.clone()]
+        };
         SimpleHugrConfig::new()
-            .with_ins(vec![ty.clone()])
+            .with_ins(hugr_input_tys)
             .with_outs(vec![ty.clone()])
             .with_extensions(STD_REG.clone())
             .finish(|mut hugr_builder| {
-                let [in1] = hugr_builder.input_wires_arr();
+                let in_wire = match input {
+                    None => hugr_builder.input_wires_arr::<1>()[0],
+                    Some(input) => hugr_builder.add_load_value(input),
+                };
                 let ext_op = int_ops::EXTENSION
                     .instantiate_extension_op(name.as_ref(), [(log_width as u64).into()])
                     .unwrap();
                 let outputs = hugr_builder
-                    .add_dataflow_op(ext_op, [in1])
+                    .add_dataflow_op(ext_op, [in_wire])
                     .unwrap()
                     .outputs();
                 hugr_builder.finish_with_outputs(outputs).unwrap()
@@ -379,7 +376,7 @@ mod test {
     #[rstest]
     fn test_neg_emission(mut llvm_ctx: TestContext) {
         llvm_ctx.add_extensions(add_int_extensions);
-        let hugr = test_unary_int_op("ineg", 2);
+        let hugr = test_unary_int_op("ineg", 2, None);
         check_emission!("ineg", hugr, llvm_ctx);
     }
 
@@ -420,11 +417,11 @@ mod test {
     ) {
         exec_ctx.add_extensions(add_int_extensions);
         let ty = &INT_TYPES[6].clone();
-        let args = vec![
+        let inputs = [
             ConstInt::new_u(6, lhs).unwrap(),
             ConstInt::new_u(6, rhs).unwrap(),
         ];
-        let hugr = test_binary_int_op_with_results_inputs(op, 6, args, vec![ty.clone()]);
+        let hugr = test_binary_int_op_with_results(op, 6, Some(inputs), vec![ty.clone()]);
         assert_eq!(exec_ctx.exec_hugr_u64(hugr, "main"), result);
     }
 
@@ -450,11 +447,11 @@ mod test {
     ) {
         exec_ctx.add_extensions(add_int_extensions);
         let ty = &INT_TYPES[6].clone();
-        let args = vec![
+        let inputs = [
             ConstInt::new_s(6, lhs).unwrap(),
             ConstInt::new_s(6, rhs).unwrap(),
         ];
-        let hugr = test_binary_int_op_with_results_inputs(op, 6, args, vec![ty.clone()]);
+        let hugr = test_binary_int_op_with_results(op, 6, Some(inputs), vec![ty.clone()]);
         assert_eq!(exec_ctx.exec_hugr_i64(hugr, "main"), result);
     }
 
@@ -468,9 +465,8 @@ mod test {
         #[case] result: i64,
     ) {
         exec_ctx.add_extensions(add_int_extensions);
-        let ty = &INT_TYPES[6].clone();
-        let args = vec![ConstInt::new_s(6, arg).unwrap()];
-        let hugr = test_binary_int_op_with_results_inputs(op, 6, args, vec![ty.clone()]);
+        let input = ConstInt::new_s(6, arg).unwrap();
+        let hugr = test_unary_int_op(op, 6, Some(input));
         assert_eq!(exec_ctx.exec_hugr_i64(hugr, "main"), result);
     }
 }

--- a/hugr-llvm/src/extension/int.rs
+++ b/hugr-llvm/src/extension/int.rs
@@ -463,6 +463,7 @@ mod test {
     #[rstest]
     // LHS: Most significant bit (2^63), RHS: All the other bits combined
     #[case::inot("inot", 9223372036854775808, 9223372036854775807)]
+    #[case::inot("inot", 1, 0)]
     fn test_exec_unsigned_unary_op(
         mut exec_ctx: TestContext,
         #[case] op: String,

--- a/hugr-llvm/src/extension/int.rs
+++ b/hugr-llvm/src/extension/int.rs
@@ -286,7 +286,7 @@ mod test {
             int_ops,
             int_types::{ConstInt, INT_TYPES},
         },
-        types::TypeRow,
+        types::Type,
         Hugr,
     };
     use rstest::rstest;
@@ -300,11 +300,11 @@ mod test {
 
     fn test_binary_int_op(name: impl AsRef<str>, log_width: u8) -> Hugr {
         let ty = &INT_TYPES[log_width as usize];
-        test_int_op_with_results::<2>(name, log_width, None, vec![ty.clone()])
+        test_int_op_with_results::<2>(name, log_width, None, ty.clone())
     }
 
     fn test_binary_icmp_op(name: impl AsRef<str>, log_width: u8) -> Hugr {
-        test_int_op_with_results::<2>(name, log_width, None, vec![bool_t()])
+        test_int_op_with_results::<2>(name, log_width, None, bool_t())
     }
 
     fn test_int_op_with_results<const N: usize>(
@@ -312,7 +312,7 @@ mod test {
         name: impl AsRef<str>,
         log_width: u8,
         inputs: Option<[ConstInt; N]>, // If inputs are provided, they'll be wired into the op, otherwise the inputs to the hugr will be wired into the op
-        output_types: impl Into<TypeRow>,
+        output_type: Type,
     ) -> Hugr {
         let ty = &INT_TYPES[log_width as usize];
         let input_tys = if inputs.is_some() {
@@ -322,7 +322,7 @@ mod test {
         };
         SimpleHugrConfig::new()
             .with_ins(input_tys)
-            .with_outs(output_types.into())
+            .with_outs(vec![output_type])
             .with_extensions(STD_REG.clone())
             .finish(|mut hugr_builder| {
                 let input_wires = match inputs {
@@ -351,7 +351,7 @@ mod test {
     fn test_neg_emission(mut llvm_ctx: TestContext) {
         llvm_ctx.add_extensions(add_int_extensions);
         let ty = INT_TYPES[2].clone();
-        let hugr = test_int_op_with_results::<1>("ineg", 2, None, vec![ty.clone()]);
+        let hugr = test_int_op_with_results::<1>("ineg", 2, None, ty.clone());
         check_emission!("ineg", hugr, llvm_ctx);
     }
 
@@ -396,7 +396,7 @@ mod test {
             ConstInt::new_u(6, lhs).unwrap(),
             ConstInt::new_u(6, rhs).unwrap(),
         ];
-        let hugr = test_int_op_with_results::<2>(op, 6, Some(inputs), vec![ty.clone()]);
+        let hugr = test_int_op_with_results::<2>(op, 6, Some(inputs), ty.clone());
         assert_eq!(exec_ctx.exec_hugr_u64(hugr, "main"), result);
     }
 
@@ -426,7 +426,7 @@ mod test {
             ConstInt::new_s(6, lhs).unwrap(),
             ConstInt::new_s(6, rhs).unwrap(),
         ];
-        let hugr = test_int_op_with_results::<2>(op, 6, Some(inputs), vec![ty.clone()]);
+        let hugr = test_int_op_with_results::<2>(op, 6, Some(inputs), ty.clone());
         assert_eq!(exec_ctx.exec_hugr_i64(hugr, "main"), result);
     }
 
@@ -442,7 +442,7 @@ mod test {
         exec_ctx.add_extensions(add_int_extensions);
         let input = ConstInt::new_s(6, arg).unwrap();
         let ty = INT_TYPES[6].clone();
-        let hugr = test_int_op_with_results::<1>(op, 6, Some([input]), vec![ty.clone()]);
+        let hugr = test_int_op_with_results::<1>(op, 6, Some([input]), ty.clone());
         assert_eq!(exec_ctx.exec_hugr_i64(hugr, "main"), result);
     }
 }

--- a/hugr-llvm/src/test.rs
+++ b/hugr-llvm/src/test.rs
@@ -160,6 +160,13 @@ impl TestContext {
         emission.exec_u64(entry_point).unwrap()
     }
 
+    pub fn exec_hugr_i64(&self, hugr: THugrView, entry_point: impl AsRef<str>) -> i64 {
+        let emission = Emission::emit_hugr(hugr.fat_root().unwrap(), self.get_emit_hugr()).unwrap();
+        emission.verify().unwrap();
+
+        emission.exec_i64(entry_point).unwrap()
+    }
+
     pub fn exec_hugr_f64(&self, hugr: THugrView, entry_point: impl AsRef<str>) -> f64 {
         let emission = Emission::emit_hugr(hugr.fat_root().unwrap(), self.get_emit_hugr()).unwrap();
 


### PR DESCRIPTION
More work on #1702. Adds `ine`, `iabs`, `imax_{s,u}`, `imin_{s,u}`, `ishl`, `ishr`, `ixor`, `ior`, `inot`, `iand`