### PR TITLE
fix: Fix the grammar for constant function terms

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - '**'
+      - "**"
   merge_group:
     types: [checks_requested]
   workflow_dispatch: {}
@@ -25,7 +25,6 @@ env:
   LLVM_VERSION: "14.0"
   LLVM_FEATURE_NAME: "14-0"
 
-
 jobs:
   # Check if changes were made to the relevant files.
   # Always returns true if running on the default branch, to ensure all changes are thoroughly checked.
@@ -43,25 +42,25 @@ jobs:
       model: ${{ steps.filter.outputs.model == 'true' || steps.override.outputs.out == 'true' }}
       llvm: ${{ steps.filter.outputs.llvm == 'true' || steps.override.outputs.out == 'true' }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Override label
-      id: override
-      run: |
-        echo "Label contains run-ci-checks: $OVERRIDE_LABEL"
-        if [ "$OVERRIDE_LABEL" == "true" ]; then
-          echo "Overriding due to label 'run-ci-checks'"
-          echo "out=true" >> $GITHUB_OUTPUT
-        elif [ "$DEFAULT_BRANCH" == "true" ]; then
-          echo "Overriding due to running on the default branch"
-          echo "out=true" >> $GITHUB_OUTPUT
-        fi
-      env:
-        OVERRIDE_LABEL: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'run-ci-checks') }}
-        DEFAULT_BRANCH: ${{ github.ref_name == github.event.repository.default_branch }}
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: .github/change-filters.yml
+      - uses: actions/checkout@v4
+      - name: Override label
+        id: override
+        run: |
+          echo "Label contains run-ci-checks: $OVERRIDE_LABEL"
+          if [ "$OVERRIDE_LABEL" == "true" ]; then
+            echo "Overriding due to label 'run-ci-checks'"
+            echo "out=true" >> $GITHUB_OUTPUT
+          elif [ "$DEFAULT_BRANCH" == "true" ]; then
+            echo "Overriding due to running on the default branch"
+            echo "out=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          OVERRIDE_LABEL: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'run-ci-checks') }}
+          DEFAULT_BRANCH: ${{ github.ref_name == github.event.repository.default_branch }}
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: .github/change-filters.yml
 
   check:
     needs: changes
@@ -109,7 +108,7 @@ jobs:
       - name: Override criterion with the CodSpeed harness
         run: cargo add --dev codspeed-criterion-compat --rename criterion --package hugr
       - name: Build benchmarks
-        run: cargo codspeed build --profile bench --features extension_inference,declarative,model_unstable,llvm,llvm-test
+        run: cargo codspeed build --profile bench --features extension_inference,declarative,llvm,llvm-test
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 [features]
 extension_inference = []
 declarative = ["serde_yaml"]
-model_unstable = ["hugr-model"]
 zstd = ["dep:zstd"]
 
 [lib]
@@ -27,10 +26,9 @@ bench = false
 
 [[test]]
 name = "model"
-required-features = ["model_unstable"]
 
 [dependencies]
-hugr-model = { version = "0.19.0", path = "../hugr-model", optional = true }
+hugr-model = { version = "0.19.0", path = "../hugr-model" }
 
 cgmath = { workspace = true, features = ["serde"] }
 delegate = { workspace = true }

--- a/hugr-core/README.md
+++ b/hugr-core/README.md
@@ -1,7 +1,6 @@
 ![](/hugr/assets/hugr_logo.svg)
 
-hugr-core
-===============
+# hugr-core
 
 [![build_status][]](https://github.com/CQCL/hugr/actions)
 [![crates][]](https://crates.io/crates/hugr-core)
@@ -21,9 +20,6 @@ Please read the [API documentation here][].
   Not enabled by default.
 - `declarative`:
   Experimental support for declaring extensions in YAML files, support is limited.
-- `model_unstable`
-  Import and export from the representation defined in the `hugr-model` crate.
-  Unstable and subject to change. Not enabled by default.
 
 ## Recent Changes
 
@@ -38,10 +34,10 @@ See [DEVELOPMENT.md](https://github.com/CQCL/hugr/blob/main/DEVELOPMENT.md) for 
 
 This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http://www.apache.org/licenses/LICENSE-2.0).
 
-  [API documentation here]: https://docs.rs/hugr-core/
-  [build_status]: https://github.com/CQCL/hugr/actions/workflows/ci-rs.yml/badge.svg?branch=main
-  [msrv]: https://img.shields.io/badge/rust-1.75.0%2B-blue.svg
-  [crates]: https://img.shields.io/crates/v/hugr-core
-  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/hugr?logo=codecov
-  [LICENSE]: https://github.com/CQCL/hugr/blob/main/LICENCE
-  [CHANGELOG]: https://github.com/CQCL/hugr/blob/main/hugr-core/CHANGELOG.md
+[API documentation here]: https://docs.rs/hugr-core/
+[build_status]: https://github.com/CQCL/hugr/actions/workflows/ci-rs.yml/badge.svg?branch=main
+[msrv]: https://img.shields.io/badge/rust-1.75.0%2B-blue.svg
+[crates]: https://img.shields.io/crates/v/hugr-core
+[codecov]: https://img.shields.io/codecov/c/gh/CQCL/hugr?logo=codecov
+[LICENSE]: https://github.com/CQCL/hugr/blob/main/LICENCE
+[CHANGELOG]: https://github.com/CQCL/hugr/blob/main/hugr-core/CHANGELOG.md

--- a/hugr-core/src/lib.rs
+++ b/hugr-core/src/lib.rs
@@ -12,11 +12,9 @@
 pub mod builder;
 pub mod core;
 pub mod envelope;
-#[cfg(feature = "model_unstable")]
 pub mod export;
 pub mod extension;
 pub mod hugr;
-#[cfg(feature = "model_unstable")]
 pub mod import;
 pub mod macros;
 pub mod ops;

--- a/hugr-core/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_types.rs
@@ -65,7 +65,6 @@ impl std::ops::Deref for ConstF64 {
 
 impl ConstF64 {
     /// Name of the constructor for creating constant 64bit floats.
-    #[cfg_attr(not(feature = "model_unstable"), allow(dead_code))]
     pub(crate) const CTR_NAME: &'static str = "arithmetic.float.const_f64";
 
     /// Create a new [`ConstF64`]

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -105,7 +105,6 @@ pub struct ConstInt {
 
 impl ConstInt {
     /// Name of the constructor for creating constant integers.
-    #[cfg_attr(not(feature = "model_unstable"), allow(dead_code))]
     pub(crate) const CTR_NAME: &'static str = "arithmetic.int.const";
 
     /// Create a new [`ConstInt`] with a given width and unsigned value

--- a/hugr-core/src/std_extensions/collections/array.rs
+++ b/hugr-core/src/std_extensions/collections/array.rs
@@ -45,7 +45,6 @@ pub struct ArrayValue {
 
 impl ArrayValue {
     /// Name of the constructor for creating constant arrays.
-    #[cfg_attr(not(feature = "model_unstable"), allow(dead_code))]
     pub(crate) const CTR_NAME: &'static str = "collections.array.const";
 
     /// Create a new [CustomConst] for an array of values of type `typ`.

--- a/hugr-model/src/v0/ast/hugr.pest
+++ b/hugr-model/src/v0/ast/hugr.pest
@@ -81,7 +81,7 @@ term_apply      =  { symbol_name | ("(" ~ symbol_name ~ term* ~ ")") }
 term_list       =  { "[" ~ part* ~ "]" }
 term_tuple      =  { "(" ~ "tuple" ~ part* ~ ")" }
 term_list_type  =  { "(" ~ "list" ~ term ~ ")" }
-term_const_func =  { "(" ~ "fn" ~ term ~ ")" }
+term_const_func =  { "(" ~ "fn" ~ region ~ ")" }
 
 part         = { spliced_term | term }
 spliced_term = { term ~ "..." }

--- a/hugr-model/tests/binary.rs
+++ b/hugr-model/tests/binary.rs
@@ -77,3 +77,8 @@ pub fn test_const() {
 pub fn test_literals() {
     binary_roundtrip(include_str!("fixtures/model-literals.edn"));
 }
+
+#[test]
+pub fn test_const_func() {
+    binary_roundtrip(include_str!("fixtures/model-const-func.edn"));
+}

--- a/hugr-model/tests/fixtures/model-const-func.edn
+++ b/hugr-model/tests/fixtures/model-const-func.edn
@@ -1,0 +1,8 @@
+(hugr 0)
+
+(mod)
+
+(define-alias id
+  (param ?t core.type)
+  (core.const (core.fn [?t] [?t]))
+  (fn (dfg [%x] [%x])))

--- a/hugr-model/tests/snapshots/text__const_func.snap
+++ b/hugr-model/tests/snapshots/text__const_func.snap
@@ -1,0 +1,13 @@
+---
+source: hugr-model/tests/text.rs
+expression: "roundtrip(include_str!(\"fixtures/model-const-func.edn\"))"
+---
+(hugr 0)
+
+(mod)
+
+(define-alias
+  id
+  (param ?t core.type)
+  (core.const (core.fn [?t] [?t]))
+  (fn (dfg [%x] [%x])))

--- a/hugr-model/tests/text.rs
+++ b/hugr-model/tests/text.rs
@@ -19,3 +19,9 @@ pub fn test_declarative_extensions() {
 pub fn test_literals() {
     insta::assert_snapshot!(roundtrip(include_str!("fixtures/model-literals.edn")))
 }
+
+#[test]
+#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
+pub fn test_const_func() {
+    insta::assert_snapshot!(roundtrip(include_str!("fixtures/model-const-func.edn")))
+}

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -26,13 +26,12 @@ default = ["zstd"]
 
 extension_inference = ["hugr-core/extension_inference"]
 declarative = ["hugr-core/declarative"]
-model_unstable = ["hugr-core/model_unstable", "hugr-model"]
 llvm = ["hugr-llvm/llvm14-0"]
 llvm-test = ["hugr-llvm/llvm14-0", "hugr-llvm/test-utils"]
 zstd = ["hugr-core/zstd"]
 
 [dependencies]
-hugr-model = { path = "../hugr-model", optional = true, version = "0.19.0" }
+hugr-model = { path = "../hugr-model", version = "0.19.0" }
 hugr-core = { path = "../hugr-core", version = "0.15.3" }
 hugr-passes = { path = "../hugr-passes", version = "0.15.3" }
 hugr-llvm = { path = "../hugr-llvm", version = "0.15.3", optional = true }

--- a/hugr/benches/benchmarks/hugr.rs
+++ b/hugr/benches/benchmarks/hugr.rs
@@ -24,10 +24,8 @@ impl Serializer for JsonSer {
     }
 }
 
-#[cfg(feature = "model_unstable")]
 struct CapnpSer;
 
-#[cfg(feature = "model_unstable")]
 impl Serializer for CapnpSer {
     fn serialize(&self, hugr: &Hugr) -> Vec<u8> {
         let bump = bumpalo::Bump::new();
@@ -90,20 +88,17 @@ fn bench_serialization(c: &mut Criterion) {
     }
     group.finish();
 
-    #[cfg(feature = "model_unstable")]
-    {
-        let mut group = c.benchmark_group("circuit_roundtrip/capnp");
-        group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-        for size in [0, 1, 10, 100, 1000].iter() {
-            group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
-                let h = circuit(size).0;
-                b.iter(|| {
-                    black_box(roundtrip(&h, CapnpSer));
-                });
+    let mut group = c.benchmark_group("circuit_roundtrip/capnp");
+    group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+    for size in [0, 1, 10, 100, 1000].iter() {
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            let h = circuit(size).0;
+            b.iter(|| {
+                black_box(roundtrip(&h, CapnpSer));
             });
-        }
-        group.finish();
+        });
     }
+    group.finish();
 }
 
 criterion_group! {

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -63,9 +63,7 @@ version_group = "hugr"
 [[package]]
 name = "hugr-model"
 release = true
-# Use a separate version group while the dependency is `-unstable`,
-# to avoid breaking releases of the main package.
-version_group = "hugr-model"
+version_group = "hugr"
 
 [[package]]
 name = "hugr-llvm"


### PR DESCRIPTION
This PR fixes the PEST grammar for constant function terms. It erroneously expected a nested `term` instead of a nested `region`. Regression tests are included.