### PR TITLE
feat!: Accept outgoing ports in SimpleReplacement nu_out

### DIFF
--- a/hugr-core/src/hugr/patch/port_types.rs
+++ b/hugr-core/src/hugr/patch/port_types.rs
@@ -23,7 +23,7 @@ pub enum BoundaryPort<HostNode, P> {
 pub struct HostPort<N, P>(pub N, pub P);
 
 /// A port in the replacement graph.
-#[derive(Debug, Clone, Copy, From)]
+#[derive(Debug, Clone, Copy, From, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ReplacementPort<P>(pub Node, pub P);
 
 impl<HostNode: Copy, P> BoundaryPort<HostNode, P> {

--- a/hugr-core/src/hugr/patch/simple_replace.rs
+++ b/hugr-core/src/hugr/patch/simple_replace.rs
@@ -1134,7 +1134,7 @@ pub(in crate::hugr::patch) mod test {
             .nodes()
             .find(|node: &Node| *h.get_optype(*node) == cx_gate().into())
             .unwrap();
-        let s: Vec<Node> = vec![h_node_cx].into_iter().collect();
+        let s = vec![h_node_cx];
         // 2. Construct a new DFG-rooted hugr for the replacement
         let n: Hugr = dfg_hugr2;
         // 3. Construct the input and output matchings

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -10,7 +10,7 @@
 //! hierarchy.
 
 use std::cell::OnceCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::mem;
 
 use itertools::Itertools;
@@ -433,14 +433,11 @@ impl<N: HugrNode> SiblingSubgraph<N> {
                     })
             })
             .collect();
-        let nu_out = self
+        let nu_out: HashMap<_, _> = self
             .outputs
             .iter()
             .zip_eq(rep_outputs)
-            .flat_map(|(&(self_source_n, self_source_p), (_, rep_target_p))| {
-                hugr.linked_inputs(self_source_n, self_source_p)
-                    .map(move |self_target| (self_target, rep_target_p))
-            })
+            .map(|(&self_target, (_, rep_target_p))| (self_target, rep_target_p))
             .collect();
 
         Ok(SimpleReplacement::new(


### PR DESCRIPTION
Currently, SimpleReplacement stores its output boundary map nu_out by referring to nodes outside the deleted subgraph in the host graph. This forces the invalidation set of the replacements to include nodes past the output, forbidding simultaneous adjacent replacements.

This PR fixes this by allowing the keys of `nu_out` (i.e. the ports on the output boundary of the subgraph) to be either incoming ports (as before), or outgoing ports (in which case this is equivalent to specifying the map on all incoming ports linked to the given outgoing ports). The latter is less general but covers most use cases and reduces the size of the invalidation set.

Closes https://github.com/CQCL/hugr/issues/2098

BREAKING CHANGE: Generalised arguments to [`SimpleReplacement::new`] and [`SimpleReplacement::map_host_output`] to allow for outgoing ports. Previous type signatures remain valid, however, type inference may fail.