### PR TITLE
feat: Add ExtensionOp helpers

### DIFF
--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -301,9 +301,10 @@ impl OpType {
     }
 
     /// Cast to an extension operation.
+    ///
+    /// Returns `None` if the operation is not of the requested type.
     pub fn cast<T: MakeExtensionOp>(&self) -> Option<T> {
-        self.as_extension_op()
-            .and_then(|o| T::from_extension_op(o).ok())
+        self.as_extension_op().and_then(ExtensionOp::cast)
     }
 
     /// Returns the extension where the operation is defined, if any.

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -131,6 +131,11 @@ impl ExtensionOp {
     pub fn cast<T: MakeExtensionOp>(&self) -> Option<T> {
         T::from_extension_op(self).ok()
     }
+
+    /// Returns the extension id of the operation.
+    pub fn extension_id(&self) -> &ExtensionId {
+        self.def.extension_id()
+    }
 }
 
 impl From<ExtensionOp> for OpaqueOp {

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -12,6 +12,7 @@ use {
     ::proptest_derive::Arbitrary,
 };
 
+use crate::extension::simple_op::MakeExtensionOp;
 use crate::extension::{ConstFoldResult, ExtensionId, OpDef, SignatureError};
 use crate::types::{type_param::TypeArg, Signature};
 use crate::{ops, IncomingPort, Node};
@@ -122,6 +123,13 @@ impl ExtensionOp {
     /// Returns a mutable reference to the type arguments of the operation.
     pub(crate) fn args_mut(&mut self) -> &mut [TypeArg] {
         self.args.as_mut_slice()
+    }
+
+    /// Cast the operation to an specific extension op.
+    ///
+    /// Returns `None` if the operation is not of the requested type.
+    pub fn cast<T: MakeExtensionOp>(&self) -> Option<T> {
+        T::from_extension_op(self).ok()
     }
 }
 


### PR DESCRIPTION
- We had `OpType::cast` but were missing it in `ExtensionOp` itself.
- Adds a `ExtensionOp::extension_id` call