### PR TITLE
refactor!: remove unused dependencies

### DIFF
--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -33,7 +33,6 @@ portgraph = { workspace = true, features = ["serde", "petgraph"] }
 thiserror = { workspace = true }
 regex = { workspace = true }
 cgmath = { workspace = true, features = ["serde"] }
-num-rational = { workspace = true, features = ["serde"] }
 downcast-rs = { workspace = true }
 # Rc used here for Extension, but unfortunately we must turn the feature on globally
 serde = { workspace = true, features = ["derive", "rc"] }
@@ -43,7 +42,6 @@ smol_str = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true, features = ["display", "error", "from"] }
 itertools = { workspace = true }
 html-escape = { workspace = true }
-bitvec = { workspace = true, features = ["serde"] }
 enum_dispatch = { workspace = true }
 lazy_static = { workspace = true }
 petgraph = { workspace = true }
@@ -64,7 +62,6 @@ insta = { workspace = true, features = ["yaml"] }
 jsonschema = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
-regex-syntax = { workspace = true }
 
 
 # Required for documentation examples

--- a/hugr-llvm/Cargo.toml
+++ b/hugr-llvm/Cargo.toml
@@ -20,10 +20,6 @@ test-utils = [
     "insta",
     "rstest",
     "portgraph",
-    "pathsearch",
-    "serde_json",
-    "serde",
-    "typetag",
 ]
 
 default = ["llvm14-0"]
@@ -37,16 +33,11 @@ anyhow = "1.0.83"
 itertools.workspace = true
 delegate.workspace = true
 petgraph.workspace = true
-lazy_static.workspace = true
 strum.workspace = true
 
 insta = { workspace = true, optional = true }
 rstest = { workspace = true, optional = true }
 portgraph = { workspace = true, optional = true }
-pathsearch = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-typetag = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["debug"] }
 
 [dev-dependencies]

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -35,7 +35,6 @@ hugr-passes = { path = "../hugr-passes", version = "0.14.4" }
 hugr-llvm = { path = "../hugr-llvm", version = "0.14.4", optional = true }
 
 [dev-dependencies]
-rstest = { workspace = true }
 lazy_static = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
found using cargo-machete

no easy way to remove unused entries from the workspace Cargo.toml


BREAKING CHANGE: Removed some unused dependencies from hugr-llvm test-utils feature.