### PR TITLE
revert: `unstable-*` features should not be default

### DIFF
--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 extension_inference = []
 declarative = ["serde_yaml"]
 model_unstable = ["hugr-model"]
-default = ["model_unstable"]
 
 [lib]
 bench = false


### PR DESCRIPTION
Reverts change from #1953