### PR TITLE
chore!: Update to `portgraph 0.13` / `petgraph 0.7`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ jsonschema = "0.27.0"
 lazy_static = "1.4.0"
 num-rational = "0.4.1"
 paste = "1.0"
-petgraph = { version = "0.6.3", default-features = false }
+petgraph = { version = "0.7.1", default-features = false }
 proptest = "1.4.0"
 proptest-derive = "0.5.0"
 regex = "1.9.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,11 @@ missing_docs = "warn"
 # https://github.com/rust-lang/rust-clippy/issues/5112
 debug_assert_with_mut_call = "warn"
 
+[patch.crates-io]
+#portgraph = { git = 'https://github.com/cqcl/portgraph.git', branch = "ab/boundary-order" }
+
 [workspace.dependencies]
-portgraph = { version = "0.12.2" }
+portgraph = { version = "0.13.0" }
 insta = { version = "1.34.0" }
 bitvec = "1.0.1"
 cgmath = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ missing_docs = "warn"
 # https://github.com/rust-lang/rust-clippy/issues/5112
 debug_assert_with_mut_call = "warn"
 
-[patch.crates-io]
-#portgraph = { git = 'https://github.com/cqcl/portgraph.git', branch = "ab/boundary-order" }
-
 [workspace.dependencies]
 portgraph = { version = "0.13.0" }
 insta = { version = "1.34.0" }

--- a/hugr-core/src/hugr/views/descendants.rs
+++ b/hugr-core/src/hugr/views/descendants.rs
@@ -137,7 +137,7 @@ where
         let hugr = hugr.base_hugr();
         Ok(Self {
             root,
-            graph: RegionGraph::new_region(&hugr.graph, &hugr.hierarchy, root.pg_index()),
+            graph: RegionGraph::new(&hugr.graph, &hugr.hierarchy, root.pg_index()),
             hugr,
             _phantom: std::marker::PhantomData,
         })
@@ -247,7 +247,7 @@ pub(super) mod test {
             Some(Signature::new(vec![usize_t()], vec![usize_t()]))
         );
         assert_eq!(inner_region.node_count(), 3);
-        assert_eq!(inner_region.edge_count(), 2);
+        assert_eq!(inner_region.edge_count(), 1);
         assert_eq!(inner_region.children(inner).count(), 2);
         assert_eq!(inner_region.children(hugr.root()).count(), 0);
         assert_eq!(

--- a/hugr-core/src/hugr/views/sibling.rs
+++ b/hugr-core/src/hugr/views/sibling.rs
@@ -149,7 +149,7 @@ impl<'a, Root: NodeHandle> SiblingGraph<'a, Root> {
         let hugr = hugr.base_hugr();
         Self {
             root,
-            graph: FlatRegionGraph::new_flat_region(&hugr.graph, &hugr.hierarchy, root.pg_index()),
+            graph: FlatRegionGraph::new(&hugr.graph, &hugr.hierarchy, root.pg_index()),
             hugr,
             _phantom: std::marker::PhantomData,
         }
@@ -249,7 +249,7 @@ impl<'g, Root: NodeHandle> HugrInternals for SiblingMut<'g, Root> {
         Root: 'p;
 
     fn portgraph(&self) -> Self::Portgraph<'_> {
-        FlatRegionGraph::new_flat_region(
+        FlatRegionGraph::new(
             &self.base_hugr().graph,
             &self.base_hugr().hierarchy,
             self.root.pg_index(),

--- a/hugr/benches/benchmarks/subgraph.rs
+++ b/hugr/benches/benchmarks/subgraph.rs
@@ -30,6 +30,35 @@ fn bench_singleton_subgraph(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_fewnode_subgraph(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fewnode_subgraph");
+    group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+
+    let num_layers = [10, 100, 1000];
+
+    for layers in num_layers.into_iter() {
+        let (hugr, layer_ids) = circuit(layers);
+
+        // Get a subgraph with a fixed number of nodes in the middle of the circuit.
+        group.bench_with_input(
+            BenchmarkId::from_parameter(layers),
+            &layers,
+            |b, &_layers| {
+                // Pick all the nodes in four layers in the middle of the circuit.
+                let nodes: Vec<_> = layer_ids
+                    .iter()
+                    .skip(layers / 2)
+                    .take(4)
+                    .flat_map(|ids| [ids.h, ids.cx1, ids.cx2])
+                    .collect();
+                b.iter(|| black_box(SiblingSubgraph::try_from_nodes(nodes.clone(), &hugr)))
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn bench_multinode_subgraph(c: &mut Criterion) {
     let mut group = c.benchmark_group("multinode_subgraph");
     group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
@@ -59,5 +88,6 @@ criterion_group! {
     config = Criterion::default();
     targets =
         bench_singleton_subgraph,
+        bench_fewnode_subgraph,
         bench_multinode_subgraph,
 }


### PR DESCRIPTION
The new portgraph release comes with some perf improvements.
We require this update for #1869.

Closes #1872.

I added a benchmark variation for subgraphs with few nodes as a drive-by.
This got improved by the new portgraph (skipping a full graph traversal), but the runtime is still mostly the `O(n)` full-graph traversal required for the convexity checking when building the subgraph.

BREAKING CHANGE: Bumped public dependency `portgraph` to breaking version `0.13`.