### PR TITLE
feat: Represent order edges in `hugr-model` as metadata.

### DIFF
--- a/hugr-core/tests/model.rs
+++ b/hugr-core/tests/model.rs
@@ -78,3 +78,10 @@ pub fn test_roundtrip_const() {
         "../../hugr-model/tests/fixtures/model-const.edn"
     )));
 }
+
+#[test]
+pub fn test_roundtrip_order() {
+    insta::assert_snapshot!(roundtrip(include_str!(
+        "../../hugr-model/tests/fixtures/model-order.edn"
+    )));
+}

--- a/hugr-core/tests/snapshots/model__roundtrip_order.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_order.snap
@@ -1,0 +1,60 @@
+---
+source: hugr-core/tests/model.rs
+expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-order.edn\"))"
+---
+(hugr 0)
+
+(mod)
+
+(import core.order_hint.key)
+
+(import core.fn)
+
+(import core.order_hint.order)
+
+(import arithmetic.int.types.int)
+
+(import arithmetic.int.ineg)
+
+(define-func
+  main
+  (core.fn
+    [arithmetic.int.types.int
+     arithmetic.int.types.int
+     arithmetic.int.types.int
+     arithmetic.int.types.int]
+    [arithmetic.int.types.int
+     arithmetic.int.types.int
+     arithmetic.int.types.int
+     arithmetic.int.types.int])
+  (dfg [%0 %1 %2 %3] [%4 %5 %6 %7]
+    (signature
+      (core.fn
+        [arithmetic.int.types.int
+         arithmetic.int.types.int
+         arithmetic.int.types.int
+         arithmetic.int.types.int]
+        [arithmetic.int.types.int
+         arithmetic.int.types.int
+         arithmetic.int.types.int
+         arithmetic.int.types.int]))
+    (meta (core.order_hint.order 4 7))
+    (meta (core.order_hint.order 5 6))
+    (meta (core.order_hint.order 5 4))
+    (meta (core.order_hint.order 6 7))
+    (arithmetic.int.ineg [%0] [%4]
+      (signature
+        (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (meta (core.order_hint.key 4)))
+    (arithmetic.int.ineg [%1] [%5]
+      (signature
+        (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (meta (core.order_hint.key 5)))
+    (arithmetic.int.ineg [%2] [%6]
+      (signature
+        (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (meta (core.order_hint.key 6)))
+    (arithmetic.int.ineg [%3] [%7]
+      (signature
+        (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (meta (core.order_hint.key 7)))))

--- a/hugr-model/src/v0/ast/hugr.pest
+++ b/hugr-model/src/v0/ast/hugr.pest
@@ -1,7 +1,6 @@
 WHITESPACE  = _{ " " | "\t" | "\r" | "\n" }
 COMMENT     = _{ ";" ~ (!("\n") ~ ANY)* ~ "\n" }
 identifier  = @{ (ASCII_ALPHA | "_" | "-") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
-ext_name    = @{ identifier ~ ("." ~ identifier)* }
 symbol_name = @{ identifier ~ ("." ~ identifier)* }
 link_name   = @{ "%" ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
 
@@ -71,7 +70,6 @@ term = {
   | term_list
   | term_list_type
   | literal
-  | term_ext_set
   | term_tuple
   | term_const_func
   | term_apply
@@ -83,7 +81,6 @@ term_apply      =  { symbol_name | ("(" ~ symbol_name ~ term* ~ ")") }
 term_list       =  { "[" ~ part* ~ "]" }
 term_tuple      =  { "(" ~ "tuple" ~ part* ~ ")" }
 term_list_type  =  { "(" ~ "list" ~ term ~ ")" }
-term_ext_set    =  { "(" ~ "ext" ~ (spliced_term | ext_name)* ~ ")" }
 term_const_func =  { "(" ~ "fn" ~ term ~ ")" }
 
 part         = { spliced_term | term }

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -265,6 +265,33 @@ pub const COMPAT_META_JSON: &str = "compat.meta_json";
 /// - **Result:** `(core.const ?type)`
 pub const COMPAT_CONST_JSON: &str = "compat.const_json";
 
+/// Metadata constructor for order hint keys.
+///
+/// Nodes in a dataflow region can be annotated with a key. Each node may have
+/// at most one key and the key must be unique among all nodes in the same
+/// dataflow region. The parent dataflow graph can then use the
+/// `order_hint.order` metadata to imply a desired ordering relation, referring
+/// to the nodes by their key.
+///
+/// - **Parameter:** `?key : core.nat`
+/// - **Result:** `core.meta`
+pub const ORDER_HINT_KEY: &str = "core.order_hint.key";
+
+/// Metadata constructor for order hints.
+///
+/// When this metadata is attached to a dataflow region, it can indicate a
+/// preferred ordering relation between child nodes. Code generation must take
+/// this into account when deciding on an execution order. The child nodes are
+/// identified by a key, using the `order_hint.key` metadata.
+///
+/// The graph consisting of both value dependencies between nodes and order
+/// hints must be directed acyclic.
+///
+/// - **Parameter:** `?before : core.nat`
+/// - **Parameter:** `?after : core.nat`
+/// - **Result:** `core.meta`
+pub const ORDER_HINT_ORDER: &str = "core.order_hint.order";
+
 pub mod ast;
 pub mod binary;
 pub mod scope;

--- a/hugr-model/tests/fixtures/model-order.edn
+++ b/hugr-model/tests/fixtures/model-order.edn
@@ -1,0 +1,50 @@
+(hugr 0)
+
+(mod)
+
+(define-func main
+  (core.fn
+    [arithmetic.int.types.int
+      arithmetic.int.types.int
+      arithmetic.int.types.int
+      arithmetic.int.types.int]
+    [arithmetic.int.types.int
+      arithmetic.int.types.int
+      arithmetic.int.types.int
+      arithmetic.int.types.int])
+  (dfg [%0 %1 %2 %3] [%4 %5 %6 %7]
+    (signature
+      (core.fn
+        [arithmetic.int.types.int
+         arithmetic.int.types.int
+         arithmetic.int.types.int
+         arithmetic.int.types.int]
+        [arithmetic.int.types.int
+         arithmetic.int.types.int
+         arithmetic.int.types.int
+         arithmetic.int.types.int]))
+
+    (meta (core.order_hint.order 1 2))
+    (meta (core.order_hint.order 1 0))
+    (meta (core.order_hint.order 2 3))
+    (meta (core.order_hint.order 0 3))
+
+    (arithmetic.int.ineg
+      [%0] [%4]
+      (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (meta (core.order_hint.key 0)))
+
+    (arithmetic.int.ineg
+      [%1] [%5]
+      (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (meta (core.order_hint.key 1)))
+
+    (arithmetic.int.ineg
+      [%2] [%6]
+      (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (meta (core.order_hint.key 2)))
+
+    (arithmetic.int.ineg
+      [%3] [%7]
+      (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (meta (core.order_hint.key 3)))))


### PR DESCRIPTION
This PR introduces metadata to encode order edges in `hugr-model`. The children of a dataflow region can be assigned a key via `order_hint.key` metadata. Then `order_hint.order` metadata on the dataflow region encodes order edges between keys. The PR includes the necessary import and export code in `hugr-core`.