### PR TITLE
fix: Hugr-model using undeclared derive_more features

### DIFF
--- a/hugr-model/Cargo.toml
+++ b/hugr-model/Cargo.toml
@@ -19,7 +19,7 @@ bench = false
 base64 = { workspace = true }
 bumpalo = { workspace = true, features = ["collections"] }
 capnp = { workspace = true }
-derive_more = { workspace = true, features = ["display"] }
+derive_more = { workspace = true, features = ["display", "error", "from"] }
 fxhash.workspace = true
 indexmap.workspace = true
 ordered-float = { workspace = true }


### PR DESCRIPTION
Fixes #1939

The semver checks run still fail here because the `main` baseline still has the error 💀 