### PR TITLE
feat: Introduce new enum for constant folding; deprecate Value::Function

### DIFF
--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -34,7 +34,7 @@ pub mod resolution;
 pub mod simple_op;
 mod type_def;
 
-pub use const_fold::{fold_out_row, ConstFold, ConstFoldResult, Folder};
+pub use const_fold::{fold_out_row, ConstFold, ConstFoldResult, FoldVal, Folder};
 pub use op_def::{
     CustomSignatureFunc, CustomValidator, LowerFunc, OpDef, SignatureFromArgs, SignatureFunc,
     ValidateJustArgs, ValidateTypeArgs,

--- a/hugr-core/src/extension/const_fold.rs
+++ b/hugr-core/src/extension/const_fold.rs
@@ -101,9 +101,10 @@ pub trait ConstFold: Send + Sync {
     ///
     /// Defaults to calling [Self::fold] with those arguments that can be converted ---
     /// [FoldVal::LoadedFunction]s will be lost as these are not representable as [Value]s.
-    fn fold2(&self, type_args: &[TypeArg], inputs: Vec<FoldVal>, outputs: &mut [FoldVal]) {
+    fn fold2(&self, type_args: &[TypeArg], inputs: &[FoldVal], outputs: &mut [FoldVal]) {
         let consts = inputs
-            .into_iter()
+            .iter()
+            .cloned()
             .enumerate()
             .filter_map(|(p, fv)| Some((p.into(), fv.try_into().ok()?)))
             .collect::<Vec<_>>();

--- a/hugr-core/src/extension/const_fold.rs
+++ b/hugr-core/src/extension/const_fold.rs
@@ -2,6 +2,7 @@ use std::fmt::Formatter;
 
 use std::fmt::Debug;
 
+use crate::ops::constant::CustomConst;
 use crate::ops::constant::{OpaqueValue, Sum};
 use crate::ops::Value;
 use crate::types::{SumType, TypeArg};
@@ -10,7 +11,7 @@ use crate::{IncomingPort, Node, OutgoingPort, PortIndex};
 /// Representation of values used for constant folding.
 // Should we be non-exhaustive??
 // No point in parametrizing by HugrNode since then ConstFold would not be dyn/object-safe
-#[derive(Clone, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub enum FoldVal {
     /// Value is unknown, must assume that it could be anything
     #[default]
@@ -29,6 +30,52 @@ pub enum FoldVal {
     Extension(OpaqueValue),
     /// A function pointer loaded from a [FuncDefn](crate::ops::FuncDefn) or `FuncDecl`
     LoadedFunction(Node, Vec<TypeArg>), // Deliberately skipping Function(Box<Hugr>) ATM
+}
+
+impl<T> From<T> for FoldVal
+where
+    T: CustomConst,
+{
+    fn from(value: T) -> Self {
+        Self::Extension(value.into())
+    }
+}
+
+impl FoldVal {
+    /// Returns a constant "false" value, i.e. the first variant of Sum((), ()).
+    pub const fn false_val() -> Self {
+        Self::Sum {
+            tag: 0,
+            sum_type: SumType::Unit { size: 2 },
+            items: vec![],
+        }
+    }
+
+    /// Returns a constant "true" value, i.e. the second variant of Sum((), ()).
+    pub const fn true_val() -> Self {
+        Self::Sum {
+            tag: 1,
+            sum_type: SumType::Unit { size: 2 },
+            items: vec![],
+        }
+    }
+
+    /// Returns a constant boolean - either [Self::false_val] or [Self::true_val]
+    pub const fn from_bool(b: bool) -> Self {
+        if b {
+            Self::true_val()
+        } else {
+            Self::false_val()
+        }
+    }
+
+    /// Extract the specified type of [CustomConst] fro this instance, if it is one
+    pub fn get_custom_value<T: CustomConst>(&self) -> Option<&T> {
+        let Self::Extension(e) = self else {
+            return None;
+        };
+        e.value().downcast_ref()
+    }
 }
 
 impl TryFrom<FoldVal> for Value {
@@ -108,6 +155,7 @@ pub trait ConstFold: Send + Sync {
             .enumerate()
             .filter_map(|(p, fv)| Some((p.into(), fv.try_into().ok()?)))
             .collect::<Vec<_>>();
+        #[allow(deprecated)] // remove this when fold is removed
         let outs = self.fold(type_args, &consts);
         for (p, v) in outs.unwrap_or_default() {
             outputs[p.index()] = v.into();
@@ -117,6 +165,7 @@ pub trait ConstFold: Send + Sync {
     /// Given type arguments `type_args` and
     /// [`crate::ops::Const`] values for inputs at [`crate::IncomingPort`]s,
     /// try to evaluate the operation.
+    #[deprecated(note = "Use fold2")]
     fn fold(
         &self,
         type_args: &[TypeArg],

--- a/hugr-core/src/extension/const_fold.rs
+++ b/hugr-core/src/extension/const_fold.rs
@@ -2,18 +2,87 @@ use std::fmt::Formatter;
 
 use std::fmt::Debug;
 
+use crate::ops::constant::{OpaqueValue, Sum};
 use crate::ops::Value;
-use crate::types::TypeArg;
+use crate::types::{SumType, TypeArg};
+use crate::{IncomingPort, Node, OutgoingPort, PortIndex};
 
-use crate::IncomingPort;
-use crate::OutgoingPort;
+/// Representation of values used for constant folding.
+// Should we be non-exhaustive??
+// No point in parametrizing by HugrNode since then ConstFold would not be dyn/object-safe
+#[derive(Clone, PartialEq, Default)]
+pub enum FoldVal {
+    /// Value is unknown, must assume that it could be anything
+    #[default]
+    Unknown,
+    /// A variant of a [SumType]
+    Sum {
+        /// Which variant of the sum type this value is.
+        tag: usize,
+        /// Describes the type of the whole value.
+        // Can we deprecate this immediately? It is only for converting to Value
+        sum_type: SumType,
+        /// A value for each element (type) within the variant
+        items: Vec<FoldVal>,
+    },
+    /// A constant value defined by an extension
+    Extension(OpaqueValue),
+    /// A function pointer loaded from a [FuncDefn](crate::ops::FuncDefn) or `FuncDecl`
+    LoadedFunction(Node, Vec<TypeArg>), // Deliberately skipping Function(Box<Hugr>) ATM
+}
 
-use crate::ops;
+impl TryFrom<FoldVal> for Value {
+    type Error = Option<Node>;
+
+    fn try_from(value: FoldVal) -> Result<Self, Self::Error> {
+        match value {
+            FoldVal::Unknown => Err(None),
+            FoldVal::Sum {
+                tag,
+                sum_type,
+                items,
+            } => {
+                let values = items
+                    .into_iter()
+                    .map(Value::try_from)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Value::Sum(Sum {
+                    tag,
+                    values,
+                    sum_type,
+                }))
+            }
+            FoldVal::Extension(e) => Ok(Value::Extension { e }),
+            FoldVal::LoadedFunction(node, _) => Err(Some(node)),
+        }
+    }
+}
+
+impl From<Value> for FoldVal {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Extension { e } => FoldVal::Extension(e),
+            Value::Function { .. } => FoldVal::Unknown,
+            Value::Sum(Sum {
+                tag,
+                values,
+                sum_type,
+            }) => {
+                let items = values.into_iter().map(FoldVal::from).collect();
+                FoldVal::Sum {
+                    tag,
+                    sum_type,
+                    items,
+                }
+            }
+        }
+    }
+}
 
 /// Output of constant folding an operation, None indicates folding was either
 /// not possible or unsuccessful. An empty vector indicates folding was
 /// successful and no values are output.
-pub type ConstFoldResult = Option<Vec<(OutgoingPort, ops::Value)>>;
+pub type ConstFoldResult = Option<Vec<(OutgoingPort, Value)>>;
 
 /// Tag some output constants with [`OutgoingPort`] inferred from the ordering.
 pub fn fold_out_row(consts: impl IntoIterator<Item = Value>) -> ConstFoldResult {
@@ -27,6 +96,23 @@ pub fn fold_out_row(consts: impl IntoIterator<Item = Value>) -> ConstFoldResult 
 
 /// Trait implemented by extension operations that can perform constant folding.
 pub trait ConstFold: Send + Sync {
+    /// Given type arguments `type_args` and [`FoldVal`]s for each input,
+    /// update the outputs (these will be initialized to [FoldVal::Unknown]).
+    ///
+    /// Defaults to calling [Self::fold] with those arguments that can be converted ---
+    /// [FoldVal::LoadedFunction]s will be lost as these are not representable as [Value]s.
+    fn fold2(&self, type_args: &[TypeArg], inputs: Vec<FoldVal>, outputs: &mut [FoldVal]) {
+        let consts = inputs
+            .into_iter()
+            .enumerate()
+            .filter_map(|(p, fv)| Some((p.into(), fv.try_into().ok()?)))
+            .collect::<Vec<_>>();
+        let outs = self.fold(type_args, &consts);
+        for (p, v) in outs.unwrap_or_default() {
+            outputs[p.index()] = v.into();
+        }
+    }
+
     /// Given type arguments `type_args` and
     /// [`crate::ops::Const`] values for inputs at [`crate::IncomingPort`]s,
     /// try to evaluate the operation.

--- a/hugr-core/src/extension/const_fold.rs
+++ b/hugr-core/src/extension/const_fold.rs
@@ -109,6 +109,7 @@ impl From<Value> for FoldVal {
     fn from(value: Value) -> Self {
         match value {
             Value::Extension { e } => FoldVal::Extension(e),
+            #[allow(deprecated)] // remove when Value::Function removed
             Value::Function { .. } => FoldVal::Unknown,
             Value::Sum(Sum {
                 tag,

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -472,7 +472,7 @@ impl OpDef {
     pub fn constant_fold2(
         &self,
         type_args: &[TypeArg],
-        inputs: Vec<FoldVal>,
+        inputs: &[FoldVal],
         outputs: &mut [FoldVal],
     ) {
         if let Some(cf) = self.constant_folder.as_ref() {

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -458,11 +458,13 @@ impl OpDef {
 
     /// Evaluate an instance of this [`OpDef`] defined by the `type_args`, given
     /// [`crate::ops::Const`] values for inputs at [`crate::IncomingPort`]s.
+    #[deprecated(note = "use constant_fold2")]
     pub fn constant_fold(
         &self,
         type_args: &[TypeArg],
         consts: &[(IncomingPort, Value)],
     ) -> ConstFoldResult {
+        #[allow(deprecated)] // we are in deprecated function, remove at same time
         (self.constant_folder.as_ref())?.fold(type_args, consts)
     }
 

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -4,15 +4,16 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Weak};
 
+use super::const_fold::FoldVal;
 use super::{
     ConstFold, ConstFoldResult, Extension, ExtensionBuildError, ExtensionId, ExtensionSet,
     SignatureError,
 };
 
-use crate::ops::{OpName, OpNameRef};
+use crate::ops::{OpName, OpNameRef, Value};
 use crate::types::type_param::{check_type_args, TypeArg, TypeParam};
 use crate::types::{FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature};
-use crate::Hugr;
+use crate::{Hugr, IncomingPort};
 mod serialize_signature_func;
 
 /// Trait necessary for binary computations of OpDef signature
@@ -460,9 +461,23 @@ impl OpDef {
     pub fn constant_fold(
         &self,
         type_args: &[TypeArg],
-        consts: &[(crate::IncomingPort, crate::ops::Value)],
+        consts: &[(IncomingPort, Value)],
     ) -> ConstFoldResult {
         (self.constant_folder.as_ref())?.fold(type_args, consts)
+    }
+
+    /// Evaluate an instance of this [`OpDef`] defined by the `type_args`, given
+    /// [FoldVal] values for each input, and update the outputs, which should be
+    /// initialised to [FoldVal::Unknown].
+    pub fn constant_fold2(
+        &self,
+        type_args: &[TypeArg],
+        inputs: Vec<FoldVal>,
+        outputs: &mut [FoldVal],
+    ) {
+        if let Some(cf) = self.constant_folder.as_ref() {
+            cf.fold2(type_args, inputs, outputs)
+        }
     }
 
     /// Returns a reference to the signature function of this [`OpDef`].

--- a/hugr-core/src/extension/prelude/generic.rs
+++ b/hugr-core/src/extension/prelude/generic.rs
@@ -169,11 +169,14 @@ impl HasConcrete for LoadNatDef {
 mod tests {
     use crate::{
         builder::{inout_sig, DFGBuilder, Dataflow, DataflowHugr},
-        extension::prelude::{usize_t, ConstUsize},
-        ops::{constant, OpType},
+        extension::{
+            prelude::{usize_t, ConstUsize},
+            FoldVal,
+        },
+        ops::OpType,
         type_row,
         types::TypeArg,
-        HugrView, OutgoingPort,
+        HugrView,
     };
 
     use super::LoadNat;
@@ -209,10 +212,10 @@ mod tests {
 
         match optype {
             OpType::ExtensionOp(ext_op) => {
-                let result = ext_op.constant_fold(&[]);
-                let exp_port: OutgoingPort = 0.into();
-                let exp_val: constant::Value = ConstUsize::new(5).into();
-                assert_eq!(result, Some(vec![(exp_port, exp_val)]))
+                let mut out = [FoldVal::Unknown];
+                ext_op.constant_fold2(&[], &mut out);
+                let exp_val: FoldVal = ConstUsize::new(5).into();
+                assert_eq!(out, [exp_val])
             }
             _ => panic!(),
         }

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -245,6 +245,7 @@ fn collect_value_exts(
             let typ = e.get_type();
             collect_type_exts(&typ, used_extensions, missing_extensions);
         }
+        #[allow(deprecated)] // remove when Value::Function removed
         Value::Function { hugr: _ } => {
             // The extensions used by nested hugrs do not need to be counted for the root hugr.
         }

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -249,6 +249,7 @@ pub(super) fn resolve_value_exts(
                 });
             }
         }
+        #[allow(deprecated)] // remove when Value::Function removed
         Value::Function { hugr } => {
             // We don't need to add the nested hugr's extensions to the main one here,
             // but we run resolution on it independently.

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -476,6 +476,7 @@ fn roundtrip_sumtype(#[case] sum_type: SumType) {
 #[case(Value::extension(ConstInt::new_u(2,1).unwrap()))]
 #[case(Value::sum(1,[Value::extension(ConstInt::new_u(2,1).unwrap())], SumType::new([vec![], vec![INT_TYPES[2].clone()]])).unwrap())]
 #[case(Value::tuple([Value::false_val(), Value::extension(ConstInt::new_s(2,1).unwrap())]))]
+#[allow(deprecated)] // remove when Value::Function removed
 #[case(Value::function(crate::builder::test::simple_dfg_hugr()).unwrap())]
 fn roundtrip_value(#[case] value: Value) {
     check_testing_roundtrip(value);
@@ -538,6 +539,7 @@ fn roundtrip_polyfunctype_varlen(#[case] poly_func_type: PolyFuncTypeRV) {
 #[case(ops::AliasDefn { name: "aliasdefn".into(), definition: Type::new_unit_sum(4)})]
 #[case(ops::AliasDecl { name: "aliasdecl".into(), bound: TypeBound::Any})]
 #[case(ops::Const::new(Value::false_val()))]
+#[allow(deprecated)] // remove when Value::Function removed
 #[case(ops::Const::new(Value::function(crate::builder::test::simple_dfg_hugr()).unwrap()))]
 #[case(ops::Input::new(vec![Type::new_var_use(3,TypeBound::Copyable)]))]
 #[case(ops::Output::new(vec![Type::new_function(FuncValueType::new_endo(type_row![]))]))]

--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -197,28 +197,35 @@ impl From<Sum> for SerialSum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "v")]
-/// A value that can be stored as a static constant. Representing core types and
-/// extension types.
-pub enum Value {
-    /// An extension constant value, that can check it is of a given [CustomType].
-    Extension {
-        #[serde(flatten)]
-        /// The custom constant value.
-        e: OpaqueValue,
-    },
-    /// A higher-order function value.
-    // TODO use a root parametrised hugr, e.g. Hugr<DFG>.
-    Function {
-        /// A Hugr defining the function.
-        hugr: Box<Hugr>,
-    },
-    /// A Sum variant, with a tag indicating the index of the variant and its
-    /// value.
-    #[serde(alias = "Tuple")]
-    Sum(Sum),
+mod inner {
+    #![allow(deprecated)] // serde-generated code refers to the deprecated Value::Function
+
+    use super::{Hugr, OpaqueValue, Sum};
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+    #[serde(tag = "v")]
+    /// A value that can be stored as a static constant. Representing core types and
+    /// extension types.
+    pub enum Value {
+        /// An extension constant value, that can check it is of a given [CustomType].
+        Extension {
+            #[serde(flatten)]
+            /// The custom constant value.
+            e: OpaqueValue,
+        },
+        /// A higher-order function value.
+        // TODO use a root parametrised hugr, e.g. Hugr<DFG>.
+        #[deprecated(note = "Flatten and lift contents to a FuncDefn")]
+        Function {
+            /// A Hugr defining the function.
+            hugr: Box<Hugr>,
+        },
+        /// A Sum variant, with a tag indicating the index of the variant and its
+        /// value.
+        #[serde(alias = "Tuple")]
+        Sum(Sum),
+    }
 }
+pub use inner::Value;
 
 /// An opaque newtype around a [`Box<dyn CustomConst>`](CustomConst).
 ///
@@ -382,6 +389,7 @@ impl Value {
         match self {
             Self::Extension { e } => e.get_type(),
             Self::Sum(Sum { sum_type, .. }) => sum_type.clone().into(),
+            #[allow(deprecated)] // remove when Value::Function removed
             Self::Function { hugr } => {
                 let func_type = mono_fn_type(hugr).unwrap_or_else(|e| panic!("{}", e));
                 Type::new_function(func_type.into_owned())
@@ -419,9 +427,11 @@ impl Value {
     /// # Errors
     ///
     /// Returns an error if the Hugr root node does not define a function.
+    #[deprecated(note = "Flatten and lift contents to a FuncDefn")]
     pub fn function(hugr: impl Into<Hugr>) -> Result<Self, ConstTypeError> {
         let hugr = hugr.into();
         mono_fn_type(&hugr)?;
+        #[allow(deprecated)] // In deprecated function, remove at same time
         Ok(Self::Function {
             hugr: Box::new(hugr),
         })
@@ -501,6 +511,7 @@ impl Value {
     fn name(&self) -> OpName {
         match self {
             Self::Extension { e } => format!("const:custom:{}", e.name()),
+            #[allow(deprecated)] // remove when Value::Function removed
             Self::Function { hugr: h } => {
                 let Ok(t) = mono_fn_type(h) else {
                     panic!("HUGR root node isn't a valid function parent.");
@@ -527,6 +538,7 @@ impl Value {
     pub fn extension_reqs(&self) -> ExtensionSet {
         match self {
             Self::Extension { e } => e.extension_reqs().clone(),
+            #[allow(deprecated)] // remove when Value::Function removed
             Self::Function { .. } => ExtensionSet::new(), // no extensions required to load Hugr (only to run)
             Self::Sum(Sum { values, .. }) => {
                 ExtensionSet::union_over(values.iter().map(|x| x.extension_reqs()))
@@ -538,6 +550,7 @@ impl Value {
     pub fn validate(&self) -> Result<(), ConstTypeError> {
         match self {
             Self::Extension { e } => Ok(e.value().validate()?),
+            #[allow(deprecated)] // remove when Value::Function removed
             Self::Function { hugr } => {
                 mono_fn_type(hugr)?;
                 Ok(())
@@ -568,6 +581,7 @@ impl Value {
     pub fn try_hash<H: Hasher>(&self, st: &mut H) -> bool {
         match self {
             Value::Extension { e } => e.value().try_hash(&mut *st),
+            #[allow(deprecated)] // remove when Value::Function removed
             Value::Function { .. } => false,
             Value::Sum(s) => s.try_hash(st),
         }
@@ -740,6 +754,7 @@ pub(crate) mod test {
         );
     }
 
+    #[allow(deprecated)] // remove when Value::Function removed
     #[rstest]
     fn function_value(simple_dfg_hugr: Hugr) {
         let v = Value::function(simple_dfg_hugr).unwrap();
@@ -944,10 +959,8 @@ pub(crate) mod test {
             type Strategy = BoxedStrategy<Self>;
             fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
                 use ::proptest::collection::vec;
-                let leaf_strat = prop_oneof![
-                    any::<OpaqueValue>().prop_map(|e| Self::Extension { e }),
-                    crate::proptest::any_hugr().prop_map(|x| Value::function(x).unwrap())
-                ];
+                let leaf_strat = any::<OpaqueValue>().prop_map(|e| Self::Extension { e });
+
                 leaf_strat
                     .prop_recursive(
                         3,  // No more than 3 branch levels deep

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -97,7 +97,7 @@ impl ExtensionOp {
     }
 
     /// Attempt to evaluate this operation, See ['OpDef::constant_fold2`]
-    pub fn constant_fold2(&self, inputs: Vec<FoldVal>, outputs: &mut [FoldVal]) {
+    pub fn constant_fold2(&self, inputs: &[FoldVal], outputs: &mut [FoldVal]) {
         self.def().constant_fold2(self.args(), inputs, outputs)
     }
 

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -12,7 +12,7 @@ use {
     ::proptest_derive::Arbitrary,
 };
 
-use crate::extension::{ConstFoldResult, ExtensionId, OpDef, SignatureError};
+use crate::extension::{ConstFoldResult, ExtensionId, FoldVal, OpDef, SignatureError};
 use crate::types::{type_param::TypeArg, Signature};
 use crate::{ops, IncomingPort, Node};
 
@@ -94,6 +94,11 @@ impl ExtensionOp {
     /// Attempt to evaluate this operation. See [`OpDef::constant_fold`].
     pub fn constant_fold(&self, consts: &[(IncomingPort, ops::Value)]) -> ConstFoldResult {
         self.def().constant_fold(self.args(), consts)
+    }
+
+    /// Attempt to evaluate this operation, See ['OpDef::constant_fold2`]
+    pub fn constant_fold2(&self, inputs: Vec<FoldVal>, outputs: &mut [FoldVal]) {
+        self.def().constant_fold2(self.args(), inputs, outputs)
     }
 
     /// Creates a new [`OpaqueOp`] as a downgraded version of this

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -92,7 +92,9 @@ impl ExtensionOp {
     }
 
     /// Attempt to evaluate this operation. See [`OpDef::constant_fold`].
+    #[deprecated(note = "use constant_fold2")]
     pub fn constant_fold(&self, consts: &[(IncomingPort, ops::Value)]) -> ConstFoldResult {
+        #[allow(deprecated)] // in deprecated function, remove at same time
         self.def().constant_fold(self.args(), consts)
     }
 

--- a/hugr-core/src/std_extensions/arithmetic/conversions.rs
+++ b/hugr-core/src/std_extensions/arithmetic/conversions.rs
@@ -212,10 +212,9 @@ impl HasDef for ConvertOpType {
 mod test {
     use rstest::rstest;
 
-    use crate::extension::prelude::ConstUsize;
-    use crate::ops::Value;
+    use crate::extension::{prelude::ConstUsize, FoldVal};
+
     use crate::std_extensions::arithmetic::int_types::ConstInt;
-    use crate::IncomingPort;
 
     use super::*;
 
@@ -249,35 +248,21 @@ mod test {
     }
 
     #[rstest]
-    #[case::itobool_false(ConvertOpDef::itobool.without_log_width(), &[ConstInt::new_u(0, 0).unwrap().into()], &[Value::false_val()])]
-    #[case::itobool_true(ConvertOpDef::itobool.without_log_width(), &[ConstInt::new_u(0, 1).unwrap().into()], &[Value::true_val()])]
-    #[case::ifrombool_false(ConvertOpDef::ifrombool.without_log_width(), &[Value::false_val()], &[ConstInt::new_u(0, 0).unwrap().into()])]
-    #[case::ifrombool_true(ConvertOpDef::ifrombool.without_log_width(), &[Value::true_val()], &[ConstInt::new_u(0, 1).unwrap().into()])]
+    #[case::itobool_false(ConvertOpDef::itobool.without_log_width(), &[ConstInt::new_u(0, 0).unwrap().into()], &[FoldVal::false_val()])]
+    #[case::itobool_true(ConvertOpDef::itobool.without_log_width(), &[ConstInt::new_u(0, 1).unwrap().into()], &[FoldVal::true_val()])]
+    #[case::ifrombool_false(ConvertOpDef::ifrombool.without_log_width(), &[FoldVal::false_val()], &[ConstInt::new_u(0, 0).unwrap().into()])]
+    #[case::ifrombool_true(ConvertOpDef::ifrombool.without_log_width(), &[FoldVal::true_val()], &[ConstInt::new_u(0, 1).unwrap().into()])]
     #[case::itousize(ConvertOpDef::itousize.without_log_width(), &[ConstInt::new_u(6, 42).unwrap().into()], &[ConstUsize::new(42).into()])]
     #[case::ifromusize(ConvertOpDef::ifromusize.without_log_width(), &[ConstUsize::new(42).into()], &[ConstInt::new_u(6, 42).unwrap().into()])]
     fn convert_fold(
         #[case] op: ConvertOpType,
-        #[case] inputs: &[Value],
-        #[case] outputs: &[Value],
+        #[case] inputs: &[FoldVal],
+        #[case] outputs: &[FoldVal],
     ) {
-        use crate::ops::Value;
-
-        let consts: Vec<(IncomingPort, Value)> = inputs
-            .iter()
-            .enumerate()
-            .map(|(i, v)| (i.into(), v.clone()))
-            .collect();
-
-        let res = op
-            .to_extension_op()
+        let mut working = vec![FoldVal::Unknown; outputs.len()];
+        op.to_extension_op()
             .unwrap()
-            .constant_fold(&consts)
-            .unwrap();
-
-        for (i, expected) in outputs.iter().enumerate() {
-            let res_val: &Value = &res.get(i).unwrap().1;
-
-            assert_eq!(res_val, expected);
-        }
+            .constant_fold2(inputs, &mut working);
+        assert_eq!(&working, outputs);
     }
 }

--- a/hugr-core/src/std_extensions/arithmetic/float_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_ops.rs
@@ -129,7 +129,10 @@ impl MakeRegisteredOp for FloatOps {
 
 #[cfg(test)]
 mod test {
+    use crate::extension::FoldVal;
+    use crate::std_extensions::arithmetic::float_types::ConstF64;
     use cgmath::AbsDiffEq;
+    use itertools::Itertools;
     use rstest::rstest;
 
     use super::*;
@@ -154,28 +157,20 @@ mod test {
     #[case::fceil(FloatOps::fceil, &[42.42], &[43.])]
     #[case::fround(FloatOps::fround, &[42.42], &[42.])]
     fn float_fold(#[case] op: FloatOps, #[case] inputs: &[f64], #[case] outputs: &[f64]) {
-        use crate::ops::Value;
-        use crate::std_extensions::arithmetic::float_types::ConstF64;
-
         let consts: Vec<_> = inputs
             .iter()
-            .enumerate()
-            .map(|(i, &x)| (i.into(), Value::extension(ConstF64::new(x))))
+            .map(|&f| FoldVal::from(ConstF64::new(f)))
             .collect();
 
-        let res = op
-            .to_extension_op()
+        let mut actual = vec![FoldVal::Unknown; outputs.len()];
+        op.to_extension_op()
             .unwrap()
-            .constant_fold(&consts)
-            .unwrap();
+            .constant_fold2(&consts, &mut actual);
 
-        for (i, expected) in outputs.iter().enumerate() {
-            let res_val: f64 = res
-                .get(i)
-                .unwrap()
-                .1
+        for (act, expected) in actual.into_iter().zip_eq(outputs) {
+            let res_val: f64 = act
                 .get_custom_value::<ConstF64>()
-                .expect("This function assumes all incoming constants are floats.")
+                .expect("This function assumes all output constants are floats.")
                 .value();
 
             assert!(

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -350,12 +350,11 @@ fn sum_ty_with_err(t: Type) -> Type {
 
 #[cfg(test)]
 mod test {
+    use itertools::Itertools;
     use rstest::rstest;
 
-    use crate::{
-        ops::dataflow::DataflowOpTrait, std_extensions::arithmetic::int_types::int_type,
-        types::Signature,
-    };
+    use crate::std_extensions::arithmetic::int_types::{int_type, ConstInt};
+    use crate::{extension::FoldVal, ops::dataflow::DataflowOpTrait, types::Signature};
 
     use super::*;
 
@@ -442,33 +441,20 @@ mod test {
         #[case] outputs: &[u64],
         #[case] log_width: u8,
     ) {
-        use crate::ops::Value;
-        use crate::std_extensions::arithmetic::int_types::ConstInt;
-
         let consts: Vec<_> = inputs
             .iter()
-            .enumerate()
-            .map(|(i, &x)| {
-                (
-                    i.into(),
-                    Value::extension(ConstInt::new_u(log_width, x).unwrap()),
-                )
-            })
+            .map(|&x| FoldVal::from(ConstInt::new_u(log_width, x).unwrap()))
             .collect();
 
-        let res = op
-            .to_extension_op()
+        let mut outs = vec![FoldVal::Unknown; outputs.len()];
+        op.to_extension_op()
             .unwrap()
-            .constant_fold(&consts)
-            .unwrap();
+            .constant_fold2(&consts, &mut outs);
 
-        for (i, &expected) in outputs.iter().enumerate() {
-            let res_val: u64 = res
-                .get(i)
-                .unwrap()
-                .1
+        for (act, &expected) in outs.into_iter().zip_eq(outputs) {
+            let res_val: u64 = act
                 .get_custom_value::<ConstInt>()
-                .expect("This function assumes all incoming constants are floats.")
+                .expect("This function assumes all result constants are floats.")
                 .value_u();
 
             assert_eq!(res_val, expected);

--- a/hugr-core/src/std_extensions/collections/list.rs
+++ b/hugr-core/src/std_extensions/collections/list.rs
@@ -383,12 +383,11 @@ mod test {
     use rstest::rstest;
 
     use crate::extension::prelude::{
-        const_fail_tuple, const_none, const_ok_tuple, const_some_tuple,
+        const_fail_tuple, const_none, const_ok_tuple, const_some_tuple, qb_t, usize_t, ConstUsize,
     };
     use crate::ops::OpTrait;
-    use crate::PortIndex;
     use crate::{
-        extension::prelude::{qb_t, usize_t, ConstUsize},
+        extension::FoldVal,
         std_extensions::arithmetic::float_types::{float64_type, ConstF64},
         types::TypeRow,
     };
@@ -506,29 +505,23 @@ mod test {
     #[case::insert_invalid(ListOp::insert, &[TestVal::List(vec![77,88,42]), TestVal::Idx(52), TestVal::Elem(99)], &[TestVal::List(vec![77,88,42]), TestVal::Err(Type::UNIT.into(), vec![TestVal::Elem(99)])])]
     #[case::length(ListOp::length, &[TestVal::List(vec![77,88,42])], &[TestVal::Elem(3)])]
     fn list_fold(#[case] op: ListOp, #[case] inputs: &[TestVal], #[case] outputs: &[TestVal]) {
-        let consts: Vec<_> = inputs
+        let inputs: Vec<_> = inputs
             .iter()
-            .enumerate()
-            .map(|(i, x)| (i.into(), x.to_value()))
+            .map(TestVal::to_value)
+            .map(FoldVal::from)
             .collect();
 
-        let res = op
-            .with_type(usize_t())
+        let mut actual = vec![FoldVal::Unknown; outputs.len()];
+
+        op.with_type(usize_t())
             .to_extension_op()
             .unwrap()
-            .constant_fold(&consts)
-            .unwrap();
+            .constant_fold2(&inputs, &mut actual);
 
-        for (i, expected) in outputs.iter().enumerate() {
-            let expected = expected.to_value();
-            let res_val = res
-                .iter()
-                .find(|(port, _)| port.index() == i)
-                .unwrap()
-                .1
-                .clone();
+        for (act, expected) in actual.into_iter().zip_eq(outputs) {
+            let expected = expected.to_value().into();
 
-            assert_eq!(res_val, expected);
+            assert_eq!(act, expected);
         }
     }
 }

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -173,15 +173,15 @@ pub(crate) mod test {
     use std::sync::Arc;
 
     use super::{extension, LogicOp, FALSE_NAME, TRUE_NAME};
+
     use crate::{
-        extension::{
-            prelude::bool_t,
-            simple_op::{MakeOpDef, MakeRegisteredOp},
-        },
-        ops::{NamedOp, Value},
+        extension::simple_op::{MakeOpDef, MakeRegisteredOp},
+        extension::{prelude::bool_t, ConstFold, FoldVal},
+        ops::NamedOp,
         Extension,
     };
 
+    use itertools::Itertools;
     use rstest::rstest;
     use strum::IntoEnumIterator;
 
@@ -248,15 +248,11 @@ pub(crate) mod test {
         use itertools::Itertools;
 
         use crate::extension::ConstFold;
-        let in_vals = ins
-            .into_iter()
-            .enumerate()
-            .map(|(i, b)| (i.into(), Value::from_bool(b)))
-            .collect_vec();
-        assert_eq!(
-            Some(vec![(0.into(), Value::from_bool(out))]),
-            op.fold(&[(in_vals.len() as u64).into()], &in_vals)
-        );
+        let in_vals = ins.into_iter().map(FoldVal::from_bool).collect_vec();
+        let type_args = [(in_vals.len() as u64).into()];
+        let mut outs = [FoldVal::Unknown];
+        op.fold2(&type_args, &in_vals, &mut outs);
+        assert_eq!(outs, [FoldVal::from_bool(out)]);
     }
 
     #[rstest]
@@ -272,18 +268,13 @@ pub(crate) mod test {
         #[case] ins: impl IntoIterator<Item = Option<bool>>,
         #[case] mb_out: Option<bool>,
     ) {
-        use itertools::Itertools;
-
-        use crate::extension::ConstFold;
-        let in_vals0 = ins.into_iter().enumerate().collect_vec();
-        let num_args = in_vals0.len() as u64;
-        let in_vals = in_vals0
+        let in_vals = ins
             .into_iter()
-            .filter_map(|(i, mb_b)| mb_b.map(|b| (i.into(), Value::from_bool(b))))
+            .map(|mb_b| mb_b.map_or(FoldVal::Unknown, FoldVal::from_bool))
             .collect_vec();
-        assert_eq!(
-            mb_out.map(|out| vec![(0.into(), Value::from_bool(out))]),
-            op.fold(&[num_args.into()], &in_vals)
-        );
+        let type_args = [(in_vals.len() as u64).into()];
+        let mut outs = [FoldVal::Unknown];
+        op.fold2(&type_args, &in_vals, &mut outs);
+        assert_eq!(outs, [mb_out.map_or(FoldVal::Unknown, FoldVal::from_bool)]);
     }
 }

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -244,7 +244,7 @@ impl DFContext<ValueHandle<Node>> for ConstFoldContext {
             .map(|(ty, pv)| pv.clone().try_into_concrete(ty).unwrap_or_default())
             .collect::<Vec<_>>();
         let mut out_fvs = vec![FoldVal::Unknown; outs.len()];
-        op.constant_fold2(inp_fvs, &mut out_fvs);
+        op.constant_fold2(&inp_fvs, &mut out_fvs);
         for ((p, out), out_fv) in outs.iter_mut().enumerate().zip(out_fvs) {
             // UGH. Need a partial_from_const for FoldVal, *as well* as the one from Value
             // 'coz we need to keep the latter for constants!!

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -3,11 +3,12 @@
 //! An (example) use of the [dataflow analysis framework](super::dataflow).
 
 pub mod value_handle;
+use itertools::Itertools;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 
 use hugr_core::{
-    core::HugrNode,
+    extension::FoldVal,
     hugr::hugrmut::HugrMut,
     ops::{
         constant::OpaqueValue, Const, DataflowOpTrait, ExtensionOp, LoadConstant, OpType, Value,
@@ -18,7 +19,7 @@ use hugr_core::{
 use value_handle::ValueHandle;
 
 use crate::dataflow::{
-    partial_from_const, ConstLoader, ConstLocation, DFContext, Machine, PartialValue,
+    partial_from_const, ConstLoader, ConstLocation, DFContext, Machine, PartialSum, PartialValue,
     TailLoopTermination,
 };
 use crate::dead_code::{DeadCodeElimPass, PreserveNode};
@@ -127,6 +128,9 @@ impl ConstantFoldPass {
                 (!hugr.get_optype(src).is_load_constant() && Some(src) != mb_root_inp).then_some((
                     n,
                     ip,
+                    // TODO switch to using FoldVal rather than Value here, thus enabling turning CallIndirect
+                    // into Call when the function input is known. (This will mean we will be unable to handle
+                    // Value::Function's, so best to wait until those are removed.)
                     results
                         .try_read_wire_concrete::<Value, _, _, _>(Wire::new(src, outp))
                         .ok()?,
@@ -204,51 +208,72 @@ pub fn constant_fold_pass<H: HugrMut>(h: &mut H) {
 
 struct ConstFoldContext;
 
-impl<N: HugrNode> ConstLoader<ValueHandle<N>> for ConstFoldContext {
-    type Node = N;
+impl ConstLoader<ValueHandle<Node>> for ConstFoldContext {
+    type Node = Node;
 
     fn value_from_opaque(
         &self,
-        loc: ConstLocation<N>,
+        loc: ConstLocation<Node>,
         val: &OpaqueValue,
-    ) -> Option<ValueHandle<N>> {
+    ) -> Option<ValueHandle<Node>> {
         Some(ValueHandle::new_opaque(loc, val.clone()))
     }
 
     fn value_from_const_hugr(
         &self,
-        loc: ConstLocation<N>,
+        loc: ConstLocation<Node>,
         h: &hugr_core::Hugr,
-    ) -> Option<ValueHandle<N>> {
+    ) -> Option<ValueHandle<Node>> {
         Some(ValueHandle::new_const_hugr(loc, Box::new(h.clone())))
     }
 }
 
-impl<N: HugrNode> DFContext<ValueHandle<N>> for ConstFoldContext {
+impl DFContext<ValueHandle<Node>> for ConstFoldContext {
     fn interpret_leaf_op(
         &mut self,
-        node: N,
+        node: Node,
         op: &ExtensionOp,
-        ins: &[PartialValue<ValueHandle<N>, N>],
-        outs: &mut [PartialValue<ValueHandle<N>, N>],
+        ins: &[PartialValue<ValueHandle<Node>, Node>],
+        outs: &mut [PartialValue<ValueHandle<Node>, Node>],
     ) {
         let sig = op.signature();
-        let known_ins = sig
+        let inp_fvs = sig
             .input_types()
             .iter()
-            .enumerate()
-            .zip(ins.iter())
-            .filter_map(|((i, ty), pv)| {
-                pv.clone()
-                    .try_into_concrete(ty)
-                    .ok()
-                    .map(|v| (IncomingPort::from(i), v))
-            })
+            .zip_eq(ins.iter())
+            .map(|(ty, pv)| pv.clone().try_into_concrete(ty).unwrap_or_default())
             .collect::<Vec<_>>();
-        for (p, v) in op.constant_fold(&known_ins).unwrap_or_default() {
-            outs[p.index()] =
-                partial_from_const(self, ConstLocation::Field(p.index(), &node.into()), &v);
+        let mut out_fvs = vec![FoldVal::Unknown; outs.len()];
+        op.constant_fold2(inp_fvs, &mut out_fvs);
+        for ((p, out), out_fv) in outs.iter_mut().enumerate().zip(out_fvs) {
+            // UGH. Need a partial_from_const for FoldVal, *as well* as the one from Value
+            // 'coz we need to keep the latter for constants!!
+            *out = pv_from_fold_val(ConstLocation::Field(p, &node.into()), out_fv);
         }
+    }
+}
+
+fn pv_from_fold_val(
+    loc: ConstLocation<Node>,
+    value: FoldVal,
+) -> PartialValue<ValueHandle<Node>, Node> {
+    match value {
+        FoldVal::Unknown => PartialValue::Top,
+        FoldVal::Sum {
+            tag,
+            sum_type: _,
+            items,
+        } => PartialValue::PartialSum(PartialSum::new_variant(
+            tag,
+            items
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| pv_from_fold_val(ConstLocation::Field(i, &loc), v)),
+        )),
+        FoldVal::Extension(opaque_value) => {
+            PartialValue::Value(ValueHandle::new_opaque(loc, opaque_value))
+        }
+        FoldVal::LoadedFunction(node, args) => PartialValue::new_load(node, args),
     }
 }
 

--- a/hugr-passes/src/const_fold/test.rs
+++ b/hugr-passes/src/const_fold/test.rs
@@ -42,8 +42,7 @@ fn value_handling(#[case] k: impl CustomConst + Clone, #[case] eq: bool) {
     let n = Node::from(portgraph::NodeIndex::new(7));
     let st = SumType::new([vec![k.get_type()], vec![]]);
     let subject_val = Value::sum(0, [k.clone().into()], st).unwrap();
-    let temp = Hugr::default();
-    let ctx: ConstFoldContext<Hugr> = ConstFoldContext(&temp);
+    let ctx = ConstFoldContext;
     let v1 = partial_from_const(&ctx, n, &subject_val);
 
     let v1_subfield = {
@@ -114,8 +113,7 @@ fn test_add(#[case] a: f64, #[case] b: f64, #[case] c: f64) {
         v.get_custom_value::<ConstF64>().unwrap().value()
     }
     let [n, n_a, n_b] = [0, 1, 2].map(portgraph::NodeIndex::new).map(Node::from);
-    let temp = Hugr::default();
-    let mut ctx = ConstFoldContext(&temp);
+    let mut ctx = ConstFoldContext;
     let v_a = partial_from_const(&ctx, n_a, &f2c(a));
     let v_b = partial_from_const(&ctx, n_b, &f2c(b));
     assert_eq!(unwrap_float(v_a.clone()), a);

--- a/hugr-passes/src/const_fold/value_handle.rs
+++ b/hugr-passes/src/const_fold/value_handle.rs
@@ -5,12 +5,13 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use hugr_core::core::HugrNode;
+use hugr_core::extension::FoldVal;
 use hugr_core::ops::constant::OpaqueValue;
 use hugr_core::ops::Value;
 use hugr_core::{Hugr, Node};
 use itertools::Either;
 
-use crate::dataflow::{AbstractValue, ConstLocation};
+use crate::dataflow::{AbstractValue, ConstLocation, LoadedFunction};
 
 /// A custom constant that has been successfully hashed via [TryHash](hugr_core::ops::constant::TryHash)
 #[derive(Clone, Debug)]
@@ -170,6 +171,26 @@ impl<N: HugrNode> From<ValueHandle<N>> for Value {
                 .map_err(|e| e.to_string())
                 .unwrap(),
         }
+    }
+}
+
+impl From<ValueHandle<Node>> for FoldVal {
+    fn from(value: ValueHandle<Node>) -> FoldVal {
+        match value {
+            ValueHandle::Hashable(HashedConst { val, .. })
+            | ValueHandle::Unhashable {
+                leaf: Either::Left(val),
+                ..
+            } => FoldVal::Extension(Arc::try_unwrap(val).unwrap_or_else(|a| a.as_ref().clone())),
+            _ => FoldVal::Unknown,
+        }
+    }
+}
+
+impl From<LoadedFunction<Node>> for FoldVal {
+    fn from(value: LoadedFunction<Node>) -> Self {
+        let LoadedFunction { func_node, args } = value;
+        FoldVal::LoadedFunction(func_node, args)
     }
 }
 

--- a/hugr-passes/src/const_fold/value_handle.rs
+++ b/hugr-passes/src/const_fold/value_handle.rs
@@ -164,6 +164,8 @@ impl<N: HugrNode> From<ValueHandle<N>> for Value {
             } => Value::Extension {
                 e: Arc::try_unwrap(val).unwrap_or_else(|a| a.as_ref().clone()),
             },
+            #[allow(deprecated)]
+            // When we remove Value::Function, have to change `leaf` to be OpaqueValue only
             ValueHandle::Unhashable {
                 leaf: Either::Right(hugr),
                 ..

--- a/hugr-passes/src/dataflow.rs
+++ b/hugr-passes/src/dataflow.rs
@@ -70,6 +70,7 @@ pub trait ConstLoader<V> {
 
     /// Produces an abstract value from a Hugr in a [Value::Function], if possible.
     /// The default just returns `None`, which will be interpreted as [PartialValue::Top].
+    #[deprecated(note = "Remove along with Value::Function")]
     fn value_from_const_hugr(&self, _loc: ConstLocation<Self::Node>, _h: &Hugr) -> Option<V> {
         None
     }
@@ -112,6 +113,7 @@ where
             .value_from_opaque(loc, e)
             .map(PartialValue::from)
             .unwrap_or(PartialValue::Top),
+        #[allow(deprecated)] // remove when Value::Function removed
         Value::Function { hugr } => cl
             .value_from_const_hugr(loc, hugr)
             .map(PartialValue::from)

--- a/hugr-passes/src/dataflow/partial_value.rs
+++ b/hugr-passes/src/dataflow/partial_value.rs
@@ -1,5 +1,6 @@
 use ascent::lattice::BoundedLattice;
 use ascent::Lattice;
+use hugr_core::extension::FoldVal;
 use hugr_core::ops::Value;
 use hugr_core::types::{ConstTypeError, SumType, Type, TypeArg, TypeEnum, TypeRow};
 use hugr_core::Node;
@@ -427,6 +428,17 @@ impl TryFrom<Sum<Value>> for Value {
 
     fn try_from(value: Sum<Value>) -> Result<Self, Self::Error> {
         Self::sum(value.tag, value.values, value.st)
+    }
+}
+
+impl From<Sum<FoldVal>> for FoldVal {
+    fn from(value: Sum<FoldVal>) -> Self {
+        let Sum { tag, values, st } = value;
+        Self::Sum {
+            tag,
+            sum_type: st,
+            items: values,
+        }
     }
 }
 

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -344,6 +344,7 @@ impl ReplaceTypes {
                     false
                 }
             }),
+            #[allow(deprecated)] // remove when Value::Function removed
             Value::Function { hugr } => self.run_no_validate(&mut **hugr),
         }
     }


### PR DESCRIPTION
We've been using `ops::Value` for constant-folding, which is a bit of a shortcut but leads to significant problems: the result of ` LoadFunction` cannot fit into a Value (you'd need to copy all other external functions used by the loaded one inside it, or something - not really practical, and you've lost the understanding that you were calling another function in the same Hugr, too). #2059, which this follows, solves some of these; this tackles the remainder, specifically, feeding "function pointers" from LoadFunction into constant-folding.

The "solution" of extending Value to allow a reference to a node in the containing Hugr was considered in #1856 and was roundly rejected. Instead, this PR adds a separate enum `FoldVal` that looks quite similar to `Value` but adds those references/function-pointers.

I've taken the liberty of *not* including nested Hugrs in `FoldVal`, but rather deprecating `Value::Function` in favour of getting front-ends to lift these into their own FuncDefn's in the Hugr. I could be persuaded not to, and add a nested-Hugr variant to FoldVal, if we really want, but it does seem like probably more effort than it's worth - does anyone really have a good use case for `Value::Function` ?

I've also deprecated the old `constant_fold` and `fold` routines in favour of the new ones, which are currently called `fold2`. Better naming suggestions are welcome....(an alternative might be to define a new version of the ConstantFolder trait with only the new method, make OpDef store one of those, deprecate the old trait, and then `impl<T:ConstantFolder> NewConstantFolder for T` ?)