### PR TITLE
feat: separate DeadCodeElimPass, fix constant-folding of Modules

### DIFF
--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -3,7 +3,7 @@
 //! An (example) use of the [dataflow analysis framework](super::dataflow).
 
 pub mod value_handle;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::HashMap;
 use thiserror::Error;
 
 use hugr_core::{
@@ -21,10 +21,10 @@ use hugr_core::{
 use value_handle::ValueHandle;
 
 use crate::dataflow::{
-    partial_from_const, AbstractValue, AnalysisResults, ConstLoader, ConstLocation, DFContext,
-    Machine, PartialValue, TailLoopTermination,
+    partial_from_const, ConstLoader, ConstLocation, DFContext, Machine, PartialValue,
 };
 use crate::validation::{ValidatePassError, ValidationLevel};
+use crate::{dead_code::DeadCodeElimPass, find_main};
 
 #[derive(Debug, Clone, Default)]
 /// A configuration for the Constant Folding pass.
@@ -88,23 +88,15 @@ impl ConstantFoldPass {
         });
 
         let results = Machine::new(&hugr).run(ConstFoldContext(hugr), inputs);
-        let mut keep_nodes = HashSet::new();
-        self.find_needed_nodes(&results, &mut keep_nodes);
         let mb_root_inp = hugr.get_io(hugr.root()).map(|[i, _]| i);
 
-        let remove_nodes = hugr
+        let wires_to_break = hugr
             .nodes()
-            .filter(|n| !keep_nodes.contains(n))
-            .collect::<HashSet<_>>();
-        let wires_to_break = keep_nodes
-            .into_iter()
             .flat_map(|n| hugr.node_inputs(n).map(move |ip| (n, ip)))
             .filter(|(n, ip)| {
                 *n != hugr.root()
                     && matches!(hugr.get_optype(*n).port_kind(*ip), Some(EdgeKind::Value(_)))
             })
-            // Note we COULD filter out (avoid breaking) wires from other nodes that we are keeping.
-            // This would insert fewer constants, but potentially expose less parallelism.
             .filter_map(|(n, ip)| {
                 let (src, outp) = hugr.single_linked_output(n, ip).unwrap();
                 // Avoid breaking edges from existing LoadConstant (we'd only add another)
@@ -120,19 +112,25 @@ impl ConstantFoldPass {
             })
             .collect::<Vec<_>>();
 
-        for (n, import, v) in wires_to_break {
+        for (n, inport, v) in wires_to_break {
             let parent = hugr.get_parent(n).unwrap();
             let datatype = v.get_type();
             // We could try hash-consing identical Consts, but not ATM
             let cst = hugr.add_node_with_parent(parent, Const::new(v));
             let lcst = hugr.add_node_with_parent(parent, LoadConstant { datatype });
             hugr.connect(cst, OutgoingPort::from(0), lcst, IncomingPort::from(0));
-            hugr.disconnect(n, import);
-            hugr.connect(lcst, OutgoingPort::from(0), n, import);
+            hugr.disconnect(n, inport);
+            hugr.connect(lcst, OutgoingPort::from(0), n, inport);
         }
-        for n in remove_nodes {
-            hugr.remove_node(n);
+        // Dataflow analysis applies our inputs to the 'main' function if this is a Module, so do the same here
+        let mut dce = DeadCodeElimPass::default();
+        if hugr.get_optype(hugr.root()).is_module() {
+            dce = dce.with_entry_points([find_main(hugr).unwrap()])
+        };
+        if self.allow_increase_termination {
+            dce = dce.allow_increase_termination()
         }
+        dce.run(hugr)?;
         Ok(())
     }
 
@@ -140,80 +138,6 @@ impl ConstantFoldPass {
     pub fn run<H: HugrMut>(&self, hugr: &mut H) -> Result<(), ConstFoldError> {
         self.validation
             .run_validated_pass(hugr, |hugr: &mut H, _| self.run_no_validate(hugr))
-    }
-
-    fn find_needed_nodes<H: HugrView>(
-        &self,
-        results: &AnalysisResults<ValueHandle, H>,
-        needed: &mut HashSet<Node>,
-    ) {
-        let mut q = VecDeque::new();
-        let h = results.hugr();
-        q.push_back(h.root());
-        while let Some(n) = q.pop_front() {
-            if !needed.insert(n) {
-                continue;
-            };
-
-            if h.get_optype(n).is_cfg() {
-                for bb in h.children(n) {
-                    //if results.bb_reachable(bb).unwrap() { // no, we'd need to patch up predicates
-                    q.push_back(bb);
-                }
-            } else if let Some(inout) = h.get_io(n) {
-                // Dataflow. Find minimal nodes necessary to compute output, including StateOrder edges.
-                q.extend(inout); // Input also necessary for legality even if unreachable
-
-                if !self.allow_increase_termination {
-                    // Also add on anything that might not terminate (even if results not required -
-                    // if its results are required we'll add it by following dataflow, below.)
-                    for ch in h.children(n) {
-                        if might_diverge(results, ch) {
-                            q.push_back(ch);
-                        }
-                    }
-                }
-            }
-            // Also follow dataflow demand
-            for (src, op) in h.all_linked_outputs(n) {
-                let needs_predecessor = match h.get_optype(src).port_kind(op).unwrap() {
-                    EdgeKind::Value(_) => {
-                        h.get_optype(src).is_load_constant()
-                            || results
-                                .try_read_wire_concrete::<Value, _, _>(Wire::new(src, op))
-                                .is_err()
-                    }
-                    EdgeKind::StateOrder | EdgeKind::Const(_) | EdgeKind::Function(_) => true,
-                    EdgeKind::ControlFlow => false, // we always include all children of a CFG above
-                    _ => true, // needed as EdgeKind non-exhaustive; not knowing what it is, assume the worst
-                };
-                if needs_predecessor {
-                    q.push_back(src);
-                }
-            }
-        }
-    }
-}
-
-// "Diverge" aka "never-terminate"
-// TODO would be more efficient to compute this bottom-up and cache (dynamic programming)
-fn might_diverge<V: AbstractValue>(results: &AnalysisResults<V, impl HugrView>, n: Node) -> bool {
-    let op = results.hugr().get_optype(n);
-    if op.is_cfg() {
-        // TODO if the CFG has no cycles (that are possible given predicates)
-        // then we could say it definitely terminates (i.e. return false)
-        true
-    } else if op.is_tail_loop()
-        && results.tail_loop_terminates(n).unwrap() != TailLoopTermination::NeverContinues
-    {
-        // If we can even figure out the number of iterations is bounded that would allow returning false.
-        true
-    } else {
-        // Node does not introduce non-termination, but still non-terminates if any of its children does
-        results
-            .hugr()
-            .children(n)
-            .any(|ch| might_diverge(results, ch))
     }
 }
 

--- a/hugr-passes/src/const_fold/test.rs
+++ b/hugr-passes/src/const_fold/test.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 
 use hugr_core::ops::handle::NodeHandle;
 use hugr_core::ops::Const;
+use hugr_core::std_extensions::arithmetic::{int_ops, int_types};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use rstest::rstest;
@@ -1586,7 +1587,12 @@ fn test_cfg(
 #[test]
 fn test_module() -> Result<(), Box<dyn std::error::Error>> {
     let mut mb = ModuleBuilder::new();
-    let mut main = mb.define_function("main", Signature::new_endo(INT_TYPES[5].clone()))?;
+    let mut main = mb.define_function(
+        "main",
+        Signature::new_endo(INT_TYPES[5].clone())
+            .with_extension_delta(int_types::EXTENSION_ID)
+            .with_extension_delta(int_ops::EXTENSION_ID),
+    )?;
     let c7 = main.add_load_value(ConstInt::new_u(5, 7)?);
     let c17 = main.add_load_value(ConstInt::new_u(5, 17)?);
     let res = main.add_dataflow_op(IntOpDef::iadd.with_log_width(5), [c7, c17])?;

--- a/hugr-passes/src/dataflow/datalog.rs
+++ b/hugr-passes/src/dataflow/datalog.rs
@@ -10,6 +10,8 @@ use hugr_core::extension::prelude::{MakeTuple, UnpackTuple};
 use hugr_core::ops::{OpTrait, OpType, TailLoop};
 use hugr_core::{HugrView, IncomingPort, Node, OutgoingPort, PortIndex as _, Wire};
 
+use crate::find_main;
+
 use super::value_row::ValueRow;
 use super::{
     partial_from_const, row_contains_bottom, AbstractValue, AnalysisResults, DFContext,
@@ -83,12 +85,7 @@ impl<H: HugrView, V: AbstractValue> Machine<H, V> {
         // we must find the corresponding Input node.
         let input_node_parent = match self.0.get_optype(root) {
             OpType::Module(_) => {
-                let main = self.0.children(root).find(|n| {
-                    self.0
-                        .get_optype(*n)
-                        .as_func_defn()
-                        .is_some_and(|f| f.name == "main")
-                });
+                let main = find_main(&self.0);
                 if main.is_none() && in_values.next().is_some() {
                     panic!("Cannot give inputs to module with no 'main'");
                 }

--- a/hugr-passes/src/dead_code.rs
+++ b/hugr-passes/src/dead_code.rs
@@ -1,0 +1,140 @@
+//! Pass for removing dead code, i.e. that computes values that are then discarded
+
+use std::collections::{HashSet, VecDeque};
+
+use hugr_core::{hugr::hugrmut::HugrMut, ops::OpType, HugrView, Node};
+
+use crate::validation::{ValidatePassError, ValidationLevel};
+
+/// Configuration for Dead Code Elimination pass
+#[derive(Clone, Debug, Default)]
+pub struct DeadCodeElimPass {
+    entry_points: Vec<Node>,
+    allow_increase_termination: bool,
+    validation: ValidationLevel,
+}
+
+impl DeadCodeElimPass {
+    /// Sets the validation level used before and after the pass is run
+    #[allow(unused)]
+    pub fn validation_level(mut self, level: ValidationLevel) -> Self {
+        self.validation = level;
+        self
+    }
+
+    /// Allows the pass to remove potentially-non-terminating [TailLoop]s and [CFG] if their
+    /// result (if/when they do terminate) is either known or not needed.
+    ///
+    /// [TailLoop]: hugr_core::ops::TailLoop
+    /// [CFG]: hugr_core::ops::CFG
+    pub fn allow_increase_termination(mut self) -> Self {
+        self.allow_increase_termination = true;
+        self
+    }
+
+    /// Mark some nodes as entry-points to the Hugr.
+    /// The root node is assumed to be an entry point;
+    /// for Module roots the client will want to mark some of the FuncDefn children
+    /// as entry-points too.
+    pub fn with_entry_points(mut self, entry_points: impl IntoIterator<Item = Node>) -> Self {
+        self.entry_points.extend(entry_points);
+        self
+    }
+
+    fn find_needed_nodes(&self, h: impl HugrView) -> HashSet<Node> {
+        let mut needed = HashSet::new();
+        let mut q = VecDeque::from_iter(self.entry_points.iter().cloned());
+        q.push_front(h.root());
+        while let Some(n) = q.pop_front() {
+            if !needed.insert(n) {
+                continue;
+            };
+            // TODO if we really want to support
+            if matches!(
+                h.get_optype(n),
+                OpType::Conditional(_) | OpType::CFG(_) | OpType::Module(_)
+            ) {
+                // All Cases are reachable, but don't assume so for e.g. Constants/FuncDefns
+                for ch in h.children(n) {
+                    match h.get_optype(ch) {
+                        // Include only if reachable by static edges (from Call/LoadConst/LoadFunction):
+                        OpType::FuncDecl(_) | OpType::FuncDefn(_) | OpType::Const(_) => continue,
+                        // Include all cases / BBs, and Aliases (we do not track their uses in types)
+                        OpType::Case(_)
+                        | OpType::DataflowBlock(_)
+                        | OpType::ExitBlock(_)
+                        | OpType::AliasDecl(_)
+                        | OpType::AliasDefn(_) => q.push_back(ch),
+                        op => panic!("Unexpected optype {}", op),
+                    }
+                }
+            } else if let Some(inout) = h.get_io(n) {
+                // Dataflow container, e.g. FuncDefn. Find minimal nodes necessary to compute output,
+                // including StateOrder edges.
+                q.extend(inout); // Input also necessary for legality even if unreachable
+
+                if !self.allow_increase_termination {
+                    // Also add on anything that might not terminate (even if results not required -
+                    // if its results are required we'll add it by following dataflow, below.)
+                    for ch in h.children(n) {
+                        if might_diverge(&h, ch) {
+                            q.push_back(ch);
+                        }
+                    }
+                }
+            }
+            // Finally, follow dataflow demand (including e.g. edges from Call to FuncDefn)
+            for src in h.input_neighbours(n) {
+                // Following ControlFlow edges backwards is harmless, we've already assumed all
+                // BBs are reachable above.
+                q.push_back(src);
+            }
+        }
+        needed
+    }
+
+    pub fn run(&self, hugr: &mut impl HugrMut) -> Result<(), ValidatePassError> {
+        self.validation
+            .run_validated_pass(hugr, |h, _| self.run_no_validate(h))
+    }
+
+    fn run_no_validate(&self, hugr: &mut impl HugrMut) -> Result<(), ValidatePassError> {
+        let needed = self.find_needed_nodes(&*hugr);
+        let remove = hugr
+            .nodes()
+            .filter(|n| !needed.contains(n))
+            .collect::<Vec<_>>();
+        for n in remove {
+            hugr.remove_node(n);
+        }
+        Ok(())
+    }
+}
+
+// "Diverge" aka "never-terminate"
+// TODO would be more efficient to compute this bottom-up and cache (dynamic programming)
+fn might_diverge(h: &impl HugrView, n: Node) -> bool {
+    match h.get_optype(n) {
+        OpType::CFG(_) => {
+            // TODO if the CFG has no cycles (that are possible given predicates)
+            // then we could say it definitely terminates (i.e. return false)
+            true
+        }
+        OpType::TailLoop(_) => {
+            // If the TailLoop never continues, clearly it doesn't terminate, but we haven't got
+            // dataflow results to tell us that. Instead rely on an earlier pass having rewritten
+            // such a TailLoop into a non-loop.
+            // Even just an upper-bound on the number of iterations would allow returning false.
+            true
+        }
+        OpType::Call(_) => {
+            // We could scan the target FuncDefn, but that might contain calls to itself, so we'd need
+            // a "seen" set...instead just rely on calls being inlined if we want to remove them.
+            true
+        }
+        _ => {
+            // Node does not introduce non-termination, but still non-terminates if any of its children does
+            h.children(n).any(|ch| might_diverge(h, ch))
+        }
+    }
+}

--- a/hugr-passes/src/dead_code.rs
+++ b/hugr-passes/src/dead_code.rs
@@ -13,7 +13,7 @@ use crate::validation::{ValidatePassError, ValidationLevel};
 #[derive(Clone, Default)]
 pub struct DeadCodeElimPass {
     entry_points: Vec<Node>,
-    diverge_callback: Option<Arc<dyn Fn(&Hugr, Node) -> NodeDivergence>>,
+    diverge_callback: Option<Arc<DivergeCallback>>,
     validation: ValidationLevel,
 }
 
@@ -37,6 +37,8 @@ impl Debug for DeadCodeElimPass {
         )
     }
 }
+
+pub type DivergeCallback = dyn Fn(&Hugr, Node) -> NodeDivergence;
 
 pub enum NodeDivergence {
     #[allow(unused)]
@@ -67,7 +69,7 @@ impl DeadCodeElimPass {
     /// [Call]: hugr_core::ops::Call
     /// [CFG]: hugr_core::ops::CFG
     /// [TailLoop]: hugr_core::ops::TailLoop
-    pub fn set_diverge_callback(mut self, cb: Arc<dyn Fn(&Hugr, Node) -> NodeDivergence>) -> Self {
+    pub fn set_diverge_callback(mut self, cb: Arc<DivergeCallback>) -> Self {
         self.diverge_callback = Some(cb);
         self
     }

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod call_graph;
 pub mod const_fold;
 pub mod dataflow;
+mod dead_code;
 mod dead_funcs;
 pub use dead_funcs::{remove_dead_funcs, RemoveDeadFuncsError, RemoveDeadFuncsPass};
 pub mod force_order;

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -10,6 +10,7 @@ mod half_node;
 pub mod lower;
 pub mod merge_bbs;
 mod monomorphize;
+use hugr_core::{HugrView, Node};
 // TODO: Deprecated re-export. Remove on a breaking release.
 #[deprecated(
     since = "0.14.1",
@@ -31,3 +32,15 @@ pub mod validation;
 pub use force_order::{force_order, force_order_by_key};
 pub use lower::{lower_ops, replace_many_ops};
 pub use non_local::{ensure_no_nonlocal_edges, nonlocal_edges};
+
+fn find_main(h: &impl HugrView) -> Option<Node> {
+    let root = h.root();
+    if !h.get_optype(root).is_module() {
+        return None;
+    }
+    h.children(root).find(|n| {
+        h.get_optype(*n)
+            .as_func_defn()
+            .is_some_and(|f| f.name == "main")
+    })
+}


### PR DESCRIPTION
* Constant Folding now just breaks wires and inserts Const + LoadConst even for "unnecessary" (DCE-able) ops
* Followup DCE pass removes these
* DCE pass allows explicit specification of entry points for Module-rooted Hugrs
   * constant folding assumes `main` entry-point (in common with dataflow analysis, for now) - I've added a test for #1797 that this fixes
* DCE pass takes an arbitrary callback for `NodeDivergence` aka "purity" - naming suggestions most welcome here

Could use more DCE-specific tests.

Thus, two in one:
closes #1797, #1807 