### PR TITLE
feat!: remove ExtensionValue

### DIFF
--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -19,9 +19,8 @@ use derive_more::Display;
 use thiserror::Error;
 
 use crate::hugr::IdentList;
-use crate::ops::constant::{ValueName, ValueNameRef};
 use crate::ops::custom::{ExtensionOp, OpaqueOp};
-use crate::ops::{self, OpName, OpNameRef};
+use crate::ops::{OpName, OpNameRef};
 use crate::types::type_param::{TypeArg, TypeArgError, TypeParam};
 use crate::types::RowVariable;
 use crate::types::{check_typevar_decl, CustomType, Substitution, TypeBound, TypeName};
@@ -497,37 +496,6 @@ impl CustomConcrete for CustomType {
     }
 }
 
-/// A constant value provided by a extension.
-/// Must be an instance of a type available to the extension.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct ExtensionValue {
-    extension: ExtensionId,
-    name: ValueName,
-    typed_value: ops::Value,
-}
-
-impl ExtensionValue {
-    /// Returns a reference to the typed value of this [`ExtensionValue`].
-    pub fn typed_value(&self) -> &ops::Value {
-        &self.typed_value
-    }
-
-    /// Returns a mutable reference to the typed value of this [`ExtensionValue`].
-    pub(super) fn typed_value_mut(&mut self) -> &mut ops::Value {
-        &mut self.typed_value
-    }
-
-    /// Returns a reference to the name of this [`ExtensionValue`].
-    pub fn name(&self) -> &str {
-        self.name.as_str()
-    }
-
-    /// Returns a reference to the extension this [`ExtensionValue`] belongs to.
-    pub fn extension(&self) -> &ExtensionId {
-        &self.extension
-    }
-}
-
 /// A unique identifier for a extension.
 ///
 /// The actual [`Extension`] is stored externally.
@@ -583,8 +551,6 @@ pub struct Extension {
     pub runtime_reqs: ExtensionSet,
     /// Types defined by this extension.
     types: BTreeMap<TypeName, TypeDef>,
-    /// Static values defined by this extension.
-    values: BTreeMap<ValueName, ExtensionValue>,
     /// Operation declarations with serializable definitions.
     // Note: serde will serialize this because we configure with `features=["rc"]`.
     // That will clone anything that has multiple references, but each
@@ -608,7 +574,6 @@ impl Extension {
             version,
             runtime_reqs: Default::default(),
             types: Default::default(),
-            values: Default::default(),
             operations: Default::default(),
         }
     }
@@ -680,11 +645,6 @@ impl Extension {
         self.types.get(type_name)
     }
 
-    /// Allows read-only access to the values in this Extension
-    pub fn get_value(&self, value_name: &ValueNameRef) -> Option<&ExtensionValue> {
-        self.values.get(value_name)
-    }
-
     /// Returns the name of the extension.
     pub fn name(&self) -> &ExtensionId {
         &self.name
@@ -703,25 +663,6 @@ impl Extension {
     /// Iterator over the types of this [`Extension`].
     pub fn types(&self) -> impl Iterator<Item = (&TypeName, &TypeDef)> {
         self.types.iter()
-    }
-
-    /// Add a named static value to the extension.
-    pub fn add_value(
-        &mut self,
-        name: impl Into<ValueName>,
-        typed_value: ops::Value,
-    ) -> Result<&mut ExtensionValue, ExtensionBuildError> {
-        let extension_value = ExtensionValue {
-            extension: self.name.clone(),
-            name: name.into(),
-            typed_value,
-        };
-        match self.values.entry(extension_value.name.clone()) {
-            btree_map::Entry::Occupied(_) => {
-                Err(ExtensionBuildError::ValueExists(extension_value.name))
-            }
-            btree_map::Entry::Vacant(ve) => Ok(ve.insert(extension_value)),
-        }
     }
 
     /// Instantiate an [`ExtensionOp`] which references an [`OpDef`] in this extension.
@@ -784,9 +725,6 @@ pub enum ExtensionBuildError {
     /// Existing [`TypeDef`]
     #[error("Extension already has an type called {0}.")]
     TypeDefExists(TypeName),
-    /// Existing [`ExtensionValue`]
-    #[error("Extension already has an extension value called {0}.")]
-    ValueExists(ValueName),
 }
 
 /// A set of extensions identified by their unique [`ExtensionId`].

--- a/hugr-core/src/extension/resolution/extension.rs
+++ b/hugr-core/src/extension/resolution/extension.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use crate::extension::{Extension, ExtensionId, ExtensionRegistry, OpDef, SignatureFunc, TypeDef};
 
-use super::types_mut::{resolve_signature_exts, resolve_value_exts};
+use super::types_mut::resolve_signature_exts;
 use super::{ExtensionResolutionError, WeakExtensionRegistry};
 
 impl ExtensionRegistry {
@@ -59,14 +59,7 @@ impl Extension {
         for type_def in self.types.values_mut() {
             resolve_typedef_exts(&self.name, type_def, extensions, &mut used_extensions)?;
         }
-        for val in self.values.values_mut() {
-            resolve_value_exts(
-                None,
-                val.typed_value_mut(),
-                extensions,
-                &mut used_extensions,
-            )?;
-        }
+
         let ops = mem::take(&mut self.operations);
         for (op_id, mut op_def) in ops {
             // TODO: We should be able to clone the definition if needed by using `make_mut`,

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -20,7 +20,6 @@ use crate::ops::handle::NodeHandle;
 use crate::ops::{self, OpType, Value};
 use crate::std_extensions::logic::test::{and_op, or_op};
 use crate::std_extensions::logic::LogicOp;
-use crate::std_extensions::logic::{self};
 use crate::types::type_param::{TypeArg, TypeArgError};
 use crate::types::{
     CustomType, FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature, Type, TypeBound, TypeRV,
@@ -307,12 +306,7 @@ fn test_local_const() {
             port_kind: EdgeKind::Value(bool_t())
         })
     );
-    let const_op: ops::Const = logic::EXTENSION
-        .get_value(&logic::TRUE_NAME)
-        .unwrap()
-        .typed_value()
-        .clone()
-        .into();
+    let const_op: ops::Const = ops::Value::from_bool(true).into();
     // Second input of Xor from a constant
     let cst = h.add_node_with_parent(h.root(), const_op);
     let lcst = h.add_node_with_parent(h.root(), ops::LoadConstant { datatype: bool_t() });

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -124,13 +124,6 @@ pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 fn extension() -> Arc<Extension> {
     Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
         LogicOp::load_all_ops(extension, extension_ref).unwrap();
-
-        extension
-            .add_value(FALSE_NAME, ops::Value::false_val())
-            .unwrap();
-        extension
-            .add_value(TRUE_NAME, ops::Value::true_val())
-            .unwrap();
     })
 }
 
@@ -172,12 +165,9 @@ fn read_inputs(consts: &[(IncomingPort, ops::Value)]) -> Option<Vec<bool>> {
 pub(crate) mod test {
     use std::sync::Arc;
 
-    use super::{extension, LogicOp, FALSE_NAME, TRUE_NAME};
+    use super::{extension, LogicOp};
     use crate::{
-        extension::{
-            prelude::bool_t,
-            simple_op::{MakeOpDef, MakeRegisteredOp},
-        },
+        extension::simple_op::{MakeOpDef, MakeRegisteredOp},
         ops::{NamedOp, Value},
         Extension,
     };
@@ -204,18 +194,6 @@ pub(crate) mod test {
         for o in LogicOp::iter() {
             let ext_op = o.to_extension_op().unwrap();
             assert_eq!(LogicOp::from_op(&ext_op).unwrap(), o);
-        }
-    }
-
-    #[test]
-    fn test_values() {
-        let r: Arc<Extension> = extension();
-        let false_val = r.get_value(&FALSE_NAME).unwrap();
-        let true_val = r.get_value(&TRUE_NAME).unwrap();
-
-        for v in [false_val, true_val] {
-            let simpl = v.typed_value().get_type();
-            assert_eq!(simpl, bool_t());
         }
     }
 

--- a/hugr-py/src/hugr/_serialization/extension.py
+++ b/hugr-py/src/hugr/_serialization/extension.py
@@ -8,7 +8,6 @@ from pydantic_extra_types.semantic_version import SemanticVersion  # noqa: TCH00
 from hugr.hugr.base import Hugr
 from hugr.utils import deser_it
 
-from .ops import Value
 from .serial_hugr import SerialHugr, serialization_version
 from .tys import (
     ConfiguredBaseModel,
@@ -20,7 +19,6 @@ from .tys import (
 )
 
 if TYPE_CHECKING:
-    from .ops import Value
     from .serial_hugr import SerialHugr
 
 
@@ -58,20 +56,6 @@ class TypeDef(ConfiguredBaseModel):
                 description=self.description,
                 params=deser_it(self.params),
                 bound=self.bound.root.deserialize(),
-            )
-        )
-
-
-class ExtensionValue(ConfiguredBaseModel):
-    extension: ExtensionId
-    name: str
-    typed_value: Value
-
-    def deserialize(self, extension: ext.Extension) -> ext.ExtensionValue:
-        return extension.add_extension_value(
-            ext.ExtensionValue(
-                name=self.name,
-                val=self.typed_value.deserialize(),
             )
         )
 
@@ -124,7 +108,6 @@ class Extension(ConfiguredBaseModel):
     name: ExtensionId
     runtime_reqs: set[ExtensionId]
     types: dict[str, TypeDef]
-    values: dict[str, ExtensionValue]
     operations: dict[str, OpDef]
 
     @classmethod
@@ -145,10 +128,6 @@ class Extension(ConfiguredBaseModel):
         for k, o in self.operations.items():
             assert k == o.name, "Operation name must match key"
             e.add_op_def(o.deserialize(e))
-
-        for k, v in self.values.items():
-            assert k == v.name, "Value name must match key"
-            e.add_extension_value(v.deserialize(e))
 
         return e
 

--- a/hugr-py/src/hugr/std/_json_defs/arithmetic/conversions.json
+++ b/hugr-py/src/hugr/std/_json_defs/arithmetic/conversions.json
@@ -6,7 +6,6 @@
     "arithmetic.int.types"
   ],
   "types": {},
-  "values": {},
   "operations": {
     "bytecast_float64_to_int64": {
       "extension": "arithmetic.conversions",

--- a/hugr-py/src/hugr/std/_json_defs/arithmetic/float.json
+++ b/hugr-py/src/hugr/std/_json_defs/arithmetic/float.json
@@ -5,7 +5,6 @@
     "arithmetic.int.types"
   ],
   "types": {},
-  "values": {},
   "operations": {
     "fabs": {
       "extension": "arithmetic.float",

--- a/hugr-py/src/hugr/std/_json_defs/arithmetic/float/types.json
+++ b/hugr-py/src/hugr/std/_json_defs/arithmetic/float/types.json
@@ -14,6 +14,5 @@
       }
     }
   },
-  "values": {},
   "operations": {}
 }

--- a/hugr-py/src/hugr/std/_json_defs/arithmetic/int.json
+++ b/hugr-py/src/hugr/std/_json_defs/arithmetic/int.json
@@ -5,7 +5,6 @@
     "arithmetic.int.types"
   ],
   "types": {},
-  "values": {},
   "operations": {
     "iabs": {
       "extension": "arithmetic.int",

--- a/hugr-py/src/hugr/std/_json_defs/arithmetic/int/types.json
+++ b/hugr-py/src/hugr/std/_json_defs/arithmetic/int/types.json
@@ -19,6 +19,5 @@
       }
     }
   },
-  "values": {},
   "operations": {}
 }

--- a/hugr-py/src/hugr/std/_json_defs/collections/array.json
+++ b/hugr-py/src/hugr/std/_json_defs/collections/array.json
@@ -25,7 +25,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "discard_empty": {
       "extension": "collections.array",

--- a/hugr-py/src/hugr/std/_json_defs/collections/list.json
+++ b/hugr-py/src/hugr/std/_json_defs/collections/list.json
@@ -21,7 +21,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "get": {
       "extension": "collections.list",

--- a/hugr-py/src/hugr/std/_json_defs/collections/static_array.json
+++ b/hugr-py/src/hugr/std/_json_defs/collections/static_array.json
@@ -19,7 +19,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "get": {
       "extension": "collections.static_array",

--- a/hugr-py/src/hugr/std/_json_defs/logic.json
+++ b/hugr-py/src/hugr/std/_json_defs/logic.json
@@ -3,34 +3,6 @@
   "name": "logic",
   "runtime_reqs": [],
   "types": {},
-  "values": {
-    "FALSE": {
-      "extension": "logic",
-      "name": "FALSE",
-      "typed_value": {
-        "v": "Sum",
-        "tag": 0,
-        "vs": [],
-        "typ": {
-          "s": "Unit",
-          "size": 2
-        }
-      }
-    },
-    "TRUE": {
-      "extension": "logic",
-      "name": "TRUE",
-      "typed_value": {
-        "v": "Sum",
-        "tag": 1,
-        "vs": [],
-        "typ": {
-          "s": "Unit",
-          "size": 2
-        }
-      }
-    }
-  },
   "operations": {
     "And": {
       "extension": "logic",

--- a/hugr-py/src/hugr/std/_json_defs/prelude.json
+++ b/hugr-py/src/hugr/std/_json_defs/prelude.json
@@ -44,7 +44,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "Barrier": {
       "extension": "prelude",

--- a/hugr-py/src/hugr/std/_json_defs/ptr.json
+++ b/hugr-py/src/hugr/std/_json_defs/ptr.json
@@ -19,7 +19,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "New": {
       "extension": "ptr",

--- a/specification/schema/hugr_schema_live.json
+++ b/specification/schema/hugr_schema_live.json
@@ -517,13 +517,6 @@
                     "title": "Types",
                     "type": "object"
                 },
-                "values": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/ExtensionValue"
-                    },
-                    "title": "Values",
-                    "type": "object"
-                },
                 "operations": {
                     "additionalProperties": {
                         "$ref": "#/$defs/OpDef"
@@ -537,7 +530,6 @@
                 "name",
                 "runtime_reqs",
                 "types",
-                "values",
                 "operations"
             ],
             "title": "Extension",
@@ -587,28 +579,6 @@
                 "name"
             ],
             "title": "ExtensionOp",
-            "type": "object"
-        },
-        "ExtensionValue": {
-            "properties": {
-                "extension": {
-                    "title": "Extension",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "typed_value": {
-                    "$ref": "#/$defs/Value"
-                }
-            },
-            "required": [
-                "extension",
-                "name",
-                "typed_value"
-            ],
-            "title": "ExtensionValue",
             "type": "object"
         },
         "ExtensionsArg": {

--- a/specification/schema/hugr_schema_strict_live.json
+++ b/specification/schema/hugr_schema_strict_live.json
@@ -517,13 +517,6 @@
                     "title": "Types",
                     "type": "object"
                 },
-                "values": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/ExtensionValue"
-                    },
-                    "title": "Values",
-                    "type": "object"
-                },
                 "operations": {
                     "additionalProperties": {
                         "$ref": "#/$defs/OpDef"
@@ -537,7 +530,6 @@
                 "name",
                 "runtime_reqs",
                 "types",
-                "values",
                 "operations"
             ],
             "title": "Extension",
@@ -587,28 +579,6 @@
                 "name"
             ],
             "title": "ExtensionOp",
-            "type": "object"
-        },
-        "ExtensionValue": {
-            "properties": {
-                "extension": {
-                    "title": "Extension",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "typed_value": {
-                    "$ref": "#/$defs/Value"
-                }
-            },
-            "required": [
-                "extension",
-                "name",
-                "typed_value"
-            ],
-            "title": "ExtensionValue",
             "type": "object"
         },
         "ExtensionsArg": {

--- a/specification/schema/testing_hugr_schema_live.json
+++ b/specification/schema/testing_hugr_schema_live.json
@@ -517,13 +517,6 @@
                     "title": "Types",
                     "type": "object"
                 },
-                "values": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/ExtensionValue"
-                    },
-                    "title": "Values",
-                    "type": "object"
-                },
                 "operations": {
                     "additionalProperties": {
                         "$ref": "#/$defs/OpDef"
@@ -537,7 +530,6 @@
                 "name",
                 "runtime_reqs",
                 "types",
-                "values",
                 "operations"
             ],
             "title": "Extension",
@@ -587,28 +579,6 @@
                 "name"
             ],
             "title": "ExtensionOp",
-            "type": "object"
-        },
-        "ExtensionValue": {
-            "properties": {
-                "extension": {
-                    "title": "Extension",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "typed_value": {
-                    "$ref": "#/$defs/Value"
-                }
-            },
-            "required": [
-                "extension",
-                "name",
-                "typed_value"
-            ],
-            "title": "ExtensionValue",
             "type": "object"
         },
         "ExtensionsArg": {

--- a/specification/schema/testing_hugr_schema_strict_live.json
+++ b/specification/schema/testing_hugr_schema_strict_live.json
@@ -517,13 +517,6 @@
                     "title": "Types",
                     "type": "object"
                 },
-                "values": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/ExtensionValue"
-                    },
-                    "title": "Values",
-                    "type": "object"
-                },
                 "operations": {
                     "additionalProperties": {
                         "$ref": "#/$defs/OpDef"
@@ -537,7 +530,6 @@
                 "name",
                 "runtime_reqs",
                 "types",
-                "values",
                 "operations"
             ],
             "title": "Extension",
@@ -587,28 +579,6 @@
                 "name"
             ],
             "title": "ExtensionOp",
-            "type": "object"
-        },
-        "ExtensionValue": {
-            "properties": {
-                "extension": {
-                    "title": "Extension",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "typed_value": {
-                    "$ref": "#/$defs/Value"
-                }
-            },
-            "required": [
-                "extension",
-                "name",
-                "typed_value"
-            ],
-            "title": "ExtensionValue",
             "type": "object"
         },
         "ExtensionsArg": {

--- a/specification/std_extensions/arithmetic/conversions.json
+++ b/specification/std_extensions/arithmetic/conversions.json
@@ -6,7 +6,6 @@
     "arithmetic.int.types"
   ],
   "types": {},
-  "values": {},
   "operations": {
     "bytecast_float64_to_int64": {
       "extension": "arithmetic.conversions",

--- a/specification/std_extensions/arithmetic/float.json
+++ b/specification/std_extensions/arithmetic/float.json
@@ -5,7 +5,6 @@
     "arithmetic.int.types"
   ],
   "types": {},
-  "values": {},
   "operations": {
     "fabs": {
       "extension": "arithmetic.float",

--- a/specification/std_extensions/arithmetic/float/types.json
+++ b/specification/std_extensions/arithmetic/float/types.json
@@ -14,6 +14,5 @@
       }
     }
   },
-  "values": {},
   "operations": {}
 }

--- a/specification/std_extensions/arithmetic/int.json
+++ b/specification/std_extensions/arithmetic/int.json
@@ -5,7 +5,6 @@
     "arithmetic.int.types"
   ],
   "types": {},
-  "values": {},
   "operations": {
     "iabs": {
       "extension": "arithmetic.int",

--- a/specification/std_extensions/arithmetic/int/types.json
+++ b/specification/std_extensions/arithmetic/int/types.json
@@ -19,6 +19,5 @@
       }
     }
   },
-  "values": {},
   "operations": {}
 }

--- a/specification/std_extensions/collections/array.json
+++ b/specification/std_extensions/collections/array.json
@@ -25,7 +25,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "discard_empty": {
       "extension": "collections.array",

--- a/specification/std_extensions/collections/list.json
+++ b/specification/std_extensions/collections/list.json
@@ -21,7 +21,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "get": {
       "extension": "collections.list",

--- a/specification/std_extensions/collections/static_array.json
+++ b/specification/std_extensions/collections/static_array.json
@@ -19,7 +19,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "get": {
       "extension": "collections.static_array",

--- a/specification/std_extensions/logic.json
+++ b/specification/std_extensions/logic.json
@@ -3,34 +3,6 @@
   "name": "logic",
   "runtime_reqs": [],
   "types": {},
-  "values": {
-    "FALSE": {
-      "extension": "logic",
-      "name": "FALSE",
-      "typed_value": {
-        "v": "Sum",
-        "tag": 0,
-        "vs": [],
-        "typ": {
-          "s": "Unit",
-          "size": 2
-        }
-      }
-    },
-    "TRUE": {
-      "extension": "logic",
-      "name": "TRUE",
-      "typed_value": {
-        "v": "Sum",
-        "tag": 1,
-        "vs": [],
-        "typ": {
-          "s": "Unit",
-          "size": 2
-        }
-      }
-    }
-  },
   "operations": {
     "And": {
       "extension": "logic",

--- a/specification/std_extensions/prelude.json
+++ b/specification/std_extensions/prelude.json
@@ -44,7 +44,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "Barrier": {
       "extension": "prelude",

--- a/specification/std_extensions/ptr.json
+++ b/specification/std_extensions/ptr.json
@@ -19,7 +19,6 @@
       }
     }
   },
-  "values": {},
   "operations": {
     "New": {
       "extension": "ptr",


### PR DESCRIPTION
Closes #1595

BREAKING CHANGE: `values` field in `Extension` and `ExtensionValue` struct/class removed in rust and python. Use 0-input ops that return constant values.