### PR TITLE
ci: fixes to runner image update

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -72,10 +72,15 @@ jobs:
         run: sudo apt-get install -y capnproto
       - name: Check formatting
         run: cargo fmt -- --check
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "14.0"
+          env: true
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features  -- -D warnings
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
       - name: Build docs
-        run: cargo doc --no-deps --all-features
+        run: cargo doc --no-deps --all-features --workspace
         env:
           RUSTDOCFLAGS: "-Dwarnings"
 
@@ -91,6 +96,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install CapnProto
         run: sudo apt-get install -y capnproto
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "14.0"
+          env: true
       - name: Build benchmarks with no features
         run: cargo bench --verbose --no-run  --no-default-features
       - name: Build benchmarks with all features

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -256,7 +256,7 @@ jobs:
           flags: rust
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  tests-check-llvm:
+  tests-stable-llvm:
     needs: changes
     if: ${{ ( needs.changes.outputs.llvm == 'true' && github.event_name != 'push' )}}
     runs-on: ubuntu-latest
@@ -285,13 +285,6 @@ jobs:
         with:
           version: ${{ matrix.llvm-version[0] }}
           env: true
-      - name: Run clippy
-        run: cargo clippy -p hugr-llvm -- -D warnings
-      - name: Build docs
-        run: cargo doc -p hugr-llvm --no-deps
-        env:
-          RUSTDOCFLAGS: "-Dwarnings"
-
       - name: Build
         run: cargo test -p hugr-llvm --verbose --features llvm${{ matrix.llvm-version[1] }} --no-run
       - name: Tests with no features

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -73,9 +73,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+        run: cargo clippy --all-targets --all-features  -- -D warnings
       - name: Build docs
-        run: cargo doc --no-deps --all-features --workspace
+        run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: "-Dwarnings"
 
@@ -248,7 +248,7 @@ jobs:
 
   tests-stable-llvm:
     needs: changes
-    if: ${{ ( needs.changes.outputs.llvm == 'true' && github.event_name == 'push' ) || needs.changes.outputs.override == 'true' }}
+    if: ${{ ( needs.changes.outputs.llvm == 'true' && github.event_name != 'push' )}}
     runs-on: ubuntu-latest
     name: tests hugr-llvm
     strategy:
@@ -261,10 +261,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.7
-      - id: toolchain
-        uses: dtolnay/rust-toolchain@master
+      - name: Install stable toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "stable"
+          components: rustfmt, clippy
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Install CapnProto
@@ -274,6 +275,13 @@ jobs:
         with:
           version: ${{ matrix.llvm-version[0] }}
           env: true
+      - name: Run clippy
+        run: cargo clippy -p hugr-llvm -- -D warnings
+      - name: Build docs
+        run: cargo doc -p hugr-llvm --no-deps
+        env:
+          RUSTDOCFLAGS: "-Dwarnings"
+
       - name: Build
         run: cargo test -p hugr-llvm --verbose --features llvm${{ matrix.llvm-version[1] }} --no-run
       - name: Tests with no features

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -124,6 +124,11 @@ jobs:
 
       - name: Install CapnProto
         run: sudo apt-get install -y capnproto
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "14.0"
+          env: true
       - name: Build with no features
         run: cargo test --verbose  --no-default-features --no-run
       - name: Tests with no features
@@ -135,6 +140,13 @@ jobs:
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     name: tests (Rust stable, all features)
+    strategy:
+      matrix:
+        llvm-version:
+          # different strings for install action and feature name
+          # adapted from https://github.com/TheDan64/inkwell/blob/master/.github/workflows/test.yml
+          - ["14.0", "14-0"]
+
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.7
@@ -147,10 +159,21 @@ jobs:
 
       - name: Install CapnProto
         run: sudo apt-get install -y capnproto
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "14.0"
+          env: true
       - name: Build with all features
         run: cargo test --verbose  --all-features --no-run
       - name: Tests with all features
         run: cargo test --verbose  --all-features
+      - name: Build hugr-llvm
+        if: ${{ needs.changes.outputs.llvm == 'true'}}
+        run: cargo test -p hugr-llvm --verbose --features llvm${{ matrix.llvm-version[1] }} --no-run
+      - name: Tests hugr-llvm
+        if: ${{ needs.changes.outputs.llvm == 'true'}}
+        run: cargo test -p hugr-llvm --verbose --features llvm${{ matrix.llvm-version[1] }}
       - name: Build HUGR binary
         run: cargo build -p hugr-cli
       - name: Upload the binary to the artifacts
@@ -182,6 +205,11 @@ jobs:
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Install CapnProto
         run: sudo apt-get install -y capnproto
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "14.0"
+          env: true
       - name: Build with no features
         run: cargo test --verbose  --no-default-features --no-run
       - name: Tests with no features
@@ -255,40 +283,6 @@ jobs:
           name: rust
           flags: rust
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  tests-stable-llvm:
-    needs: changes
-    if: ${{ ( needs.changes.outputs.llvm == 'true' && github.event_name != 'push' )}}
-    runs-on: ubuntu-latest
-    name: tests hugr-llvm
-    strategy:
-      matrix:
-        llvm-version:
-          # different strings for install action and feature name
-          # adapted from https://github.com/TheDan64/inkwell/blob/master/.github/workflows/test.yml
-          - ["14.0", "14-0"]
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: mozilla-actions/sccache-action@v0.0.7
-      - name: Install stable toolchain
-        id: toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - name: Configure default rust toolchain
-        run: rustup override set ${{steps.toolchain.outputs.name}}
-      - name: Install CapnProto
-        run: sudo apt-get install -y capnproto
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: ${{ matrix.llvm-version[0] }}
-          env: true
-      - name: Build
-        run: cargo test -p hugr-llvm --verbose --features llvm${{ matrix.llvm-version[1] }} --no-run
-      - name: Tests with no features
-        run: cargo test -p hugr-llvm --verbose --features llvm${{ matrix.llvm-version[1] }}
 
   # This is a meta job to mark successful completion of the required checks,
   # even if they are skipped due to no changes in the relevant files.

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -20,6 +20,11 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   HUGR_TEST_SCHEMA: "1"
+  # different strings for install action and feature name
+  # adapted from https://github.com/TheDan64/inkwell/blob/master/.github/workflows/test.yml
+  LLVM_VERSION: "14.0"
+  LLVM_FEATURE_NAME: "14-0"
+
 
 jobs:
   # Check if changes were made to the relevant files.
@@ -75,8 +80,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "14.0"
-          env: true
+          version: ${{ env.LLVM_VERSION }}
       - name: Run clippy
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
       - name: Build docs
@@ -99,8 +103,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "14.0"
-          env: true
+          version: ${{ env.LLVM_VERSION }}
       - name: Build benchmarks with no features
         run: cargo bench --verbose --no-run  --no-default-features
       - name: Build benchmarks with all features
@@ -127,8 +130,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "14.0"
-          env: true
+          version: ${{ env.LLVM_VERSION }}
       - name: Build with no features
         run: cargo test --verbose  --no-default-features --no-run
       - name: Tests with no features
@@ -140,12 +142,6 @@ jobs:
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     name: tests (Rust stable, all features)
-    strategy:
-      matrix:
-        llvm-version:
-          # different strings for install action and feature name
-          # adapted from https://github.com/TheDan64/inkwell/blob/master/.github/workflows/test.yml
-          - ["14.0", "14-0"]
 
     steps:
       - uses: actions/checkout@v4
@@ -162,18 +158,17 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "14.0"
-          env: true
+          version: ${{ env.LLVM_VERSION }}
       - name: Build with all features
         run: cargo test --verbose  --all-features --no-run
       - name: Tests with all features
         run: cargo test --verbose  --all-features
       - name: Build hugr-llvm
         if: ${{ needs.changes.outputs.llvm == 'true'}}
-        run: cargo test -p hugr-llvm --verbose --features llvm${{ matrix.llvm-version[1] }} --no-run
+        run: cargo test -p hugr-llvm --verbose --features llvm${{ env.LLVM_FEATURE_NAME }} --no-run
       - name: Tests hugr-llvm
         if: ${{ needs.changes.outputs.llvm == 'true'}}
-        run: cargo test -p hugr-llvm --verbose --features llvm${{ matrix.llvm-version[1] }}
+        run: cargo test -p hugr-llvm --verbose --features llvm${{ env.LLVM_FEATURE_NAME }}
       - name: Build HUGR binary
         run: cargo build -p hugr-cli
       - name: Upload the binary to the artifacts
@@ -208,8 +203,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "14.0"
-          env: true
+          version: ${{ env.LLVM_VERSION }}
       - name: Build with no features
         run: cargo test --verbose  --no-default-features --no-run
       - name: Tests with no features
@@ -264,8 +258,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "14.0"
-          env: true
+          version: ${{ env.LLVM_VERSION }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run tests with coverage instrumentation

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -246,7 +246,7 @@ jobs:
           flags: rust
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  tests-stable-llvm:
+  tests-check-llvm:
     needs: changes
     if: ${{ ( needs.changes.outputs.llvm == 'true' && github.event_name != 'push' )}}
     runs-on: ubuntu-latest

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -44,6 +44,6 @@ jobs:
     if: ${{ needs.changes.outputs.rust == 'true' }}
     uses: CQCL/hugrverse-actions/.github/workflows/rs-semver-checks.yml@main
     with:
-      apt-dependencies: capnproto
+      apt-dependencies: llvm-14 capnproto
     secrets:
       GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1728385239,
+        "lastModified": 1736426010,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "f16bfde40bb9df8f9fd88bd3a5036a4a99c09bb1",
+        "rev": "1c384bc4be3ee571511fbbc6fdc94fe47d60f6cf",
         "type": "github"
       },
       "original": {
@@ -24,10 +24,10 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1728369208,
+        "lastModified": 1736318091,
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "1938b54a55c1cab94be7b9d8dbaf58007a607e24",
+        "rev": "9e13860d50cbfd42e79101a516e1939c7723f093",
         "type": "github"
       },
       "original": {
@@ -39,10 +39,10 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
+        "lastModified": 1733328505,
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -73,10 +73,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736357384,
+        "lastModified": 1736447052,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2553b4dde78983ab00daebe1cfce32208c982e85",
+        "rev": "156eeac81bc295d151a080eb63e41ae4dc461064",
         "type": "github"
       },
       "original": {
@@ -100,35 +100,19 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable_2": {
-      "locked": {
-        "lastModified": 1728193676,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ecbc1ca8ffd6aea8372ad16be9ebbb39889e55b6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable_2"
+        ]
       },
       "locked": {
-        "lastModified": 1728092656,
+        "lastModified": 1735882644,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
+        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
         "type": "github"
       },
       "original": {
@@ -149,10 +133,10 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1728383944,
+        "lastModified": 1736331291,
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "9806060d5534502218076f9a956548e40d50a2c0",
+        "rev": "32b86a837805a4162a01b2356c65ef9dd53dbae6",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -73,15 +73,14 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728279793,
+        "lastModified": 1736357384,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f85a2d005e83542784a755ca8da112f4f65c4aa4",
+        "rev": "2553b4dde78983ab00daebe1cfce32208c982e85",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/devenv.nix
+++ b/devenv.nix
@@ -70,7 +70,7 @@ in
     # https://devenv.sh/languages/
     # https://devenv.sh/reference/options/#languagesrustversion
     languages.rust = {
-      channel = "nixpkgs";
+      channel = "beta";
       enable = true;
       components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" ];
     };

--- a/devenv.nix
+++ b/devenv.nix
@@ -70,7 +70,7 @@ in
     # https://devenv.sh/languages/
     # https://devenv.sh/reference/options/#languagesrustversion
     languages.rust = {
-      channel = "stable";
+      channel = "nixpkgs";
       enable = true;
       components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" ];
     };

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,6 +1,6 @@
 inputs:
   nixpkgs:
-    url: github:NixOS/nixpkgs/nixpkgs-unstable
+    url: github:NixOS/nixpkgs
   nixpkgs-stable:
     url: github:NixOS/nixpkgs/nixos-23.05
   fenix:

--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -182,7 +182,7 @@ impl TryFrom<&Hugr> for SerHugrLatest {
         let find_offset = |node: Node, offset: usize, dir: Direction, hugr: &Hugr| {
             let op = hugr.get_optype(node);
             let is_value_port = offset < op.value_port_count(dir);
-            let is_static_input = op.static_port(dir).map_or(false, |p| p.index() == offset);
+            let is_static_input = op.static_port(dir).is_some_and(|p| p.index() == offset);
             let offset = (is_value_port || is_static_input).then_some(offset as u16);
             (node_rekey[&node], offset)
         };

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -537,7 +537,7 @@ impl<'a> ValidationContext<'a> {
                 };
                 if !dominator_tree
                     .dominators(ancestor)
-                    .map_or(false, |mut ds| ds.any(|n| n == from_parent))
+                    .is_some_and(|mut ds| ds.any(|n| n == from_parent))
                 {
                     return Err(InterGraphEdgeError::NonDominatedAncestor {
                         from,

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -38,7 +38,7 @@ pub struct DescendantsGraph<'g, Root = Node> {
     /// The operation handle of the root node.
     _phantom: std::marker::PhantomData<Root>,
 }
-impl<'g, Root: NodeHandle> HugrView for DescendantsGraph<'g, Root> {
+impl<Root: NodeHandle> HugrView for DescendantsGraph<'_, Root> {
     #[inline]
     fn contains_node(&self, node: Node) -> bool {
         self.graph.contains_node(node.pg_index())

--- a/hugr-core/src/hugr/views/sibling.rs
+++ b/hugr-core/src/hugr/views/sibling.rs
@@ -85,7 +85,7 @@ macro_rules! impl_base_members {
     };
 }
 
-impl<'g, Root: NodeHandle> HugrView for SiblingGraph<'g, Root> {
+impl<Root: NodeHandle> HugrView for SiblingGraph<'_, Root> {
     impl_base_members! {}
 
     #[inline]
@@ -265,7 +265,7 @@ impl<'g, Root: NodeHandle> HugrInternals for SiblingMut<'g, Root> {
     }
 }
 
-impl<'g, Root: NodeHandle> HugrView for SiblingMut<'g, Root> {
+impl<Root: NodeHandle> HugrView for SiblingMut<'_, Root> {
     impl_base_members! {}
 
     fn contains_node(&self, node: Node) -> bool {

--- a/hugr-llvm/Cargo.toml
+++ b/hugr-llvm/Cargo.toml
@@ -31,7 +31,7 @@ llvm14-0 = ["inkwell/llvm14-0"]
 
 
 [dependencies]
-inkwell = { version = "0.5.0", default-features = false, optional = true}
+inkwell = { version = "0.5.0", default-features = false }
 hugr-core = { path = "../hugr-core", version = "0.14.1" }
 anyhow = "1.0.83"
 itertools.workspace = true

--- a/hugr-llvm/Cargo.toml
+++ b/hugr-llvm/Cargo.toml
@@ -31,7 +31,7 @@ llvm14-0 = ["inkwell/llvm14-0"]
 
 
 [dependencies]
-inkwell = { version = "0.5.0", default-features = false }
+inkwell = { version = "0.5.0", default-features = false, optional = true}
 hugr-core = { path = "../hugr-core", version = "0.14.1" }
 anyhow = "1.0.83"
 itertools.workspace = true

--- a/hugr-llvm/src/lib.rs
+++ b/hugr-llvm/src/lib.rs
@@ -72,7 +72,7 @@ pub mod utils;
 pub fn llvm_version() -> &'static str {
     #[cfg(feature = "llvm14-0")]
     return "llvm14";
-    panic!("No recognised llvm feature")
+    panic!("No recognised llvm feature.")
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,9 @@ resolution-markers = [
 members = [
     "hugr",
 ]
-requirements = [
+
+[manifest.dependency-groups]
+dev = [
     { name = "mypy", specifier = ">=1.9.0,<2" },
     { name = "pre-commit", specifier = ">=3.6.2,<4" },
     { name = "pytest", specifier = ">=8.1.1,<9" },


### PR DESCRIPTION
- Updates devenv to match rust version on CI (1.84)
- clippy fixes
- Installs llvm all the time and removes separate hugr-llvm job because runner image no longer has LLVM to link to.  Follow up issue: https://github.com/CQCL/hugr/issues/1851
- ~[Nightly is failing](https://github.com/CQCL/hugr/actions/runs/12696563342/job/35390874375?pr=1847) for what appears to be an unrelated rustc bug.~ has been fixed!
- Semver checks failing because adding "llvm-14" to the `apt-dependencies` appears to not be changing anything??? https://github.com/CQCL/hugr/actions/runs/12707081975/job/35421268084?pr=1847 https://github.com/CQCL/hugr/issues/1852

Closes #1843