### PR TITLE
feat!: Mark all Error enums as non_exhaustive

### DIFF
--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -378,6 +378,7 @@ pub static EMPTY_REG: ExtensionRegistry = ExtensionRegistry {
 /// TODO: decide on failure modes
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum SignatureError {
     /// Name mismatch
     #[error("Definition name ({0}) and instantiation name ({1}) do not match.")]

--- a/hugr-core/src/hugr/serialize/upgrade.rs
+++ b/hugr-core/src/hugr/serialize/upgrade.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum UpgradeError {
     #[error(transparent)]
     Deserialize(#[from] serde_json::Error),

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -35,6 +35,7 @@ use thiserror::Error;
 
 /// Error during import.
 #[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum ImportError {
     /// The model contains a feature that is not supported by the importer yet.
     /// Errors of this kind are expected to be removed as the model format and
@@ -75,6 +76,7 @@ pub enum ImportError {
 
 /// Import error caused by incorrect order hints.
 #[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum OrderHintError {
     /// Duplicate order hint key in the same region.
     #[error("duplicate order hint key {0}")]

--- a/hugr-model/src/v0/ast/resolve.rs
+++ b/hugr-model/src/v0/ast/resolve.rs
@@ -362,6 +362,7 @@ impl<'a> Context<'a> {
 
 /// Error that may occur in [`Module::resolve`].
 #[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum ResolveError {
     /// Unknown variable.
     #[error("unknown var: {0}")]

--- a/hugr-model/src/v0/table/mod.rs
+++ b/hugr-model/src/v0/table/mod.rs
@@ -456,6 +456,7 @@ pub struct VarId(pub NodeId, pub VarIndex);
 
 /// Errors that can occur when traversing and interpreting the model.
 #[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum ModelError {
     /// There is a reference to a node that does not exist.
     #[error("node not found: {0}")]

--- a/hugr-passes/src/lower.rs
+++ b/hugr-passes/src/lower.rs
@@ -35,6 +35,7 @@ pub fn replace_many_ops<S: Into<OpType>>(
 /// Errors produced by the [`lower_ops`] function.
 #[derive(Debug, Error)]
 #[error(transparent)]
+#[non_exhaustive]
 pub enum LowerError {
     /// Invalid subgraph.
     #[error("Subgraph formed by node is invalid: {0}")]

--- a/hugr-passes/src/non_local.rs
+++ b/hugr-passes/src/non_local.rs
@@ -23,6 +23,7 @@ pub fn nonlocal_edges<H: HugrView>(hugr: &H) -> impl Iterator<Item = (H::Node, I
 }
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum NonLocalEdgesError<N> {
     #[error("Found {} nonlocal edges", .0.len())]
     Edges(Vec<(N, IncomingPort)>),

--- a/hugr-passes/src/replace_types/linearize.rs
+++ b/hugr-passes/src/replace_types/linearize.rs
@@ -127,6 +127,7 @@ pub struct CallbackHandler<'a>(#[allow(dead_code)] &'a DelegatingLinearizer);
 
 #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum LinearizeError {
     #[error("Need copy/discard op for {_0}")]
     NeedCopyDiscard(Type),

--- a/hugr-passes/src/validation.rs
+++ b/hugr-passes/src/validation.rs
@@ -25,6 +25,7 @@ pub enum ValidationLevel {
 
 #[derive(Error, Debug, PartialEq)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum ValidatePassError {
     #[error("Failed to validate input HUGR: {err}\n{pretty_hugr}")]
     InputError {


### PR DESCRIPTION
#2027 ended up being breaking due to adding a new variant to an error enum missing the `non_exhaustive` marker.

This (breaking) PR makes sure all error enums have the flag.

BREAKING CHANGE: Marked all Error enums as `non_exhaustive`