### PR TITLE
feat(hugr-cli): Nicer error when passing a non-envelope file

### DIFF
--- a/hugr-cli/src/lib.rs
+++ b/hugr-cli/src/lib.rs
@@ -53,6 +53,11 @@ pub enum CliError {
     #[display("Error decoding HUGR envelope: {_0}")]
     /// Errors produced by the `validate` subcommand.
     Envelope(EnvelopeError),
+    /// Pretty error when the user passes a non-envelope file.
+    #[display(
+        "Input file is not a HUGR envelope. Invalid magic number.\n\nUse `--hugr-json` to read a raw HUGR JSON file instead."
+    )]
+    NotAnEnvelope,
 }
 
 /// Other arguments affecting the HUGR CLI runtime.


### PR DESCRIPTION
Minor special-casing for CLI message error.

Before:
```
$ hugr validate invalid.hugr
Error decoding HUGR envelope: Bad magic number. expected 0x4855475269484A76 found 0x7B0A20202020226D
```
After:
```
$ hugr validate invalid.hugr
Input file is not a HUGR envelope. Invalid magic number.

Use `--hugr-json` to read a raw HUGR JSON file instead.
```