### PR TITLE
feat!: ReplaceTypes: allow lowering ops into a Call to a function already in the Hugr

### DIFF
--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -60,6 +60,9 @@ impl NodeTemplate {
     /// # Panics
     ///
     /// * If `parent` is not in the `hugr`
+    ///
+    /// # Errors
+    ///
     /// * If `self` is a [Self::Call] and the target Node either
     ///    * is neither a [FuncDefn] nor a [FuncDecl]
     ///    * has a [`signature`] which the type-args of the [Self::Call] do not match

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -46,10 +46,8 @@ pub enum NodeTemplate {
     /// Note this will be of limited use before [monomorphization](super::monomorphize())
     /// because the new subtree will not be able to use type variables present in the
     /// parent Hugr or previous op.
-    // TODO: store also a vec<TypeParam>, and update Hugr::validate to take &[TypeParam]s
-    // (defaulting to empty list) - see https://github.com/CQCL/hugr/issues/709
     CompoundOp(Box<Hugr>),
-    /// A Call to a function (already) existing in the Hugr.
+    /// A Call to an existing function.
     Call(Node, Vec<TypeArg>),
 }
 

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -579,18 +579,17 @@ mod test {
         FunctionBuilder, HugrBuilder, ModuleBuilder, SubContainer, TailLoopBuilder,
     };
     use hugr_core::extension::prelude::{
-        bool_t, option_type, qb_t, usize_t, ConstUsize, UnwrapBuilder,
+        bool_t, option_type, qb_t, usize_t, ConstUsize, UnwrapBuilder, PRELUDE_ID,
     };
-    use hugr_core::extension::simple_op::MakeExtensionOp;
-    use hugr_core::extension::{TypeDefBound, Version};
+    use hugr_core::extension::{simple_op::MakeExtensionOp, ExtensionSet, TypeDefBound, Version};
 
     use hugr_core::hugr::hugrmut::HugrMut;
     use hugr_core::ops::constant::OpaqueValue;
     use hugr_core::ops::{ExtensionOp, NamedOp, OpTrait, OpType, Tag, Value};
-    use hugr_core::std_extensions::arithmetic::int_types::ConstInt;
-    use hugr_core::std_extensions::arithmetic::{conversions::ConvertOpDef, int_types::INT_TYPES};
+    use hugr_core::std_extensions::arithmetic::conversions::{self, ConvertOpDef};
+    use hugr_core::std_extensions::arithmetic::int_types::{ConstInt, INT_TYPES};
     use hugr_core::std_extensions::collections::array::{
-        array_type, array_type_def, ArrayOp, ArrayOpDef, ArrayValue,
+        self, array_type, array_type_def, ArrayOp, ArrayOpDef, ArrayValue,
     };
     use hugr_core::std_extensions::collections::list::{
         list_type, list_type_def, ListOp, ListValue,
@@ -669,10 +668,15 @@ mod test {
         elem_ty: Type,
         new: impl Fn(Signature) -> Result<T, BuildError>,
     ) -> T {
-        let mut dfb = new(inout_sig(
+        let mut dfb = new(Signature::new(
             vec![array_type(64, elem_ty.clone()), i64_t()],
             elem_ty.clone(),
-        ))
+        )
+        .with_extension_delta(ExtensionSet::from_iter([
+            PRELUDE_ID,
+            array::EXTENSION_ID,
+            conversions::EXTENSION_ID,
+        ])))
         .unwrap();
         let [val, idx] = dfb.input_wires_arr();
         let [idx] = dfb

--- a/hugr-passes/src/replace_types/handlers.rs
+++ b/hugr-passes/src/replace_types/handlers.rs
@@ -92,7 +92,7 @@ pub fn linearize_array(
             let [to_discard] = dfb.input_wires_arr();
             lin.copy_discard_op(ty, 0)?
                 .add(&mut dfb, [to_discard])
-                .unwrap();
+                .map_err(|e| LinearizeError::NestedTemplateError(ty.clone(), e))?;
             let ret = dfb.add_load_value(Value::unary_unit_sum());
             dfb.finish_hugr_with_outputs([ret]).unwrap()
         };
@@ -162,7 +162,7 @@ pub fn linearize_array(
         let mut copies = lin
             .copy_discard_op(ty, num_outports)?
             .add(&mut dfb, [elem])
-            .unwrap()
+            .map_err(|e| LinearizeError::NestedTemplateError(ty.clone(), e))?
             .outputs();
         let copy0 = copies.next().unwrap(); // We'll return this directly
 

--- a/hugr-passes/src/replace_types/linearize.rs
+++ b/hugr-passes/src/replace_types/linearize.rs
@@ -783,7 +783,11 @@ mod test {
         let mut dfb = DFGBuilder::new(inout_sig(usize_t(), type_row![])).unwrap();
         let discard_fn = {
             let mut fb = dfb
-                .define_function("drop", inout_sig(lin_t.clone(), type_row![]))
+                .define_function(
+                    "drop",
+                    Signature::new(lin_t.clone(), type_row![])
+                        .with_extension_delta(e.name().clone()),
+                )
                 .unwrap();
             let ins = fb.input_wires();
             fb.add_dataflow_op(


### PR DESCRIPTION
There are two issues:
* Errors. The previous NodeTemplates still always work, but the Call one can fail if the Hugr doesn't contain the target function node. ATM there is no channel for reporting that error so I've had to panic. Otherwise it's an even-more-breaking change to add an error type to `NodeTemplate::add()` and `NodeTemplate::add_hugr()`. Should we? (I note `HugrMut::connect` panics if the node isn't there, but could make the `NodeTemplate::add` builder method return a BuildError...and propagate that everywhere of course)
* There's a big limitation in `linearize_array` that it'll break if the *element* says it should be copied/discarded via a NodeTemplate::Call, as `linearize_array` puts the elementwise copy/discard function into a *nested Hugr* (`Value::Function`) that won't contain the function. This could be fixed via lifting those to toplevel FuncDefns with name-mangling, but I'd rather leave that for #2086 ....

BREAKING CHANGE: Add new variant NodeTemplate::Call; LinearizeError no longer derives Eq.