### PR TITLE
feat!: Generalise array op builers to arbitrary array kinds

### DIFF
--- a/hugr-core/src/std_extensions/collections/array.rs
+++ b/hugr-core/src/std_extensions/collections/array.rs
@@ -15,14 +15,15 @@ use std::sync::Arc;
 use delegate::delegate;
 use lazy_static::lazy_static;
 
+use crate::builder::{BuildError, Dataflow};
 use crate::extension::resolution::{ExtensionResolutionError, WeakExtensionRegistry};
-use crate::extension::simple_op::{MakeOpDef, MakeRegisteredOp};
+use crate::extension::simple_op::{HasConcrete, MakeOpDef, MakeRegisteredOp};
 use crate::extension::{ExtensionId, ExtensionSet, SignatureError, TypeDef, TypeDefBound};
 use crate::ops::constant::{CustomConst, ValueName};
 use crate::ops::{ExtensionOp, OpName};
 use crate::types::type_param::{TypeArg, TypeParam};
 use crate::types::{CustomCheckFailure, Type, TypeBound, TypeName};
-use crate::Extension;
+use crate::{Extension, Wire};
 
 pub use array_clone::{GenericArrayClone, GenericArrayCloneDef, ARRAY_CLONE_OP_ID};
 pub use array_conversion::{Direction, GenericArrayConvert, GenericArrayConvertDef, FROM, INTO};
@@ -32,7 +33,8 @@ pub use array_op::{GenericArrayOp, GenericArrayOpDef};
 pub use array_repeat::{GenericArrayRepeat, GenericArrayRepeatDef, ARRAY_REPEAT_OP_ID};
 pub use array_scan::{GenericArrayScan, GenericArrayScanDef, ARRAY_SCAN_OP_ID};
 pub use array_value::GenericArrayValue;
-pub use op_builder::ArrayOpBuilder;
+
+use op_builder::GenericArrayOpBuilder;
 
 /// Reported unique name of the array type.
 pub const ARRAY_TYPENAME: TypeName = TypeName::new_inline("array");
@@ -169,6 +171,236 @@ pub fn new_array_op(element_ty: Type, size: u64) -> ExtensionOp {
     let op = ArrayOpDef::new_array.to_concrete(element_ty, size);
     op.to_extension_op().unwrap()
 }
+
+/// Trait for building array operations in a dataflow graph.
+pub trait ArrayOpBuilder: GenericArrayOpBuilder {
+    /// Adds a new array operation to the dataflow graph and return the wire
+    /// representing the new array.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The type of the elements in the array.
+    /// * `values` - An iterator over the values to initialize the array with.
+    ///
+    /// # Errors
+    ///
+    /// If building the operation fails.
+    ///
+    /// # Returns
+    ///
+    /// The wire representing the new array.
+    fn add_new_array(
+        &mut self,
+        elem_ty: Type,
+        values: impl IntoIterator<Item = Wire>,
+    ) -> Result<Wire, BuildError> {
+        self.add_new_generic_array::<Array>(elem_ty, values)
+    }
+
+    /// Adds an array clone operation to the dataflow graph and return the wires
+    /// representing the originala and cloned array.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The type of the elements in the array.
+    /// * `size` - The size of the array.
+    /// * `input` - The wire representing the array.
+    ///
+    /// # Errors
+    ///
+    /// If building the operation fails.
+    ///
+    /// # Returns
+    ///
+    /// The wires representing the original and cloned array.
+    fn add_array_clone(
+        &mut self,
+        elem_ty: Type,
+        size: u64,
+        input: Wire,
+    ) -> Result<(Wire, Wire), BuildError> {
+        self.add_generic_array_clone::<Array>(elem_ty, size, input)
+    }
+
+    /// Adds an array discard operation to the dataflow graph.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The type of the elements in the array.
+    /// * `size` - The size of the array.
+    /// * `input` - The wire representing the array.
+    ///
+    /// # Errors
+    ///
+    /// If building the operation fails.
+    fn add_array_discard(
+        &mut self,
+        elem_ty: Type,
+        size: u64,
+        input: Wire,
+    ) -> Result<(), BuildError> {
+        self.add_generic_array_discard::<Array>(elem_ty, size, input)
+    }
+
+    /// Adds an array get operation to the dataflow graph.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The type of the elements in the array.
+    /// * `size` - The size of the array.
+    /// * `input` - The wire representing the array.
+    /// * `index` - The wire representing the index to get.
+    ///
+    /// # Errors
+    ///
+    /// If building the operation fails.
+    ///
+    /// # Returns
+    ///
+    /// * The wire representing the value at the specified index in the array
+    /// * The wire representing the array
+    fn add_array_get(
+        &mut self,
+        elem_ty: Type,
+        size: u64,
+        input: Wire,
+        index: Wire,
+    ) -> Result<(Wire, Wire), BuildError> {
+        self.add_generic_array_get::<Array>(elem_ty, size, input, index)
+    }
+
+    /// Adds an array set operation to the dataflow graph.
+    ///
+    /// This operation sets the value at a specified index in the array.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The type of the elements in the array.
+    /// * `size` - The size of the array.
+    /// * `input` - The wire representing the array.
+    /// * `index` - The wire representing the index to set.
+    /// * `value` - The wire representing the value to set at the specified index.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if building the operation fails.
+    ///
+    /// # Returns
+    ///
+    /// The wire representing the updated array after the set operation.
+    fn add_array_set(
+        &mut self,
+        elem_ty: Type,
+        size: u64,
+        input: Wire,
+        index: Wire,
+        value: Wire,
+    ) -> Result<Wire, BuildError> {
+        self.add_generic_array_set::<Array>(elem_ty, size, input, index, value)
+    }
+
+    /// Adds an array swap operation to the dataflow graph.
+    ///
+    /// This operation swaps the values at two specified indices in the array.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The type of the elements in the array.
+    /// * `size` - The size of the array.
+    /// * `input` - The wire representing the array.
+    /// * `index1` - The wire representing the first index to swap.
+    /// * `index2` - The wire representing the second index to swap.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if building the operation fails.
+    ///
+    /// # Returns
+    ///
+    /// The wire representing the updated array after the swap operation.
+    fn add_array_swap(
+        &mut self,
+        elem_ty: Type,
+        size: u64,
+        input: Wire,
+        index1: Wire,
+        index2: Wire,
+    ) -> Result<Wire, BuildError> {
+        let op = GenericArrayOpDef::<Array>::swap.instantiate(&[size.into(), elem_ty.into()])?;
+        let [out] = self
+            .add_dataflow_op(op, vec![input, index1, index2])?
+            .outputs_arr();
+        Ok(out)
+    }
+
+    /// Adds an array pop-left operation to the dataflow graph.
+    ///
+    /// This operation removes the leftmost element from the array.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The type of the elements in the array.
+    /// * `size` - The size of the array.
+    /// * `input` - The wire representing the array.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if building the operation fails.
+    ///
+    /// # Returns
+    ///
+    /// The wire representing the Option<elemty, array<SIZE-1, elemty>>
+    fn add_array_pop_left(
+        &mut self,
+        elem_ty: Type,
+        size: u64,
+        input: Wire,
+    ) -> Result<Wire, BuildError> {
+        self.add_generic_array_pop_left::<Array>(elem_ty, size, input)
+    }
+
+    /// Adds an array pop-right operation to the dataflow graph.
+    ///
+    /// This operation removes the rightmost element from the array.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The type of the elements in the array.
+    /// * `size` - The size of the array.
+    /// * `input` - The wire representing the array.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if building the operation fails.
+    ///
+    /// # Returns
+    ///
+    /// The wire representing the Option<elemty, array<SIZE-1, elemty>>
+    fn add_array_pop_right(
+        &mut self,
+        elem_ty: Type,
+        size: u64,
+        input: Wire,
+    ) -> Result<Wire, BuildError> {
+        self.add_generic_array_pop_right::<Array>(elem_ty, size, input)
+    }
+
+    /// Adds an operation to discard an empty array from the dataflow graph.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The type of the elements in the array.
+    /// * `input` - The wire representing the array.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if building the operation fails.
+    fn add_array_discard_empty(&mut self, elem_ty: Type, input: Wire) -> Result<(), BuildError> {
+        self.add_generic_array_discard_empty::<Array>(elem_ty, input)
+    }
+}
+
+impl<D: Dataflow> ArrayOpBuilder for D {}
 
 #[cfg(test)]
 mod test {

--- a/hugr-llvm/src/extension/collections/array.rs
+++ b/hugr-llvm/src/extension/collections/array.rs
@@ -893,6 +893,7 @@ mod test {
     use hugr_core::extension::prelude::either_type;
     use hugr_core::extension::ExtensionSet;
     use hugr_core::ops::Tag;
+    use hugr_core::std_extensions::collections::array::op_builder::build_all_array_ops;
     use hugr_core::std_extensions::collections::array::{self, array_type, ArrayRepeat, ArrayScan};
     use hugr_core::std_extensions::STD_REG;
     use hugr_core::types::Type;
@@ -923,66 +924,12 @@ mod test {
         utils::{ArrayOpBuilder, IntOpBuilder, LogicOpBuilder},
     };
 
-    /// Build all array ops
-    /// Copied from `hugr_core::std_extensions::collections::array::builder::test`
-    fn all_array_ops<B: Dataflow>(mut builder: B) -> B {
-        let us0 = builder.add_load_value(ConstUsize::new(0));
-        let us1 = builder.add_load_value(ConstUsize::new(1));
-        let us2 = builder.add_load_value(ConstUsize::new(2));
-        let arr = builder.add_new_array(usize_t(), [us1, us2]).unwrap();
-        let [arr] = {
-            let r = builder.add_array_swap(usize_t(), 2, arr, us0, us1).unwrap();
-            let res_sum_ty = {
-                let array_type = array_type(2, usize_t());
-                either_type(array_type.clone(), array_type)
-            };
-            builder.build_unwrap_sum(1, res_sum_ty, r).unwrap()
-        };
-
-        let ([elem_0], arr) = {
-            let (r, arr) = builder.add_array_get(usize_t(), 2, arr, us0).unwrap();
-            (
-                builder
-                    .build_unwrap_sum(1, option_type(usize_t()), r)
-                    .unwrap(),
-                arr,
-            )
-        };
-
-        let [_elem_1, arr] = {
-            let r = builder
-                .add_array_set(usize_t(), 2, arr, us1, elem_0)
-                .unwrap();
-            let res_sum_ty = {
-                let row = vec![usize_t(), array_type(2, usize_t())];
-                either_type(row.clone(), row)
-            };
-            builder.build_unwrap_sum(1, res_sum_ty, r).unwrap()
-        };
-
-        let [_elem_left, arr] = {
-            let r = builder.add_array_pop_left(usize_t(), 2, arr).unwrap();
-            builder
-                .build_unwrap_sum(1, option_type(vec![usize_t(), array_type(1, usize_t())]), r)
-                .unwrap()
-        };
-        let [_elem_right, arr] = {
-            let r = builder.add_array_pop_right(usize_t(), 1, arr).unwrap();
-            builder
-                .build_unwrap_sum(1, option_type(vec![usize_t(), array_type(0, usize_t())]), r)
-                .unwrap()
-        };
-
-        builder.add_array_discard_empty(usize_t(), arr).unwrap();
-        builder
-    }
-
     #[rstest]
     fn emit_all_ops(mut llvm_ctx: TestContext) {
         let hugr = SimpleHugrConfig::new()
             .with_extensions(STD_REG.to_owned())
             .finish(|mut builder| {
-                all_array_ops(builder.dfg_builder_endo([]).unwrap())
+                build_all_array_ops(builder.dfg_builder_endo([]).unwrap())
                     .finish_sub_container()
                     .unwrap();
                 builder.finish_sub_container().unwrap()


### PR DESCRIPTION
* Renamed `ArrayOpBuilder` trait to `GenericOpBuilder` whose methods are generic over the array implementation
* Defined new `ArrayOpBuilder` and `VArrayOpBuilder` traits that are implemented in terms of the generic version. I moved those into the `array` and `value_array` modules respectively, so they don't come into scope at the same time
* Moved `all_array_ops` ops function out of the tests module so we can reuse it across other tests (in particular getting rid of the code duplication in `hugr-llvm::extension::collections::array::test`

BREAKING CHANGE: `ArrayOpBuilder` was moved from `hugr_core::std_extensions::collections::array::op_builder` to `hugr_core::std_extensions::collections::array`