### PR TITLE
feat!: replace `Lift` with `Barrier`

### DIFF
--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -714,6 +714,27 @@ pub trait Dataflow: Container {
     fn as_circuit(&mut self, wires: impl IntoIterator<Item = Wire>) -> CircuitBuilder<Self> {
         CircuitBuilder::new(wires, self)
     }
+
+    /// Add a [Barrier] to a set of wires and return them in the same order.
+    ///
+    /// [Barrier]: crate::extension::prelude::Barrier
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if there is an error adding the Barrier node
+    /// or retrieving the type of the incoming wires.
+    fn add_barrier(
+        &mut self,
+        wires: impl IntoIterator<Item = Wire>,
+    ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
+        let wires = wires.into_iter().collect_vec();
+        let types: Result<Vec<Type>, _> =
+            wires.iter().map(|&wire| self.get_wire_type(wire)).collect();
+        let types = types?;
+        let barrier_op =
+            self.add_dataflow_op(crate::extension::prelude::Barrier::new(types), wires)?;
+        Ok(barrier_op)
+    }
 }
 
 /// Add a node to the graph, wiring up the `inputs` to the input ports of the resulting node.

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -314,8 +314,8 @@ pub(crate) mod test {
     use crate::builder::{
         endo_sig, inout_sig, BuilderWiringError, DataflowSubContainer, ModuleBuilder,
     };
+    use crate::extension::prelude::Noop;
     use crate::extension::prelude::{bool_t, qb_t, usize_t};
-    use crate::extension::prelude::{Barrier, Noop};
     use crate::extension::SignatureError;
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::ops::{handle::NodeHandle, OpTag};
@@ -557,22 +557,22 @@ pub(crate) mod test {
         let mut dfg_b = parent.dfg_builder(endo_sig(bool_t()), [w])?;
         let [w] = dfg_b.input_wires_arr();
 
-        let barr0 = dfg_b.add_dataflow_op(Barrier::new(bool_t()), [w])?;
+        let barr0 = dfg_b.add_barrier([w])?;
         let [w] = barr0.outputs_arr();
 
-        let barr1 = dfg_b.add_dataflow_op(Barrier::new(bool_t()), [w])?;
+        let barr1 = dfg_b.add_barrier([w])?;
         let [w] = barr1.outputs_arr();
 
         let dfg = dfg_b.finish_with_outputs([w])?;
         let [w] = dfg.outputs_arr();
 
-        let mut dfg2_b = parent.dfg_builder(endo_sig(bool_t()), [w])?;
-        let [w] = dfg2_b.input_wires_arr();
-        let barr2 = dfg2_b.add_dataflow_op(Barrier::new(bool_t()), [w])?;
+        let mut dfg2_b = parent.dfg_builder(endo_sig(vec![bool_t(), bool_t()]), [w, w])?;
+        let [w1, w2] = dfg2_b.input_wires_arr();
+        let barr2 = dfg2_b.add_barrier([w1, w2])?;
         let wires: Vec<Wire> = barr2.outputs().collect();
 
         let dfg2 = dfg2_b.finish_with_outputs(wires)?;
-        let [w] = dfg2.outputs_arr();
+        let [w, _] = dfg2.outputs_arr();
         parent.finish_hugr_with_outputs([w])?;
 
         Ok(())

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -315,8 +315,8 @@ pub(crate) mod test {
         endo_sig, inout_sig, BuilderWiringError, DataflowSubContainer, ModuleBuilder,
     };
     use crate::extension::prelude::{bool_t, qb_t, usize_t};
-    use crate::extension::prelude::{Lift, Noop};
-    use crate::extension::{ExtensionId, SignatureError};
+    use crate::extension::prelude::{Barrier, Noop};
+    use crate::extension::SignatureError;
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::ops::{handle::NodeHandle, OpTag};
     use crate::ops::{OpTrait, Value};
@@ -549,37 +549,30 @@ pub(crate) mod test {
     }
 
     #[test]
-    fn lift_node() -> Result<(), BuildError> {
-        let xa: ExtensionId = "A".try_into().unwrap();
-        let xb: ExtensionId = "B".try_into().unwrap();
-        let xc: ExtensionId = "C".try_into().unwrap();
-
+    fn barrier_node() -> Result<(), BuildError> {
         let mut parent = DFGBuilder::new(endo_sig(bool_t()))?;
 
         let [w] = parent.input_wires_arr();
 
-        // A box which adds extensions A and B, via child Lift nodes
-        let mut add_ab = parent.dfg_builder(endo_sig(bool_t()), [w])?;
-        let [w] = add_ab.input_wires_arr();
+        let mut dfg_b = parent.dfg_builder(endo_sig(bool_t()), [w])?;
+        let [w] = dfg_b.input_wires_arr();
 
-        let lift_a = add_ab.add_dataflow_op(Lift::new(vec![bool_t()].into(), xa.clone()), [w])?;
-        let [w] = lift_a.outputs_arr();
+        let barr0 = dfg_b.add_dataflow_op(Barrier::new(bool_t()), [w])?;
+        let [w] = barr0.outputs_arr();
 
-        let lift_b = add_ab.add_dataflow_op(Lift::new(vec![bool_t()].into(), xb), [w])?;
-        let [w] = lift_b.outputs_arr();
+        let barr1 = dfg_b.add_dataflow_op(Barrier::new(bool_t()), [w])?;
+        let [w] = barr1.outputs_arr();
 
-        let add_ab = add_ab.finish_with_outputs([w])?;
-        let [w] = add_ab.outputs_arr();
+        let dfg = dfg_b.finish_with_outputs([w])?;
+        let [w] = dfg.outputs_arr();
 
-        // Add another node (a sibling to add_ab) which adds extension C
-        // via a child lift node
-        let mut add_c = parent.dfg_builder(endo_sig(bool_t()), [w])?;
-        let [w] = add_c.input_wires_arr();
-        let lift_c = add_c.add_dataflow_op(Lift::new(vec![bool_t()].into(), xc), [w])?;
-        let wires: Vec<Wire> = lift_c.outputs().collect();
+        let mut dfg2_b = parent.dfg_builder(endo_sig(bool_t()), [w])?;
+        let [w] = dfg2_b.input_wires_arr();
+        let barr2 = dfg2_b.add_dataflow_op(Barrier::new(bool_t()), [w])?;
+        let wires: Vec<Wire> = barr2.outputs().collect();
 
-        let add_c = add_c.finish_with_outputs(wires)?;
-        let [w] = add_c.outputs_arr();
+        let dfg2 = dfg2_b.finish_with_outputs(wires)?;
+        let [w] = dfg2.outputs_arr();
         parent.finish_hugr_with_outputs([w])?;
 
         Ok(())

--- a/hugr-core/src/builder/tail_loop.rs
+++ b/hugr-core/src/builder/tail_loop.rs
@@ -109,7 +109,7 @@ mod test {
     use crate::extension::prelude::bool_t;
     use crate::{
         builder::{DataflowSubContainer, HugrBuilder, ModuleBuilder, SubContainer},
-        extension::prelude::{usize_t, ConstUsize, Lift, PRELUDE_ID},
+        extension::prelude::{usize_t, ConstUsize, PRELUDE_ID},
         hugr::ValidationError,
         ops::Value,
         type_row,
@@ -143,12 +143,7 @@ mod test {
                 Signature::new(vec![bool_t()], vec![usize_t()]).with_prelude(),
             )?;
             let _fdef = {
-                let [b1] = fbuild
-                    .add_dataflow_op(
-                        Lift::new(vec![bool_t()].into(), PRELUDE_ID),
-                        fbuild.input_wires(),
-                    )?
-                    .outputs_arr();
+                let [b1] = fbuild.input_wires_arr();
                 let loop_id = {
                     let mut loop_b = fbuild.tail_loop_builder(
                         vec![(bool_t(), b1)],
@@ -156,13 +151,7 @@ mod test {
                         vec![usize_t()].into(),
                     )?;
                     let signature = loop_b.loop_signature()?.clone();
-                    let const_val = Value::true_val();
                     let const_wire = loop_b.add_load_const(Value::true_val());
-                    let lift_node = loop_b.add_dataflow_op(
-                        Lift::new(vec![const_val.get_type().clone()].into(), PRELUDE_ID),
-                        [const_wire],
-                    )?;
-                    let [const_wire] = lift_node.outputs_arr();
                     let [b1] = loop_b.input_wires_arr();
                     let conditional_id = {
                         let output_row = loop_b.internal_output_row()?;

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -830,9 +830,11 @@ impl MakeRegisteredOp for Noop {
 /// A barrier operation definition.
 pub struct BarrierDef;
 
+/// Name of the barrier operation.
+pub const BARRIER_OP_ID: OpName = OpName::new_inline("Barrier");
 impl NamedOp for BarrierDef {
     fn name(&self) -> OpName {
-        "Barrier".into()
+        BARRIER_OP_ID
     }
 }
 

--- a/hugr-llvm/src/extension/prelude.rs
+++ b/hugr-llvm/src/extension/prelude.rs
@@ -5,6 +5,7 @@ use hugr_core::extension::prelude::{
     TupleOpDef, UnpackTuple,
 };
 use hugr_core::extension::prelude::{ERROR_TYPE_NAME, STRING_TYPE_NAME};
+use hugr_core::ops::ExtensionOp;
 use hugr_core::types::TypeArg;
 use hugr_core::Node;
 use hugr_core::{
@@ -18,6 +19,7 @@ use inkwell::{
 };
 use itertools::Itertools;
 
+use crate::emit::EmitOpArgs;
 use crate::{
     custom::{CodegenExtension, CodegenExtsBuilder},
     emit::{
@@ -163,9 +165,18 @@ pub trait PreludeCodegen: Clone {
             .ptr_type(AddressSpace::default())
             .as_basic_type_enum();
         let str_type = ctx.llvm_type(&str.get_type())?.as_basic_type_enum();
-        ensure!(str_type == default_str_type, "The default implementation of PreludeCodegen::string_type was overriden, but the default implementation of emit_const_string was not. String type is: {str_type}");
+        ensure!(str_type == default_str_type, "The default implementation of PreludeCodegen::string_type was overridden, but the default implementation of emit_const_string was not. String type is: {str_type}");
         let s = ctx.builder().build_global_string_ptr(str.value(), "")?;
         Ok(s.as_basic_value_enum())
+    }
+
+    fn emit_barrier<'c, H: HugrView<Node = Node>>(
+        &self,
+        _ctx: &mut EmitFuncContext<'c, '_, H>,
+        _args: EmitOpArgs<'c, '_, ExtensionOp, H>,
+    ) -> Result<()> {
+        // By default, treat barriers as no-ops.
+        Ok(())
     }
 }
 
@@ -341,6 +352,10 @@ fn add_prelude_extensions<'a, H: HugrView<Node = Node> + 'a>(
             };
             args.outputs.finish(context.builder(), vec![v.into()])
         }
+    })
+    .extension_op(prelude::PRELUDE_ID, prelude::BARRIER_OP_ID, {
+        let pcg = pcg.clone();
+        move |context, args| pcg.emit_barrier(context, args)
     })
 }
 
@@ -534,6 +549,20 @@ mod test {
                     .unwrap()
                     .out_wire(0);
                 builder.finish_with_outputs([v]).unwrap()
+            });
+        check_emission!(hugr, prelude_llvm_ctx);
+    }
+
+    #[rstest]
+    fn prelude_barrier(prelude_llvm_ctx: TestContext) {
+        let hugr = SimpleHugrConfig::new()
+            .with_ins(vec![bool_t(), bool_t()])
+            .with_outs(vec![bool_t(), bool_t()])
+            .with_extensions(prelude::PRELUDE_REGISTRY.to_owned())
+            .finish(|mut builder| {
+                let [w1, w2] = builder.input_wires_arr();
+                let [w1, w2] = builder.add_barrier([w1, w2]).unwrap().outputs_arr();
+                builder.finish_with_outputs([w1, w2]).unwrap()
             });
         check_emission!(hugr, prelude_llvm_ctx);
     }

--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__prelude__test__prelude_barrier@llvm14.snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__prelude__test__prelude_barrier@llvm14.snap
@@ -1,0 +1,16 @@
+---
+source: hugr-llvm/src/extension/prelude.rs
+expression: mod_str
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i1, i1 } @_hl.main.1(i1 %0, i1 %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %mrv = insertvalue { i1, i1 } undef, i1 undef, 0
+  %mrv7 = insertvalue { i1, i1 } %mrv, i1 undef, 1
+  ret { i1, i1 } %mrv7
+}

--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__prelude__test__prelude_barrier@llvm14.snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__prelude__test__prelude_barrier@llvm14.snap
@@ -5,12 +5,10 @@ expression: mod_str
 ; ModuleID = 'test_context'
 source_filename = "test_context"
 
-define { i1, i1 } @_hl.main.1(i1 %0, i1 %1) {
+define i64 @_hl.main.1() {
 alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  %mrv = insertvalue { i1, i1 } undef, i1 undef, 0
-  %mrv7 = insertvalue { i1, i1 } %mrv, i1 undef, 1
-  ret { i1, i1 } %mrv7
+  ret i64 42
 }

--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__prelude__test__prelude_barrier@pre-mem2reg@llvm14.snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__prelude__test__prelude_barrier@pre-mem2reg@llvm14.snap
@@ -1,0 +1,32 @@
+---
+source: hugr-llvm/src/extension/prelude.rs
+expression: mod_str
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i1, i1 } @_hl.main.1(i1 %0, i1 %1) {
+alloca_block:
+  %"0" = alloca i1, align 1
+  %"1" = alloca i1, align 1
+  %"2_0" = alloca i1, align 1
+  %"2_1" = alloca i1, align 1
+  %"4_0" = alloca i1, align 1
+  %"4_1" = alloca i1, align 1
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store i1 %0, i1* %"2_0", align 1
+  store i1 %1, i1* %"2_1", align 1
+  %"2_01" = load i1, i1* %"2_0", align 1
+  %"2_12" = load i1, i1* %"2_1", align 1
+  %"4_03" = load i1, i1* %"4_0", align 1
+  %"4_14" = load i1, i1* %"4_1", align 1
+  store i1 %"4_03", i1* %"0", align 1
+  store i1 %"4_14", i1* %"1", align 1
+  %"05" = load i1, i1* %"0", align 1
+  %"16" = load i1, i1* %"1", align 1
+  %mrv = insertvalue { i1, i1 } undef, i1 %"05", 0
+  %mrv7 = insertvalue { i1, i1 } %mrv, i1 %"16", 1
+  ret { i1, i1 } %mrv7
+}

--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__prelude__test__prelude_barrier@pre-mem2reg@llvm14.snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__prelude__test__prelude_barrier@pre-mem2reg@llvm14.snap
@@ -5,28 +5,22 @@ expression: mod_str
 ; ModuleID = 'test_context'
 source_filename = "test_context"
 
-define { i1, i1 } @_hl.main.1(i1 %0, i1 %1) {
+define i64 @_hl.main.1() {
 alloca_block:
-  %"0" = alloca i1, align 1
-  %"1" = alloca i1, align 1
-  %"2_0" = alloca i1, align 1
-  %"2_1" = alloca i1, align 1
-  %"4_0" = alloca i1, align 1
-  %"4_1" = alloca i1, align 1
+  %"0" = alloca i64, align 8
+  %"5_0" = alloca i64, align 8
+  %"6_0" = alloca i64, align 8
+  %"6_1" = alloca i64, align 8
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  store i1 %0, i1* %"2_0", align 1
-  store i1 %1, i1* %"2_1", align 1
-  %"2_01" = load i1, i1* %"2_0", align 1
-  %"2_12" = load i1, i1* %"2_1", align 1
-  %"4_03" = load i1, i1* %"4_0", align 1
-  %"4_14" = load i1, i1* %"4_1", align 1
-  store i1 %"4_03", i1* %"0", align 1
-  store i1 %"4_14", i1* %"1", align 1
-  %"05" = load i1, i1* %"0", align 1
-  %"16" = load i1, i1* %"1", align 1
-  %mrv = insertvalue { i1, i1 } undef, i1 %"05", 0
-  %mrv7 = insertvalue { i1, i1 } %mrv, i1 %"16", 1
-  ret { i1, i1 } %mrv7
+  store i64 42, i64* %"5_0", align 4
+  %"5_01" = load i64, i64* %"5_0", align 4
+  %"5_02" = load i64, i64* %"5_0", align 4
+  store i64 %"5_01", i64* %"6_0", align 4
+  store i64 %"5_02", i64* %"6_1", align 4
+  %"6_03" = load i64, i64* %"6_0", align 4
+  store i64 %"6_03", i64* %"0", align 4
+  %"04" = load i64, i64* %"0", align 4
+  ret i64 %"04"
 }

--- a/hugr-py/src/hugr/std/_json_defs/prelude.json
+++ b/hugr-py/src/hugr/std/_json_defs/prelude.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "prelude",
   "runtime_reqs": [],
   "types": {
@@ -46,15 +46,12 @@
   },
   "values": {},
   "operations": {
-    "Lift": {
+    "Barrier": {
       "extension": "prelude",
-      "name": "Lift",
-      "description": "Add extension requirements to a row of values",
+      "name": "Barrier",
+      "description": "Add a barrier to a row of values",
       "signature": {
         "params": [
-          {
-            "tp": "Extensions"
-          },
           {
             "tp": "List",
             "param": {
@@ -67,20 +64,18 @@
           "input": [
             {
               "t": "R",
-              "i": 1,
+              "i": 0,
               "b": "A"
             }
           ],
           "output": [
             {
               "t": "R",
-              "i": 1,
+              "i": 0,
               "b": "A"
             }
           ],
-          "runtime_reqs": [
-            "0"
-          ]
+          "runtime_reqs": []
         }
       },
       "binary": false

--- a/specification/std_extensions/prelude.json
+++ b/specification/std_extensions/prelude.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "prelude",
   "runtime_reqs": [],
   "types": {
@@ -46,15 +46,12 @@
   },
   "values": {},
   "operations": {
-    "Lift": {
+    "Barrier": {
       "extension": "prelude",
-      "name": "Lift",
-      "description": "Add extension requirements to a row of values",
+      "name": "Barrier",
+      "description": "Add a barrier to a row of values",
       "signature": {
         "params": [
-          {
-            "tp": "Extensions"
-          },
           {
             "tp": "List",
             "param": {
@@ -67,20 +64,18 @@
           "input": [
             {
               "t": "R",
-              "i": 1,
+              "i": 0,
               "b": "A"
             }
           ],
           "output": [
             {
               "t": "R",
-              "i": 1,
+              "i": 0,
               "b": "A"
             }
           ],
-          "runtime_reqs": [
-            "0"
-          ]
+          "runtime_reqs": []
         }
       },
       "binary": false


### PR DESCRIPTION
Difference is barrier does not add extensions

The first two commit is worth merging even without the rest.

BREAKING CHANGE: Lift op in prelude replaced with a Barrier that behaves similarly except does not add any extensions.