### PR TITLE
fix: Don't enable envelope compression by default (yet)

### DIFF
--- a/hugr-core/src/envelope/header.rs
+++ b/hugr-core/src/envelope/header.rs
@@ -117,7 +117,7 @@ impl EnvelopeConfig {
     pub const fn binary() -> Self {
         Self {
             format: EnvelopeFormat::Model,
-            zstd: Some(ZstdConfig { level: None }),
+            zstd: None,
         }
     }
 }

--- a/hugr-py/src/hugr/envelope.py
+++ b/hugr-py/src/hugr/envelope.py
@@ -185,4 +185,4 @@ class EnvelopeConfig:
 # Set EnvelopeConfig's class variables.
 # These can only be initialized _after_ the class is defined.
 EnvelopeConfig.TEXT = EnvelopeConfig(format=EnvelopeFormat.JSON, zstd=None)
-EnvelopeConfig.BINARY = EnvelopeConfig(format=EnvelopeFormat.JSON, zstd=0)
+EnvelopeConfig.BINARY = EnvelopeConfig(format=EnvelopeFormat.JSON, zstd=None)

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ wheels = [
 
 [[package]]
 name = "hugr"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "hugr-py" }
 dependencies = [
     { name = "graphviz" },


### PR DESCRIPTION
We did a hugr-rs minor release changing the default binary envelope encoding to have compression enabled.
Since compression support was added in the same minor match, previous semver-compatible releases will fail to read such envelopes.

This PR disables default compression. We should enable it on the next breaking release instead.