### PR TITLE
feat: Implement Debug for generic Wire<N>s

### DIFF
--- a/hugr-core/src/core.rs
+++ b/hugr-core/src/core.rs
@@ -301,10 +301,10 @@ impl std::fmt::Debug for OutgoingPort {
     }
 }
 
-impl std::fmt::Debug for Wire {
+impl<N: HugrNode> std::fmt::Debug for Wire<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Wire")
-            .field("node", &self.0.index())
+            .field("node", &self.0)
             .field("port", &self.1)
             .finish()
     }


### PR DESCRIPTION
This sightly changes the debug output of `Wire<Node>`, but it shouldn't matter much since this is not the `Display` impl.

before: `Wire { node: 42, port: OutgoingPort(2) }`
after: `Wire { node: Node(42), port: OutgoingPort(2) }`