### PR TITLE
fix: Remove return from val_or_panic

### DIFF
--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__int__test__emission@llvm14_is_to_u_[3].snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__int__test__emission@llvm14_is_to_u_[3].snap
@@ -27,9 +27,6 @@ panic:                                            ; preds = %panic_if_0
 
 exit:                                             ; preds = %panic_if_0, %panic
   ret i8 %0
-
-done:                                             ; No predecessors!
-  ret i8 %0
 }
 
 declare i32 @printf(i8*, ...)

--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__int__test__emission@llvm14_iu_to_s_[3].snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__int__test__emission@llvm14_iu_to_s_[3].snap
@@ -27,9 +27,6 @@ panic:                                            ; preds = %panic_if_0
 
 exit:                                             ; preds = %panic_if_0, %panic
   ret i8 %0
-
-done:                                             ; No predecessors!
-  ret i8 %0
 }
 
 declare i32 @printf(i8*, ...)

--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__int__test__emission@pre-mem2reg@llvm14_is_to_u_[3].snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__int__test__emission@pre-mem2reg@llvm14_is_to_u_[3].snap
@@ -31,9 +31,6 @@ panic:                                            ; preds = %panic_if_0
   br label %exit
 
 exit:                                             ; preds = %panic_if_0, %panic
-  ret i8 %"2_01"
-
-done:                                             ; No predecessors!
   store i8 %"2_01", i8* %"4_0", align 1
   %"4_02" = load i8, i8* %"4_0", align 1
   store i8 %"4_02", i8* %"0", align 1

--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__int__test__emission@pre-mem2reg@llvm14_iu_to_s_[3].snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__int__test__emission@pre-mem2reg@llvm14_iu_to_s_[3].snap
@@ -31,9 +31,6 @@ panic:                                            ; preds = %panic_if_0
   br label %exit
 
 exit:                                             ; preds = %panic_if_0, %panic
-  ret i8 %"2_01"
-
-done:                                             ; No predecessors!
   store i8 %"2_01", i8* %"4_0", align 1
   %"4_02" = load i8, i8* %"4_0", align 1
   store i8 %"4_02", i8* %"0", align 1


### PR DESCRIPTION
We shouldn't have been emitting a `ret` in `val_or_panic` - this leads to behaviour where code that comes after the `val_or_panic` section isn't emitted.

For example, the `test_s_to_u` test has been altered to add a constant to the number after its converted. Before this fix it would always fail because the addition was skipped.