### PR TITLE
fix: Export `RemoveDeadFuncsError`

### DIFF
--- a/hugr-passes/src/dead_funcs.rs
+++ b/hugr-passes/src/dead_funcs.rs
@@ -16,10 +16,16 @@ use super::call_graph::{CallGraph, CallGraphNode};
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-/// Errors produced by [ConstantFoldPass].
+/// Errors produced by [RemoveDeadFuncsPass].
 pub enum RemoveDeadFuncsError {
-    #[error("Node {0} was not a FuncDefn child of the Module root")]
-    InvalidEntryPoint(Node),
+    /// The specified entry point is not a FuncDefn node or is not a child of the root.
+    #[error(
+        "Entrypoint for RemoveDeadFuncsPass {node} was not a function definition in the root module"
+    )]
+    InvalidEntryPoint {
+        /// The invalid node.
+        node: Node,
+    },
     #[error(transparent)]
     #[allow(missing_docs)]
     ValidationError(#[from] ValidatePassError),
@@ -37,7 +43,7 @@ fn reachable_funcs<'a>(
         d.stack.clear();
         for n in entry_points {
             if !h.get_optype(n).is_func_defn() || h.get_parent(n) != Some(h.root()) {
-                return Err(RemoveDeadFuncsError::InvalidEntryPoint(n));
+                return Err(RemoveDeadFuncsError::InvalidEntryPoint { node: n });
             }
             d.stack.push(cg.node_index(n).unwrap())
         }
@@ -45,7 +51,7 @@ fn reachable_funcs<'a>(
     } else {
         if let Some(n) = entry_points.next() {
             // Can't be a child of the module root as there isn't a module root!
-            return Err(RemoveDeadFuncsError::InvalidEntryPoint(n));
+            return Err(RemoveDeadFuncsError::InvalidEntryPoint { node: n });
         }
         Dfs::new(g, cg.node_index(h.root()).unwrap())
     };

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -4,7 +4,7 @@ pub mod call_graph;
 pub mod const_fold;
 pub mod dataflow;
 mod dead_funcs;
-pub use dead_funcs::{remove_dead_funcs, RemoveDeadFuncsPass};
+pub use dead_funcs::{remove_dead_funcs, RemoveDeadFuncsError, RemoveDeadFuncsPass};
 pub mod force_order;
 mod half_node;
 pub mod lower;


### PR DESCRIPTION
The `RemoveDeadFuncsPass` returns this error, which was hidden inside a private module.

Adds missing docs to the struct, and converts the tuple variant into a regular struct.