### PR TITLE
chore!: Add associated type Node to HugrView

### DIFF
--- a/hugr-core/src/hugr/rewrite.rs
+++ b/hugr-core/src/hugr/rewrite.rs
@@ -26,7 +26,7 @@ pub trait Rewrite {
     /// Checks whether the rewrite would succeed on the specified Hugr.
     /// If this call succeeds, [self.apply] should also succeed on the same `h`
     /// If this calls fails, [self.apply] would fail with the same error.
-    fn verify(&self, h: &impl HugrView) -> Result<(), Self::Error>;
+    fn verify(&self, h: &impl HugrView<Node = Node>) -> Result<(), Self::Error>;
 
     /// Mutate the specified Hugr, or fail with an error.
     /// Returns [`Self::ApplyResult`] if successful.
@@ -58,7 +58,7 @@ impl<R: Rewrite> Rewrite for Transactional<R> {
     type ApplyResult = R::ApplyResult;
     const UNCHANGED_ON_FAILURE: bool = true;
 
-    fn verify(&self, h: &impl HugrView) -> Result<(), Self::Error> {
+    fn verify(&self, h: &impl HugrView<Node = Node>) -> Result<(), Self::Error> {
         self.underlying.verify(h)
     }
 

--- a/hugr-core/src/hugr/rewrite/consts.rs
+++ b/hugr-core/src/hugr/rewrite/consts.rs
@@ -10,7 +10,7 @@ use super::Rewrite;
 
 /// Remove a [`crate::ops::LoadConstant`] node with no consumers.
 #[derive(Debug, Clone)]
-pub struct RemoveLoadConstant(pub Node);
+pub struct RemoveLoadConstant<N = Node>(pub N);
 
 /// Error from an [`RemoveConst`] or [`RemoveLoadConstant`] operation.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
@@ -32,7 +32,7 @@ impl Rewrite for RemoveLoadConstant {
 
     const UNCHANGED_ON_FAILURE: bool = true;
 
-    fn verify(&self, h: &impl HugrView) -> Result<(), Self::Error> {
+    fn verify(&self, h: &impl HugrView<Node = Node>) -> Result<(), Self::Error> {
         let node = self.0;
 
         if (!h.contains_node(node)) || (!h.get_optype(node).is_load_constant()) {
@@ -80,7 +80,7 @@ impl Rewrite for RemoveConst {
 
     const UNCHANGED_ON_FAILURE: bool = true;
 
-    fn verify(&self, h: &impl HugrView) -> Result<(), Self::Error> {
+    fn verify(&self, h: &impl HugrView<Node = Node>) -> Result<(), Self::Error> {
         let node = self.0;
 
         if (!h.contains_node(node)) || (!h.get_optype(node).is_const()) {

--- a/hugr-core/src/hugr/rewrite/inline_dfg.rs
+++ b/hugr-core/src/hugr/rewrite/inline_dfg.rs
@@ -28,7 +28,7 @@ impl Rewrite for InlineDFG {
 
     const UNCHANGED_ON_FAILURE: bool = true;
 
-    fn verify(&self, h: &impl crate::HugrView) -> Result<(), Self::Error> {
+    fn verify(&self, h: &impl crate::HugrView<Node = Node>) -> Result<(), Self::Error> {
         let n = self.0.node();
         if h.get_optype(n).as_dfg().is_none() {
             return Err(InlineDFGError::NotDFG(n));
@@ -147,17 +147,17 @@ mod test {
     use crate::std_extensions::arithmetic::int_types::{self, ConstInt};
     use crate::types::Signature;
     use crate::utils::test_quantum_extension;
-    use crate::{type_row, Direction, HugrView, Node, Port};
+    use crate::{type_row, Direction, HugrView, Port};
     use crate::{Hugr, Wire};
 
     use super::InlineDFG;
 
-    fn find_dfgs(h: &impl HugrView) -> Vec<Node> {
+    fn find_dfgs<H: HugrView>(h: &H) -> Vec<H::Node> {
         h.nodes()
             .filter(|n| h.get_optype(*n).as_dfg().is_some())
             .collect()
     }
-    fn extension_ops(h: &impl HugrView) -> Vec<Node> {
+    fn extension_ops<H: HugrView>(h: &H) -> Vec<H::Node> {
         h.nodes()
             .filter(|n| matches!(h.get_optype(*n), OpType::ExtensionOp(_)))
             .collect()

--- a/hugr-core/src/hugr/rewrite/outline_cfg.rs
+++ b/hugr-core/src/hugr/rewrite/outline_cfg.rs
@@ -37,7 +37,7 @@ impl OutlineCfg {
     /// the combined extension_deltas of all of the blocks.
     fn compute_entry_exit_outside_extensions(
         &self,
-        h: &impl HugrView,
+        h: &impl HugrView<Node = Node>,
     ) -> Result<(Node, Node, Node, ExtensionSet), OutlineCfgError> {
         let cfg_n = match self
             .blocks
@@ -102,11 +102,11 @@ impl Rewrite for OutlineCfg {
     type ApplyResult = (Node, Node);
 
     const UNCHANGED_ON_FAILURE: bool = true;
-    fn verify(&self, h: &impl HugrView) -> Result<(), OutlineCfgError> {
+    fn verify(&self, h: &impl HugrView<Node = Node>) -> Result<(), OutlineCfgError> {
         self.compute_entry_exit_outside_extensions(h)?;
         Ok(())
     }
-    fn apply(self, h: &mut impl HugrMut) -> Result<(Node, Node), OutlineCfgError> {
+    fn apply(self, h: &mut impl HugrMut<Node = Node>) -> Result<(Node, Node), OutlineCfgError> {
         let (entry, exit, outside, extension_delta) =
             self.compute_entry_exit_outside_extensions(h)?;
         // 1. Compute signature

--- a/hugr-core/src/hugr/rewrite/replace.rs
+++ b/hugr-core/src/hugr/rewrite/replace.rs
@@ -83,7 +83,11 @@ pub struct Replacement {
 }
 
 impl NewEdgeSpec {
-    fn check_src(&self, h: &impl HugrView, err_spec: &NewEdgeSpec) -> Result<(), ReplaceError> {
+    fn check_src(
+        &self,
+        h: &impl HugrView<Node = Node>,
+        err_spec: &NewEdgeSpec,
+    ) -> Result<(), ReplaceError> {
         let optype = h.get_optype(self.src);
         let ok = match self.kind {
             NewEdgeKind::Order => optype.other_output() == Some(EdgeKind::StateOrder),
@@ -101,7 +105,11 @@ impl NewEdgeSpec {
         ok.then_some(())
             .ok_or_else(|| ReplaceError::BadEdgeKind(Direction::Outgoing, err_spec.clone()))
     }
-    fn check_tgt(&self, h: &impl HugrView, err_spec: &NewEdgeSpec) -> Result<(), ReplaceError> {
+    fn check_tgt(
+        &self,
+        h: &impl HugrView<Node = Node>,
+        err_spec: &NewEdgeSpec,
+    ) -> Result<(), ReplaceError> {
         let optype = h.get_optype(self.tgt);
         let ok = match self.kind {
             NewEdgeKind::Order => optype.other_input() == Some(EdgeKind::StateOrder),
@@ -123,7 +131,7 @@ impl NewEdgeSpec {
 
     fn check_existing_edge(
         &self,
-        h: &impl HugrView,
+        h: &impl HugrView<Node = Node>,
         legal_src_ancestors: &HashSet<Node>,
         err_edge: impl Fn() -> NewEdgeSpec,
     ) -> Result<(), ReplaceError> {
@@ -150,7 +158,7 @@ impl NewEdgeSpec {
 }
 
 impl Replacement {
-    fn check_parent(&self, h: &impl HugrView) -> Result<Node, ReplaceError> {
+    fn check_parent(&self, h: &impl HugrView<Node = Node>) -> Result<Node, ReplaceError> {
         let parent = self
             .removal
             .iter()
@@ -173,7 +181,10 @@ impl Replacement {
         Ok(parent)
     }
 
-    fn get_removed_nodes(&self, h: &impl HugrView) -> Result<HashSet<Node>, ReplaceError> {
+    fn get_removed_nodes(
+        &self,
+        h: &impl HugrView<Node = Node>,
+    ) -> Result<HashSet<Node>, ReplaceError> {
         // Check the keys of the transfer map too, the values we'll use imminently
         self.adoptions.keys().try_for_each(|&n| {
             (self.replacement.contains_node(n)
@@ -218,7 +229,7 @@ impl Rewrite for Replacement {
 
     const UNCHANGED_ON_FAILURE: bool = false;
 
-    fn verify(&self, h: &impl crate::HugrView) -> Result<(), Self::Error> {
+    fn verify(&self, h: &impl HugrView<Node = Node>) -> Result<(), Self::Error> {
         self.check_parent(h)?;
         let removed = self.get_removed_nodes(h)?;
         // Edge sources...

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -26,14 +26,14 @@ use portgraph::{LinkView, PortView};
 
 use super::internal::HugrInternals;
 use super::{
-    Hugr, HugrError, HugrMut, NodeMetadata, NodeMetadataMap, ValidationError, DEFAULT_OPTYPE,
+    Hugr, HugrError, HugrMut, Node, NodeMetadata, NodeMetadataMap, ValidationError, DEFAULT_OPTYPE,
 };
 use crate::extension::ExtensionRegistry;
 use crate::ops::handle::NodeHandle;
 use crate::ops::{OpParent, OpTag, OpTrait, OpType};
 
 use crate::types::{EdgeKind, PolyFuncType, Signature, Type};
-use crate::{Direction, IncomingPort, Node, OutgoingPort, Port};
+use crate::{Direction, IncomingPort, NodeIndex, OutgoingPort, Port};
 
 use itertools::Either;
 
@@ -42,7 +42,7 @@ use itertools::Either;
 pub trait HugrView: HugrInternals {
     /// Return the root node of this view.
     #[inline]
-    fn root(&self) -> Node {
+    fn root(&self) -> Self::Node {
         self.root_node()
     }
 
@@ -56,11 +56,11 @@ pub trait HugrView: HugrInternals {
     }
 
     /// Returns whether the node exists.
-    fn contains_node(&self, node: Node) -> bool;
+    fn contains_node(&self, node: Self::Node) -> bool;
 
     /// Validates that a node is valid in the graph.
     #[inline]
-    fn valid_node(&self, node: Node) -> bool {
+    fn valid_node(&self, node: Self::Node) -> bool {
         self.contains_node(node)
     }
 
@@ -68,13 +68,13 @@ pub trait HugrView: HugrInternals {
     ///
     /// To include the root node use [`HugrView::valid_node`] instead.
     #[inline]
-    fn valid_non_root(&self, node: Node) -> bool {
+    fn valid_non_root(&self, node: Self::Node) -> bool {
         self.root() != node && self.valid_node(node)
     }
 
     /// Returns the parent of a node.
     #[inline]
-    fn get_parent(&self, node: Node) -> Option<Node> {
+    fn get_parent(&self, node: Self::Node) -> Option<Self::Node> {
         if !self.valid_non_root(node) {
             return None;
         };
@@ -86,7 +86,7 @@ pub trait HugrView: HugrInternals {
 
     /// Returns the operation type of a node.
     #[inline]
-    fn get_optype(&self, node: Node) -> &OpType {
+    fn get_optype(&self, node: Self::Node) -> &OpType {
         match self.contains_node(node) {
             true => self.base_hugr().op_types.get(node.pg_index()),
             false => &DEFAULT_OPTYPE,
@@ -95,7 +95,7 @@ pub trait HugrView: HugrInternals {
 
     /// Returns the metadata associated with a node.
     #[inline]
-    fn get_metadata(&self, node: Node, key: impl AsRef<str>) -> Option<&NodeMetadata> {
+    fn get_metadata(&self, node: Self::Node, key: impl AsRef<str>) -> Option<&NodeMetadata> {
         match self.contains_node(node) {
             true => self.get_node_metadata(node)?.get(key.as_ref()),
             false => None,
@@ -103,7 +103,7 @@ pub trait HugrView: HugrInternals {
     }
 
     /// Retrieve the complete metadata map for a node.
-    fn get_node_metadata(&self, node: Node) -> Option<&NodeMetadataMap> {
+    fn get_node_metadata(&self, node: Self::Node) -> Option<&NodeMetadataMap> {
         if !self.valid_node(node) {
             return None;
         }
@@ -117,16 +117,16 @@ pub trait HugrView: HugrInternals {
     fn edge_count(&self) -> usize;
 
     /// Iterates over the nodes in the port graph.
-    fn nodes(&self) -> impl Iterator<Item = Node> + Clone;
+    fn nodes(&self) -> impl Iterator<Item = Self::Node> + Clone;
 
     /// Iterator over ports of node in a given direction.
-    fn node_ports(&self, node: Node, dir: Direction) -> impl Iterator<Item = Port> + Clone;
+    fn node_ports(&self, node: Self::Node, dir: Direction) -> impl Iterator<Item = Port> + Clone;
 
     /// Iterator over output ports of node.
     /// Like [`node_ports`][HugrView::node_ports]`(node, Direction::Outgoing)`
     /// but preserves knowledge that the ports are [OutgoingPort]s.
     #[inline]
-    fn node_outputs(&self, node: Node) -> impl Iterator<Item = OutgoingPort> + Clone {
+    fn node_outputs(&self, node: Self::Node) -> impl Iterator<Item = OutgoingPort> + Clone {
         self.node_ports(node, Direction::Outgoing)
             .map(|p| p.as_outgoing().unwrap())
     }
@@ -135,29 +135,29 @@ pub trait HugrView: HugrInternals {
     /// Like [`node_ports`][HugrView::node_ports]`(node, Direction::Incoming)`
     /// but preserves knowledge that the ports are [IncomingPort]s.
     #[inline]
-    fn node_inputs(&self, node: Node) -> impl Iterator<Item = IncomingPort> + Clone {
+    fn node_inputs(&self, node: Self::Node) -> impl Iterator<Item = IncomingPort> + Clone {
         self.node_ports(node, Direction::Incoming)
             .map(|p| p.as_incoming().unwrap())
     }
 
     /// Iterator over both the input and output ports of node.
-    fn all_node_ports(&self, node: Node) -> impl Iterator<Item = Port> + Clone;
+    fn all_node_ports(&self, node: Self::Node) -> impl Iterator<Item = Port> + Clone;
 
     /// Iterator over the nodes and ports connected to a port.
     fn linked_ports(
         &self,
-        node: Node,
+        node: Self::Node,
         port: impl Into<Port>,
-    ) -> impl Iterator<Item = (Node, Port)> + Clone;
+    ) -> impl Iterator<Item = (Self::Node, Port)> + Clone;
 
     /// Iterator over all the nodes and ports connected to a node in a given direction.
     fn all_linked_ports(
         &self,
-        node: Node,
+        node: Self::Node,
         dir: Direction,
     ) -> Either<
-        impl Iterator<Item = (Node, OutgoingPort)>,
-        impl Iterator<Item = (Node, IncomingPort)>,
+        impl Iterator<Item = (Self::Node, OutgoingPort)>,
+        impl Iterator<Item = (Self::Node, IncomingPort)>,
     > {
         match dir {
             Direction::Incoming => Either::Left(
@@ -172,14 +172,20 @@ pub trait HugrView: HugrInternals {
     }
 
     /// Iterator over all the nodes and ports connected to a node's inputs.
-    fn all_linked_outputs(&self, node: Node) -> impl Iterator<Item = (Node, OutgoingPort)> {
+    fn all_linked_outputs(
+        &self,
+        node: Self::Node,
+    ) -> impl Iterator<Item = (Self::Node, OutgoingPort)> {
         self.all_linked_ports(node, Direction::Incoming)
             .left()
             .unwrap()
     }
 
     /// Iterator over all the nodes and ports connected to a node's outputs.
-    fn all_linked_inputs(&self, node: Node) -> impl Iterator<Item = (Node, IncomingPort)> {
+    fn all_linked_inputs(
+        &self,
+        node: Self::Node,
+    ) -> impl Iterator<Item = (Self::Node, IncomingPort)> {
         self.all_linked_ports(node, Direction::Outgoing)
             .right()
             .unwrap()
@@ -187,7 +193,11 @@ pub trait HugrView: HugrInternals {
 
     /// If there is exactly one port connected to this port, return
     /// it and its node.
-    fn single_linked_port(&self, node: Node, port: impl Into<Port>) -> Option<(Node, Port)> {
+    fn single_linked_port(
+        &self,
+        node: Self::Node,
+        port: impl Into<Port>,
+    ) -> Option<(Self::Node, Port)> {
         self.linked_ports(node, port).exactly_one().ok()
     }
 
@@ -195,9 +205,9 @@ pub trait HugrView: HugrInternals {
     /// it and its node.
     fn single_linked_output(
         &self,
-        node: Node,
+        node: Self::Node,
         port: impl Into<IncomingPort>,
-    ) -> Option<(Node, OutgoingPort)> {
+    ) -> Option<(Self::Node, OutgoingPort)> {
         self.single_linked_port(node, port.into())
             .map(|(n, p)| (n, p.as_outgoing().unwrap()))
     }
@@ -206,9 +216,9 @@ pub trait HugrView: HugrInternals {
     /// it and its node.
     fn single_linked_input(
         &self,
-        node: Node,
+        node: Self::Node,
         port: impl Into<OutgoingPort>,
-    ) -> Option<(Node, IncomingPort)> {
+    ) -> Option<(Self::Node, IncomingPort)> {
         self.single_linked_port(node, port.into())
             .map(|(n, p)| (n, p.as_incoming().unwrap()))
     }
@@ -217,9 +227,9 @@ pub trait HugrView: HugrInternals {
     /// that the linked ports are [OutgoingPort]s.
     fn linked_outputs(
         &self,
-        node: Node,
+        node: Self::Node,
         port: impl Into<IncomingPort>,
-    ) -> impl Iterator<Item = (Node, OutgoingPort)> {
+    ) -> impl Iterator<Item = (Self::Node, OutgoingPort)> {
         self.linked_ports(node, port.into())
             .map(|(n, p)| (n, p.as_outgoing().unwrap()))
     }
@@ -229,72 +239,80 @@ pub trait HugrView: HugrInternals {
     /// that the linked ports are [IncomingPort]s.
     fn linked_inputs(
         &self,
-        node: Node,
+        node: Self::Node,
         port: impl Into<OutgoingPort>,
-    ) -> impl Iterator<Item = (Node, IncomingPort)> {
+    ) -> impl Iterator<Item = (Self::Node, IncomingPort)> {
         self.linked_ports(node, port.into())
             .map(|(n, p)| (n, p.as_incoming().unwrap()))
     }
 
     /// Iterator the links between two nodes.
-    fn node_connections(&self, node: Node, other: Node) -> impl Iterator<Item = [Port; 2]> + Clone;
+    fn node_connections(
+        &self,
+        node: Self::Node,
+        other: Self::Node,
+    ) -> impl Iterator<Item = [Port; 2]> + Clone;
 
     /// Returns whether a port is connected.
-    fn is_linked(&self, node: Node, port: impl Into<Port>) -> bool {
+    fn is_linked(&self, node: Self::Node, port: impl Into<Port>) -> bool {
         self.linked_ports(node, port).next().is_some()
     }
 
     /// Number of ports in node for a given direction.
-    fn num_ports(&self, node: Node, dir: Direction) -> usize;
+    fn num_ports(&self, node: Self::Node, dir: Direction) -> usize;
 
     /// Number of inputs to a node.
     /// Shorthand for [`num_ports`][HugrView::num_ports]`(node, Direction::Incoming)`.
     #[inline]
-    fn num_inputs(&self, node: Node) -> usize {
+    fn num_inputs(&self, node: Self::Node) -> usize {
         self.num_ports(node, Direction::Incoming)
     }
 
     /// Number of outputs from a node.
     /// Shorthand for [`num_ports`][HugrView::num_ports]`(node, Direction::Outgoing)`.
     #[inline]
-    fn num_outputs(&self, node: Node) -> usize {
+    fn num_outputs(&self, node: Self::Node) -> usize {
         self.num_ports(node, Direction::Outgoing)
     }
 
     /// Return iterator over the direct children of node.
-    fn children(&self, node: Node) -> impl DoubleEndedIterator<Item = Node> + Clone;
+    fn children(&self, node: Self::Node) -> impl DoubleEndedIterator<Item = Self::Node> + Clone;
 
     /// Returns the first child of the specified node (if it is a parent).
     /// Useful because `x.children().next()` leaves x borrowed.
-    fn first_child(&self, node: Node) -> Option<Node> {
+    fn first_child(&self, node: Self::Node) -> Option<Self::Node> {
         self.children(node).next()
     }
 
     /// Iterates over neighbour nodes in the given direction.
     /// May contain duplicates if the graph has multiple links between nodes.
-    fn neighbours(&self, node: Node, dir: Direction) -> impl Iterator<Item = Node> + Clone;
+    fn neighbours(
+        &self,
+        node: Self::Node,
+        dir: Direction,
+    ) -> impl Iterator<Item = Self::Node> + Clone;
 
     /// Iterates over the input neighbours of the `node`.
     /// Shorthand for [`neighbours`][HugrView::neighbours]`(node, Direction::Incoming)`.
     #[inline]
-    fn input_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone {
+    fn input_neighbours(&self, node: Self::Node) -> impl Iterator<Item = Self::Node> + Clone {
         self.neighbours(node, Direction::Incoming)
     }
 
     /// Iterates over the output neighbours of the `node`.
     /// Shorthand for [`neighbours`][HugrView::neighbours]`(node, Direction::Outgoing)`.
     #[inline]
-    fn output_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone {
+    fn output_neighbours(&self, node: Self::Node) -> impl Iterator<Item = Self::Node> + Clone {
         self.neighbours(node, Direction::Outgoing)
     }
 
     /// Iterates over the input and output neighbours of the `node` in sequence.
-    fn all_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone;
+    fn all_neighbours(&self, node: Self::Node) -> impl Iterator<Item = Self::Node> + Clone;
 
     /// Get the input and output child nodes of a dataflow parent.
     /// If the node isn't a dataflow parent, then return None
     #[inline]
-    fn get_io(&self, node: Node) -> Option<[Node; 2]> {
+    fn get_io(&self, node: Self::Node) -> Option<[Self::Node; 2]> {
         let op = self.get_optype(node);
         // Nodes outside the view have no children (and a non-DataflowParent OpType::default())
         if OpTag::DataflowParent.is_superset(op.tag()) {
@@ -397,26 +415,29 @@ pub trait HugrView: HugrInternals {
     }
 
     /// If a node has a static input, return the source node.
-    fn static_source(&self, node: Node) -> Option<Node> {
+    fn static_source(&self, node: Self::Node) -> Option<Self::Node> {
         self.linked_outputs(node, self.get_optype(node).static_input_port()?)
             .next()
             .map(|(n, _)| n)
     }
 
     /// If a node has a static output, return the targets.
-    fn static_targets(&self, node: Node) -> Option<impl Iterator<Item = (Node, IncomingPort)>> {
+    fn static_targets(
+        &self,
+        node: Self::Node,
+    ) -> Option<impl Iterator<Item = (Self::Node, IncomingPort)>> {
         Some(self.linked_inputs(node, self.get_optype(node).static_output_port()?))
     }
 
     /// Get the "signature" (incoming and outgoing types) of a node, non-Value
     /// kind ports will be missing.
-    fn signature(&self, node: Node) -> Option<Cow<'_, Signature>> {
+    fn signature(&self, node: Self::Node) -> Option<Cow<'_, Signature>> {
         self.get_optype(node).dataflow_signature()
     }
 
     /// Iterator over all outgoing ports that have Value type, along
     /// with corresponding types.
-    fn value_types(&self, node: Node, dir: Direction) -> impl Iterator<Item = (Port, Type)> {
+    fn value_types(&self, node: Self::Node, dir: Direction) -> impl Iterator<Item = (Port, Type)> {
         let sig = self.signature(node).unwrap_or_default();
         self.node_ports(node, dir)
             .flat_map(move |port| sig.port_type(port).map(|typ| (port, typ.clone())))
@@ -424,14 +445,14 @@ pub trait HugrView: HugrInternals {
 
     /// Iterator over all incoming ports that have Value type, along
     /// with corresponding types.
-    fn in_value_types(&self, node: Node) -> impl Iterator<Item = (IncomingPort, Type)> {
+    fn in_value_types(&self, node: Self::Node) -> impl Iterator<Item = (IncomingPort, Type)> {
         self.value_types(node, Direction::Incoming)
             .map(|(p, t)| (p.as_incoming().unwrap(), t))
     }
 
     /// Iterator over all incoming ports that have Value type, along
     /// with corresponding types.
-    fn out_value_types(&self, node: Node) -> impl Iterator<Item = (OutgoingPort, Type)> {
+    fn out_value_types(&self, node: Self::Node) -> impl Iterator<Item = (OutgoingPort, Type)> {
         self.value_types(node, Direction::Outgoing)
             .map(|(p, t)| (p.as_outgoing().unwrap(), t))
     }
@@ -478,7 +499,10 @@ pub trait HierarchyView<'a>: RootTagged + Sized {
     ///
     /// # Errors
     /// Returns [`HugrError::InvalidTag`] if the root isn't a node of the required [OpTag]
-    fn try_new(hugr: &'a impl HugrView, root: Node) -> Result<Self, HugrError>;
+    fn try_new(
+        hugr: &'a impl HugrView<Node = Self::Node>,
+        root: Self::Node,
+    ) -> Result<Self, HugrError>;
 }
 
 /// A trait for [`HugrView`]s that can be extracted into a valid HUGR containing
@@ -496,7 +520,10 @@ pub trait ExtractHugr: HugrView + Sized {
     }
 }
 
-fn check_tag<Required: NodeHandle>(hugr: &impl HugrView, node: Node) -> Result<(), HugrError> {
+fn check_tag<Required: NodeHandle, N>(
+    hugr: &impl HugrView<Node = N>,
+    node: N,
+) -> Result<(), HugrError> {
     let actual = hugr.get_optype(node).tag();
     let required = Required::TAG;
     if !required.is_superset(actual) {
@@ -625,7 +652,10 @@ where
 {
     /// Filter an iterator of node-ports to only dataflow dependency specifying
     /// ports (Value and StateOrder)
-    fn dataflow_ports_only(self, hugr: &impl HugrView) -> impl Iterator<Item = (Node, P)> {
+    fn dataflow_ports_only(
+        self,
+        hugr: &impl HugrView<Node = Node>,
+    ) -> impl Iterator<Item = (Node, P)> {
         self.filter_edge_kind(
             |kind| matches!(kind, Some(EdgeKind::Value(..) | EdgeKind::StateOrder)),
             hugr,
@@ -636,7 +666,7 @@ where
     fn filter_edge_kind(
         self,
         predicate: impl Fn(Option<EdgeKind>) -> bool,
-        hugr: &impl HugrView,
+        hugr: &impl HugrView<Node = Node>,
     ) -> impl Iterator<Item = (Node, P)> {
         self.filter(move |(n, p)| {
             let kind = hugr.get_optype(*n).port_kind(*p);

--- a/hugr-core/src/hugr/views/impls.rs
+++ b/hugr-core/src/hugr/views/impls.rs
@@ -9,7 +9,7 @@ use crate::{
     hugr::{NodeMetadata, NodeMetadataMap, ValidationError},
     ops::OpType,
     types::{PolyFuncType, Signature, Type},
-    Direction, Hugr, IncomingPort, Node, OutgoingPort, Port,
+    Direction, Hugr, IncomingPort, OutgoingPort, Port,
 };
 
 macro_rules! hugr_view_methods {
@@ -17,54 +17,54 @@ macro_rules! hugr_view_methods {
     ($arg:ident, $e:expr) => {
         delegate! {
             to ({let $arg=self; $e}) {
-                fn root(&self) -> Node;
+                fn root(&self) -> Self::Node;
                 fn root_type(&self) -> &OpType;
-                fn contains_node(&self, node: Node) -> bool;
-                fn valid_node(&self, node: Node) -> bool;
-                fn valid_non_root(&self, node: Node) -> bool;
-                fn get_parent(&self, node: Node) -> Option<Node>;
-                fn get_optype(&self, node: Node) -> &OpType;
-                fn get_metadata(&self, node: Node, key: impl AsRef<str>) -> Option<&NodeMetadata>;
-                fn get_node_metadata(&self, node: Node) -> Option<&NodeMetadataMap>;
+                fn contains_node(&self, node: Self::Node) -> bool;
+                fn valid_node(&self, node: Self::Node) -> bool;
+                fn valid_non_root(&self, node: Self::Node) -> bool;
+                fn get_parent(&self, node: Self::Node) -> Option<Self::Node>;
+                fn get_optype(&self, node: Self::Node) -> &OpType;
+                fn get_metadata(&self, node: Self::Node, key: impl AsRef<str>) -> Option<&NodeMetadata>;
+                fn get_node_metadata(&self, node: Self::Node) -> Option<&NodeMetadataMap>;
                 fn node_count(&self) -> usize;
                 fn edge_count(&self) -> usize;
-                fn nodes(&self) -> impl Iterator<Item = Node> + Clone;
-                fn node_ports(&self, node: Node, dir: Direction) -> impl Iterator<Item = Port> + Clone;
-                fn node_outputs(&self, node: Node) -> impl Iterator<Item = OutgoingPort> + Clone;
-                fn node_inputs(&self, node: Node) -> impl Iterator<Item = IncomingPort> + Clone;
-                fn all_node_ports(&self, node: Node) -> impl Iterator<Item = Port> + Clone;
+                fn nodes(&self) -> impl Iterator<Item = Self::Node> + Clone;
+                fn node_ports(&self, node: Self::Node, dir: Direction) -> impl Iterator<Item = Port> + Clone;
+                fn node_outputs(&self, node: Self::Node) -> impl Iterator<Item = OutgoingPort> + Clone;
+                fn node_inputs(&self, node: Self::Node) -> impl Iterator<Item = IncomingPort> + Clone;
+                fn all_node_ports(&self, node: Self::Node) -> impl Iterator<Item = Port> + Clone;
                 fn linked_ports(
                     &self,
-                    node: Node,
+                    node: Self::Node,
                     port: impl Into<Port>,
-                ) -> impl Iterator<Item = (Node, Port)> + Clone;
+                ) -> impl Iterator<Item = (Self::Node, Port)> + Clone;
                 fn all_linked_ports(
                     &self,
-                    node: Node,
+                    node: Self::Node,
                     dir: Direction,
                 ) -> Either<
-                    impl Iterator<Item = (Node, OutgoingPort)>,
-                    impl Iterator<Item = (Node, IncomingPort)>,
+                    impl Iterator<Item = (Self::Node, OutgoingPort)>,
+                    impl Iterator<Item = (Self::Node, IncomingPort)>,
                 >;
-                fn all_linked_outputs(&self, node: Node) -> impl Iterator<Item = (Node, OutgoingPort)>;
-                fn all_linked_inputs(&self, node: Node) -> impl Iterator<Item = (Node, IncomingPort)>;
-                fn single_linked_port(&self, node: Node, port: impl Into<Port>) -> Option<(Node, Port)>;
-                fn single_linked_output(&self, node: Node, port: impl Into<IncomingPort>) -> Option<(Node, OutgoingPort)>;
-                fn single_linked_input(&self, node: Node, port: impl Into<OutgoingPort>) -> Option<(Node, IncomingPort)>;
-                fn linked_outputs(&self, node: Node, port: impl Into<IncomingPort>) -> impl Iterator<Item = (Node, OutgoingPort)>;
-                fn linked_inputs(&self, node: Node, port: impl Into<OutgoingPort>) -> impl Iterator<Item = (Node, IncomingPort)>;
-                fn node_connections(&self, node: Node, other: Node) -> impl Iterator<Item = [Port; 2]> + Clone;
-                fn is_linked(&self, node: Node, port: impl Into<Port>) -> bool;
-                fn num_ports(&self, node: Node, dir: Direction) -> usize;
-                fn num_inputs(&self, node: Node) -> usize;
-                fn num_outputs(&self, node: Node) -> usize;
-                fn children(&self, node: Node) -> impl DoubleEndedIterator<Item = Node> + Clone;
-                fn first_child(&self, node: Node) -> Option<Node>;
-                fn neighbours(&self, node: Node, dir: Direction) -> impl Iterator<Item = Node> + Clone;
-                fn input_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone;
-                fn output_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone;
-                fn all_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone;
-                fn get_io(&self, node: Node) -> Option<[Node; 2]>;
+                fn all_linked_outputs(&self, node: Self::Node) -> impl Iterator<Item = (Self::Node, OutgoingPort)>;
+                fn all_linked_inputs(&self, node: Self::Node) -> impl Iterator<Item = (Self::Node, IncomingPort)>;
+                fn single_linked_port(&self, node: Self::Node, port: impl Into<Port>) -> Option<(Self::Node, Port)>;
+                fn single_linked_output(&self, node: Self::Node, port: impl Into<IncomingPort>) -> Option<(Self::Node, OutgoingPort)>;
+                fn single_linked_input(&self, node: Self::Node, port: impl Into<OutgoingPort>) -> Option<(Self::Node, IncomingPort)>;
+                fn linked_outputs(&self, node: Self::Node, port: impl Into<IncomingPort>) -> impl Iterator<Item = (Self::Node, OutgoingPort)>;
+                fn linked_inputs(&self, node: Self::Node, port: impl Into<OutgoingPort>) -> impl Iterator<Item = (Self::Node, IncomingPort)>;
+                fn node_connections(&self, node: Self::Node, other: Self::Node) -> impl Iterator<Item = [Port; 2]> + Clone;
+                fn is_linked(&self, node: Self::Node, port: impl Into<Port>) -> bool;
+                fn num_ports(&self, node: Self::Node, dir: Direction) -> usize;
+                fn num_inputs(&self, node: Self::Node) -> usize;
+                fn num_outputs(&self, node: Self::Node) -> usize;
+                fn children(&self, node: Self::Node) -> impl DoubleEndedIterator<Item = Self::Node> + Clone;
+                fn first_child(&self, node: Self::Node) -> Option<Self::Node>;
+                fn neighbours(&self, node: Self::Node, dir: Direction) -> impl Iterator<Item = Self::Node> + Clone;
+                fn input_neighbours(&self, node: Self::Node) -> impl Iterator<Item = Self::Node> + Clone;
+                fn output_neighbours(&self, node: Self::Node) -> impl Iterator<Item = Self::Node> + Clone;
+                fn all_neighbours(&self, node: Self::Node) -> impl Iterator<Item = Self::Node> + Clone;
+                fn get_io(&self, node: Self::Node) -> Option<[Self::Node; 2]>;
                 fn inner_function_type(&self) -> Option<Cow<'_, Signature>>;
                 fn poly_func_type(&self) -> Option<PolyFuncType>;
                 // TODO: cannot use delegate here. `PetgraphWrapper` is a thin
@@ -74,12 +74,12 @@ macro_rules! hugr_view_methods {
                 fn mermaid_string(&self) -> String;
                 fn mermaid_string_with_config(&self, config: RenderConfig) -> String;
                 fn dot_string(&self) -> String;
-                fn static_source(&self, node: Node) -> Option<Node>;
-                fn static_targets(&self, node: Node) -> Option<impl Iterator<Item = (Node, IncomingPort)>>;
-                fn signature(&self, node: Node) -> Option<Cow<'_, Signature>>;
-                fn value_types(&self, node: Node, dir: Direction) -> impl Iterator<Item = (Port, Type)>;
-                fn in_value_types(&self, node: Node) -> impl Iterator<Item = (IncomingPort, Type)>;
-                fn out_value_types(&self, node: Node) -> impl Iterator<Item = (OutgoingPort, Type)>;
+                fn static_source(&self, node: Self::Node) -> Option<Self::Node>;
+                fn static_targets(&self, node: Self::Node) -> Option<impl Iterator<Item = (Self::Node, IncomingPort)>>;
+                fn signature(&self, node: Self::Node) -> Option<Cow<'_, Signature>>;
+                fn value_types(&self, node: Self::Node, dir: Direction) -> impl Iterator<Item = (Port, Type)>;
+                fn in_value_types(&self, node: Self::Node) -> impl Iterator<Item = (IncomingPort, Type)>;
+                fn out_value_types(&self, node: Self::Node) -> impl Iterator<Item = (OutgoingPort, Type)>;
                 fn extensions(&self) -> &ExtensionRegistry;
                 fn validate(&self) -> Result<(), ValidationError>;
                 fn validate_no_extensions(&self) -> Result<(), ValidationError>;
@@ -125,7 +125,7 @@ mod test {
 
     struct ViewWrapper<H>(H);
     impl<H: HugrView> ViewWrapper<H> {
-        fn nodes(&self) -> impl Iterator<Item = Node> + '_ {
+        fn nodes(&self) -> impl Iterator<Item = H::Node> + '_ {
             self.0.nodes()
         }
     }

--- a/hugr-core/src/hugr/views/petgraph.rs
+++ b/hugr-core/src/hugr/views/petgraph.rs
@@ -4,7 +4,7 @@ use crate::hugr::HugrView;
 use crate::ops::OpType;
 use crate::types::EdgeKind;
 use crate::NodeIndex;
-use crate::{Node, Port};
+use crate::Port;
 
 use petgraph::visit as pv;
 
@@ -37,8 +37,8 @@ impl<T> pv::GraphBase for PetgraphWrapper<'_, T>
 where
     T: HugrView,
 {
-    type NodeId = Node;
-    type EdgeId = ((Node, Port), (Node, Port));
+    type NodeId = T::Node;
+    type EdgeId = ((T::Node, Port), (T::Node, Port));
 }
 
 impl<T> pv::GraphProp for PetgraphWrapper<'_, T>
@@ -97,8 +97,8 @@ impl<'a, T> pv::IntoNodeReferences for PetgraphWrapper<'a, T>
 where
     T: HugrView,
 {
-    type NodeRef = HugrNodeRef<'a>;
-    type NodeReferences = Box<dyn Iterator<Item = HugrNodeRef<'a>> + 'a>;
+    type NodeRef = HugrNodeRef<'a, T::Node>;
+    type NodeReferences = Box<dyn Iterator<Item = HugrNodeRef<'a, T::Node>> + 'a>;
 
     fn node_references(self) -> Self::NodeReferences {
         Box::new(
@@ -113,7 +113,7 @@ impl<'a, T> pv::IntoNodeIdentifiers for PetgraphWrapper<'a, T>
 where
     T: HugrView,
 {
-    type NodeIdentifiers = Box<dyn Iterator<Item = Node> + 'a>;
+    type NodeIdentifiers = Box<dyn Iterator<Item = T::Node> + 'a>;
 
     fn node_identifiers(self) -> Self::NodeIdentifiers {
         Box::new(self.hugr.nodes())
@@ -124,7 +124,7 @@ impl<'a, T> pv::IntoNeighbors for PetgraphWrapper<'a, T>
 where
     T: HugrView,
 {
-    type Neighbors = Box<dyn Iterator<Item = Node> + 'a>;
+    type Neighbors = Box<dyn Iterator<Item = T::Node> + 'a>;
 
     fn neighbors(self, n: Self::NodeId) -> Self::Neighbors {
         Box::new(self.hugr.output_neighbours(n))
@@ -135,7 +135,7 @@ impl<'a, T> pv::IntoNeighborsDirected for PetgraphWrapper<'a, T>
 where
     T: HugrView,
 {
-    type NeighborsDirected = Box<dyn Iterator<Item = Node> + 'a>;
+    type NeighborsDirected = Box<dyn Iterator<Item = T::Node> + 'a>;
 
     fn neighbors_directed(
         self,
@@ -184,13 +184,13 @@ where
 
 /// Reference to a Hugr node and its associated OpType.
 #[derive(Debug, Clone, Copy)]
-pub struct HugrNodeRef<'a> {
-    node: Node,
+pub struct HugrNodeRef<'a, N> {
+    node: N,
     op: &'a OpType,
 }
 
-impl<'a> HugrNodeRef<'a> {
-    pub(self) fn from_node(node: Node, hugr: &'a impl HugrView) -> Self {
+impl<'a, N: NodeIndex> HugrNodeRef<'a, N> {
+    pub(self) fn from_node(node: N, hugr: &'a impl HugrView<Node = N>) -> Self {
         Self {
             node,
             op: hugr.get_optype(node),
@@ -198,8 +198,8 @@ impl<'a> HugrNodeRef<'a> {
     }
 }
 
-impl pv::NodeRef for HugrNodeRef<'_> {
-    type NodeId = Node;
+impl<N: NodeIndex> pv::NodeRef for HugrNodeRef<'_, N> {
+    type NodeId = N;
 
     type Weight = OpType;
 

--- a/hugr-core/src/hugr/views/root_checked.rs
+++ b/hugr-core/src/hugr/views/root_checked.rs
@@ -29,7 +29,7 @@ impl<H: RootTagged + AsRef<Hugr>, Root: NodeHandle> RootChecked<H, Root> {
                 actual: Root::TAG,
             });
         }
-        check_tag::<Root>(&hugr, hugr.root())?;
+        check_tag::<Root, _>(&hugr, hugr.root())?;
         Ok(Self(hugr, PhantomData))
     }
 }
@@ -53,6 +53,8 @@ impl<H: AsRef<Hugr>, Root> HugrInternals for RootChecked<H, Root> {
         = &'p MultiPortGraph
     where
         Self: 'p;
+    type Node = Node;
+
     delegate! {
         to self.as_ref() {
             fn portgraph(&self) -> Self::Portgraph<'_>;

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -26,7 +26,7 @@ use crate::ops::dataflow::DataflowOpTrait;
 use crate::ops::handle::{ContainerHandle, DataflowOpID};
 use crate::ops::{NamedOp, OpTag, OpTrait, OpType};
 use crate::types::{Signature, Type};
-use crate::{Hugr, IncomingPort, Node, OutgoingPort, Port, SimpleReplacement};
+use crate::{Hugr, IncomingPort, Node, NodeIndex, OutgoingPort, Port, SimpleReplacement};
 
 /// A non-empty convex subgraph of a HUGR sibling graph.
 ///
@@ -55,19 +55,19 @@ use crate::{Hugr, IncomingPort, Node, OutgoingPort, Port, SimpleReplacement};
 // TODO: implement a borrowing wrapper that implements a view into the Hugr
 // given a reference.
 #[derive(Clone, Debug)]
-pub struct SiblingSubgraph {
+pub struct SiblingSubgraph<N = Node> {
     /// The nodes of the induced subgraph.
-    nodes: Vec<Node>,
+    nodes: Vec<N>,
     /// The input ports of the subgraph.
     ///
     /// Grouped by input parameter. Each port must be unique and belong to a
     /// node in `nodes`.
-    inputs: Vec<Vec<(Node, IncomingPort)>>,
+    inputs: Vec<Vec<(N, IncomingPort)>>,
     /// The output ports of the subgraph.
     ///
     /// Repeated ports are allowed and correspond to copying the output. Every
     /// port must belong to a node in `nodes`.
-    outputs: Vec<(Node, OutgoingPort)>,
+    outputs: Vec<(N, OutgoingPort)>,
 }
 
 /// The type of the incoming boundary of [`SiblingSubgraph`].
@@ -76,11 +76,11 @@ pub struct SiblingSubgraph {
 /// input parameter. A set in the partition that has more than one element
 /// corresponds to an input parameter that is copied and useful multiple times
 /// in the subgraph.
-pub type IncomingPorts = Vec<Vec<(Node, IncomingPort)>>;
+pub type IncomingPorts<N = Node> = Vec<Vec<(N, IncomingPort)>>;
 /// The type of the outgoing boundary of [`SiblingSubgraph`].
-pub type OutgoingPorts = Vec<(Node, OutgoingPort)>;
+pub type OutgoingPorts<N = Node> = Vec<(N, OutgoingPort)>;
 
-impl SiblingSubgraph {
+impl<N: NodeIndex> SiblingSubgraph<N> {
     /// A sibling subgraph from a [`crate::ops::OpTag::DataflowParent`]-rooted
     /// HUGR.
     ///
@@ -94,9 +94,9 @@ impl SiblingSubgraph {
     ///
     /// This will return an [`InvalidSubgraph::EmptySubgraph`] error if the
     /// subgraph is empty.
-    pub fn try_new_dataflow_subgraph<H, Root>(dfg_graph: &H) -> Result<Self, InvalidSubgraph>
+    pub fn try_new_dataflow_subgraph<H, Root>(dfg_graph: &H) -> Result<Self, InvalidSubgraph<N>>
     where
-        H: Clone + RootTagged<RootHandle = Root>,
+        H: Clone + RootTagged<RootHandle = Root, Node = N>,
         Root: ContainerHandle<ChildrenHandle = DataflowOpID>,
     {
         let parent = dfg_graph.root();
@@ -156,10 +156,10 @@ impl SiblingSubgraph {
     /// This function fails if the subgraph is not convex, if the nodes
     /// do not share a common parent or if the subgraph is empty.
     pub fn try_new(
-        incoming: IncomingPorts,
-        outgoing: OutgoingPorts,
-        hugr: &impl HugrView,
-    ) -> Result<Self, InvalidSubgraph> {
+        incoming: IncomingPorts<N>,
+        outgoing: OutgoingPorts<N>,
+        hugr: &impl HugrView<Node = N>,
+    ) -> Result<Self, InvalidSubgraph<N>> {
         let checker = TopoConvexChecker::new(hugr);
         Self::try_new_with_checker(incoming, outgoing, hugr, &checker)
     }
@@ -173,11 +173,11 @@ impl SiblingSubgraph {
     /// Refer to [`SiblingSubgraph::try_new`] for the full
     /// documentation.
     pub fn try_new_with_checker(
-        inputs: IncomingPorts,
-        outputs: OutgoingPorts,
-        hugr: &impl HugrView,
+        inputs: IncomingPorts<N>,
+        outputs: OutgoingPorts<N>,
+        hugr: &impl HugrView<Node = N>,
         checker: &impl ConvexChecker,
-    ) -> Result<Self, InvalidSubgraph> {
+    ) -> Result<Self, InvalidSubgraph<N>> {
         let pg = hugr.portgraph();
 
         // Ordering of the edges here is preserved and becomes ordering of the signature.
@@ -212,9 +212,9 @@ impl SiblingSubgraph {
     /// assumption is made that no two incoming edges have the same source
     /// (no copy nodes at the input boundary).
     pub fn try_from_nodes(
-        nodes: impl Into<Vec<Node>>,
-        hugr: &impl HugrView,
-    ) -> Result<Self, InvalidSubgraph> {
+        nodes: impl Into<Vec<N>>,
+        hugr: &impl HugrView<Node = N>,
+    ) -> Result<Self, InvalidSubgraph<N>> {
         let checker = TopoConvexChecker::new(hugr);
         Self::try_from_nodes_with_checker(nodes, hugr, &checker)
     }
@@ -227,11 +227,11 @@ impl SiblingSubgraph {
     ///
     /// Refer to [`SiblingSubgraph::try_from_nodes`] for the full
     /// documentation.
-    pub fn try_from_nodes_with_checker<'c, 'h: 'c, H: HugrView>(
-        nodes: impl Into<Vec<Node>>,
-        hugr: &'h H,
+    pub fn try_from_nodes_with_checker<'c, 'h: 'c>(
+        nodes: impl Into<Vec<N>>,
+        hugr: &'h impl HugrView<Node = N>,
         checker: &impl ConvexChecker,
-    ) -> Result<Self, InvalidSubgraph> {
+    ) -> Result<Self, InvalidSubgraph<N>> {
         let nodes = nodes.into();
 
         // If there's one or less nodes, we don't need to check convexity.
@@ -271,7 +271,7 @@ impl SiblingSubgraph {
     /// Create a subgraph containing a single node.
     ///
     /// The subgraph signature will be given by signature of the node.
-    pub fn from_node(node: Node, hugr: &impl HugrView) -> Self {
+    pub fn from_node(node: N, hugr: &impl HugrView<Node = N>) -> Self {
         let nodes = vec![node];
         let inputs = hugr
             .node_inputs(node)
@@ -301,7 +301,7 @@ impl SiblingSubgraph {
     }
 
     /// An iterator over the nodes in the subgraph.
-    pub fn nodes(&self) -> &[Node] {
+    pub fn nodes(&self) -> &[N] {
         &self.nodes
     }
 
@@ -311,17 +311,17 @@ impl SiblingSubgraph {
     }
 
     /// Returns the computed [`IncomingPorts`] of the subgraph.
-    pub fn incoming_ports(&self) -> &IncomingPorts {
+    pub fn incoming_ports(&self) -> &IncomingPorts<N> {
         &self.inputs
     }
 
     /// Returns the computed [`OutgoingPorts`] of the subgraph.
-    pub fn outgoing_ports(&self) -> &OutgoingPorts {
+    pub fn outgoing_ports(&self) -> &OutgoingPorts<N> {
         &self.outputs
     }
 
     /// The signature of the subgraph.
-    pub fn signature(&self, hugr: &impl HugrView) -> Signature {
+    pub fn signature(&self, hugr: &impl HugrView<Node = N>) -> Signature {
         let input = self
             .inputs
             .iter()
@@ -347,7 +347,7 @@ impl SiblingSubgraph {
     }
 
     /// The parent of the sibling subgraph.
-    pub fn get_parent(&self, hugr: &impl HugrView) -> Node {
+    pub fn get_parent(&self, hugr: &impl HugrView<Node = N>) -> N {
         hugr.get_parent(self.nodes[0]).expect("invalid subgraph")
     }
 
@@ -368,9 +368,9 @@ impl SiblingSubgraph {
     /// the replacement graph, this will panic.
     pub fn create_simple_replacement(
         &self,
-        hugr: &impl HugrView,
+        hugr: &impl HugrView<Node = N>,
         replacement: Hugr,
-    ) -> Result<SimpleReplacement, InvalidReplacement> {
+    ) -> Result<SimpleReplacement<N>, InvalidReplacement> {
         let rep_root = replacement.root();
         let dfg_optype = replacement.get_optype(rep_root);
         if !OpTag::Dfg.is_superset(dfg_optype.tag()) {
@@ -445,12 +445,18 @@ impl SiblingSubgraph {
             nu_out,
         ))
     }
+}
 
+impl SiblingSubgraph {
     /// Create a new Hugr containing only the subgraph.
     ///
     /// The new Hugr will contain a [FuncDefn][crate::ops::FuncDefn] root
     /// with the same signature as the subgraph and the specified `name`
-    pub fn extract_subgraph(&self, hugr: &impl HugrView, name: impl Into<String>) -> Hugr {
+    pub fn extract_subgraph(
+        &self,
+        hugr: &impl HugrView<Node = Node>,
+        name: impl Into<String>,
+    ) -> Hugr {
         let mut builder = FunctionBuilder::new(name, self.signature(hugr)).unwrap();
         // Take the unfinished Hugr from the builder, to avoid unnecessary
         // validation checks that require connecting the inputs and outputs.
@@ -481,31 +487,35 @@ impl SiblingSubgraph {
 }
 
 /// Returns an iterator over the input ports.
-fn iter_incoming(inputs: &IncomingPorts) -> impl Iterator<Item = (Node, IncomingPort)> + '_ {
+fn iter_incoming<N: NodeIndex>(
+    inputs: &IncomingPorts<N>,
+) -> impl Iterator<Item = (N, IncomingPort)> + '_ {
     inputs.iter().flat_map(|part| part.iter().copied())
 }
 
 /// Returns an iterator over the output ports.
-fn iter_outgoing(outputs: &OutgoingPorts) -> impl Iterator<Item = (Node, OutgoingPort)> + '_ {
+fn iter_outgoing<N: NodeIndex>(
+    outputs: &OutgoingPorts<N>,
+) -> impl Iterator<Item = (N, OutgoingPort)> + '_ {
     outputs.iter().copied()
 }
 
 /// Returns an iterator over both incoming and outgoing ports.
-fn iter_io<'a>(
-    inputs: &'a IncomingPorts,
-    outputs: &'a OutgoingPorts,
-) -> impl Iterator<Item = (Node, Port)> + 'a {
+fn iter_io<'a, N: NodeIndex>(
+    inputs: &'a IncomingPorts<N>,
+    outputs: &'a OutgoingPorts<N>,
+) -> impl Iterator<Item = (N, Port)> + 'a {
     iter_incoming(inputs)
         .map(|(n, p)| (n, Port::from(p)))
         .chain(iter_outgoing(outputs).map(|(n, p)| (n, Port::from(p))))
 }
 
-fn make_boundary<'a>(
-    hugr: &impl HugrView,
-    inputs: &'a IncomingPorts,
-    outputs: &'a OutgoingPorts,
+fn make_boundary<'a, N: NodeIndex>(
+    hugr: &impl HugrView<Node = N>,
+    inputs: &'a IncomingPorts<N>,
+    outputs: &'a OutgoingPorts<N>,
 ) -> Boundary {
-    let to_pg_index = |n: Node, p: Port| {
+    let to_pg_index = |n: N, p: Port| {
         hugr.portgraph()
             .port_index(n.pg_index(), p.pg_offset())
             .unwrap()
@@ -561,7 +571,10 @@ impl<Base: HugrView> ConvexChecker for TopoConvexChecker<'_, Base> {
 /// The type of all ports in the iterator.
 ///
 /// If the array is empty or a port does not exist, returns `None`.
-fn get_edge_type<H: HugrView, P: Into<Port> + Copy>(hugr: &H, ports: &[(Node, P)]) -> Option<Type> {
+fn get_edge_type<H: HugrView, P: Into<Port> + Copy>(
+    hugr: &H,
+    ports: &[(H::Node, P)],
+) -> Option<Type> {
     let &(n, p) = ports.first()?;
     let edge_t = hugr.signature(n)?.port_type(p)?.clone();
     ports
@@ -581,10 +594,10 @@ fn get_edge_type<H: HugrView, P: Into<Port> + Copy>(hugr: &H, ports: &[(Node, P)
 /// induced graph.
 fn validate_subgraph<H: HugrView>(
     hugr: &H,
-    nodes: &[Node],
-    inputs: &IncomingPorts,
-    outputs: &OutgoingPorts,
-) -> Result<(), InvalidSubgraph> {
+    nodes: &[H::Node],
+    inputs: &IncomingPorts<H::Node>,
+    outputs: &OutgoingPorts<H::Node>,
+) -> Result<(), InvalidSubgraph<H::Node>> {
     // Copy of the nodes for fast lookup.
     let node_set = nodes.iter().copied().collect::<HashSet<_>>();
 
@@ -674,7 +687,9 @@ fn validate_subgraph<H: HugrView>(
     Ok(())
 }
 
-fn get_input_output_ports<H: HugrView>(hugr: &H) -> (IncomingPorts, OutgoingPorts) {
+fn get_input_output_ports<H: HugrView>(
+    hugr: &H,
+) -> (IncomingPorts<H::Node>, OutgoingPorts<H::Node>) {
     let [inp, out] = hugr.get_io(hugr.root()).expect("invalid DFG");
     if has_other_edge(hugr, inp, Direction::Outgoing) {
         unimplemented!("Non-dataflow output not supported at input node")
@@ -716,13 +731,13 @@ fn get_input_output_ports<H: HugrView>(hugr: &H) -> (IncomingPorts, OutgoingPort
 }
 
 /// Whether a port is linked to a state order edge.
-fn is_order_edge<H: HugrView>(hugr: &H, node: Node, port: Port) -> bool {
+fn is_order_edge<H: HugrView>(hugr: &H, node: H::Node, port: Port) -> bool {
     let op = hugr.get_optype(node);
     op.other_port(port.direction()) == Some(port) && hugr.is_linked(node, port)
 }
 
 /// Whether node has a non-df linked port in the given direction.
-fn has_other_edge<H: HugrView>(hugr: &H, node: Node, dir: Direction) -> bool {
+fn has_other_edge<H: HugrView>(hugr: &H, node: H::Node, dir: Direction) -> bool {
     let op = hugr.get_optype(node);
     op.other_port_kind(dir).is_some() && hugr.is_linked(node, op.other_port(dir).unwrap())
 }
@@ -758,7 +773,7 @@ pub enum InvalidReplacement {
 /// Errors that can occur while constructing a [`SiblingSubgraph`].
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
-pub enum InvalidSubgraph {
+pub enum InvalidSubgraph<N: NodeIndex = Node> {
     /// The subgraph is not convex.
     #[error("The subgraph is not convex.")]
     NotConvex,
@@ -770,32 +785,32 @@ pub enum InvalidSubgraph {
     )]
     NoSharedParent {
         /// The first node.
-        first_node: Node,
+        first_node: N,
         /// The parent of the first node.
-        first_parent: Option<Node>,
+        first_parent: Option<N>,
         /// The other node.
-        other_node: Node,
+        other_node: N,
         /// The parent of the other node.
-        other_parent: Option<Node>,
+        other_parent: Option<N>,
     },
     /// Empty subgraphs are not supported.
     #[error("Empty subgraphs are not supported.")]
     EmptySubgraph,
     /// An invalid boundary port was found.
     #[error("Invalid boundary port.")]
-    InvalidBoundary(#[from] InvalidSubgraphBoundary),
+    InvalidBoundary(#[from] InvalidSubgraphBoundary<N>),
 }
 
 /// Errors that can occur while constructing a [`SiblingSubgraph`].
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
-pub enum InvalidSubgraphBoundary {
+pub enum InvalidSubgraphBoundary<N: NodeIndex = Node> {
     /// A boundary port's node is not in the set of nodes.
     #[error("(node {0}, port {1}) is in the boundary, but node {0} is not in the set.")]
-    PortNodeNotInSet(Node, Port),
+    PortNodeNotInSet(N, Port),
     /// A boundary port has no connections outside the subgraph.
     #[error("(node {0}, port {1}) is in the boundary, but the port is not connected to a node outside the subgraph.")]
-    DisconnectedBoundaryPort(Node, Port),
+    DisconnectedBoundaryPort(N, Port),
     /// There's a non-unique input-boundary port.
     #[error("A port in the input boundary is used multiple times.")]
     NonUniqueInput,
@@ -831,7 +846,7 @@ mod tests {
 
     use super::*;
 
-    impl SiblingSubgraph {
+    impl<N: NodeIndex> SiblingSubgraph<N> {
         /// A sibling subgraph from a HUGR.
         ///
         /// The subgraph is given by the sibling graph of the root. If you wish to
@@ -840,7 +855,9 @@ mod tests {
         ///
         /// This will return an [`InvalidSubgraph::EmptySubgraph`] error if the
         /// subgraph is empty.
-        fn from_sibling_graph(sibling_graph: &impl HugrView) -> Result<Self, InvalidSubgraph> {
+        fn from_sibling_graph(
+            sibling_graph: &impl HugrView<Node = N>,
+        ) -> Result<Self, InvalidSubgraph<N>> {
             let root = sibling_graph.root();
             let nodes = sibling_graph.children(root).collect_vec();
             if nodes.is_empty() {

--- a/hugr-llvm/src/utils/fat.rs
+++ b/hugr-llvm/src/utils/fat.rs
@@ -302,11 +302,19 @@ impl<OT, H> NodeIndex for FatNode<'_, OT, H> {
     fn index(self) -> usize {
         self.node.index()
     }
+
+    fn pg_index(self) -> usize {
+        self.node.pg_index()
+    }
 }
 
 impl<OT, H> NodeIndex for &FatNode<'_, OT, H> {
     fn index(self) -> usize {
         self.node.index()
+    }
+
+    fn pg_index(self) -> usize {
+        self.node.pg_index()
     }
 }
 

--- a/hugr-passes/src/call_graph.rs
+++ b/hugr-passes/src/call_graph.rs
@@ -2,23 +2,23 @@
 //! Data structure for call graphs of a Hugr
 use std::collections::HashMap;
 
-use hugr_core::{ops::OpType, HugrView, Node};
-use petgraph::{graph::NodeIndex, Graph};
+use hugr_core::{ops::OpType, HugrView, Node, NodeIndex};
+use petgraph::Graph;
 
 /// Weight for an edge in a [CallGraph]
-pub enum CallGraphEdge {
+pub enum CallGraphEdge<N = Node> {
     /// Edge corresponds to a [Call](OpType::Call) node (specified) in the Hugr
-    Call(Node),
+    Call(N),
     /// Edge corresponds to a [LoadFunction](OpType::LoadFunction) node (specified) in the Hugr
-    LoadFunction(Node),
+    LoadFunction(N),
 }
 
 /// Weight for a petgraph-node in a [CallGraph]
-pub enum CallGraphNode {
+pub enum CallGraphNode<N = Node> {
     /// petgraph-node corresponds to a [FuncDecl](OpType::FuncDecl) node (specified) in the Hugr
-    FuncDecl(Node),
+    FuncDecl(N),
     /// petgraph-node corresponds to a [FuncDefn](OpType::FuncDefn) node (specified) in the Hugr
-    FuncDefn(Node),
+    FuncDefn(N),
     /// petgraph-node corresponds to the root node of the hugr, that is not
     /// a [FuncDefn](OpType::FuncDefn). Note that it will not be a [Module](OpType::Module)
     /// either, as such a node could not have outgoing edges, so is not represented in the petgraph.
@@ -35,15 +35,15 @@ pub enum CallGraphNode {
 /// [Call]: OpType::Call
 /// [FuncDefn]: OpType::FuncDefn
 /// [LoadFunction]: OpType::LoadFunction
-pub struct CallGraph {
-    g: Graph<CallGraphNode, CallGraphEdge>,
-    node_to_g: HashMap<Node, NodeIndex<u32>>,
+pub struct CallGraph<N = Node> {
+    g: Graph<CallGraphNode<N>, CallGraphEdge<N>>,
+    node_to_g: HashMap<N, petgraph::graph::NodeIndex<u32>>,
 }
 
-impl CallGraph {
+impl<N: NodeIndex> CallGraph<N> {
     /// Makes a new CallGraph for a specified (subview) of a Hugr.
     /// Calls to functions outside the view will be dropped.
-    pub fn new(hugr: &impl HugrView) -> Self {
+    pub fn new(hugr: &impl HugrView<Node = N>) -> Self {
         let mut g = Graph::default();
         let non_func_root = (!hugr.get_optype(hugr.root()).is_module()).then_some(hugr.root());
         let node_to_g = hugr
@@ -60,12 +60,12 @@ impl CallGraph {
         for (func, cg_node) in node_to_g.iter() {
             traverse(hugr, *cg_node, *func, &mut g, &node_to_g)
         }
-        fn traverse(
-            h: &impl HugrView,
-            enclosing_func: NodeIndex<u32>,
-            node: Node, // Nonstrict-descendant of `enclosing_func``
-            g: &mut Graph<CallGraphNode, CallGraphEdge>,
-            node_to_g: &HashMap<Node, NodeIndex<u32>>,
+        fn traverse<N: NodeIndex>(
+            h: &impl HugrView<Node = N>,
+            enclosing_func: petgraph::graph::NodeIndex<u32>,
+            node: N, // Nonstrict-descendant of `enclosing_func``
+            g: &mut Graph<CallGraphNode<N>, CallGraphEdge<N>>,
+            node_to_g: &HashMap<N, petgraph::graph::NodeIndex<u32>>,
         ) {
             for ch in h.children(node) {
                 if h.get_optype(ch).is_func_defn() {
@@ -86,14 +86,14 @@ impl CallGraph {
     }
 
     /// Allows access to the petgraph
-    pub fn graph(&self) -> &Graph<CallGraphNode, CallGraphEdge> {
+    pub fn graph(&self) -> &Graph<CallGraphNode<N>, CallGraphEdge<N>> {
         &self.g
     }
 
     /// Convert a Hugr [Node] into a petgraph node index.
     /// Result will be `None` if `n` is not a [FuncDefn](OpType::FuncDefn),
     /// [FuncDecl](OpType::FuncDecl) or the hugr root.
-    pub fn node_index(&self, n: Node) -> Option<NodeIndex<u32>> {
+    pub fn node_index(&self, n: N) -> Option<petgraph::graph::NodeIndex<u32>> {
         self.node_to_g.get(&n).copied()
     }
 }

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -144,7 +144,7 @@ impl ConstantFoldPass {
     fn find_needed_nodes<H: HugrView>(
         &self,
         results: &AnalysisResults<ValueHandle, H>,
-    ) -> HashSet<Node> {
+    ) -> HashSet<H::Node> {
         let mut needed = HashSet::new();
         let h = results.hugr();
         let mut q = VecDeque::from_iter([h.root()]);
@@ -210,7 +210,10 @@ impl ConstantFoldPass {
 
 // "Diverge" aka "never-terminate"
 // TODO would be more efficient to compute this bottom-up and cache (dynamic programming)
-fn might_diverge<V: AbstractValue>(results: &AnalysisResults<V, impl HugrView>, n: Node) -> bool {
+fn might_diverge<V: AbstractValue, N: NodeIndex>(
+    results: &AnalysisResults<V, impl HugrView<Node = N>>,
+    n: N,
+) -> bool {
     let op = results.hugr().get_optype(n);
     if op.is_cfg() {
         // TODO if the CFG has no cycles (that are possible given predicates)
@@ -244,27 +247,37 @@ impl<H: HugrView> std::ops::Deref for ConstFoldContext<'_, H> {
     }
 }
 
-impl<H: HugrView> ConstLoader<ValueHandle> for ConstFoldContext<'_, H> {
-    fn value_from_opaque(&self, loc: ConstLocation, val: &OpaqueValue) -> Option<ValueHandle> {
+impl<H: HugrView> ConstLoader<ValueHandle<H::Node>> for ConstFoldContext<'_, H> {
+    type Node = H::Node;
+
+    fn value_from_opaque(
+        &self,
+        loc: ConstLocation<H::Node>,
+        val: &OpaqueValue,
+    ) -> Option<ValueHandle<H::Node>> {
         Some(ValueHandle::new_opaque(loc, val.clone()))
     }
 
     fn value_from_const_hugr(
         &self,
-        loc: ConstLocation,
+        loc: ConstLocation<H::Node>,
         h: &hugr_core::Hugr,
-    ) -> Option<ValueHandle> {
+    ) -> Option<ValueHandle<H::Node>> {
         Some(ValueHandle::new_const_hugr(loc, Box::new(h.clone())))
     }
 
-    fn value_from_function(&self, node: Node, type_args: &[TypeArg]) -> Option<ValueHandle> {
+    fn value_from_function(
+        &self,
+        node: H::Node,
+        type_args: &[TypeArg],
+    ) -> Option<ValueHandle<H::Node>> {
         if !type_args.is_empty() {
             // TODO: substitution across Hugr (https://github.com/CQCL/hugr/issues/709)
             return None;
         };
         // Returning the function body as a value, here, would be sufficient for inlining IndirectCall
         // but not for transforming to a direct Call.
-        let func = DescendantsGraph::<FuncID<true>>::try_new(&**self, node).ok()?;
+        let func = DescendantsGraph::<FuncID<true>, H::Node>::try_new(&**self, node).ok()?;
         Some(ValueHandle::new_const_hugr(
             ConstLocation::Node(node),
             Box::new(func.extract_hugr()),
@@ -272,13 +285,13 @@ impl<H: HugrView> ConstLoader<ValueHandle> for ConstFoldContext<'_, H> {
     }
 }
 
-impl<H: HugrView> DFContext<ValueHandle> for ConstFoldContext<'_, H> {
+impl<H: HugrView> DFContext<ValueHandle<H::Node>> for ConstFoldContext<'_, H> {
     fn interpret_leaf_op(
         &mut self,
-        node: Node,
+        node: H::Node,
         op: &ExtensionOp,
-        ins: &[PartialValue<ValueHandle>],
-        outs: &mut [PartialValue<ValueHandle>],
+        ins: &[PartialValue<ValueHandle<H::Node>>],
+        outs: &mut [PartialValue<ValueHandle<H::Node>>],
     ) {
         let sig = op.signature();
         let known_ins = sig

--- a/hugr-passes/src/dataflow.rs
+++ b/hugr-passes/src/dataflow.rs
@@ -14,7 +14,7 @@ pub use partial_value::{AbstractValue, PartialSum, PartialValue, Sum};
 use hugr_core::ops::constant::OpaqueValue;
 use hugr_core::ops::{ExtensionOp, Value};
 use hugr_core::types::TypeArg;
-use hugr_core::{Hugr, Node};
+use hugr_core::Hugr;
 
 /// Clients of the dataflow framework (particular analyses, such as constant folding)
 /// must implement this trait (including providing an appropriate domain type `V`).
@@ -29,7 +29,7 @@ pub trait DFContext<V>: ConstLoader<V> {
     /// [UnpackTuple]: hugr_core::extension::prelude::UnpackTuple
     fn interpret_leaf_op(
         &mut self,
-        _node: Node,
+        _node: Self::Node,
         _e: &ExtensionOp,
         _ins: &[PartialValue<V>],
         _outs: &mut [PartialValue<V>],
@@ -41,15 +41,15 @@ pub trait DFContext<V>: ConstLoader<V> {
 /// (perhaps deeply nested within [Value::Sum]s) within a [Node]
 /// that is a [Const](hugr_core::ops::Const).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum ConstLocation<'a> {
+pub enum ConstLocation<'a, N> {
     /// The specified-index'th field of the [Value::Sum] constant identified by the RHS
-    Field(usize, &'a ConstLocation<'a>),
+    Field(usize, &'a ConstLocation<'a, N>),
     /// The entire ([Const::value](hugr_core::ops::Const::value)) of the node.
-    Node(Node),
+    Node(N),
 }
 
-impl From<Node> for ConstLocation<'_> {
-    fn from(value: Node) -> Self {
+impl<N> From<N> for ConstLocation<'_, N> {
+    fn from(value: N) -> Self {
         ConstLocation::Node(value)
     }
 }
@@ -59,15 +59,18 @@ impl From<Node> for ConstLocation<'_> {
 /// [Self::value_from_const_hugr], and [Self::value_from_function]: the defaults
 /// are "correct" but maximally conservative (minimally informative).
 pub trait ConstLoader<V> {
+    /// The type of nodes in the Hugr.
+    type Node;
+
     /// Produces an abstract value from an [OpaqueValue], if possible.
     /// The default just returns `None`, which will be interpreted as [PartialValue::Top].
-    fn value_from_opaque(&self, _loc: ConstLocation, _val: &OpaqueValue) -> Option<V> {
+    fn value_from_opaque(&self, _loc: ConstLocation<Self::Node>, _val: &OpaqueValue) -> Option<V> {
         None
     }
 
     /// Produces an abstract value from a Hugr in a [Value::Function], if possible.
     /// The default just returns `None`, which will be interpreted as [PartialValue::Top].
-    fn value_from_const_hugr(&self, _loc: ConstLocation, _h: &Hugr) -> Option<V> {
+    fn value_from_const_hugr(&self, _loc: ConstLocation<Self::Node>, _h: &Hugr) -> Option<V> {
         None
     }
 
@@ -78,7 +81,7 @@ pub trait ConstLoader<V> {
     /// [FuncDefn]: hugr_core::ops::FuncDefn
     /// [FuncDecl]: hugr_core::ops::FuncDecl
     /// [LoadFunction]: hugr_core::ops::LoadFunction
-    fn value_from_function(&self, _node: Node, _type_args: &[TypeArg]) -> Option<V> {
+    fn value_from_function(&self, _node: Self::Node, _type_args: &[TypeArg]) -> Option<V> {
         None
     }
 }
@@ -87,11 +90,14 @@ pub trait ConstLoader<V> {
 /// to their leaves ([Value::Extension] and [Value::Function]),
 /// converts these using [ConstLoader::value_from_opaque] and [ConstLoader::value_from_const_hugr],
 /// and builds nested [PartialValue::new_variant] to represent the structure.
-pub fn partial_from_const<'a, V>(
-    cl: &impl ConstLoader<V>,
-    loc: impl Into<ConstLocation<'a>>,
+pub fn partial_from_const<'a, V, CL: ConstLoader<V>>(
+    cl: &CL,
+    loc: impl Into<ConstLocation<'a, CL::Node>>,
     cst: &Value,
-) -> PartialValue<V> {
+) -> PartialValue<V>
+where
+    CL::Node: 'a,
+{
     let loc = loc.into();
     match cst {
         Value::Sum(hugr_core::ops::constant::Sum { tag, values, .. }) => {

--- a/hugr-passes/src/dataflow/datalog.rs
+++ b/hugr-passes/src/dataflow/datalog.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 
 use hugr_core::extension::prelude::{MakeTuple, UnpackTuple};
 use hugr_core::ops::{OpTrait, OpType, TailLoop};
-use hugr_core::{HugrView, IncomingPort, Node, OutgoingPort, PortIndex as _, Wire};
+use hugr_core::{HugrView, IncomingPort, OutgoingPort, PortIndex as _, Wire};
 
 use super::value_row::ValueRow;
 use super::{
@@ -26,7 +26,7 @@ type PV<V> = PartialValue<V>;
 ///    [Self::prepopulate_df_inputs] can be used on each externally-callable
 ///    [FuncDefn](OpType::FuncDefn) to set all inputs to [PartialValue::Top].
 /// 3. Call [Self::run] to produce [AnalysisResults]
-pub struct Machine<H: HugrView, V: AbstractValue>(H, Vec<(Node, IncomingPort, PartialValue<V>)>);
+pub struct Machine<H: HugrView, V: AbstractValue>(H, Vec<(H::Node, IncomingPort, PartialValue<V>)>);
 
 impl<H: HugrView, V: AbstractValue> Machine<H, V> {
     /// Create a new Machine to analyse the given Hugr(View)
@@ -37,7 +37,7 @@ impl<H: HugrView, V: AbstractValue> Machine<H, V> {
 
 impl<H: HugrView, V: AbstractValue> Machine<H, V> {
     /// Provide initial values for a wire - these will be `join`d with any computed.
-    pub fn prepopulate_wire(&mut self, w: Wire, v: PartialValue<V>) {
+    pub fn prepopulate_wire(&mut self, w: Wire<H::Node>, v: PartialValue<V>) {
         self.1.extend(
             self.0
                 .linked_inputs(w.node(), w.source())
@@ -50,7 +50,7 @@ impl<H: HugrView, V: AbstractValue> Machine<H, V> {
     /// Any out-ports of said same `Input` node, not given values by `in_values`, are set to [PartialValue::Top].
     pub fn prepopulate_df_inputs(
         &mut self,
-        parent: Node,
+        parent: H::Node,
         in_values: impl IntoIterator<Item = (OutgoingPort, PartialValue<V>)>,
     ) {
         // Put values onto out-wires of Input node
@@ -74,7 +74,7 @@ impl<H: HugrView, V: AbstractValue> Machine<H, V> {
     /// or if any `in_values` are provided for a module-rooted Hugr without a function `"main"`.
     pub fn run(
         mut self,
-        context: impl DFContext<V>,
+        context: impl DFContext<V, Node = H::Node>,
         in_values: impl IntoIterator<Item = (IncomingPort, PartialValue<V>)>,
     ) -> AnalysisResults<V, H> {
         let mut in_values = in_values.into_iter();
@@ -127,9 +127,9 @@ impl<H: HugrView, V: AbstractValue> Machine<H, V> {
 }
 
 pub(super) fn run_datalog<V: AbstractValue, H: HugrView>(
-    mut ctx: impl DFContext<V>,
+    mut ctx: impl DFContext<V, Node = H::Node>,
     hugr: H,
-    in_wire_value_proto: Vec<(Node, IncomingPort, PV<V>)>,
+    in_wire_value_proto: Vec<(H::Node, IncomingPort, PV<V>)>,
 ) -> AnalysisResults<V, H> {
     // ascent-(macro-)generated code generates a bunch of warnings,
     // keep code in here to a minimum.
@@ -139,16 +139,16 @@ pub(super) fn run_datalog<V: AbstractValue, H: HugrView>(
         clippy::collapsible_if
     )]
     let all_results = ascent::ascent_run! {
-        pub(super) struct AscentProgram<V: AbstractValue>;
-        relation node(Node); // <Node> exists in the hugr
-        relation in_wire(Node, IncomingPort); // <Node> has an <IncomingPort> of `EdgeKind::Value`
-        relation out_wire(Node, OutgoingPort); // <Node> has an <OutgoingPort> of `EdgeKind::Value`
-        relation parent_of_node(Node, Node); // <Node> is parent of <Node>
-        relation input_child(Node, Node); // <Node> has 1st child <Node> that is its `Input`
-        relation output_child(Node, Node); // <Node> has 2nd child <Node> that is its `Output`
-        lattice out_wire_value(Node, OutgoingPort, PV<V>); // <Node> produces, on <OutgoingPort>, the value <PV>
-        lattice in_wire_value(Node, IncomingPort, PV<V>); // <Node> receives, on <IncomingPort>, the value <PV>
-        lattice node_in_value_row(Node, ValueRow<V>); // <Node>'s inputs are <ValueRow>
+        pub(super) struct AscentProgram<V: AbstractValue, H: HugrView>;
+        relation node(H::Node); // <Node> exists in the hugr
+        relation in_wire(H::Node, IncomingPort); // <Node> has an <IncomingPort> of `EdgeKind::Value`
+        relation out_wire(H::Node, OutgoingPort); // <Node> has an <OutgoingPort> of `EdgeKind::Value`
+        relation parent_of_node(H::Node, H::Node); // <Node> is parent of <Node>
+        relation input_child(H::Node, H::Node); // <Node> has 1st child <Node> that is its `Input`
+        relation output_child(H::Node, H::Node); // <Node> has 2nd child <Node> that is its `Output`
+        lattice out_wire_value(H::Node, OutgoingPort, PV<V>); // <Node> produces, on <OutgoingPort>, the value <PV>
+        lattice in_wire_value(H::Node, IncomingPort, PV<V>); // <Node> receives, on <IncomingPort>, the value <PV>
+        lattice node_in_value_row(H::Node, ValueRow<V>); // <Node>'s inputs are <ValueRow>
 
         node(n) <-- for n in hugr.nodes();
 
@@ -191,7 +191,7 @@ pub(super) fn run_datalog<V: AbstractValue, H: HugrView>(
            for (p, v) in (0..).map(OutgoingPort::from).zip(outs);
 
         // DFG --------------------
-        relation dfg_node(Node); // <Node> is a `DFG`
+        relation dfg_node(H::Node); // <Node> is a `DFG`
         dfg_node(n) <-- node(n), if hugr.get_optype(*n).is_dfg();
 
         out_wire_value(i, OutgoingPort::from(p.index()), v) <-- dfg_node(dfg),
@@ -228,7 +228,7 @@ pub(super) fn run_datalog<V: AbstractValue, H: HugrView>(
 
         // Conditional --------------------
         // <Node> is a `Conditional` and its <usize>'th child (a `Case`) is <Node>:
-        relation case_node(Node, usize, Node);
+        relation case_node(H::Node, usize, H::Node);
         case_node(cond, i, case) <-- node(cond),
           if hugr.get_optype(*cond).is_conditional(),
           for (i, case) in hugr.children(*cond).enumerate(),
@@ -251,17 +251,17 @@ pub(super) fn run_datalog<V: AbstractValue, H: HugrView>(
           in_wire_value(o, o_p, v);
 
         // In `Conditional` <Node>, child `Case` <Node> is reachable given our knowledge of predicate:
-        relation case_reachable(Node, Node);
+        relation case_reachable(H::Node, H::Node);
         case_reachable(cond, case) <-- case_node(cond, i, case),
             in_wire_value(cond, IncomingPort::from(0), v),
             if v.supports_tag(*i);
 
         // CFG --------------------
-        relation cfg_node(Node); // <Node> is a `CFG`
+        relation cfg_node(H::Node); // <Node> is a `CFG`
         cfg_node(n) <-- node(n), if hugr.get_optype(*n).is_cfg();
 
         // In `CFG` <Node>, basic block <Node> is reachable given our knowledge of predicates:
-        relation bb_reachable(Node, Node);
+        relation bb_reachable(H::Node, H::Node);
         bb_reachable(cfg, entry) <-- cfg_node(cfg), if let Some(entry) = hugr.children(*cfg).next();
         bb_reachable(cfg, bb) <-- cfg_node(cfg),
             bb_reachable(cfg, pred),
@@ -279,7 +279,7 @@ pub(super) fn run_datalog<V: AbstractValue, H: HugrView>(
 
         // In `CFG` <Node>, values fed along a control-flow edge to <Node>
         //     come out of Value outports of <Node>:
-        relation _cfg_succ_dest(Node, Node, Node);
+        relation _cfg_succ_dest(H::Node, H::Node, H::Node);
         _cfg_succ_dest(cfg, exit, cfg) <-- cfg_node(cfg), if let Some(exit) = hugr.children(*cfg).nth(1);
         _cfg_succ_dest(cfg, blk, inp) <-- cfg_node(cfg),
             for blk in hugr.children(*cfg),
@@ -298,7 +298,7 @@ pub(super) fn run_datalog<V: AbstractValue, H: HugrView>(
             for (out_p, v) in fields.enumerate();
 
         // Call --------------------
-        relation func_call(Node, Node); // <Node> is a `Call` to `FuncDefn` <Node>
+        relation func_call(H::Node, H::Node); // <Node> is a `Call` to `FuncDefn` <Node>
         func_call(call, func_defn) <--
             node(call),
             if hugr.get_optype(*call).is_call(),
@@ -328,10 +328,10 @@ pub(super) fn run_datalog<V: AbstractValue, H: HugrView>(
     }
 }
 
-fn propagate_leaf_op<V: AbstractValue>(
-    ctx: &mut impl DFContext<V>,
-    hugr: &impl HugrView,
-    n: Node,
+fn propagate_leaf_op<V: AbstractValue, H: HugrView>(
+    ctx: &mut impl DFContext<V, Node = H::Node>,
+    hugr: &H,
+    n: H::Node,
     ins: &[PV<V>],
     num_outs: usize,
 ) -> Option<ValueRow<V>> {

--- a/hugr-passes/src/dataflow/results.rs
+++ b/hugr-passes/src/dataflow/results.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use hugr_core::{HugrView, IncomingPort, Node, PortIndex, Wire};
+use hugr_core::{HugrView, IncomingPort, PortIndex, Wire};
 
 use super::{partial_value::ExtractValueError, AbstractValue, PartialValue, Sum};
 
@@ -8,10 +8,10 @@ use super::{partial_value::ExtractValueError, AbstractValue, PartialValue, Sum};
 /// Methods allow inspection, specifically [read_out_wire](Self::read_out_wire).
 pub struct AnalysisResults<V: AbstractValue, H: HugrView> {
     pub(super) hugr: H,
-    pub(super) in_wire_value: Vec<(Node, IncomingPort, PartialValue<V>)>,
-    pub(super) case_reachable: Vec<(Node, Node)>,
-    pub(super) bb_reachable: Vec<(Node, Node)>,
-    pub(super) out_wire_values: HashMap<Wire, PartialValue<V>>,
+    pub(super) in_wire_value: Vec<(H::Node, IncomingPort, PartialValue<V>)>,
+    pub(super) case_reachable: Vec<(H::Node, H::Node)>,
+    pub(super) bb_reachable: Vec<(H::Node, H::Node)>,
+    pub(super) out_wire_values: HashMap<Wire<H::Node>, PartialValue<V>>,
 }
 
 impl<V: AbstractValue, H: HugrView> AnalysisResults<V, H> {
@@ -21,7 +21,7 @@ impl<V: AbstractValue, H: HugrView> AnalysisResults<V, H> {
     }
 
     /// Gets the lattice value computed for the given wire
-    pub fn read_out_wire(&self, w: Wire) -> Option<PartialValue<V>> {
+    pub fn read_out_wire(&self, w: Wire<H::Node>) -> Option<PartialValue<V>> {
         self.out_wire_values.get(&w).cloned()
     }
 
@@ -30,7 +30,7 @@ impl<V: AbstractValue, H: HugrView> AnalysisResults<V, H> {
     /// Returns `None` if the specified `node` is not a [TailLoop].
     ///
     /// [TailLoop]: hugr_core::ops::TailLoop
-    pub fn tail_loop_terminates(&self, node: Node) -> Option<TailLoopTermination> {
+    pub fn tail_loop_terminates(&self, node: H::Node) -> Option<TailLoopTermination> {
         self.hugr.get_optype(node).as_tail_loop()?;
         let [_, out] = self.hugr.get_io(node).unwrap();
         Some(TailLoopTermination::from_control_value(
@@ -48,7 +48,7 @@ impl<V: AbstractValue, H: HugrView> AnalysisResults<V, H> {
     ///
     /// [Case]: hugr_core::ops::Case
     /// [Conditional]: hugr_core::ops::Conditional
-    pub fn case_reachable(&self, case: Node) -> Option<bool> {
+    pub fn case_reachable(&self, case: H::Node) -> Option<bool> {
         self.hugr.get_optype(case).as_case()?;
         let cond = self.hugr.get_parent(case)?;
         self.hugr.get_optype(cond).as_conditional()?;
@@ -65,7 +65,7 @@ impl<V: AbstractValue, H: HugrView> AnalysisResults<V, H> {
     /// [CFG]: hugr_core::ops::CFG
     /// [DataflowBlock]: hugr_core::ops::DataflowBlock
     /// [ExitBlock]: hugr_core::ops::ExitBlock
-    pub fn bb_reachable(&self, bb: Node) -> Option<bool> {
+    pub fn bb_reachable(&self, bb: H::Node) -> Option<bool> {
         let cfg = self.hugr.get_parent(bb)?; // Not really required...??
         self.hugr.get_optype(cfg).as_cfg()?;
         let t = self.hugr.get_optype(bb);
@@ -86,7 +86,7 @@ impl<V: AbstractValue, H: HugrView> AnalysisResults<V, H> {
     /// `Some(e)` if [conversion to a concrete value](PartialValue::try_into_concrete) failed with error `e`
     pub fn try_read_wire_concrete<V2, VE, SE>(
         &self,
-        w: Wire,
+        w: Wire<H::Node>,
     ) -> Result<V2, Option<ExtractValueError<V, VE, SE>>>
     where
         V2: TryFrom<V, Error = VE> + TryFrom<Sum<V2>, Error = SE>,

--- a/hugr-passes/src/dataflow/test.rs
+++ b/hugr-passes/src/dataflow/test.rs
@@ -16,7 +16,7 @@ use hugr_core::{
     types::{Signature, SumType, Type},
     HugrView,
 };
-use hugr_core::{Hugr, Wire};
+use hugr_core::{Hugr, Node, Wire};
 use rstest::{fixture, rstest};
 
 use super::{AbstractValue, ConstLoader, DFContext, Machine, PartialValue, TailLoopTermination};
@@ -29,7 +29,9 @@ impl AbstractValue for Void {}
 
 struct TestContext;
 
-impl ConstLoader<Void> for TestContext {}
+impl ConstLoader<Void> for TestContext {
+    type Node = Node;
+}
 impl DFContext<Void> for TestContext {}
 
 // This allows testing creation of tuple/sum Values (only)

--- a/hugr-passes/src/dead_funcs.rs
+++ b/hugr-passes/src/dead_funcs.rs
@@ -17,25 +17,25 @@ use super::call_graph::{CallGraph, CallGraphNode};
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 /// Errors produced by [RemoveDeadFuncsPass].
-pub enum RemoveDeadFuncsError {
+pub enum RemoveDeadFuncsError<N = Node> {
     /// The specified entry point is not a FuncDefn node or is not a child of the root.
     #[error(
         "Entrypoint for RemoveDeadFuncsPass {node} was not a function definition in the root module"
     )]
     InvalidEntryPoint {
         /// The invalid node.
-        node: Node,
+        node: N,
     },
     #[error(transparent)]
     #[allow(missing_docs)]
     ValidationError(#[from] ValidatePassError),
 }
 
-fn reachable_funcs<'a>(
-    cg: &'a CallGraph,
-    h: &'a impl HugrView,
-    entry_points: impl IntoIterator<Item = Node>,
-) -> Result<impl Iterator<Item = Node> + 'a, RemoveDeadFuncsError> {
+fn reachable_funcs<'a, H: HugrView>(
+    cg: &'a CallGraph<H::Node>,
+    h: &'a H,
+    entry_points: impl IntoIterator<Item = H::Node>,
+) -> Result<impl Iterator<Item = H::Node> + 'a, RemoveDeadFuncsError<H::Node>> {
     let g = cg.graph();
     let mut entry_points = entry_points.into_iter();
     let searcher = if h.get_optype(h.root()).is_module() {

--- a/hugr-passes/src/merge_bbs.rs
+++ b/hugr-passes/src/merge_bbs.rs
@@ -46,7 +46,7 @@ pub fn merge_basic_blocks(cfg: &mut impl HugrMut<RootHandle = CfgID>) {
 }
 
 fn mk_rep(
-    cfg: &impl RootTagged<RootHandle = CfgID>,
+    cfg: &impl RootTagged<RootHandle = CfgID, Node = Node>,
     pred: Node,
     succ: Node,
 ) -> (Replacement, Node, [Node; 2]) {


### PR DESCRIPTION
Yey, this is a fun one 🫠 

This makes `HugrView` general over the `Node` type. Note that `HugrMut` and all operations that mutate hugrs still only act on the node type `Node`.

I suggest once this is merged in that we add a `.git-blame-ignore-revs` file to simplify future git blames:
```
# Commits to be ignored by git blame

# Add Node associated type to HugrView (large mechanical change)
<commit of this PR on main>
```