### PR TITLE
fix: determine correct bounds of custom types

### DIFF
--- a/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
@@ -4,18 +4,21 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
 ---
 (hugr 0)
 
-(import prelude.Array)
+(import collections.array.array)
 
 (declare-func array.replicate
-  (forall ?0 type)
-  (forall ?1 nat)
-  (where (nonlinear ?0))
-  [?0] [(@ prelude.Array ?0 ?1)] (ext))
+  (forall ?0 nat)
+  (forall ?1 type)
+  (where (nonlinear ?1))
+  [?1] [(@ collections.array.array ?0 ?1)] (ext))
 
 (declare-func array.copy
-  (forall ?0 type)
-  (where (nonlinear ?0))
-  [(@ prelude.Array ?0)] [(@ prelude.Array ?0) (@ prelude.Array ?0)] (ext))
+  (forall ?0 nat)
+  (forall ?1 type)
+  (where (nonlinear ?1))
+  [(@ collections.array.array ?0 ?1)]
+  [(@ collections.array.array ?0 ?1) (@ collections.array.array ?0 ?1)]
+  (ext))
 
 (define-func util.copy
   (forall ?0 type)

--- a/hugr-model/tests/fixtures/model-constraints.edn
+++ b/hugr-model/tests/fixtures/model-constraints.edn
@@ -1,16 +1,17 @@
 (hugr 0)
 
 (declare-func array.replicate
-  (forall ?t type)
   (forall ?n nat)
+  (forall ?t type)
   (where (nonlinear ?t))
-  [?t] [(@ prelude.Array ?t ?n)]
+  [?t] [(@ collections.array.array ?n ?t)]
   (ext))
 
 (declare-func array.copy
+  (forall ?n nat)
   (forall ?t type)
   (where (nonlinear ?t))
-  [(@ prelude.Array ?t)] [(@ prelude.Array ?t) (@ prelude.Array ?t)] (ext))
+  [(@ collections.array.array ?n ?t)] [(@ collections.array.array ?n ?t) (@ collections.array.array ?n ?t)] (ext))
 
 (define-func util.copy
   (forall ?t type)


### PR DESCRIPTION
Import now determines the bound of the custom type correctly.

Fixes #1876.