### PR TITLE
feat!: Expand SimpleReplacement::ApplyResult type

### DIFF
--- a/hugr-core/src/hugr/patch/simple_replace.rs
+++ b/hugr-core/src/hugr/patch/simple_replace.rs
@@ -296,15 +296,15 @@ impl<HostNode: HugrNode> VerifyPatch for SimpleReplacement<HostNode> {
 }
 
 /// Result of applying a [`SimpleReplacement`].
-pub struct ApplyOutcome {
+pub struct SimpleReplacementOutcome {
     /// Map from Node in replacement to corresponding Node in the result Hugr
     pub node_map: HashMap<Node, Node>,
     /// Nodes removed from the result Hugr and their weights
-    pub removed_nodes: Vec<(Node, OpType)>,
+    pub removed_nodes: HashMap<Node, OpType>,
 }
 
 impl ApplyPatchHugrMut for SimpleReplacement<Node> {
-    type Outcome = ApplyOutcome;
+    type Outcome = SimpleReplacementOutcome;
     const UNCHANGED_ON_FAILURE: bool = true;
 
     fn apply_hugr_mut(self, h: &mut impl HugrMut) -> Result<Self::Outcome, Self::Error> {
@@ -356,7 +356,7 @@ impl ApplyPatchHugrMut for SimpleReplacement<Node> {
             .map(|&node| (node, h.remove_node(node)))
             .collect();
 
-        Ok(ApplyOutcome {
+        Ok(SimpleReplacementOutcome {
             node_map,
             removed_nodes,
         })

--- a/hugr-passes/src/lower.rs
+++ b/hugr-passes/src/lower.rs
@@ -69,9 +69,9 @@ pub fn lower_ops(
         .map(|(node, replacement)| {
             let subcirc = SiblingSubgraph::from_node(node, hugr);
             let rw = subcirc.create_simple_replacement(hugr, replacement)?;
-            let mut repls = hugr.apply_rewrite(rw)?;
-            debug_assert_eq!(repls.len(), 1);
-            Ok(repls.remove(0))
+            let mut removed_nodes = hugr.apply_rewrite(rw)?.removed_nodes;
+            debug_assert_eq!(removed_nodes.len(), 1);
+            Ok(removed_nodes.remove(0))
         })
         .collect()
 }


### PR DESCRIPTION
It is currently impossible to obtain the map from nodes in the replacement graph to newly inserted nodes in `self` from the `ApplyResult` type for `SimpleReplacement`.

This PR fixes this.

BREAKING CHANGE: The `ApplyResult` associated type of `SimpleReplacement` is now a custom struct. The deleted nodes returned previously can be obtained using the `result.deleted_nodes` field.