### PR TITLE
feat: Export the portgraph hierarchy in HugrInternals

### DIFF
--- a/hugr-core/src/hugr/internal.rs
+++ b/hugr-core/src/hugr/internal.rs
@@ -32,6 +32,12 @@ pub trait HugrInternals {
     /// Returns a reference to the underlying portgraph.
     fn portgraph(&self) -> Self::Portgraph<'_>;
 
+    /// Returns the portgraph [Hierarchy](portgraph::Hierarchy) of the graph
+    /// returned by [`HugrInternals::portgraph`].
+    fn hierarchy(&self) -> Cow<'_, portgraph::Hierarchy> {
+        Cow::Borrowed(&self.base_hugr().hierarchy)
+    }
+
     /// Returns the Hugr at the base of a chain of views.
     fn base_hugr(&self) -> &Hugr;
 


### PR DESCRIPTION
Currently external packages can query the hugr's portgraph, but they cannot access the associated hierarchy.

This non-breaking change adds a default-implemented method to `HugrInternals` that returns it. It returns a `Cow` instead of a straight reference, that can be used for more exotic hugr wrappers.

See the `base_hugr` refactoring issue for more discussion: https://github.com/CQCL/hugr/issues/1926