### PR TITLE
rfc: hugr-rs v0.16.0 release

### DIFF
--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - '**'
   merge_group:
     types: [checks_requested]
   workflow_dispatch: {}

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - '**'
   merge_group:
     types: [checks_requested]
   workflow_dispatch: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,7 +2,7 @@ name: Check Conventional Commits format
 on:
   pull_request_target:
     branches:
-      - main
+      - '**'
     types:
       - opened
       - edited

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -2,7 +2,7 @@ name: Rust Semver Checks
 on:
   pull_request_target:
     branches:
-      - main
+      - '**'
 
 jobs:
   # Check if changes were made to the relevant files.


### PR DESCRIPTION
This draft PR tracks the release branch that accumulates breaking changes to be published in `hugr-rs 0.16.0`. Milestone: https://github.com/CQCL/hugr/milestone/10.

Breaking PRs should target this branch. We may also merge in changes from `main` as needed.

Instead of merging this PR, a repo admin should rebase it into `main` once we decide to bring the breaking changes to `main`.