### PR TITLE
feat: Make NodeHandle generic

### DIFF
--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -9,6 +9,7 @@ pub mod module;
 pub mod sum;
 pub mod tag;
 pub mod validate;
+use crate::core::HugrNode;
 use crate::extension::resolution::{
     collect_op_extension, collect_op_types_extensions, ExtensionCollectionError,
 };
@@ -20,6 +21,7 @@ use crate::types::{EdgeKind, Signature, Substitution};
 use crate::{Direction, OutgoingPort, Port};
 use crate::{IncomingPort, PortIndex};
 use derive_more::Display;
+use handle::NodeHandle;
 use paste::paste;
 use portgraph::NodeIndex;
 
@@ -41,7 +43,6 @@ pub use tag::OpTag;
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 /// The concrete operation types for a node in the HUGR.
-// TODO: Link the NodeHandles to the OpType.
 #[non_exhaustive]
 #[allow(missing_docs)]
 #[serde(tag = "op")]
@@ -376,6 +377,19 @@ pub trait OpTrait: Sized + Clone {
 
     /// Tag identifying the operation.
     fn tag(&self) -> OpTag;
+
+    /// Tries to create a specific [`NodeHandle`] for a node with this operation
+    /// type.
+    ///
+    /// Fails if the operation's [`OpTrait::tag`] does not match the
+    /// [`NodeHandle::TAG`] of the requested handle.
+    fn try_node_handle<N, H>(&self, node: N) -> Option<H>
+    where
+        N: HugrNode,
+        H: NodeHandle<N> + From<N>,
+    {
+        H::TAG.is_superset(self.tag()).then(|| node.into())
+    }
 
     /// The signature of the operation.
     ///


### PR DESCRIPTION
Adds a generic node type to the `NodeHandle` type.

This is a required change for #2029.

drive-by: Implement the "Link the NodeHandles to the OpType" TODO