### PR TITLE
ci: Fix llvm install on release-plz workflow (again)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,6 +30,9 @@ jobs:
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: ${{ env.LLVM_VERSION }}
+          # Use a temporary directory to avoid polluting the workspace,
+          # otherwise release-plz fails due to uncommitted changes.
+          directory: ${{ runner.temp }}/llvm
 
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5


### PR DESCRIPTION
It seems the `install-llvm-action` downloads it directly into the working directory, and makes the workflow fail due to uncommitted changes:
https://github.com/CQCL/hugr/actions/runs/12870816871/job/35882749195#step:6:275

Can't really test this without merging, but I think it should work alright...