### PR TITLE
feat: Special cased array, float and int constants in hugr-model export

### DIFF
--- a/hugr-core/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_types.rs
@@ -64,6 +64,9 @@ impl std::ops::Deref for ConstF64 {
 }
 
 impl ConstF64 {
+    /// Name of the constructor for creating constant 64bit floats.
+    pub(crate) const CTR_NAME: &'static str = "arithmetic.float.const-f64";
+
     /// Create a new [`ConstF64`]
     pub fn new(value: f64) -> Self {
         // This function can't be `const` because `is_finite()` is not yet stable as a const function.

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -104,6 +104,9 @@ pub struct ConstInt {
 }
 
 impl ConstInt {
+    /// Name of the constructor for creating constant integers.
+    pub(crate) const CTR_NAME: &'static str = "arithmetic.int.const";
+
     /// Create a new [`ConstInt`] with a given width and unsigned value
     pub fn new_u(log_width: u8, value: u64) -> Result<Self, ConstTypeError> {
         if !is_valid_log_width(log_width) {

--- a/hugr-core/src/std_extensions/collections/array.rs
+++ b/hugr-core/src/std_extensions/collections/array.rs
@@ -42,6 +42,9 @@ pub struct ArrayValue {
 }
 
 impl ArrayValue {
+    /// Name of the constructor for creating constant arrays.
+    pub(crate) const CTR_NAME: &'static str = "collections.array.const";
+
     /// Create a new [CustomConst] for an array of values of type `typ`.
     /// That all values are of type `typ` is not checked here.
     pub fn new(typ: Type, contents: impl IntoIterator<Item = Value>) -> Self {

--- a/hugr-core/tests/snapshots/model__roundtrip_const.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_const.snap
@@ -4,9 +4,19 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
 ---
 (hugr 0)
 
+(import collections.array.array)
+
+(import collections.array.const)
+
 (import compat.const-json)
 
 (import arithmetic.float.types.float64)
+
+(import arithmetic.int.const)
+
+(import arithmetic.int.types.int)
+
+(import arithmetic.float.const-f64)
 
 (define-func example.bools
   [] [(adt [[] []]) (adt [[] []])] (ext)
@@ -19,7 +29,8 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
 (define-func example.make-pair
   []
   [(adt
-     [[(@ arithmetic.float.types.float64) (@ arithmetic.float.types.float64)]])]
+     [[(@ collections.array.array 5 (@ arithmetic.int.types.int 6))
+       (@ arithmetic.float.types.float64)]])]
   (ext)
   (dfg
     [] [%0]
@@ -27,32 +38,32 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
       (->
         []
         [(adt
-           [[(@ arithmetic.float.types.float64)
+           [[(@ collections.array.array 5 (@ arithmetic.int.types.int 6))
              (@ arithmetic.float.types.float64)]])]
         (ext)))
     (const
       (tag
         0
         [(@
-           compat.const-json
-           (@ arithmetic.float.types.float64)
-           "{\"c\":\"ConstF64\",\"v\":{\"value\":2.0}}"
-           (ext arithmetic.float.types))
-         (@
-           compat.const-json
-           (@ arithmetic.float.types.float64)
-           "{\"c\":\"ConstF64\",\"v\":{\"value\":3.0}}"
-           (ext arithmetic.float.types))])
+           collections.array.const
+           5
+           (@ arithmetic.int.types.int 6)
+           [(@ arithmetic.int.const 6 1)
+            (@ arithmetic.int.const 6 2)
+            (@ arithmetic.int.const 6 3)
+            (@ arithmetic.int.const 6 4)
+            (@ arithmetic.int.const 6 5)])
+         (@ arithmetic.float.const-f64 -3.0)])
       [] [%0]
       (signature
         (->
           []
           [(adt
-             [[(@ arithmetic.float.types.float64)
+             [[(@ collections.array.array 5 (@ arithmetic.int.types.int 6))
                (@ arithmetic.float.types.float64)]])]
           (ext))))))
 
-(define-func example.f64
+(define-func example.f64-json
   [] [(@ arithmetic.float.types.float64)] (ext)
   (dfg
     [] [%0 %1]
@@ -62,11 +73,7 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
         [(@ arithmetic.float.types.float64) (@ arithmetic.float.types.float64)]
         (ext)))
     (const
-      (@
-        compat.const-json
-        (@ arithmetic.float.types.float64)
-        "{\"c\":\"ConstF64\",\"v\":{\"value\":1.0}}"
-        (ext arithmetic.float.types))
+      (@ arithmetic.float.const-f64 1.0)
       [] [%0]
       (signature (-> [] [(@ arithmetic.float.types.float64)] (ext))))
     (const

--- a/hugr-model/Cargo.toml
+++ b/hugr-model/Cargo.toml
@@ -22,6 +22,7 @@ capnp = "0.20.1"
 derive_more = { version = "1.0.0", features = ["display"] }
 fxhash.workspace = true
 indexmap.workspace = true
+ordered-float = "4.6.0"
 pest = "2.7.12"
 pest_derive = "2.7.12"
 pretty = "0.12.3"

--- a/hugr-model/capnp/hugr-v0.capnp
+++ b/hugr-model/capnp/hugr-v0.capnp
@@ -155,6 +155,8 @@ struct Term {
         bytes @24 :Data;
         bytesType @25 :Void;
         meta @26 :Void;
+        float @27 :Float64;
+        floatType @28 :Void;
     }
 
     struct Apply {

--- a/hugr-model/src/v0/binary/read.rs
+++ b/hugr-model/src/v0/binary/read.rs
@@ -341,6 +341,11 @@ fn read_term<'a>(bump: &'a Bump, reader: hugr_capnp::term::Reader) -> ReadResult
             data: bump.alloc_slice_copy(bytes?),
         },
         Which::BytesType(()) => model::Term::BytesType,
+
+        Which::Float(value) => model::Term::Float {
+            value: value.into(),
+        },
+        Which::FloatType(()) => model::Term::FloatType,
     })
 }
 

--- a/hugr-model/src/v0/binary/write.rs
+++ b/hugr-model/src/v0/binary/write.rs
@@ -224,6 +224,8 @@ fn write_term(mut builder: hugr_capnp::term::Builder, term: &model::Term) {
         model::Term::Meta => {
             builder.set_meta(());
         }
+        model::Term::Float { value } => builder.set_float(value.into_inner()),
+        model::Term::FloatType => builder.set_float_type(()),
     }
 }
 

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -87,6 +87,7 @@
 //! [#1546]: https://github.com/CQCL/hugr/issues/1546
 //! [#1553]: https://github.com/CQCL/hugr/issues/1553
 //! [#1554]: https://github.com/CQCL/hugr/issues/1554
+use ordered_float::OrderedFloat;
 use smol_str::SmolStr;
 use thiserror::Error;
 
@@ -718,6 +719,15 @@ pub enum Term<'a> {
 
     /// The type of metadata.
     Meta,
+
+    /// A literal floating-point number.
+    Float {
+        /// The value of the floating-point number.
+        value: OrderedFloat<f64>,
+    },
+
+    /// The type of floating-point numbers.
+    FloatType,
 }
 
 /// A part of a list term.

--- a/hugr-model/src/v0/text/hugr.pest
+++ b/hugr-model/src/v0/text/hugr.pest
@@ -86,6 +86,7 @@ term = {
   | term_list_type
   | term_str
   | term_str_type
+  | term_float
   | term_nat
   | term_nat_type
   | term_ext_set
@@ -102,33 +103,37 @@ term = {
   | term_bytes_type
   | term_bytes
   | term_meta
+  | term_float
+  | term_float_type
 }
 
-term_wildcard     = { "_" }
-term_type         = { "type" }
-term_static       = { "static" }
-term_constraint   = { "constraint" }
-term_var          = { "?" ~ identifier }
-term_apply_full   = { ("(" ~ "@" ~ symbol ~ term* ~ ")") }
-term_apply        = { symbol | ("(" ~ symbol ~ term* ~ ")") }
-term_const        = { "(" ~ "const" ~ term ~ term ~ ")" }
-term_list         = { "[" ~ (spliced_term | term)* ~ "]" }
-term_list_type    = { "(" ~ "list" ~ term ~ ")" }
-term_str          = { string }
-term_str_type     = { "str" }
-term_nat          = { (ASCII_DIGIT)+ }
-term_nat_type     = { "nat" }
-term_ext_set      = { "(" ~ "ext" ~ (spliced_term | ext_name)* ~ ")" }
-term_ext_set_type = { "ext-set" }
-term_adt          = { "(" ~ "adt" ~ term ~ ")" }
-term_func_type    = { "(" ~ "->" ~ term ~ term ~ term ~ ")" }
-term_ctrl         = { "(" ~ "ctrl" ~ term ~ ")" }
-term_ctrl_type    = { "ctrl" }
-term_non_linear   = { "(" ~ "nonlinear" ~ term ~ ")" }
-term_const_func   = { "(" ~ "fn" ~ term ~ ")" }
-term_const_adt    = { "(" ~ "tag" ~ tag ~ term* ~ ")" }
-term_bytes_type   = { "bytes" }
-term_bytes        = { "(" ~ "bytes" ~ base64_string ~ ")" }
-term_meta         = { "meta" }
+term_wildcard     =  { "_" }
+term_type         =  { "type" }
+term_static       =  { "static" }
+term_constraint   =  { "constraint" }
+term_var          =  { "?" ~ identifier }
+term_apply_full   =  { ("(" ~ "@" ~ symbol ~ term* ~ ")") }
+term_apply        =  { symbol | ("(" ~ symbol ~ term* ~ ")") }
+term_const        =  { "(" ~ "const" ~ term ~ term ~ ")" }
+term_list         =  { "[" ~ (spliced_term | term)* ~ "]" }
+term_list_type    =  { "(" ~ "list" ~ term ~ ")" }
+term_str          =  { string }
+term_str_type     =  { "str" }
+term_nat          = @{ (ASCII_DIGIT)+ }
+term_nat_type     =  { "nat" }
+term_ext_set      =  { "(" ~ "ext" ~ (spliced_term | ext_name)* ~ ")" }
+term_ext_set_type =  { "ext-set" }
+term_adt          =  { "(" ~ "adt" ~ term ~ ")" }
+term_func_type    =  { "(" ~ "->" ~ term ~ term ~ term ~ ")" }
+term_ctrl         =  { "(" ~ "ctrl" ~ term ~ ")" }
+term_ctrl_type    =  { "ctrl" }
+term_non_linear   =  { "(" ~ "nonlinear" ~ term ~ ")" }
+term_const_func   =  { "(" ~ "fn" ~ term ~ ")" }
+term_const_adt    =  { "(" ~ "tag" ~ tag ~ term* ~ ")" }
+term_bytes_type   =  { "bytes" }
+term_bytes        =  { "(" ~ "bytes" ~ base64_string ~ ")" }
+term_meta         =  { "meta" }
+term_float_type   =  { "float" }
+term_float        = @{ ("+" | "-")? ~ (ASCII_DIGIT)+ ~ "." ~ (ASCII_DIGIT)+ }
 
 spliced_term = { term ~ "..." }

--- a/hugr-model/src/v0/text/parse.rs
+++ b/hugr-model/src/v0/text/parse.rs
@@ -114,6 +114,7 @@ impl<'a> ParseContext<'a> {
         debug_assert_eq!(pair.as_rule(), Rule::term);
         let pair = pair.into_inner().next().unwrap();
         let rule = pair.as_rule();
+        let str_slice = pair.as_str();
         let mut inner = pair.into_inner();
 
         let term =
@@ -203,7 +204,7 @@ impl<'a> ParseContext<'a> {
                 }
 
                 Rule::term_nat => {
-                    let value = inner.next().unwrap().as_str().parse().unwrap();
+                    let value = str_slice.trim().parse().unwrap();
                     Term::Nat(value)
                 }
 
@@ -276,6 +277,14 @@ impl<'a> ParseContext<'a> {
                     })?;
                     let data = self.bump.alloc_slice_copy(&data);
                     Term::Bytes { data }
+                }
+
+                Rule::term_float_type => Term::FloatType,
+                Rule::term_float => {
+                    let value: f64 = str_slice.trim().parse().unwrap();
+                    Term::Float {
+                        value: value.into(),
+                    }
                 }
 
                 r => unreachable!("term: {:?}", r),

--- a/hugr-model/src/v0/text/print.rs
+++ b/hugr-model/src/v0/text/print.rs
@@ -612,6 +612,15 @@ impl<'p, 'a: 'p> PrintContext<'p, 'a> {
                 self.print_text("meta");
                 Ok(())
             }
+            Term::Float { value } => {
+                // The debug representation of a float always includes a decimal point.
+                self.print_text(format!("{:?}", value.into_inner()));
+                Ok(())
+            }
+            Term::FloatType => {
+                self.print_text("float");
+                Ok(())
+            }
         }
     }
 

--- a/hugr-model/tests/fixtures/model-const.edn
+++ b/hugr-model/tests/fixtures/model-const.edn
@@ -13,27 +13,42 @@
 
 (define-func example.make-pair
   []
-  [(adt [[(@ arithmetic.float.types.float64) (@ arithmetic.float.types.float64)]])]
+  [(adt
+     [[(@ collections.array.array 5 (@ arithmetic.int.types.int 6))
+       (@ arithmetic.float.types.float64)]])]
   (ext)
-  (dfg [] [%pair]
+  (dfg
+    [] [%0]
     (signature
       (->
         []
-        [(adt [[(@ arithmetic.float.types.float64) (@ arithmetic.float.types.float64)]])]
+        [(adt
+           [[(@ collections.array.array 5 (@ arithmetic.int.types.int 6))
+             (@ arithmetic.float.types.float64)]])]
         (ext)))
     (const
       (tag
         0
-        [(@ compat.const-json (@ arithmetic.float.types.float64) "{\"c\":\"ConstF64\",\"v\":{\"value\":2.0}}" (ext))
-         (@ compat.const-json (@ arithmetic.float.types.float64) "{\"c\":\"ConstF64\",\"v\":{\"value\":3.0}}" (ext))])
-      [] [%pair]
+        [(@
+           collections.array.const
+           5
+           (@ arithmetic.int.types.int 6)
+           [(@ arithmetic.int.const 6 1)
+            (@ arithmetic.int.const 6 2)
+            (@ arithmetic.int.const 6 3)
+            (@ arithmetic.int.const 6 4)
+            (@ arithmetic.int.const 6 5)])
+         (@ arithmetic.float.const-f64 -3.0)])
+      [] [%0]
       (signature
         (->
           []
-          [(adt [[(@ arithmetic.float.types.float64) (@ arithmetic.float.types.float64)]])]
+          [(adt
+             [[(@ collections.array.array 5 (@ arithmetic.int.types.int 6))
+               (@ arithmetic.float.types.float64)]])]
           (ext))))))
 
-(define-func example.f64
+(define-func example.f64-json
   []
   [(@ arithmetic.float.types.float64)]
   (ext)

--- a/hugr-model/tests/fixtures/model-literals.edn
+++ b/hugr-model/tests/fixtures/model-literals.edn
@@ -2,3 +2,4 @@
 
 (define-alias mod.string str "\"\n\r\t\\\u{1F44D}")
 (define-alias mod.bytes bytes (bytes "SGVsbG8gd29ybGQg8J+Yig=="))
+(define-alias mod.float float -3.141)

--- a/hugr-model/tests/snapshots/text__literals.snap
+++ b/hugr-model/tests/snapshots/text__literals.snap
@@ -7,3 +7,5 @@ expression: "roundtrip(include_str!(\"fixtures/model-literals.edn\"))"
 (define-alias mod.string str "\"\n\r\t\\👍")
 
 (define-alias mod.bytes bytes (bytes "SGVsbG8gd29ybGQg8J+Yig=="))
+
+(define-alias mod.float float -3.141)


### PR DESCRIPTION
This PR special cases the import/export of array, float and int constants so that they are represented as terms in `hugr-model`. This representation is a lot more efficient to handle than the encoding as JSON. In the future we should do this for all constants.