### PR TITLE
chore: Enable deprecation warnings on pre-313 python

### DIFF
--- a/hugr-py/pyproject.toml
+++ b/hugr-py/pyproject.toml
@@ -27,10 +27,11 @@ classifiers = [
 ]
 
 dependencies = [
+    "graphviz>=0.20.3",
     "pydantic>=2.8,<2.11",
     "pydantic-extra-types>=2.9.0",
     "semver>=3.0.2",
-    "graphviz>=0.20.3",
+    "typing-extensions~=4.12",
     "zstd>=1.5.6.6",
 ]
 

--- a/hugr-py/src/hugr/build/cond_loop.py
+++ b/hugr-py/src/hugr/build/cond_loop.py
@@ -8,7 +8,7 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from hugr import ops
 from hugr.build.base import ParentBuilder
@@ -19,7 +19,6 @@ from hugr.tys import Sum
 if TYPE_CHECKING:
     from hugr.hugr.node_port import Node, ToNode, Wire
     from hugr.tys import TypeRow
-import warnings
 
 
 class Case(DfBase[ops.Case]):
@@ -84,9 +83,11 @@ class Else(_IfElse):
     See :class:`If` for an example.
     """
 
+    @deprecated(
+        "`Else.finish` is deprecated, use `conditional_node` instead."
+    )  # TODO: Remove in a breaking change
     def finish(self) -> Node:
         """Deprecated, use `conditional_node` property."""
-        # TODO remove in 0.4.0
         return self.conditional_node  # pragma: no cover
 
 
@@ -128,18 +129,11 @@ class Conditional(ParentBuilder[ops.Conditional], AbstractContextManager):
             self._case_builders.append((new_case, False))
 
     @property
+    @deprecated(
+        "The 'cases' property is deprecated and will be removed in a future version."
+    )  # TODO: Remove in a breaking change
     def cases(self) -> dict[int, Node | None]:
-        """Map from case index to node holding the :class:`Case <hugr.ops.Case>`.
-
-        DEPRECATED
-        """
-        # TODO remove in 0.10
-        warnings.warn(
-            "The 'cases' property is deprecated and"
-            " will be removed in a future version.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        """Map from case index to node holding the :class:`Case <hugr.ops.Case>`."""
         return {
             i: case.parent_node if b else None
             for i, (case, b) in enumerate(self._case_builders)

--- a/hugr-py/src/hugr/package.py
+++ b/hugr-py/src/hugr/package.py
@@ -5,16 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
-try:
-    from warnings import deprecated  # type: ignore[attr-defined]
-except ImportError:
-    # Python < 3.13
-    def deprecated(_msg):  # type: ignore[no-redef]
-        def _deprecated(func):
-            return func
-
-        return _deprecated
-
+from typing_extensions import deprecated
 
 import hugr._serialization.extension as ext_s
 from hugr.envelope import (

--- a/uv.lock
+++ b/uv.lock
@@ -282,6 +282,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
     { name = "semver" },
+    { name = "typing-extensions" },
     { name = "zstd" },
 ]
 
@@ -300,6 +301,7 @@ requires-dist = [
     { name = "semver", specifier = ">=3.0.2" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1.3,<9.0.0" },
     { name = "sphinx-book-theme", marker = "extra == 'docs'", specifier = ">=1.1.2" },
+    { name = "typing-extensions", specifier = "~=4.12" },
     { name = "zstd", specifier = ">=1.5.6.6" },
 ]
 provides-extras = ["docs"]


### PR DESCRIPTION
`typing_extensions` defines a `@deprecated` decorator compatible with `python<3.13`

drive-by: Added decorator to `Else.finish`, which said it was deprecated in its docstring but didn't raise any warnings.