### PR TITLE
chore: Fix lints coming in rust 1.86

### DIFF
--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -6,10 +6,10 @@
 //! the following builders:
 //!
 //! - [ModuleBuilder]: For building a module with function declarations and
-//!       definitions.
+//!   definitions.
 //! - [DFGBuilder]: For building a dataflow graph.
 //! - [FunctionBuilder]: A `DFGBuilder` specialised in defining functions with a
-//!       dataflow graph.
+//!   dataflow graph.
 //! - [CFGBuilder]: For building a control flow graph.
 //! - [ConditionalBuilder]: For building a conditional node.
 //! - [TailLoopBuilder]: For building a tail-loop node.

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -196,7 +196,7 @@ impl FunctionBuilder<Hugr> {
         // Update the builder metadata
         self.0.num_in_wires += 1;
 
-        self.input_wires().last().unwrap()
+        self.input_wires().next_back().unwrap()
     }
 
     /// Add a new output to the function being constructed.

--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -59,7 +59,7 @@ use crate::import::ImportError;
 /// Parameters:
 /// - `reader`: The reader to read the envelope from.
 /// - `registry`: An extension registry with additional extensions to use when
-///     decoding the HUGR, if they are not already included in the package.
+///   decoding the HUGR, if they are not already included in the package.
 pub fn read_envelope(
     mut reader: impl BufRead,
     registry: &ExtensionRegistry,

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -206,8 +206,8 @@ impl Hugr {
     /// # Parameters
     ///
     /// - `extensions`: The extension set considered when resolving opaque
-    ///     operations and types. The original Hugr's internal extension
-    ///     registry is ignored and replaced with the newly computed one.
+    ///   operations and types. The original Hugr's internal extension
+    ///   registry is ignored and replaced with the newly computed one.
     ///
     /// # Errors
     ///

--- a/hugr-passes/src/monomorphize.rs
+++ b/hugr-passes/src/monomorphize.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 /// * then the original polymorphic [FuncDefn]s are left untouched (including Calls inside them)
 ///     - [crate::remove_dead_funcs] can be used when no other Hugr will be linked in that might instantiate these
 /// * else, the originals are removed (they are invisible from outside the Hugr); however, note
-///     that this behaviour is expected to change in a future release to match Module-rooted Hugrs.
+///   that this behaviour is expected to change in a future release to match Module-rooted Hugrs.
 ///
 /// If the Hugr is [FuncDefn](OpType::FuncDefn)-rooted with polymorphic
 /// signature then the HUGR will not be modified.

--- a/hugr-passes/src/nest_cfgs.rs
+++ b/hugr-passes/src/nest_cfgs.rs
@@ -13,14 +13,14 @@
 //!    *a and b are cycle-equivalent in the CFG with an extra edge from the exit node to the entry*
 //!    where cycle-equivalent means every cycle has either both a and b, or neither
 //! 2. cycle equivalence is unaffected if all edges are considered *un*directed
-//!     (not obvious, see paper for proof)
+//!    (not obvious, see paper for proof)
 //! 3. take undirected CFG, perform depth-first traversal
-//!     => all edges are either *tree edges*, or *backedges* where one endpoint is an ancestor of the other
+//!    => all edges are either *tree edges*, or *backedges* where one endpoint is an ancestor of the other
 //! 4. identify the "bracketlist" of each tree edge - the set of backedges going from a descendant of that edge to an ancestor
-//!     -- post-order traversal, merging bracketlists of children,
-//!            then delete backedges from below to here, add backedges from here to above
-//!     => tree edges with the same bracketlist are cycle-equivalent;
-//!        + a tree edge with a single-element bracketlist is cycle-equivalent with that single element
+//!    - post-order traversal, merging bracketlists of children,
+//!      then delete backedges from below to here, add backedges from here to above
+//!    - tree edges with the same bracketlist are cycle-equivalent;
+//!    + a tree edge with a single-element bracketlist is cycle-equivalent with that single element
 //! 5. this would be expensive (comparing large sets of backedges) - so to optimize,
 //!     - the backedge most recently added (at the top) of the bracketlist, plus the size of the bracketlist,
 //!       is sufficient to identify the set *when the UDFS tree is linear*;

--- a/uv.lock
+++ b/uv.lock
@@ -276,7 +276,7 @@ wheels = [
 
 [[package]]
 name = "hugr"
-version = "0.11.3"
+version = "0.11.4"
 source = { editable = "hugr-py" }
 dependencies = [
     { name = "graphviz" },


### PR DESCRIPTION
It's rust release week!

New lint warnings checked with `rustup override set beta`.
It's mostly `doc_overindented_list_items` and a case of `Iterator::last` called where `DoubleEndedIterator::next_back` could be used instead.