### PR TITLE
fix: Three bugfixes in model import and export.

### DIFF
--- a/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
@@ -14,7 +14,7 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cfg.
       (signature (-> [?0] [?0] (ext)))
       (cfg
         [%2] [%3]
-        (signature (-> [?0] [?0] (ext)))
+        (signature (-> [(ctrl [?0])] [(ctrl [?0])] (ext)))
         (block [%2] [%6]
           (signature (-> [(ctrl [?0])] [(ctrl [?0])] (ext)))
           (dfg

--- a/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
@@ -21,9 +21,12 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cfg.
             [%4] [%5]
             (signature (-> [?0] [(adt [[?0]])] (ext)))
             (tag 0 [%4] [%5] (signature (-> [?0] [(adt [[?0]])] (ext))))))
-        (block [%6] [%3]
-          (signature (-> [(ctrl [?0])] [(ctrl [?0])] (ext)))
+        (block [%6] [%3 %9]
+          (signature (-> [(ctrl [?0])] [(ctrl [?0]) (ctrl [?0])] (ext)))
           (dfg
             [%7] [%8]
-            (signature (-> [?0] [(adt [[?0]])] (ext)))
-            (tag 0 [%7] [%8] (signature (-> [?0] [(adt [[?0]])] (ext))))))))))
+            (signature (-> [?0] [(adt [[?0] [?0]])] (ext)))
+            (tag
+              0
+              [%7] [%8]
+              (signature (-> [?0] [(adt [[?0] [?0]])] (ext))))))))))

--- a/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
@@ -16,3 +16,9 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
   (forall ?0 type)
   (where (nonlinear ?0))
   [(@ prelude.Array ?0)] [(@ prelude.Array ?0) (@ prelude.Array ?0)] (ext))
+
+(define-func util.copy
+  (forall ?0 type)
+  (where (nonlinear ?0))
+  [?0] [?0 ?0] (ext)
+  (dfg [%0] [%0 %0] (signature (-> [?0] [?0 ?0] (ext)))))

--- a/hugr-model/tests/fixtures/model-cfg.edn
+++ b/hugr-model/tests/fixtures/model-cfg.edn
@@ -9,9 +9,9 @@
       (signature (-> [?a] [?a] (ext)))
       (cfg [%2] [%4]
         (signature (-> [(ctrl [?a])] [(ctrl [?a])] (ext)))
-        (block [%2] [%4]
-          (signature (-> [(ctrl [?a])] [(ctrl [?a])] (ext)))
+        (block [%2] [%4 %2]
+          (signature (-> [(ctrl [?a])] [(ctrl [?a]) (ctrl [?a])] (ext)))
           (dfg [%5] [%6]
-            (signature (-> [?a] [(adt [[?a]])] (ext)))
+            (signature (-> [?a] [(adt [[?a] [?a]])] (ext)))
             (tag 0 [%5] [%6]
-              (signature (-> [?a] [(adt [[?a]])] (ext))))))))))
+              (signature (-> [?a] [(adt [[?a] [?a]])] (ext))))))))))

--- a/hugr-model/tests/fixtures/model-constraints.edn
+++ b/hugr-model/tests/fixtures/model-constraints.edn
@@ -11,3 +11,10 @@
   (forall ?t type)
   (where (nonlinear ?t))
   [(@ prelude.Array ?t)] [(@ prelude.Array ?t) (@ prelude.Array ?t)] (ext))
+
+(define-func util.copy
+  (forall ?t type)
+  (where (nonlinear ?t))
+  [?t] [?t ?t] (ext)
+  (dfg [%0] [%0 %0]
+    (signature (-> [?t] [?t ?t] (ext)))))


### PR DESCRIPTION
This PR fixes three bugs in the import/export between `hugr_model` and `hugr_core`.

1. The types of the source and target ports of a CFG region must be wrapped in a `ctrl` type on export.
2. Importing links that have a single input or output but aren't otherwise connected should be valid.
3. Runtime types are valid `TypeArg`s.