### PR TITLE
wip: start on bytecasting ops

### DIFF
--- a/hugr-core/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions.rs
@@ -40,6 +40,8 @@ pub enum ConvertOpDef {
     itostring_s,
     itousize,
     ifromusize,
+    bytecast_int_float,
+    bytecast_float_int,
 }
 
 impl MakeOpDef for ConvertOpDef {
@@ -69,6 +71,8 @@ impl MakeOpDef for ConvertOpDef {
             itostring_u | itostring_s => int_polytype(1, vec![int_tv(0)], vec![string_type()]),
             itousize => int_polytype(0, vec![int_type(6)], vec![usize_t()]),
             ifromusize => int_polytype(0, vec![usize_t()], vec![int_type(6)]),
+            bytecast_int_float => int_polytype(0, vec![int_type(6)], vec![float64_type()]),
+            bytecast_float_int => int_polytype(0, vec![float64_type()], vec![int_type(6)]),
         }
         .into()
     }
@@ -86,6 +90,8 @@ impl MakeOpDef for ConvertOpDef {
             itostring_u => "convert an unsigned integer to its string representation",
             itousize => "convert a 64b unsigned integer to its usize representation",
             ifromusize => "convert a usize to a 64b unsigned integer",
+            bytecast_int_float => "reinterpret an int as a float based on its bytes",
+            bytecast_float_int => "reinterpret an float as an int based on its bytes",
         }
         .to_string()
     }

--- a/hugr-core/src/std_extensions/arithmetic/conversions/const_fold.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions/const_fold.rs
@@ -32,6 +32,8 @@ pub(super) fn set_fold(op: &ConvertOpDef, def: &mut OpDef) {
         itostring_s => def.set_constant_folder(IToStringS),
         itousize => def.set_constant_folder(IToUsize),
         ifromusize => def.set_constant_folder(IFromUsize),
+        bytecast_float_int => panic!("Bytecasting not supported in constant folding"),
+        bytecast_int_float => panic!("Bytecasting not supported in constant folding"),
     }
 }
 


### PR DESCRIPTION
Start work on bytecast ops for #1937.

1) I didn't implement constant folding, because I thought these ops should only ever come up in the llvm pipeline. My test fails because constant folding isn't implemented and i have no idea why that should be

2) I think there's a schema that needs to be regenerated with the new op signatures before this goes in