### PR TITLE
feat: Remove extension sets from `hugr-model`.

### DIFF
--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -21,7 +21,6 @@ extension_inference = []
 declarative = ["serde_yaml"]
 model_unstable = ["hugr-model"]
 zstd = ["dep:zstd"]
-default = ["model_unstable"]
 
 [lib]
 bench = false

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -21,6 +21,7 @@ extension_inference = []
 declarative = ["serde_yaml"]
 model_unstable = ["hugr-model"]
 zstd = ["dep:zstd"]
+default = ["model_unstable"]
 
 [lib]
 bench = false

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -1,6 +1,6 @@
 //! Exporting HUGR graphs to their `hugr-model` representation.
 use crate::{
-    extension::{ExtensionId, ExtensionSet, OpDef, SignatureFunc},
+    extension::{ExtensionId, OpDef, SignatureFunc},
     hugr::{IdentList, NodeMetadataMap},
     ops::{
         constant::CustomSerialized, DataflowBlock, DataflowOpTrait, OpName, OpTrait, OpType, Value,
@@ -278,13 +278,10 @@ impl<'a> Context<'a> {
                 panic!("output nodes should have been handled by the region export")
             }
 
-            OpType::DFG(dfg) => {
-                let extensions = self.export_ext_set(&dfg.signature.runtime_reqs);
-                regions = self.bump.alloc_slice_copy(&[self.export_dfg(
-                    node,
-                    extensions,
-                    model::ScopeClosure::Open,
-                )]);
+            OpType::DFG(_) => {
+                regions = self
+                    .bump
+                    .alloc_slice_copy(&[self.export_dfg(node, model::ScopeClosure::Open)]);
                 table::Operation::Dfg
             }
 
@@ -303,25 +300,19 @@ impl<'a> Context<'a> {
                 todo!("case nodes should have been handled by the region export")
             }
 
-            OpType::DataflowBlock(block) => {
-                let extensions = self.export_ext_set(&block.extension_delta);
-                regions = self.bump.alloc_slice_copy(&[self.export_dfg(
-                    node,
-                    extensions,
-                    model::ScopeClosure::Open,
-                )]);
+            OpType::DataflowBlock(_) => {
+                regions = self
+                    .bump
+                    .alloc_slice_copy(&[self.export_dfg(node, model::ScopeClosure::Open)]);
                 table::Operation::Block
             }
 
             OpType::FuncDefn(func) => self.with_local_scope(node_id, |this| {
                 let name = this.get_func_name(node).unwrap();
                 let symbol = this.export_poly_func_type(name, &func.signature);
-                let extensions = this.export_ext_set(&func.signature.body().runtime_reqs);
-                regions = this.bump.alloc_slice_copy(&[this.export_dfg(
-                    node,
-                    extensions,
-                    model::ScopeClosure::Closed,
-                )]);
+                regions = this
+                    .bump
+                    .alloc_slice_copy(&[this.export_dfg(node, model::ScopeClosure::Closed)]);
                 table::Operation::DefineFunc(symbol)
             }),
 
@@ -369,9 +360,7 @@ impl<'a> Context<'a> {
                 let signature = call.signature();
                 let inputs = self.export_type_row(&signature.input);
                 let outputs = self.export_type_row(&signature.output);
-                let ext = self.export_ext_set(&signature.runtime_reqs);
-                let operation =
-                    self.make_term_apply(model::CORE_CALL, &[inputs, outputs, ext, func]);
+                let operation = self.make_term_apply(model::CORE_CALL, &[inputs, outputs, func]);
                 table::Operation::Custom(operation)
             }
 
@@ -383,9 +372,7 @@ impl<'a> Context<'a> {
                 let args = args.into_bump_slice();
                 let func = self.make_term(table::Term::Apply(symbol, args));
                 let runtime_type = self.make_term(table::Term::Wildcard);
-                let ext = self.make_term(table::Term::Wildcard);
-                let operation =
-                    self.make_term_apply(model::CORE_LOAD_CONST, &[runtime_type, ext, func]);
+                let operation = self.make_term_apply(model::CORE_LOAD_CONST, &[runtime_type, func]);
                 table::Operation::Custom(operation)
             }
 
@@ -405,19 +392,16 @@ impl<'a> Context<'a> {
                 // TODO: Share the constant value between all nodes that load it.
 
                 let runtime_type = self.make_term(table::Term::Wildcard);
-                let ext = self.make_term(table::Term::Wildcard);
                 let value = self.export_value(&const_node_data.value);
                 let operation =
-                    self.make_term_apply(model::CORE_LOAD_CONST, &[runtime_type, ext, value]);
+                    self.make_term_apply(model::CORE_LOAD_CONST, &[runtime_type, value]);
                 table::Operation::Custom(operation)
             }
 
             OpType::CallIndirect(call) => {
                 let inputs = self.export_type_row(&call.signature.input);
                 let outputs = self.export_type_row(&call.signature.output);
-                let ext = self.export_ext_set(&call.signature.runtime_reqs);
-                let operation =
-                    self.make_term_apply(model::CORE_CALL_INDIRECT, &[inputs, outputs, ext]);
+                let operation = self.make_term_apply(model::CORE_CALL_INDIRECT, &[inputs, outputs]);
                 table::Operation::Custom(operation)
             }
 
@@ -429,13 +413,10 @@ impl<'a> Context<'a> {
                 table::Operation::Custom(operation)
             }
 
-            OpType::TailLoop(tail_loop) => {
-                let extensions = self.export_ext_set(&tail_loop.extension_delta);
-                regions = self.bump.alloc_slice_copy(&[self.export_dfg(
-                    node,
-                    extensions,
-                    model::ScopeClosure::Open,
-                )]);
+            OpType::TailLoop(_) => {
+                regions = self
+                    .bump
+                    .alloc_slice_copy(&[self.export_dfg(node, model::ScopeClosure::Open)]);
                 table::Operation::TailLoop
             }
 
@@ -578,19 +559,13 @@ impl<'a> Context<'a> {
             self.make_term(table::Term::List(outputs.into_bump_slice()))
         };
 
-        let extensions = self.export_ext_set(&block.extension_delta);
-        self.make_term_apply(model::CORE_FN, &[inputs, outputs, extensions])
+        self.make_term_apply(model::CORE_FN, &[inputs, outputs])
     }
 
     /// Creates a data flow region from the given node's children.
     ///
     /// `Input` and `Output` nodes are used to determine the source and target ports of the region.
-    pub fn export_dfg(
-        &mut self,
-        node: Node,
-        extensions: table::TermId,
-        closure: model::ScopeClosure,
-    ) -> table::RegionId {
+    pub fn export_dfg(&mut self, node: Node, closure: model::ScopeClosure) -> table::RegionId {
         let region = self.module.insert_region(table::Region::default());
 
         self.symbols.enter(region);
@@ -631,7 +606,7 @@ impl<'a> Context<'a> {
         let signature = {
             let inputs = self.export_type_row(input_types.unwrap());
             let outputs = self.export_type_row(output_types.unwrap());
-            Some(self.make_term_apply(model::CORE_FN, &[inputs, outputs, extensions]))
+            Some(self.make_term_apply(model::CORE_FN, &[inputs, outputs]))
         };
 
         let scope = match closure {
@@ -707,8 +682,7 @@ impl<'a> Context<'a> {
 
             let inputs = wrap_ctrl(node_signature.input());
             let outputs = wrap_ctrl(node_signature.output());
-            let extensions = self.export_ext_set(&node_signature.runtime_reqs);
-            Some(self.make_term_apply(model::CORE_FN, &[inputs, outputs, extensions]))
+            Some(self.make_term_apply(model::CORE_FN, &[inputs, outputs]))
         };
 
         let scope = match closure {
@@ -739,12 +713,11 @@ impl<'a> Context<'a> {
         let mut regions = BumpVec::with_capacity_in(children.size_hint().0, self.bump);
 
         for child in children {
-            let OpType::Case(case_op) = self.hugr.get_optype(child) else {
+            let OpType::Case(_) = self.hugr.get_optype(child) else {
                 panic!("expected a `Case` node as a child of a `Conditional` node");
             };
 
-            let extensions = self.export_ext_set(&case_op.signature.runtime_reqs);
-            regions.push(self.export_dfg(child, extensions, model::ScopeClosure::Open));
+            regions.push(self.export_dfg(child, model::ScopeClosure::Open));
         }
 
         regions.into_bump_slice()
@@ -803,8 +776,7 @@ impl<'a> Context<'a> {
     pub fn export_func_type<RV: MaybeRV>(&mut self, t: &FuncTypeBase<RV>) -> table::TermId {
         let inputs = self.export_type_row(t.input());
         let outputs = self.export_type_row(t.output());
-        let extensions = self.export_ext_set(&t.runtime_reqs);
-        self.make_term_apply(model::CORE_FN, &[inputs, outputs, extensions])
+        self.make_term_apply(model::CORE_FN, &[inputs, outputs])
     }
 
     pub fn export_custom_type(&mut self, t: &CustomType) -> table::TermId {
@@ -831,7 +803,7 @@ impl<'a> Context<'a> {
                 );
                 self.make_term(table::Term::List(parts))
             }
-            TypeArg::Extensions { es } => self.export_ext_set(es),
+            TypeArg::Extensions { .. } => self.make_term_apply("compat.ext_set", &[]),
             TypeArg::Variable { v } => self.export_type_arg_var(v),
         }
     }
@@ -938,27 +910,8 @@ impl<'a> Context<'a> {
                 let types = self.make_term(table::Term::List(parts));
                 self.make_term_apply(model::CORE_TUPLE_TYPE, &[types])
             }
-            TypeParam::Extensions => self.make_term_apply(model::CORE_EXT_SET, &[]),
+            TypeParam::Extensions => self.make_term_apply("compat.ext_set_type", &[]),
         }
-    }
-
-    pub fn export_ext_set(&mut self, ext_set: &ExtensionSet) -> table::TermId {
-        let capacity = ext_set.iter().size_hint().0;
-        let mut parts = BumpVec::with_capacity_in(capacity, self.bump);
-
-        for ext in ext_set.iter() {
-            // `ExtensionSet`s represent variables by extension names that parse to integers.
-            match ext.parse::<u16>() {
-                Ok(index) => {
-                    let node = self.local_scope.expect("local variable out of scope");
-                    let term = self.make_term(table::Term::Var(table::VarId(node, index)));
-                    parts.push(table::ExtSetPart::Splice(term));
-                }
-                Err(_) => parts.push(table::ExtSetPart::Extension(self.bump.alloc_str(ext))),
-            }
-        }
-
-        self.make_term(table::Term::ExtSet(parts.into_bump_slice()))
     }
 
     fn export_value(&mut self, value: &'a Value) -> table::TermId {
@@ -1009,10 +962,7 @@ impl<'a> Context<'a> {
 
                 let json = self.make_term(model::Literal::Str(json.into()).into());
                 let runtime_type = self.export_type(&e.get_type());
-                let extensions = self.export_ext_set(&e.extension_reqs());
-                let args = self
-                    .bump
-                    .alloc_slice_copy(&[runtime_type, extensions, json]);
+                let args = self.bump.alloc_slice_copy(&[runtime_type, json]);
                 let symbol = self.resolve_symbol(model::COMPAT_CONST_JSON);
                 self.make_term(table::Term::Apply(symbol, args))
             }
@@ -1022,22 +972,18 @@ impl<'a> Context<'a> {
                 let outer_node_to_id = std::mem::take(&mut self.node_to_id);
 
                 let region = match hugr.root_type() {
-                    OpType::DFG(dfg) => {
-                        let extensions = self.export_ext_set(&dfg.extension_delta());
-                        self.export_dfg(hugr.root(), extensions, model::ScopeClosure::Closed)
-                    }
+                    OpType::DFG(_) => self.export_dfg(hugr.root(), model::ScopeClosure::Closed),
                     _ => panic!("Value::Function root must be a DFG"),
                 };
 
                 self.node_to_id = outer_node_to_id;
                 self.hugr = outer_hugr;
 
-                self.make_term(table::Term::ConstFunc(region))
+                self.make_term(table::Term::Func(region))
             }
 
             Value::Sum(sum) => {
                 let variants = self.export_sum_variants(&sum.sum_type);
-                let ext = self.make_term(table::Term::Wildcard);
                 let types = self.make_term(table::Term::Wildcard);
                 let tag = self.make_term(model::Literal::Nat(sum.tag as u64).into());
 
@@ -1051,7 +997,7 @@ impl<'a> Context<'a> {
                     self.make_term(table::Term::Tuple(values.into_bump_slice()))
                 };
 
-                self.make_term_apply(model::CORE_CONST_ADT, &[variants, ext, types, tag, values])
+                self.make_term_apply(model::CORE_CONST_ADT, &[variants, types, tag, values])
             }
         }
     }

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -383,14 +383,14 @@ impl<'a> Context<'a> {
             }
 
             table::Operation::Custom(operation) => {
-                if let Some([]) = self.match_symbol(operation, model::CORE_CALL_INDIRECT)? {
+                if let Some([_, _]) = self.match_symbol(operation, model::CORE_CALL_INDIRECT)? {
                     let signature = self.get_node_signature(node_id)?;
                     let optype = OpType::CallIndirect(CallIndirect { signature });
                     let node = self.make_node(node_id, optype, parent)?;
                     return Ok(Some(node));
                 }
 
-                if let Some([_, _, _, func]) = self.match_symbol(operation, model::CORE_CALL)? {
+                if let Some([_, _, func]) = self.match_symbol(operation, model::CORE_CALL)? {
                     let table::Term::Apply(symbol, args) = self.get_term(func)? else {
                         return Err(table::ModelError::TypeError(func).into());
                     };
@@ -1119,7 +1119,7 @@ impl<'a> Context<'a> {
         &mut self,
         term_id: table::TermId,
     ) -> Result<TypeBase<RV>, ImportError> {
-        if let Some([_, _, _]) = self.match_symbol(term_id, model::CORE_FN)? {
+        if let Some([_, _]) = self.match_symbol(term_id, model::CORE_FN)? {
             let func_type = self.import_func_type::<RowVariable>(term_id)?;
             return Ok(TypeBase::new_function(func_type));
         }

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::{
     extension::{ExtensionId, ExtensionRegistry, ExtensionSet, SignatureError},
-    hugr::{HugrMut, IdentList},
+    hugr::HugrMut,
     ops::{
         constant::{CustomConst, CustomSerialized, OpaqueValue},
         AliasDecl, AliasDefn, Call, CallIndirect, Case, Conditional, Const, DataflowBlock,
@@ -409,7 +409,7 @@ impl<'a> Context<'a> {
                     return Ok(Some(node));
                 }
 
-                if let Some([_, _, value]) = self.match_symbol(operation, model::CORE_LOAD_CONST)? {
+                if let Some([_, value]) = self.match_symbol(operation, model::CORE_LOAD_CONST)? {
                     // If the constant refers directly to a function, import this as the `LoadFunc` operation.
                     if let table::Term::Apply(symbol, args) = self.get_term(value)? {
                         let func_node_data = self
@@ -440,7 +440,7 @@ impl<'a> Context<'a> {
                     let signature = node_data
                         .signature
                         .ok_or_else(|| error_uninferred!("node signature"))?;
-                    let [_, outputs, _] = self.get_func_type(signature)?;
+                    let [_, outputs] = self.get_func_type(signature)?;
                     let outputs = self.import_closed_list(outputs)?;
                     let output = outputs
                         .first()
@@ -474,7 +474,7 @@ impl<'a> Context<'a> {
                     let signature = node_data
                         .signature
                         .ok_or_else(|| error_uninferred!("node signature"))?;
-                    let [_, outputs, _] = self.get_func_type(signature)?;
+                    let [_, outputs] = self.get_func_type(signature)?;
                     let (variants, _) = self.import_adt_and_rest(node_id, outputs)?;
                     let node = self.make_node(
                         node_id,
@@ -643,7 +643,7 @@ impl<'a> Context<'a> {
         };
         let region_data = self.get_region(*region)?;
 
-        let [_, region_outputs, _] = self.get_func_type(
+        let [_, region_outputs] = self.get_func_type(
             region_data
                 .signature
                 .ok_or_else(|| error_uninferred!("region signature"))?,
@@ -684,7 +684,7 @@ impl<'a> Context<'a> {
     ) -> Result<Node, ImportError> {
         let node_data = self.get_node(node_id)?;
         debug_assert_eq!(node_data.operation, table::Operation::Conditional);
-        let [inputs, outputs, _] = self.get_func_type(
+        let [inputs, outputs] = self.get_func_type(
             node_data
                 .signature
                 .ok_or_else(|| error_uninferred!("node signature"))?,
@@ -736,7 +736,7 @@ impl<'a> Context<'a> {
             self.region_scope = region;
         }
 
-        let [region_source, region_targets, _] = self.get_func_type(
+        let [region_source, region_targets] = self.get_func_type(
             region_data
                 .signature
                 .ok_or_else(|| error_uninferred!("region signature"))?,
@@ -853,20 +853,19 @@ impl<'a> Context<'a> {
             return Err(table::ModelError::InvalidRegions(node_id).into());
         };
         let region_data = self.get_region(*region)?;
-        let [inputs, outputs, extensions] = self.get_func_type(
+        let [inputs, outputs] = self.get_func_type(
             region_data
                 .signature
                 .ok_or_else(|| error_uninferred!("region signature"))?,
         )?;
         let inputs = self.import_type_row(inputs)?;
         let (sum_rows, other_outputs) = self.import_adt_and_rest(node_id, outputs)?;
-        let extension_delta = self.import_extension_set(extensions)?;
 
         let optype = OpType::DataflowBlock(DataflowBlock {
             inputs,
             other_outputs,
             sum_rows,
-            extension_delta,
+            extension_delta: ExtensionSet::new(),
         });
         let node = self.make_node(node_id, optype, parent)?;
 
@@ -971,10 +970,6 @@ impl<'a> Context<'a> {
             ));
         }
 
-        if let Some([]) = self.match_symbol(term_id, model::CORE_EXT_SET)? {
-            return Ok(TypeParam::Extensions);
-        }
-
         if let Some([item_type]) = self.match_symbol(term_id, model::CORE_LIST_TYPE)? {
             // At present `hugr-model` has no way to express that the item
             // type of a list must be copyable. Therefore we import it as `Any`.
@@ -999,8 +994,7 @@ impl<'a> Context<'a> {
 
             table::Term::Tuple(_)
             | table::Term::List { .. }
-            | table::Term::ExtSet { .. }
-            | table::Term::ConstFunc { .. }
+            | table::Term::Func { .. }
             | table::Term::Literal(_) => Err(table::ModelError::TypeError(term_id).into()),
         }
     }
@@ -1048,10 +1042,6 @@ impl<'a> Context<'a> {
 
         if let Some([]) = self.match_symbol(term_id, model::CORE_STATIC)? {
             return Err(error_unsupported!("`{}` as `TypeArg`", model::CORE_STATIC));
-        }
-
-        if let Some([]) = self.match_symbol(term_id, model::CORE_EXT_SET)? {
-            return Err(error_unsupported!("`{}` as `TypeArg`", model::CORE_EXT_SET));
         }
 
         if let Some([]) = self.match_symbol(term_id, model::CORE_CTRL_TYPE)? {
@@ -1108,9 +1098,6 @@ impl<'a> Context<'a> {
             table::Term::Literal(model::Literal::Nat(value)) => {
                 Ok(TypeArg::BoundedNat { n: *value })
             }
-            table::Term::ExtSet { .. } => Ok(TypeArg::Extensions {
-                es: self.import_extension_set(term_id)?,
-            }),
 
             table::Term::Literal(model::Literal::Bytes(_)) => {
                 Err(error_unsupported!("`(bytes ..)` as `TypeArg`"))
@@ -1118,53 +1105,13 @@ impl<'a> Context<'a> {
             table::Term::Literal(model::Literal::Float(_)) => {
                 Err(error_unsupported!("float literal as `TypeArg`"))
             }
-            table::Term::ConstFunc { .. } => {
-                Err(error_unsupported!("function constant as `TypeArg`"))
-            }
+            table::Term::Func { .. } => Err(error_unsupported!("function constant as `TypeArg`")),
 
             table::Term::Apply { .. } => {
                 let ty = self.import_type(term_id)?;
                 Ok(TypeArg::Type { ty })
             }
         }
-    }
-
-    fn import_extension_set(
-        &mut self,
-        term_id: table::TermId,
-    ) -> Result<ExtensionSet, ImportError> {
-        let mut es = ExtensionSet::new();
-        let mut stack = vec![term_id];
-
-        while let Some(term_id) = stack.pop() {
-            match self.get_term(term_id)? {
-                table::Term::Wildcard => return Err(error_uninferred!("wildcard")),
-
-                table::Term::Var(table::VarId(_, index)) => {
-                    es.insert_type_var(*index as _);
-                }
-
-                table::Term::ExtSet(parts) => {
-                    for part in *parts {
-                        match part {
-                            table::ExtSetPart::Extension(ext) => {
-                                let ext_ident = IdentList::new(*ext).map_err(|_| {
-                                    table::ModelError::MalformedName(ext.to_smolstr())
-                                })?;
-                                es.insert(ext_ident);
-                            }
-                            table::ExtSetPart::Splice(term_id) => {
-                                // The order in an extension set does not matter.
-                                stack.push(*term_id);
-                            }
-                        }
-                    }
-                }
-                _ => return Err(table::ModelError::TypeError(term_id).into()),
-            }
-        }
-
-        Ok(es)
     }
 
     /// Import a `Type` from a term that represents a runtime type.
@@ -1231,15 +1178,14 @@ impl<'a> Context<'a> {
 
             // The following terms are not runtime types, but the core `Type` only contains runtime types.
             // We therefore report a type error here.
-            table::Term::ExtSet { .. }
-            | table::Term::List { .. }
+            table::Term::List { .. }
             | table::Term::Tuple { .. }
             | table::Term::Literal(_)
-            | table::Term::ConstFunc { .. } => Err(table::ModelError::TypeError(term_id).into()),
+            | table::Term::Func { .. } => Err(table::ModelError::TypeError(term_id).into()),
         }
     }
 
-    fn get_func_type(&mut self, term_id: table::TermId) -> Result<[table::TermId; 3], ImportError> {
+    fn get_func_type(&mut self, term_id: table::TermId) -> Result<[table::TermId; 2], ImportError> {
         self.match_symbol(term_id, model::CORE_FN)?
             .ok_or(table::ModelError::TypeError(term_id).into())
     }
@@ -1248,11 +1194,10 @@ impl<'a> Context<'a> {
         &mut self,
         term_id: table::TermId,
     ) -> Result<FuncTypeBase<RV>, ImportError> {
-        let [inputs, outputs, extensions] = self.get_func_type(term_id)?;
+        let [inputs, outputs] = self.get_func_type(term_id)?;
         let inputs = self.import_type_row(inputs)?;
         let outputs = self.import_type_row(outputs)?;
-        let extensions = self.import_extension_set(extensions)?;
-        Ok(FuncTypeBase::new(inputs, outputs).with_extension_delta(extensions))
+        Ok(FuncTypeBase::new(inputs, outputs))
     }
 
     fn import_closed_list(
@@ -1428,9 +1373,7 @@ impl<'a> Context<'a> {
         // NOTE: We have special cased arrays, integers, and floats for now.
         // TODO: Allow arbitrary extension values to be imported from terms.
 
-        if let Some([runtime_type, extensions, json]) =
-            self.match_symbol(term_id, model::COMPAT_CONST_JSON)?
-        {
+        if let Some([runtime_type, json]) = self.match_symbol(term_id, model::COMPAT_CONST_JSON)? {
             let table::Term::Literal(model::Literal::Str(json)) = self.get_term(json)? else {
                 return Err(table::ModelError::TypeError(term_id).into());
             };
@@ -1445,11 +1388,9 @@ impl<'a> Context<'a> {
                 return Ok(Value::Extension { e: opaque_value });
             } else {
                 let runtime_type = self.import_type(runtime_type)?;
-                let extensions = self.import_extension_set(extensions)?;
-
                 let value: serde_json::Value = serde_json::from_str(json)
                     .map_err(|_| table::ModelError::TypeError(term_id))?;
-                let custom_const = CustomSerialized::new(runtime_type, value, extensions);
+                let custom_const = CustomSerialized::new(runtime_type, value, ExtensionSet::new());
                 let opaque_value = OpaqueValue::new(custom_const);
                 return Ok(Value::Extension { e: opaque_value });
             }
@@ -1500,7 +1441,7 @@ impl<'a> Context<'a> {
             return Ok(ConstF64::new(value.into_inner()).into());
         }
 
-        if let Some([_, _, _, tag, values]) = self.match_symbol(term_id, model::CORE_CONST_ADT)? {
+        if let Some([_, _, tag, values]) = self.match_symbol(term_id, model::CORE_CONST_ADT)? {
             let [variants] = self.expect_symbol(type_id, model::CORE_ADT)?;
             let values = self.import_closed_tuple(values)?;
             let variants = self.import_closed_list(variants)?;
@@ -1548,12 +1489,11 @@ impl<'a> Context<'a> {
                 // - custom constructors for values
             }
 
-            table::Term::List { .. }
-            | table::Term::ExtSet { .. }
-            | table::Term::Tuple(_)
-            | table::Term::Literal(_) => Err(table::ModelError::TypeError(term_id).into()),
+            table::Term::List { .. } | table::Term::Tuple(_) | table::Term::Literal(_) => {
+                Err(table::ModelError::TypeError(term_id).into())
+            }
 
-            table::Term::ConstFunc { .. } => Err(error_unsupported!("constant function value")),
+            table::Term::Func { .. } => Err(error_unsupported!("constant function value")),
         }
     }
 

--- a/hugr-core/tests/snapshots/model__roundtrip_add.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_add.snap
@@ -14,17 +14,14 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-add.
   example.add
   (core.fn
     [arithmetic.int.types.int arithmetic.int.types.int]
-    [arithmetic.int.types.int]
-    (ext))
+    [arithmetic.int.types.int])
   (dfg [%0 %1] [%2]
     (signature
       (core.fn
         [arithmetic.int.types.int arithmetic.int.types.int]
-        [arithmetic.int.types.int]
-        (ext)))
+        [arithmetic.int.types.int]))
     (arithmetic.int.iadd [%0 %1] [%2]
       (signature
         (core.fn
           [arithmetic.int.types.int arithmetic.int.types.int]
-          [arithmetic.int.types.int]
-          (ext))))))
+          [arithmetic.int.types.int])))))

--- a/hugr-core/tests/snapshots/model__roundtrip_alias.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_alias.snap
@@ -14,4 +14,4 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-alia
 
 (define-alias local.int core.type arithmetic.int.types.int)
 
-(define-alias local.endo core.type (core.fn [] [] (ext)))
+(define-alias local.endo core.type (core.fn [] []))

--- a/hugr-core/tests/snapshots/model__roundtrip_call.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_call.snap
@@ -12,58 +12,42 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-call
 
 (import compat.meta_json)
 
-(import core.ext_set)
-
 (import arithmetic.int.types.int)
 
 (declare-func
   example.callee
-  (param ?0 core.ext_set)
-  (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext))
+  (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])
   (meta (compat.meta_json "description" "\"This is a function declaration.\""))
   (meta (compat.meta_json "title" "\"Callee\"")))
 
 (define-func
   example.caller
-  (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext))
+  (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])
   (meta
     (compat.meta_json
       "description"
       "\"This defines a function that calls the function which we declared earlier.\""))
   (meta (compat.meta_json "title" "\"Caller\""))
   (dfg [%0] [%1]
-    (signature
-      (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext)))
+    (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
     ((core.call
         [arithmetic.int.types.int]
         [arithmetic.int.types.int]
-        (ext)
-        (example.callee (ext)))
+        example.callee)
       [%0] [%1]
       (signature
-        (core.fn
-          [arithmetic.int.types.int]
-          [arithmetic.int.types.int]
-          (ext))))))
+        (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])))))
 
 (define-func
   example.load
-  (core.fn
-    []
-    [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext))]
-    (ext))
+  (core.fn [] [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])])
   (dfg [] [%0]
     (signature
       (core.fn
         []
-        [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext))]
-        (ext)))
-    ((core.load_const _ _ example.caller) [] [%0]
+        [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])]))
+    ((core.load_const _ example.caller) [] [%0]
       (signature
         (core.fn
           []
-          [(core.fn
-             [arithmetic.int.types.int]
-             [arithmetic.int.types.int]
-             (ext))]
-          (ext))))))
+          [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])])))))

--- a/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
@@ -14,26 +14,23 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cfg.
 
 (import core.adt)
 
-(define-func example.cfg (param ?0 core.type) (core.fn [?0] [?0] (ext))
+(define-func example.cfg (param ?0 core.type) (core.fn [?0] [?0])
   (dfg [%0] [%1]
-    (signature (core.fn [?0] [?0] (ext)))
+    (signature (core.fn [?0] [?0]))
     (cfg [%0] [%1]
-      (signature (core.fn [?0] [?0] (ext)))
+      (signature (core.fn [?0] [?0]))
       (cfg [%2] [%3]
-        (signature (core.fn [(core.ctrl [?0])] [(core.ctrl [?0])] (ext)))
+        (signature (core.fn [(core.ctrl [?0])] [(core.ctrl [?0])]))
         (block [%2] [%6]
-          (signature (core.fn [(core.ctrl [?0])] [(core.ctrl [?0])] (ext)))
+          (signature (core.fn [(core.ctrl [?0])] [(core.ctrl [?0])]))
           (dfg [%4] [%5]
-            (signature (core.fn [?0] [(core.adt [[?0]])] (ext)))
+            (signature (core.fn [?0] [(core.adt [[?0]])]))
             ((core.make_adt _ _ 0) [%4] [%5]
-              (signature (core.fn [?0] [(core.adt [[?0]])] (ext))))))
+              (signature (core.fn [?0] [(core.adt [[?0]])])))))
         (block [%6] [%3 %6]
           (signature
-            (core.fn
-              [(core.ctrl [?0])]
-              [(core.ctrl [?0]) (core.ctrl [?0])]
-              (ext)))
+            (core.fn [(core.ctrl [?0])] [(core.ctrl [?0]) (core.ctrl [?0])]))
           (dfg [%7] [%8]
-            (signature (core.fn [?0] [(core.adt [[?0] [?0]])] (ext)))
+            (signature (core.fn [?0] [(core.adt [[?0] [?0]])]))
             ((core.make_adt _ _ 0) [%7] [%8]
-              (signature (core.fn [?0] [(core.adt [[?0] [?0]])] (ext))))))))))
+              (signature (core.fn [?0] [(core.adt [[?0] [?0]])])))))))))

--- a/hugr-core/tests/snapshots/model__roundtrip_cond.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_cond.snap
@@ -16,32 +16,25 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cond
   example.cond
   (core.fn
     [(core.adt [[] []]) arithmetic.int.types.int]
-    [arithmetic.int.types.int]
-    (ext))
+    [arithmetic.int.types.int])
   (dfg [%0 %1] [%2]
     (signature
       (core.fn
         [(core.adt [[] []]) arithmetic.int.types.int]
-        [arithmetic.int.types.int]
-        (ext)))
+        [arithmetic.int.types.int]))
     (cond [%0 %1] [%2]
       (signature
         (core.fn
           [(core.adt [[] []]) arithmetic.int.types.int]
-          [arithmetic.int.types.int]
-          (ext)))
+          [arithmetic.int.types.int]))
       (dfg [%3] [%3]
         (signature
-          (core.fn
-            [arithmetic.int.types.int]
-            [arithmetic.int.types.int]
-            (ext))))
+          (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])))
       (dfg [%4] [%5]
         (signature
-          (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext)))
+          (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
         (arithmetic.int.ineg [%4] [%5]
           (signature
             (core.fn
               [arithmetic.int.types.int]
-              [arithmetic.int.types.int]
-              (ext))))))))
+              [arithmetic.int.types.int])))))))

--- a/hugr-core/tests/snapshots/model__roundtrip_const.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_const.snap
@@ -26,15 +26,13 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
 
 (import core.adt)
 
-(define-func
-  example.bools
-  (core.fn [] [(core.adt [[] []]) (core.adt [[] []])] (ext))
+(define-func example.bools (core.fn [] [(core.adt [[] []]) (core.adt [[] []])])
   (dfg [] [%0 %1]
-    (signature (core.fn [] [(core.adt [[] []]) (core.adt [[] []])] (ext)))
-    ((core.load_const _ _ (core.const.adt [[] []] _ _ 0 [])) [] [%0]
-      (signature (core.fn [] [(core.adt [[] []])] (ext))))
-    ((core.load_const _ _ (core.const.adt [[] []] _ _ 1 [])) [] [%1]
-      (signature (core.fn [] [(core.adt [[] []])] (ext))))))
+    (signature (core.fn [] [(core.adt [[] []]) (core.adt [[] []])]))
+    ((core.load_const _ (core.const.adt [[] []] _ 0 [])) [] [%0]
+      (signature (core.fn [] [(core.adt [[] []])])))
+    ((core.load_const _ (core.const.adt [[] []] _ 1 [])) [] [%1]
+      (signature (core.fn [] [(core.adt [[] []])])))))
 
 (define-func
   example.make-pair
@@ -42,23 +40,19 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
     []
     [(core.adt
        [[(collections.array.array 5 (arithmetic.int.types.int 6))
-         arithmetic.float.types.float64]])]
-    (ext))
+         arithmetic.float.types.float64]])])
   (dfg [] [%0]
     (signature
       (core.fn
         []
         [(core.adt
            [[(collections.array.array 5 (arithmetic.int.types.int 6))
-             arithmetic.float.types.float64]])]
-        (ext)))
+             arithmetic.float.types.float64]])]))
     ((core.load_const
-        _
         _
         (core.const.adt
           [[(collections.array.array 5 (arithmetic.int.types.int 6))
             arithmetic.float.types.float64]]
-          _
           _
           0
           [(collections.array.const
@@ -76,26 +70,20 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
           []
           [(core.adt
              [[(collections.array.array 5 (arithmetic.int.types.int 6))
-               arithmetic.float.types.float64]])]
-          (ext))))))
+               arithmetic.float.types.float64]])])))))
 
-(define-func
-  example.f64-json
-  (core.fn [] [arithmetic.float.types.float64] (ext))
+(define-func example.f64-json (core.fn [] [arithmetic.float.types.float64])
   (dfg [] [%0 %1]
     (signature
       (core.fn
         []
-        [arithmetic.float.types.float64 arithmetic.float.types.float64]
-        (ext)))
-    ((core.load_const _ _ (arithmetic.float.const_f64 1.0)) [] [%0]
-      (signature (core.fn [] [arithmetic.float.types.float64] (ext))))
+        [arithmetic.float.types.float64 arithmetic.float.types.float64]))
+    ((core.load_const _ (arithmetic.float.const_f64 1.0)) [] [%0]
+      (signature (core.fn [] [arithmetic.float.types.float64])))
     ((core.load_const
-        _
         _
         (compat.const_json
           arithmetic.float.types.float64
-          (ext)
           "{\"c\":\"ConstUnknown\",\"v\":{\"value\":1.0}}"))
       [] [%1]
-      (signature (core.fn [] [arithmetic.float.types.float64] (ext))))))
+      (signature (core.fn [] [arithmetic.float.types.float64])))))

--- a/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_constraints.snap
@@ -19,7 +19,7 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
   (param ?0 core.nat)
   (param ?1 core.type)
   (where (core.nonlinear ?1))
-  (core.fn [?1] [(collections.array.array ?0 ?1)] (ext)))
+  (core.fn [?1] [(collections.array.array ?0 ?1)]))
 
 (declare-func
   array.copy
@@ -28,12 +28,11 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
   (where (core.nonlinear ?1))
   (core.fn
     [(collections.array.array ?0 ?1)]
-    [(collections.array.array ?0 ?1) (collections.array.array ?0 ?1)]
-    (ext)))
+    [(collections.array.array ?0 ?1) (collections.array.array ?0 ?1)]))
 
 (define-func
   util.copy
   (param ?0 core.type)
   (where (core.nonlinear ?0))
-  (core.fn [?0] [?0 ?0] (ext))
-  (dfg [%0] [%0 %0] (signature (core.fn [?0] [?0 ?0] (ext)))))
+  (core.fn [?0] [?0 ?0])
+  (dfg [%0] [%0 %0] (signature (core.fn [?0] [?0 ?0]))))

--- a/hugr-core/tests/snapshots/model__roundtrip_loop.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_loop.snap
@@ -12,12 +12,12 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-loop
 
 (import core.adt)
 
-(define-func example.loop (param ?0 core.type) (core.fn [?0] [?0] (ext))
+(define-func example.loop (param ?0 core.type) (core.fn [?0] [?0])
   (dfg [%0] [%1]
-    (signature (core.fn [?0] [?0] (ext)))
+    (signature (core.fn [?0] [?0]))
     (tail-loop [%0] [%1]
-      (signature (core.fn [?0] [?0] (ext)))
+      (signature (core.fn [?0] [?0]))
       (dfg [%2] [%3]
-        (signature (core.fn [?0] [(core.adt [[?0] [?0]])] (ext)))
+        (signature (core.fn [?0] [(core.adt [[?0] [?0]])]))
         ((core.make_adt _ _ 0) [%2] [%3]
-          (signature (core.fn [?0] [(core.adt [[?0] [?0]])] (ext))))))))
+          (signature (core.fn [?0] [(core.adt [[?0] [?0]])])))))))

--- a/hugr-core/tests/snapshots/model__roundtrip_params.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_params.snap
@@ -12,5 +12,5 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-para
   example.swap
   (param ?0 core.type)
   (param ?1 core.type)
-  (core.fn [?0 ?1] [?1 ?0] (ext))
-  (dfg [%0 %1] [%1 %0] (signature (core.fn [?0 ?1] [?1 ?0] (ext)))))
+  (core.fn [?0 ?1] [?1 ?0])
+  (dfg [%0 %1] [%1 %0] (signature (core.fn [?0 ?1] [?1 ?0]))))

--- a/hugr-model/capnp/hugr-v0.capnp
+++ b/hugr-model/capnp/hugr-v0.capnp
@@ -97,24 +97,16 @@ struct Term {
         list @4 :List(SeqPart);
         string @5 :Text;
         nat @6 :UInt64;
-        extSet @7 :List(ExtSetPart);
-        bytes @8 :Data;
-        float @9 :Float64;
-        constFunc @10 :RegionId;
-        wildcard @11 :Void;
-        tuple @12 :List(SeqPart);
+        bytes @7 :Data;
+        float @8 :Float64;
+        func @9 :RegionId;
+        wildcard @10 :Void;
+        tuple @11 :List(SeqPart);
     }
 
     struct SeqPart {
         union {
             item @0 :TermId;
-            splice @1 :TermId;
-        }
-    }
-
-    struct ExtSetPart {
-        union {
-            extension @0 :Text;
             splice @1 :TermId;
         }
     }

--- a/hugr-model/src/capnp/hugr_v0_capnp.rs
+++ b/hugr-model/src/capnp/hugr_v0_capnp.rs
@@ -2769,7 +2769,7 @@ pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::in
 }
 
 pub mod term {
-  pub use self::Which::{Apply,Variable,List,String,Nat,ExtSet,Bytes,Float,ConstFunc,Wildcard,Tuple};
+  pub use self::Which::{Apply,Variable,List,String,Nat,Bytes,Float,Func,Wildcard,Tuple};
 
   #[derive(Copy, Clone)]
   pub struct Owned(());
@@ -2842,18 +2842,13 @@ pub mod term {
       !self.reader.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn has_ext_set(&self) -> bool {
+    pub fn has_bytes(&self) -> bool {
       if self.reader.get_data_field::<u16>(2) != 5 { return false; }
       !self.reader.get_pointer_field(0).is_null()
     }
     #[inline]
-    pub fn has_bytes(&self) -> bool {
-      if self.reader.get_data_field::<u16>(2) != 6 { return false; }
-      !self.reader.get_pointer_field(0).is_null()
-    }
-    #[inline]
     pub fn has_tuple(&self) -> bool {
-      if self.reader.get_data_field::<u16>(2) != 10 { return false; }
+      if self.reader.get_data_field::<u16>(2) != 9 { return false; }
       !self.reader.get_pointer_field(0).is_null()
     }
     #[inline]
@@ -2885,31 +2880,26 @@ pub mod term {
           ))
         }
         5 => {
-          ::core::result::Result::Ok(ExtSet(
-            ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-          ))
-        }
-        6 => {
           ::core::result::Result::Ok(Bytes(
             ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
           ))
         }
-        7 => {
+        6 => {
           ::core::result::Result::Ok(Float(
             self.reader.get_data_field::<f64>(1)
           ))
         }
-        8 => {
-          ::core::result::Result::Ok(ConstFunc(
+        7 => {
+          ::core::result::Result::Ok(Func(
             self.reader.get_data_field::<u32>(0)
           ))
         }
-        9 => {
+        8 => {
           ::core::result::Result::Ok(Wildcard(
             ()
           ))
         }
-        10 => {
+        9 => {
           ::core::result::Result::Ok(Tuple(
             ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
           ))
@@ -3021,62 +3011,47 @@ pub mod term {
       self.builder.set_data_field::<u64>(1, value);
     }
     #[inline]
-    pub fn set_ext_set(&mut self, value: ::capnp::struct_list::Reader<'_,crate::hugr_v0_capnp::term::ext_set_part::Owned>) -> ::capnp::Result<()> {
-      self.builder.set_data_field::<u16>(2, 5);
-      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
-    }
-    #[inline]
-    pub fn init_ext_set(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::hugr_v0_capnp::term::ext_set_part::Owned> {
-      self.builder.set_data_field::<u16>(2, 5);
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
-    }
-    #[inline]
-    pub fn has_ext_set(&self) -> bool {
-      if self.builder.get_data_field::<u16>(2) != 5 { return false; }
-      !self.builder.is_pointer_field_null(0)
-    }
-    #[inline]
     pub fn set_bytes(&mut self, value: ::capnp::data::Reader<'_>)  {
-      self.builder.set_data_field::<u16>(2, 6);
+      self.builder.set_data_field::<u16>(2, 5);
       self.builder.reborrow().get_pointer_field(0).set_data(value);
     }
     #[inline]
     pub fn init_bytes(self, size: u32) -> ::capnp::data::Builder<'a> {
-      self.builder.set_data_field::<u16>(2, 6);
+      self.builder.set_data_field::<u16>(2, 5);
       self.builder.get_pointer_field(0).init_data(size)
     }
     #[inline]
     pub fn has_bytes(&self) -> bool {
-      if self.builder.get_data_field::<u16>(2) != 6 { return false; }
+      if self.builder.get_data_field::<u16>(2) != 5 { return false; }
       !self.builder.is_pointer_field_null(0)
     }
     #[inline]
     pub fn set_float(&mut self, value: f64)  {
-      self.builder.set_data_field::<u16>(2, 7);
+      self.builder.set_data_field::<u16>(2, 6);
       self.builder.set_data_field::<f64>(1, value);
     }
     #[inline]
-    pub fn set_const_func(&mut self, value: u32)  {
-      self.builder.set_data_field::<u16>(2, 8);
+    pub fn set_func(&mut self, value: u32)  {
+      self.builder.set_data_field::<u16>(2, 7);
       self.builder.set_data_field::<u32>(0, value);
     }
     #[inline]
     pub fn set_wildcard(&mut self, _value: ())  {
-      self.builder.set_data_field::<u16>(2, 9);
+      self.builder.set_data_field::<u16>(2, 8);
     }
     #[inline]
     pub fn set_tuple(&mut self, value: ::capnp::struct_list::Reader<'_,crate::hugr_v0_capnp::term::seq_part::Owned>) -> ::capnp::Result<()> {
-      self.builder.set_data_field::<u16>(2, 10);
+      self.builder.set_data_field::<u16>(2, 9);
       ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
     }
     #[inline]
     pub fn init_tuple(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::hugr_v0_capnp::term::seq_part::Owned> {
-      self.builder.set_data_field::<u16>(2, 10);
+      self.builder.set_data_field::<u16>(2, 9);
       ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), size)
     }
     #[inline]
     pub fn has_tuple(&self) -> bool {
-      if self.builder.get_data_field::<u16>(2) != 10 { return false; }
+      if self.builder.get_data_field::<u16>(2) != 9 { return false; }
       !self.builder.is_pointer_field_null(0)
     }
     #[inline]
@@ -3108,31 +3083,26 @@ pub mod term {
           ))
         }
         5 => {
-          ::core::result::Result::Ok(ExtSet(
-            ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-          ))
-        }
-        6 => {
           ::core::result::Result::Ok(Bytes(
             ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
           ))
         }
-        7 => {
+        6 => {
           ::core::result::Result::Ok(Float(
             self.builder.get_data_field::<f64>(1)
           ))
         }
-        8 => {
-          ::core::result::Result::Ok(ConstFunc(
+        7 => {
+          ::core::result::Result::Ok(Func(
             self.builder.get_data_field::<u32>(0)
           ))
         }
-        9 => {
+        8 => {
           ::core::result::Result::Ok(Wildcard(
             ()
           ))
         }
-        10 => {
+        9 => {
           ::core::result::Result::Ok(Tuple(
             ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
           ))
@@ -3151,109 +3121,98 @@ pub mod term {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 191] = [
+    pub static ENCODED_NODE: [::capnp::Word; 167] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(178, 107, 91, 137, 60, 121, 191, 207),
       ::capnp::word(20, 0, 0, 0, 1, 0, 2, 0),
       ::capnp::word(1, 150, 80, 40, 197, 50, 43, 224),
-      ::capnp::word(1, 0, 7, 0, 0, 0, 11, 0),
+      ::capnp::word(1, 0, 7, 0, 0, 0, 10, 0),
       ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 202, 0, 0, 0),
-      ::capnp::word(33, 0, 0, 0, 39, 0, 0, 0),
+      ::capnp::word(33, 0, 0, 0, 23, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(57, 0, 0, 0, 111, 2, 0, 0),
+      ::capnp::word(41, 0, 0, 0, 55, 2, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(99, 97, 112, 110, 112, 47, 104, 117),
       ::capnp::word(103, 114, 45, 118, 48, 46, 99, 97),
       ::capnp::word(112, 110, 112, 58, 84, 101, 114, 109),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(8, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(4, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(136, 151, 188, 135, 237, 57, 73, 141),
-      ::capnp::word(9, 0, 0, 0, 66, 0, 0, 0),
-      ::capnp::word(181, 70, 208, 39, 123, 238, 28, 216),
-      ::capnp::word(5, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 66, 0, 0, 0),
       ::capnp::word(83, 101, 113, 80, 97, 114, 116, 0),
-      ::capnp::word(69, 120, 116, 83, 101, 116, 80, 97),
-      ::capnp::word(114, 116, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(44, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(40, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 255, 255, 0, 0, 0, 0),
       ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(150, 98, 109, 181, 159, 123, 122, 222),
-      ::capnp::word(37, 1, 0, 0, 50, 0, 0, 0),
+      ::capnp::word(9, 1, 0, 0, 50, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(1, 0, 254, 255, 0, 0, 0, 0),
       ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(55, 205, 218, 56, 109, 17, 119, 134),
-      ::capnp::word(13, 1, 0, 0, 74, 0, 0, 0),
+      ::capnp::word(241, 0, 0, 0, 74, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(2, 0, 253, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 4, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(249, 0, 0, 0, 42, 0, 0, 0),
+      ::capnp::word(221, 0, 0, 0, 42, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(244, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(16, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(216, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(244, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(3, 0, 252, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 5, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(13, 1, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(241, 0, 0, 0, 58, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(8, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(20, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(236, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(248, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(4, 0, 251, 255, 1, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 6, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(17, 1, 0, 0, 34, 0, 0, 0),
+      ::capnp::word(245, 0, 0, 0, 34, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(12, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(24, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(240, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(252, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(5, 0, 250, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(21, 1, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(249, 0, 0, 0, 50, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(16, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(44, 1, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(6, 0, 249, 255, 0, 0, 0, 0),
+      ::capnp::word(244, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(0, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(6, 0, 249, 255, 1, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 8, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(41, 1, 0, 0, 50, 0, 0, 0),
+      ::capnp::word(253, 0, 0, 0, 50, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(36, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(48, 1, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(7, 0, 248, 255, 1, 0, 0, 0),
+      ::capnp::word(248, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(4, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(7, 0, 248, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 9, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(45, 1, 0, 0, 50, 0, 0, 0),
+      ::capnp::word(1, 1, 0, 0, 42, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(40, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(52, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(252, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(8, 1, 0, 0, 2, 0, 1, 0),
       ::capnp::word(8, 0, 247, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 10, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(49, 1, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(5, 1, 0, 0, 74, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(48, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(60, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(4, 1, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(16, 1, 0, 0, 2, 0, 1, 0),
       ::capnp::word(9, 0, 246, 255, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 11, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(57, 1, 0, 0, 74, 0, 0, 0),
+      ::capnp::word(13, 1, 0, 0, 50, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(56, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(68, 1, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(10, 0, 245, 255, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 1, 0, 12, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(65, 1, 0, 0, 50, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(60, 1, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(88, 1, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(8, 1, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(36, 1, 0, 0, 2, 0, 1, 0),
       ::capnp::word(97, 112, 112, 108, 121, 0, 0, 0),
       ::capnp::word(118, 97, 114, 105, 97, 98, 108, 101),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3285,18 +3244,6 @@ pub mod term {
       ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(101, 120, 116, 83, 101, 116, 0, 0),
-      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(181, 70, 208, 39, 123, 238, 28, 216),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(98, 121, 116, 101, 115, 0, 0, 0),
       ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3313,8 +3260,7 @@ pub mod term {
       ::capnp::word(11, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(99, 111, 110, 115, 116, 70, 117, 110),
-      ::capnp::word(99, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(102, 117, 110, 99, 0, 0, 0, 0),
       ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3351,12 +3297,11 @@ pub mod term {
         2 => <::capnp::struct_list::Owned<crate::hugr_v0_capnp::term::seq_part::Owned> as ::capnp::introspect::Introspect>::introspect(),
         3 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
         4 => <u64 as ::capnp::introspect::Introspect>::introspect(),
-        5 => <::capnp::struct_list::Owned<crate::hugr_v0_capnp::term::ext_set_part::Owned> as ::capnp::introspect::Introspect>::introspect(),
-        6 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
-        7 => <f64 as ::capnp::introspect::Introspect>::introspect(),
-        8 => <u32 as ::capnp::introspect::Introspect>::introspect(),
-        9 => <() as ::capnp::introspect::Introspect>::introspect(),
-        10 => <::capnp::struct_list::Owned<crate::hugr_v0_capnp::term::seq_part::Owned> as ::capnp::introspect::Introspect>::introspect(),
+        5 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
+        6 => <f64 as ::capnp::introspect::Introspect>::introspect(),
+        7 => <u32 as ::capnp::introspect::Introspect>::introspect(),
+        8 => <() as ::capnp::introspect::Introspect>::introspect(),
+        9 => <::capnp::struct_list::Owned<crate::hugr_v0_capnp::term::seq_part::Owned> as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -3370,25 +3315,24 @@ pub mod term {
       members_by_name: MEMBERS_BY_NAME,
     };
     pub static NONUNION_MEMBERS : &[u16] = &[];
-    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[0,1,2,3,4,5,6,7,8,9,10];
-    pub static MEMBERS_BY_NAME : &[u16] = &[0,6,8,5,7,2,4,3,10,1,9];
+    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[0,1,2,3,4,5,6,7,8,9];
+    pub static MEMBERS_BY_NAME : &[u16] = &[0,5,6,7,2,4,3,9,1,8];
     pub const TYPE_ID: u64 = 0xcfbf_793c_895b_6bb2;
   }
-  pub enum Which<A0,A1,A2,A3,A4,A5,A6> {
+  pub enum Which<A0,A1,A2,A3,A4,A5> {
     Apply(A0),
     Variable(A1),
     List(A2),
     String(A3),
     Nat(u64),
-    ExtSet(A4),
-    Bytes(A5),
+    Bytes(A4),
     Float(f64),
-    ConstFunc(u32),
+    Func(u32),
     Wildcard(()),
-    Tuple(A6),
+    Tuple(A5),
   }
-  pub type WhichReader<'a,> = Which<crate::hugr_v0_capnp::term::apply::Reader<'a>,crate::hugr_v0_capnp::term::variable::Reader<'a>,::capnp::Result<::capnp::struct_list::Reader<'a,crate::hugr_v0_capnp::term::seq_part::Owned>>,::capnp::Result<::capnp::text::Reader<'a>>,::capnp::Result<::capnp::struct_list::Reader<'a,crate::hugr_v0_capnp::term::ext_set_part::Owned>>,::capnp::Result<::capnp::data::Reader<'a>>,::capnp::Result<::capnp::struct_list::Reader<'a,crate::hugr_v0_capnp::term::seq_part::Owned>>>;
-  pub type WhichBuilder<'a,> = Which<crate::hugr_v0_capnp::term::apply::Builder<'a>,crate::hugr_v0_capnp::term::variable::Builder<'a>,::capnp::Result<::capnp::struct_list::Builder<'a,crate::hugr_v0_capnp::term::seq_part::Owned>>,::capnp::Result<::capnp::text::Builder<'a>>,::capnp::Result<::capnp::struct_list::Builder<'a,crate::hugr_v0_capnp::term::ext_set_part::Owned>>,::capnp::Result<::capnp::data::Builder<'a>>,::capnp::Result<::capnp::struct_list::Builder<'a,crate::hugr_v0_capnp::term::seq_part::Owned>>>;
+  pub type WhichReader<'a,> = Which<crate::hugr_v0_capnp::term::apply::Reader<'a>,crate::hugr_v0_capnp::term::variable::Reader<'a>,::capnp::Result<::capnp::struct_list::Reader<'a,crate::hugr_v0_capnp::term::seq_part::Owned>>,::capnp::Result<::capnp::text::Reader<'a>>,::capnp::Result<::capnp::data::Reader<'a>>,::capnp::Result<::capnp::struct_list::Reader<'a,crate::hugr_v0_capnp::term::seq_part::Owned>>>;
+  pub type WhichBuilder<'a,> = Which<crate::hugr_v0_capnp::term::apply::Builder<'a>,crate::hugr_v0_capnp::term::variable::Builder<'a>,::capnp::Result<::capnp::struct_list::Builder<'a,crate::hugr_v0_capnp::term::seq_part::Owned>>,::capnp::Result<::capnp::text::Builder<'a>>,::capnp::Result<::capnp::data::Builder<'a>>,::capnp::Result<::capnp::struct_list::Builder<'a,crate::hugr_v0_capnp::term::seq_part::Owned>>>;
 
   pub mod seq_part {
     pub use self::Which::{Item,Splice};
@@ -3638,272 +3582,6 @@ pub mod term {
     }
     pub type WhichReader = Which;
     pub type WhichBuilder = Which;
-  }
-
-  pub mod ext_set_part {
-    pub use self::Which::{Extension,Splice};
-
-    #[derive(Copy, Clone)]
-    pub struct Owned(());
-    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
-    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-    impl <> ::core::marker::Copy for Reader<'_,>  {}
-    impl <> ::core::clone::Clone for Reader<'_,>  {
-      fn clone(&self) -> Self { *self }
-    }
-
-    impl <> ::capnp::traits::HasTypeId for Reader<'_,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
-      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
-        Self { reader,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
-      fn from(reader: Reader<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <> ::core::fmt::Debug for Reader<'_,>  {
-      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
-        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(reader.get_struct(default)?.into())
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<'_,> {
-        Self { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      #[inline]
-      pub fn has_extension(&self) -> bool {
-        if self.reader.get_data_field::<u16>(0) != 0 { return false; }
-        !self.reader.get_pointer_field(0).is_null()
-      }
-      #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
-        match self.reader.get_data_field::<u16>(0) {
-          0 => {
-            ::core::result::Result::Ok(Extension(
-              ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
-            ))
-          }
-          1 => {
-            ::core::result::Result::Ok(Splice(
-              self.reader.get_data_field::<u32>(1)
-            ))
-          }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
-        }
-      }
-    }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 1 };
-    }
-    impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
-      const TYPE_ID: u64 = _private::TYPE_ID;
-    }
-    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
-      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
-        Self { builder,  }
-      }
-    }
-
-    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
-      fn from(builder: Builder<'a,>) -> Self {
-        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
-        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
-        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
-      }
-    }
-
-    impl <> ::capnp::traits::SetterInput<Owned<>> for Reader<'_,>  {
-      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        self.builder.into_reader().into()
-      }
-      pub fn reborrow(&mut self) -> Builder<'_,> {
-        Builder { builder: self.builder.reborrow() }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
-        self.builder.as_reader().into()
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.as_reader().total_size()
-      }
-      #[inline]
-      pub fn set_extension(&mut self, value: impl ::capnp::traits::SetterInput<::capnp::text::Owned>)  {
-        self.builder.set_data_field::<u16>(0, 0);
-        ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false).unwrap()
-      }
-      #[inline]
-      pub fn init_extension(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.set_data_field::<u16>(0, 0);
-        self.builder.get_pointer_field(0).init_text(size)
-      }
-      #[inline]
-      pub fn has_extension(&self) -> bool {
-        if self.builder.get_data_field::<u16>(0) != 0 { return false; }
-        !self.builder.is_pointer_field_null(0)
-      }
-      #[inline]
-      pub fn set_splice(&mut self, value: u32)  {
-        self.builder.set_data_field::<u16>(0, 1);
-        self.builder.set_data_field::<u32>(1, value);
-      }
-      #[inline]
-      pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
-        match self.builder.get_data_field::<u16>(0) {
-          0 => {
-            ::core::result::Result::Ok(Extension(
-              ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
-            ))
-          }
-          1 => {
-            ::core::result::Result::Ok(Splice(
-              self.builder.get_data_field::<u32>(1)
-            ))
-          }
-          x => ::core::result::Result::Err(::capnp::NotInSchema(x))
-        }
-      }
-    }
-
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
-        Self { _typeless: typeless,  }
-      }
-    }
-    impl Pipeline  {
-    }
-    mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 50] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
-        ::capnp::word(181, 70, 208, 39, 123, 238, 28, 216),
-        ::capnp::word(25, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(178, 107, 91, 137, 60, 121, 191, 207),
-        ::capnp::word(1, 0, 7, 0, 0, 0, 2, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 34, 1, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(33, 0, 0, 0, 119, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(99, 97, 112, 110, 112, 47, 104, 117),
-        ::capnp::word(103, 114, 45, 118, 48, 46, 99, 97),
-        ::capnp::word(112, 110, 112, 58, 84, 101, 114, 109),
-        ::capnp::word(46, 69, 120, 116, 83, 101, 116, 80),
-        ::capnp::word(97, 114, 116, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
-        ::capnp::word(0, 0, 255, 255, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(41, 0, 0, 0, 82, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(52, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(1, 0, 254, 255, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(49, 0, 0, 0, 58, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(44, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(56, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(101, 120, 116, 101, 110, 115, 105, 111),
-        ::capnp::word(110, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(115, 112, 108, 105, 99, 101, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ];
-      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
-        match index {
-          0 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
-          1 => <u32 as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
-        }
-      }
-      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
-      }
-      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
-        encoded_node: &ENCODED_NODE,
-        nonunion_members: NONUNION_MEMBERS,
-        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
-        members_by_name: MEMBERS_BY_NAME,
-      };
-      pub static NONUNION_MEMBERS : &[u16] = &[];
-      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[0,1];
-      pub static MEMBERS_BY_NAME : &[u16] = &[0,1];
-      pub const TYPE_ID: u64 = 0xd81c_ee7b_27d0_46b5;
-    }
-    pub enum Which<A0> {
-      Extension(A0),
-      Splice(u32),
-    }
-    pub type WhichReader<'a,> = Which<::capnp::Result<::capnp::text::Reader<'a>>>;
-    pub type WhichBuilder<'a,> = Which<::capnp::Result<::capnp::text::Builder<'a>>>;
   }
 
   pub mod apply {

--- a/hugr-model/src/v0/ast/mod.rs
+++ b/hugr-model/src/v0/ast/mod.rs
@@ -233,10 +233,6 @@ pub enum Term {
     Tuple(Arc<[SeqPart]>),
     /// Function constant.
     Func(Arc<Region>),
-    /// Extension set.
-    ///
-    /// __REMARK__: Extension sets will be removed, so this is a standin.
-    ExtSet,
 }
 
 impl From<Literal> for Term {

--- a/hugr-model/src/v0/ast/parse.rs
+++ b/hugr-model/src/v0/ast/parse.rs
@@ -80,7 +80,6 @@ fn parse_term(pair: Pair<Rule>) -> ParseResult<Term> {
             let parts = pairs.map(parse_seq_part).collect::<ParseResult<_>>()?;
             Term::Tuple(parts)
         }
-        Rule::term_ext_set => Term::ExtSet,
         Rule::literal => {
             let literal = parse_literal(pair)?;
             Term::Literal(literal)

--- a/hugr-model/src/v0/ast/print.rs
+++ b/hugr-model/src/v0/ast/print.rs
@@ -144,11 +144,6 @@ fn print_term<'a>(printer: &mut Printer<'a>, term: &'a Term) {
             print_tuple_parts(printer, tuple_parts);
             printer.parens_exit();
         }
-        Term::ExtSet => {
-            printer.parens_enter();
-            printer.text("ext");
-            printer.parens_exit();
-        }
         Term::Func(region) => {
             printer.parens_enter();
             printer.text("fn");

--- a/hugr-model/src/v0/ast/python.rs
+++ b/hugr-model/src/v0/ast/python.rs
@@ -13,7 +13,6 @@ impl<'py> pyo3::FromPyObject<'py> for Term {
 
         Ok(match name.to_str()? {
             "Wildcard" => Self::Wildcard,
-            "ExtSet" => Self::ExtSet,
             "Var" => {
                 let name = term.getattr("name")?.extract()?;
                 Self::Var(name)
@@ -84,10 +83,6 @@ impl<'py> pyo3::IntoPyObject<'py> for &Term {
             Term::Func(region) => {
                 let py_class = py_module.getattr("Func")?;
                 py_class.call1((region.as_ref(),))
-            }
-            Term::ExtSet => {
-                let py_class = py_module.getattr("ExtSet")?;
-                py_class.call0()
             }
         }
     }

--- a/hugr-model/src/v0/ast/resolve.rs
+++ b/hugr-model/src/v0/ast/resolve.rs
@@ -88,9 +88,8 @@ impl<'a> Context<'a> {
             Term::Tuple(parts) => table::Term::Tuple(self.resolve_seq_parts(parts)?),
             Term::Func(region) => {
                 let region = self.resolve_region(region, ScopeClosure::Closed)?;
-                table::Term::ConstFunc(region)
+                table::Term::Func(region)
             }
-            Term::ExtSet => table::Term::ExtSet(&[]),
         };
 
         Ok(*self

--- a/hugr-model/src/v0/ast/view.rs
+++ b/hugr-model/src/v0/ast/view.rs
@@ -14,8 +14,7 @@ impl<'a> View<'a, TermId> for Term {
                 let terms = module.view(*terms)?;
                 Term::Apply(symbol, terms)
             }
-            table::Term::ExtSet(_) => Term::ExtSet,
-            table::Term::ConstFunc(region_id) => Term::Func(Arc::new(module.view(*region_id)?)),
+            table::Term::Func(region_id) => Term::Func(Arc::new(module.view(*region_id)?)),
             table::Term::List(list_parts) => Term::List(module.view(*list_parts)?),
             table::Term::Literal(literal) => Term::Literal(literal.clone()),
             table::Term::Tuple(tuple_parts) => Term::List(module.view(*tuple_parts)?),

--- a/hugr-model/src/v0/binary/read.rs
+++ b/hugr-model/src/v0/binary/read.rs
@@ -268,17 +268,12 @@ fn read_term<'a>(bump: &'a Bump, reader: hugr_capnp::term::Reader) -> ReadResult
             table::Term::List(parts)
         }
 
-        Which::ExtSet(reader) => {
-            let parts = read_list!(bump, reader?, read_ext_set_part);
-            table::Term::ExtSet(parts)
-        }
-
         Which::Tuple(reader) => {
             let parts = read_list!(bump, reader?, read_seq_part);
             table::Term::Tuple(parts)
         }
 
-        Which::ConstFunc(region) => table::Term::ConstFunc(table::RegionId(region)),
+        Which::Func(region) => table::Term::Func(table::RegionId(region)),
 
         Which::Bytes(bytes) => table::Term::Literal(model::Literal::Bytes(bytes?.into())),
         Which::Float(value) => table::Term::Literal(model::Literal::Float(value.into())),
@@ -293,17 +288,6 @@ fn read_seq_part(
     Ok(match reader.which()? {
         Which::Item(term) => table::SeqPart::Item(table::TermId(term)),
         Which::Splice(list) => table::SeqPart::Splice(table::TermId(list)),
-    })
-}
-
-fn read_ext_set_part<'a>(
-    bump: &'a Bump,
-    reader: hugr_capnp::term::ext_set_part::Reader,
-) -> ReadResult<table::ExtSetPart<'a>> {
-    use hugr_capnp::term::ext_set_part::Which;
-    Ok(match reader.which()? {
-        Which::Extension(ext) => table::ExtSetPart::Extension(bump.alloc_str(ext?.to_str()?)),
-        Which::Splice(list) => table::ExtSetPart::Splice(table::TermId(list)),
     })
 }
 

--- a/hugr-model/src/v0/binary/write.rs
+++ b/hugr-model/src/v0/binary/write.rs
@@ -154,7 +154,7 @@ fn write_term(mut builder: hugr_capnp::term::Builder, term: &table::Term) {
             model::Literal::Float(value) => builder.set_float(value.into_inner()),
         },
 
-        table::Term::ConstFunc(region) => builder.set_const_func(region.0),
+        table::Term::Func(region) => builder.set_func(region.0),
         table::Term::Apply(symbol, args) => {
             let mut builder = builder.init_apply();
             builder.set_symbol(symbol.0);
@@ -163,10 +163,6 @@ fn write_term(mut builder: hugr_capnp::term::Builder, term: &table::Term) {
 
         table::Term::List(parts) => {
             write_list!(builder, init_list, write_seq_part, parts);
-        }
-
-        table::Term::ExtSet(parts) => {
-            write_list!(builder, init_ext_set, write_ext_set_part, parts);
         }
 
         table::Term::Tuple(parts) => {
@@ -179,15 +175,5 @@ fn write_seq_part(mut builder: hugr_capnp::term::seq_part::Builder, part: &table
     match part {
         table::SeqPart::Item(term_id) => builder.set_item(term_id.0),
         table::SeqPart::Splice(term_id) => builder.set_splice(term_id.0),
-    }
-}
-
-fn write_ext_set_part(
-    mut builder: hugr_capnp::term::ext_set_part::Builder,
-    part: &table::ExtSetPart,
-) {
-    match part {
-        table::ExtSetPart::Extension(ext) => builder.set_extension(ext),
-        table::ExtSetPart::Splice(term_id) => builder.set_splice(term_id.0),
     }
 }

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -219,7 +219,6 @@ pub const CORE_CALL: &str = "core.call";
 ///
 /// - **Parameter:** `?inputs : (core.list core.type)`
 /// - **Parameter:** `?outputs : (core.list core.type)`
-/// - **Parameter:** `?ext : core.ext_set`
 /// - **Result:** `(core.fn [(core.fn ?inputs ?outputs) ?inputs ...] ?outputs)`
 pub const CORE_CALL_INDIRECT: &str = "core.call_indirect";
 

--- a/hugr-model/src/v0/mod.rs
+++ b/hugr-model/src/v0/mod.rs
@@ -95,7 +95,6 @@ use table::LinkIndex;
 ///
 /// - **Parameter:** `?inputs : (core.list core.type)`
 /// - **Parameter:** `?outputs : (core.list core.type)`
-/// - **Parameter:** `?ext : core.ext-set`
 /// - **Result:** `core.type`
 pub const CORE_FN: &str = "core.fn";
 
@@ -175,26 +174,19 @@ pub const CORE_CTRL: &str = "core.ctrl";
 /// - **Result:** `?type : core.static`
 pub const CORE_CTRL_TYPE: &str = "core.ctrl_type";
 
-/// The type of extension sets.
-///
-/// - **Result:** `?type : core.static`
-pub const CORE_EXT_SET: &str = "core.ext_set";
-
 /// The type for runtime constants.
 ///
 /// - **Parameter:** `?type : core.type`
-/// - **Parameter:** `?ext : core.ext_set`
 /// - **Result:** `core.static`
 pub const CORE_CONST: &str = "core.const";
 
 /// Constants for runtime algebraic data types.
 ///
 /// - **Parameter:** `?variants : (core.list core.type)`
-/// - **Parameter:** `?ext : core.ext_set`
 /// - **Parameter:** `?types : (core.list core.static)`
 /// - **Parameter:** `?tag : core.nat`
 /// - **Parameter:** `?values : (core.tuple ?types)`
-/// - **Result:** `(core.const (core.adt ?variants) ?ext)`
+/// - **Result:** `(core.const (core.adt ?variants))`
 pub const CORE_CONST_ADT: &str = "core.const.adt";
 
 /// The type for lists of static data.
@@ -219,8 +211,7 @@ pub const CORE_TUPLE_TYPE: &str = "core.tuple";
 ///
 /// - **Parameter:** `?inputs : (core.list core.type)`
 /// - **Parameter:** `?outputs : (core.list core.type)`
-/// - **Parameter:** `?ext : core.ext_set`
-/// - **Parameter:** `?func : (core.const (core.fn ?inputs ?outputs ?ext) ?ext)`
+/// - **Parameter:** `?func : (core.const (core.fn ?inputs ?outputs))`
 /// - **Result:** `(core.fn ?inputs ?outputs ?ext)`
 pub const CORE_CALL: &str = "core.call";
 
@@ -229,15 +220,14 @@ pub const CORE_CALL: &str = "core.call";
 /// - **Parameter:** `?inputs : (core.list core.type)`
 /// - **Parameter:** `?outputs : (core.list core.type)`
 /// - **Parameter:** `?ext : core.ext_set`
-/// - **Result:** `(core.fn [(core.fn ?inputs ?outputs ?ext) ?inputs ...] ?outputs ?ext)`
+/// - **Result:** `(core.fn [(core.fn ?inputs ?outputs) ?inputs ...] ?outputs)`
 pub const CORE_CALL_INDIRECT: &str = "core.call_indirect";
 
 /// Operation to load a constant value.
 ///
 /// - **Parameter:** `?type : core.type`
-/// - **Parameter:** `?ext : core.ext_set`
-/// - **Parameter:** `?value : (core.const ?type ?ext)`
-/// - **Result:** `(core.fn [] [?type] ?ext)`
+/// - **Parameter:** `?value : (core.const ?type)`
+/// - **Result:** `(core.fn [] [?type])`
 pub const CORE_LOAD_CONST: &str = "core.load_const";
 
 /// Operation to create a value of an algebraic data type.
@@ -245,7 +235,7 @@ pub const CORE_LOAD_CONST: &str = "core.load_const";
 /// - **Parameter:** `?variants : (core.list (core.list core.type))`
 /// - **Parameter:** `?types : (core.list core.type)`
 /// - **Parameter:** `?tag : core.nat`
-/// - **Result:** `(core.fn ?types [(core.adt ?variants)] (ext))`
+/// - **Result:** `(core.fn ?types [(core.adt ?variants)])`
 pub const CORE_MAKE_ADT: &str = "core.make_adt";
 
 /// Constructor for documentation metadata.
@@ -272,9 +262,8 @@ pub const COMPAT_META_JSON: &str = "compat.meta_json";
 /// expressed with custom constructors.
 ///
 /// - **Parameter:** `?type : core.type`
-/// - **Parameter:** `?ext : core.ext_set`
 /// - **Parameter:** `?json : core.str`
-/// - **Result:** `(core.const ?type ?ext)`
+/// - **Result:** `(core.const ?type)`
 pub const COMPAT_CONST_JSON: &str = "compat.const_json";
 
 pub mod ast;

--- a/hugr-model/src/v0/table/mod.rs
+++ b/hugr-model/src/v0/table/mod.rs
@@ -310,15 +310,10 @@ pub enum Term<'a> {
     /// A static literal value.
     Literal(Literal),
 
-    /// Extension set.
-    ///
-    /// **Type:** `core.ext_set`
-    ExtSet(&'a [ExtSetPart<'a>]),
-
     /// A constant anonymous function.
     ///
     /// **Type:** `(core.const (core.fn ?ins ?outs ?ext) (ext))`
-    ConstFunc(RegionId),
+    Func(RegionId),
 
     /// Tuple of static data.
     ///
@@ -344,15 +339,6 @@ pub enum SeqPart {
     /// A single item.
     Item(TermId),
     /// A list to be spliced into the parent list/tuple.
-    Splice(TermId),
-}
-
-/// A part of an extension set term.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ExtSetPart<'a> {
-    /// An extension.
-    Extension(&'a str),
-    /// An extension set to be spliced into the parent extension set.
     Splice(TermId),
 }
 

--- a/hugr-model/tests/fixtures/model-add.edn
+++ b/hugr-model/tests/fixtures/model-add.edn
@@ -3,12 +3,11 @@
 (define-func example.add
   (core.fn
    [arithmetic.int.types.int arithmetic.int.types.int]
-   [arithmetic.int.types.int]
-   (ext))
+   [arithmetic.int.types.int])
   (dfg
    [%0 %1]
    [%2]
-   (signature (core.fn [arithmetic.int.types.int arithmetic.int.types.int] [arithmetic.int.types.int] (ext)))
+   (signature (core.fn [arithmetic.int.types.int arithmetic.int.types.int] [arithmetic.int.types.int]))
    (arithmetic.int.iadd
     [%0 %1] [%2]
-    (signature (core.fn [arithmetic.int.types.int arithmetic.int.types.int] [arithmetic.int.types.int] (ext))))))
+    (signature (core.fn [arithmetic.int.types.int arithmetic.int.types.int] [arithmetic.int.types.int])))))

--- a/hugr-model/tests/fixtures/model-alias.edn
+++ b/hugr-model/tests/fixtures/model-alias.edn
@@ -4,4 +4,4 @@
 
 (define-alias local.int core.type arithmetic.int.types.int)
 
-(define-alias local.endo core.type (core.fn [] [] (ext)))
+(define-alias local.endo core.type (core.fn [] []))

--- a/hugr-model/tests/fixtures/model-call.edn
+++ b/hugr-model/tests/fixtures/model-call.edn
@@ -12,7 +12,7 @@
   (meta (compat.meta_json "description" "\"This defines a function that calls the function which we declared earlier.\""))
   (dfg [%3] [%4]
        (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
-       ((core.call _ _ _ example.callee) [%3] [%4]
+       ((core.call _ _ example.callee) [%3] [%4]
                                                  (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])))))
 
 (define-func
@@ -22,4 +22,4 @@
    []
    [%5]
    (signature (core.fn [] [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])]))
-   ((core.load_const _ _ example.caller) [] [%5])))
+   ((core.load_const _ example.caller) [] [%5])))

--- a/hugr-model/tests/fixtures/model-call.edn
+++ b/hugr-model/tests/fixtures/model-call.edn
@@ -2,25 +2,24 @@
 
 (declare-func
  example.callee
- (param ?ext core.ext_set)
- (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext arithmetic.int ?ext ...))
+ (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])
  (meta (compat.meta_json "title" "\"Callee\""))
  (meta (compat.meta_json "description" "\"This is a function declaration.\"")))
 
 (define-func example.caller
-  (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext arithmetic.int))
+  (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])
   (meta (compat.meta_json "title" "\"Caller\""))
   (meta (compat.meta_json "description" "\"This defines a function that calls the function which we declared earlier.\""))
   (dfg [%3] [%4]
-       (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext)))
-       ((core.call _ _ _ (example.callee (ext))) [%3] [%4]
-                                                 (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext))))))
+       (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+       ((core.call _ _ _ example.callee) [%3] [%4]
+                                                 (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])))))
 
 (define-func
   example.load
-  (core.fn [] [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext arithmetic.int))] (ext))
+  (core.fn [] [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])])
   (dfg
    []
    [%5]
-   (signature (core.fn [] [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext arithmetic.int))] (ext)))
+   (signature (core.fn [] [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])]))
    ((core.load_const _ _ example.caller) [] [%5])))

--- a/hugr-model/tests/fixtures/model-cfg.edn
+++ b/hugr-model/tests/fixtures/model-cfg.edn
@@ -2,16 +2,16 @@
 
 (define-func example.cfg
   (param ?a core.type)
-  (core.fn [?a] [?a] (ext))
+  (core.fn [?a] [?a])
   (dfg [%0] [%1]
-       (signature (core.fn [?a] [?a] (ext)))
+       (signature (core.fn [?a] [?a]))
        (cfg [%0] [%1]
-            (signature (core.fn [?a] [?a] (ext)))
+            (signature (core.fn [?a] [?a]))
             (cfg [%2] [%4]
-                 (signature (core.fn [(core.ctrl [?a])] [(core.ctrl [?a])] (ext)))
+                 (signature (core.fn [(core.ctrl [?a])] [(core.ctrl [?a])]))
                  (block [%2] [%4 %2]
-                        (signature (core.fn [(core.ctrl [?a])] [(core.ctrl [?a]) (core.ctrl [?a])] (ext)))
+                        (signature (core.fn [(core.ctrl [?a])] [(core.ctrl [?a]) (core.ctrl [?a])]))
                         (dfg [%5] [%6]
-                             (signature (core.fn [?a] [(core.adt [[?a] [?a]])] (ext)))
+                             (signature (core.fn [?a] [(core.adt [[?a] [?a]])]))
                              ((core.make_adt _ _ 0) [%5] [%6]
-                                                    (signature (core.fn [?a] [(core.adt [[?a] [?a]])] (ext))))))))))
+                                                    (signature (core.fn [?a] [(core.adt [[?a] [?a]])])))))))))

--- a/hugr-model/tests/fixtures/model-cond.edn
+++ b/hugr-model/tests/fixtures/model-cond.edn
@@ -1,15 +1,14 @@
 (hugr 0)
 (define-func example.cond
   (core.fn [(core.adt [[] []]) arithmetic.int.types.int]
-           [arithmetic.int.types.int]
-           (ext))
+           [arithmetic.int.types.int])
   (dfg [%0 %1] [%2]
-       (signature (core.fn [(core.adt [[] []]) arithmetic.int.types.int] [arithmetic.int.types.int] (ext)))
+       (signature (core.fn [(core.adt [[] []]) arithmetic.int.types.int] [arithmetic.int.types.int]))
        (cond [%0 %1] [%2]
-             (signature (core.fn [(core.adt [[] []]) arithmetic.int.types.int] [arithmetic.int.types.int] (ext)))
+             (signature (core.fn [(core.adt [[] []]) arithmetic.int.types.int] [arithmetic.int.types.int]))
              (dfg [%3] [%3]
-                  (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext))))
+                  (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])))
              (dfg [%4] [%5]
-                  (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext)))
+                  (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
                   (arithmetic.int.ineg [%4] [%5]
-                                       (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int] (ext))))))))
+                                       (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])))))))

--- a/hugr-model/tests/fixtures/model-const.edn
+++ b/hugr-model/tests/fixtures/model-const.edn
@@ -2,21 +2,19 @@
 
 (define-func example.bools
   (core.fn []
-           [(core.adt [[] []]) (core.adt [[] []])]
-           (ext))
+           [(core.adt [[] []]) (core.adt [[] []])])
   (dfg [] [%false %true]
-       (signature (core.fn [] [(core.adt [[] []]) (core.adt [[] []])] (ext)))
-       ((core.load_const _ _ (core.const.adt _ _ _ 0 (tuple))) [] [%false]
-                                                               (signature (core.fn [] [(core.adt [[] []])] (ext))))
-       ((core.load_const _ _ (core.const.adt _ _ _ 1 (tuple))) [] [%true]
-                                                               (signature (core.fn [] [(core.adt [[] []])] (ext))))))
+       (signature (core.fn [] [(core.adt [[] []]) (core.adt [[] []])]))
+       ((core.load_const _ (core.const.adt _ _ 0 (tuple))) [] [%false]
+                                                               (signature (core.fn [] [(core.adt [[] []])])))
+       ((core.load_const _ (core.const.adt _ _ 1 (tuple))) [] [%true]
+                                                               (signature (core.fn [] [(core.adt [[] []])])))))
 
 (define-func example.make-pair
   (core.fn []
            [(core.adt
              [[(collections.array.array 5 (arithmetic.int.types.int 6))
-               arithmetic.float.types.float64]])]
-           (ext))
+               arithmetic.float.types.float64]])])
   (dfg
    [] [%0]
    (signature
@@ -24,11 +22,9 @@
      []
      [(core.adt
        [[(collections.array.array 5 (arithmetic.int.types.int 6))
-         arithmetic.float.types.float64]])]
-     (ext)))
-   ((core.load_const _ _
+         arithmetic.float.types.float64]])]))
+   ((core.load_const _
                      (core.const.adt
-                      _
                       _
                       _
                       0
@@ -47,21 +43,19 @@
       []
       [(core.adt
         [[(collections.array.array 5 (arithmetic.int.types.int 6))
-          arithmetic.float.types.float64]])]
-      (ext))))))
+          arithmetic.float.types.float64]])])))))
 
 (define-func example.f64-json
   (core.fn []
-           [arithmetic.float.types.float64]
-           (ext))
+           [arithmetic.float.types.float64])
   (dfg [] [%0 %1]
-       (signature (core.fn [] [arithmetic.float.types.float64 arithmetic.float.types.float64] (ext)))
-       ((core.load_const _ _
-                         (compat.const_json arithmetic.float.types.float64 (ext) "{\"c\":\"ConstF64\",\"v\":{\"value\":1.0}}"))
+       (signature (core.fn [] [arithmetic.float.types.float64 arithmetic.float.types.float64]))
+       ((core.load_const _
+                         (compat.const_json arithmetic.float.types.float64 "{\"c\":\"ConstF64\",\"v\":{\"value\":1.0}}"))
         [] [%0]
-        (signature (core.fn [] [arithmetic.float.types.float64] (ext))))
+        (signature (core.fn [] [arithmetic.float.types.float64])))
     ; The following const is to test that import/export can deal with unknown constants.
-       ((core.load_const _ _
-                         (compat.const_json arithmetic.float.types.float64 (ext) "{\"c\":\"ConstUnknown\",\"v\":{\"value\":1.0}}"))
+       ((core.load_const _
+                         (compat.const_json arithmetic.float.types.float64 "{\"c\":\"ConstUnknown\",\"v\":{\"value\":1.0}}"))
         [] [%1]
-        (signature (core.fn [] [arithmetic.float.types.float64] (ext))))))
+        (signature (core.fn [] [arithmetic.float.types.float64])))))

--- a/hugr-model/tests/fixtures/model-constraints.edn
+++ b/hugr-model/tests/fixtures/model-constraints.edn
@@ -4,8 +4,7 @@
               (param ?n core.nat)
               (param ?t core.type)
               (where (core.nonlinear ?t))
-              (core.fn [?t] [(collections.array.array ?n ?t)]
-                       (ext)))
+              (core.fn [?t] [(collections.array.array ?n ?t)]))
 
 (declare-func
  array.copy
@@ -15,11 +14,11 @@
  (core.fn
   [(collections.array.array ?n ?t)]
   [(collections.array.array ?n ?t)
-   (collections.array.array ?n ?t)] (ext)))
+   (collections.array.array ?n ?t)]))
 
 (define-func util.copy
   (param ?t core.type)
   (where (core.nonlinear ?t))
-  (core.fn [?t] [?t ?t] (ext))
+  (core.fn [?t] [?t ?t])
   (dfg [%0] [%0 %0]
-       (signature (core.fn [?t] [?t ?t] (ext)))))
+       (signature (core.fn [?t] [?t ?t]))))

--- a/hugr-model/tests/fixtures/model-decl-exts.edn
+++ b/hugr-model/tests/fixtures/model-decl-exts.edn
@@ -9,5 +9,5 @@
 (declare-operation array.Init
                    (param ?t core.type)
                    (param ?n core.nat)
-                   (core.fn [?t] [(array.Array ?t ?n)] (ext array))
+                   (core.fn [?t] [(array.Array ?t ?n)])
                    (meta (core.meta.description "Initialize an array of size ?n with copies of a default value.")))

--- a/hugr-model/tests/fixtures/model-lists.edn
+++ b/hugr-model/tests/fixtures/model-lists.edn
@@ -11,11 +11,9 @@
                    (param ?inputs-1 (core.list core.type))
                    (param ?outputs-0 (core.list core.type))
                    (param ?outputs-1 (core.list core.type))
-                   (param ?exts core.ext-set)
                    (core.fn
-                    [(core.fn ?inputs-0 ?outputs-0 ?exts)
-                     (core.fn ?inputs-1 ?outputs-1 ?exts)
+                    [(core.fn ?inputs-0 ?outputs-0)
+                     (core.fn ?inputs-1 ?outputs-1)
                      ?inputs-0 ...
                      ?inputs-1 ...]
-                    [?outputs-0 ... ?outputs-1 ...]
-                    ?exts))
+                    [?outputs-0 ... ?outputs-1 ...]))

--- a/hugr-model/tests/fixtures/model-loop.edn
+++ b/hugr-model/tests/fixtures/model-loop.edn
@@ -2,12 +2,12 @@
 
 (define-func example.loop
   (param ?a core.type)
-  (core.fn [?a] [?a] (ext))
+  (core.fn [?a] [?a])
   (dfg [%0] [%1]
-       (signature (core.fn [?a] [?a] (ext)))
+       (signature (core.fn [?a] [?a]))
        (tail-loop [%0] [%1]
-                  (signature (core.fn [?a] [?a] (ext)))
+                  (signature (core.fn [?a] [?a]))
                   (dfg [%2] [%3]
-                       (signature (core.fn [?a] [(core.adt [[?a] [?a]])] (ext)))
+                       (signature (core.fn [?a] [(core.adt [[?a] [?a]])]))
                        ((core.make_adt _ _ 0) [%2] [%3]
-                                              (signature (core.fn [?a] [(core.adt [[?a] [?a]])] (ext))))))))
+                                              (signature (core.fn [?a] [(core.adt [[?a] [?a]])])))))))

--- a/hugr-model/tests/fixtures/model-params.edn
+++ b/hugr-model/tests/fixtures/model-params.edn
@@ -4,6 +4,6 @@
   ; The types of the values to be swapped are passed as implicit parameters.
   (param ?a core.type)
   (param ?b core.type)
-  (core.fn [?a ?b] [?b ?a] (ext))
+  (core.fn [?a ?b] [?b ?a])
   (dfg [%a %b] [%b %a]
-       (signature (core.fn [?a ?b] [?b ?a] (ext)))))
+       (signature (core.fn [?a ?b] [?b ?a]))))

--- a/hugr-model/tests/snapshots/text__declarative_extensions.snap
+++ b/hugr-model/tests/snapshots/text__declarative_extensions.snap
@@ -11,7 +11,7 @@ expression: "roundtrip(include_str!(\"fixtures/model-decl-exts.edn\"))"
   array.Init
   (param ?t core.type)
   (param ?n core.nat)
-  (core.fn [?t] [(array.Array ?t ?n)] (ext))
+  (core.fn [?t] [(array.Array ?t ?n)])
   (meta
     (core.meta.description
       "Initialize an array of size ?n with copies of a default value.")))

--- a/hugr-py/src/hugr/model/__init__.py
+++ b/hugr-py/src/hugr/model/__init__.py
@@ -77,11 +77,6 @@ class Func(Term):
     region: "Region"
 
 
-@dataclass(frozen=True)
-class ExtSet(Term):
-    """Extension set. (deprecated)."""
-
-
 @dataclass
 class Param:
     """A parameter to a Symbol."""

--- a/hugr-py/src/hugr/model/export.py
+++ b/hugr-py/src/hugr/model/export.py
@@ -179,7 +179,6 @@ class ModelExport:
                             [
                                 model.List(input_types),
                                 model.List(output_types),
-                                model.ExtSet(),
                                 func,
                             ],
                         )
@@ -204,9 +203,7 @@ class ModelExport:
 
                 return model.Node(
                     operation=model.CustomOp(
-                        model.Apply(
-                            "core.load_const", [signature, model.ExtSet(), func]
-                        )
+                        model.Apply("core.load_const", [signature, func])
                     ),
                     signature=signature,
                     inputs=inputs,
@@ -219,7 +216,7 @@ class ModelExport:
 
                 func = model.Apply(
                     "core.fn",
-                    [model.List(input_types), model.List(output_types), model.ExtSet()],
+                    [model.List(input_types), model.List(output_types)],
                 )
 
                 signature = model.Apply(
@@ -227,7 +224,6 @@ class ModelExport:
                     [
                         model.List([func, *input_types]),
                         model.List(output_types),
-                        model.ExtSet(),
                     ],
                 )
 
@@ -238,7 +234,6 @@ class ModelExport:
                             [
                                 model.List(input_types),
                                 model.List(output_types),
-                                model.ExtSet(),
                             ],
                         )
                     ),
@@ -259,7 +254,7 @@ class ModelExport:
 
                 return model.Node(
                     operation=model.CustomOp(
-                        model.Apply("core.load_const", [type, model.ExtSet(), value])
+                        model.Apply("core.load_const", [type, value])
                     ),
                     signature=signature,
                     inputs=inputs,
@@ -310,7 +305,7 @@ class ModelExport:
 
                 signature = model.Apply(
                     "core.fn",
-                    [model.List(input_types), model.List(output_types), model.ExtSet()],
+                    [model.List(input_types), model.List(output_types)],
                 )
 
                 return model.Node(
@@ -395,7 +390,7 @@ class ModelExport:
                     if child_node is not None:
                         children.append(child_node)
 
-        signature = model.Apply("core.fn", [source_types, target_types, model.ExtSet()])
+        signature = model.Apply("core.fn", [source_types, target_types])
 
         return model.Region(
             kind=model.RegionKind.DATA_FLOW,
@@ -446,7 +441,7 @@ class ModelExport:
             error = f"CFG {node} has no entry block."
             raise ValueError(error)
 
-        signature = model.Apply("core.fn", [source_types, target_types, model.ExtSet()])
+        signature = model.Apply("core.fn", [source_types, target_types])
 
         return model.Region(
             kind=model.RegionKind.CONTROL_FLOW,

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -199,7 +199,8 @@ class ExtensionsParam(TypeParam):
         return "Extensions"
 
     def to_model(self) -> model.Term:
-        return model.Apply("core.ext_set")
+        # Since extension sets will be deprecated, this is just a placeholder.
+        return model.Apply("compat.ext_set_type")
 
 
 # ------------------------------------------
@@ -293,7 +294,7 @@ class ExtensionsArg(TypeArg):
 
     def to_model(self) -> model.Term:
         # Since extension sets will be deprecated, this is just a placeholder.
-        return model.ExtSet()
+        return model.Apply("compat.ext_set")
 
 
 @dataclass(frozen=True)
@@ -585,8 +586,7 @@ class FunctionType(Type):
     def to_model(self) -> model.Term:
         inputs = model.List([input.to_model() for input in self.input])
         outputs = model.List([output.to_model() for output in self.output])
-        exts = model.ExtSet()
-        return model.Apply("core.fn", [inputs, outputs, exts])
+        return model.Apply("core.fn", [inputs, outputs])
 
 
 @dataclass(frozen=True)

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -93,7 +93,6 @@ class Sum(Value):
             "core.const.adt",
             [
                 model.List(variants),
-                model.ExtSet(),
                 model.List(types),
                 model.Literal(self.tag),
                 model.Tuple(values),
@@ -333,9 +332,7 @@ class Extension(Value):
     def to_model(self) -> model.Term:
         type = cast(model.Term, self.typ.to_model())
         json = sops.CustomConst(c=self.name, v=self.val).model_dump_json()
-        return model.Apply(
-            "compat.const_json", [type, model.ExtSet(), model.Literal(json)]
-        )
+        return model.Apply("compat.const_json", [type, model.Literal(json)])
 
 
 class ExtensionValue(Value, Protocol):


### PR DESCRIPTION
This PR removes extension sets from `hugr-model` (see #1906). `hugr-core` or `hugr-py` continue to have extension sets for now, but those are ignored by export and imported as empty. This is important to integrate before stabilising `hugr-model`, since it changes the arity of various core constructors and operations (such as `core.fn` and `core.call`).