### PR TITLE
feat!: Validate any HugrView, make errors generic

### DIFF
--- a/hugr-cli/src/validate.rs
+++ b/hugr-cli/src/validate.rs
@@ -3,7 +3,7 @@
 use clap::Parser;
 use clap_verbosity_flag::log::Level;
 use hugr::package::PackageValidationError;
-use hugr::Hugr;
+use hugr::{Hugr, HugrView};
 
 use crate::hugr_io::HugrInputArgs;
 use crate::{CliError, OtherArgs};

--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -26,7 +26,7 @@
 //! `CircuitBuilder`.
 //!
 //! ```rust
-//! # use hugr::Hugr;
+//! # use hugr::{Hugr, HugrView};
 //! # use hugr::builder::{BuildError, BuildHandle, Container, DFGBuilder, Dataflow, DataflowHugr, ModuleBuilder, DataflowSubContainer, HugrBuilder};
 //! use hugr::extension::prelude::bool_t;
 //! use hugr::std_extensions::logic::{self, LogicOp};
@@ -138,7 +138,7 @@ pub fn inout_sig(inputs: impl Into<TypeRow>, outputs: impl Into<TypeRow>) -> Sig
 pub enum BuildError {
     /// The constructed HUGR is invalid.
     #[error("The constructed HUGR is invalid: {0}.")]
-    InvalidHUGR(#[from] ValidationError),
+    InvalidHUGR(#[from] ValidationError<Node>),
     /// SignatureError in trying to construct a node (differs from
     /// [ValidationError::SignatureError] in that we could not construct a node to report about)
     #[error(transparent)]

--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -161,7 +161,7 @@ pub trait Container {
 /// (with varying root node types)
 pub trait HugrBuilder: Container {
     /// Finish building the HUGR, perform any validation checks and return it.
-    fn finish_hugr(self) -> Result<Hugr, ValidationError>;
+    fn finish_hugr(self) -> Result<Hugr, ValidationError<Node>>;
 }
 
 /// Types implementing this trait build a container graph region by borrowing a HUGR

--- a/hugr-core/src/builder/cfg.rs
+++ b/hugr-core/src/builder/cfg.rs
@@ -155,7 +155,7 @@ impl CFGBuilder<Hugr> {
 }
 
 impl HugrBuilder for CFGBuilder<Hugr> {
-    fn finish_hugr(self) -> Result<Hugr, crate::hugr::ValidationError> {
+    fn finish_hugr(self) -> Result<Hugr, crate::hugr::ValidationError<Node>> {
         self.base.validate()?;
         Ok(self.base)
     }

--- a/hugr-core/src/builder/conditional.rs
+++ b/hugr-core/src/builder/conditional.rs
@@ -138,7 +138,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
 }
 
 impl HugrBuilder for ConditionalBuilder<Hugr> {
-    fn finish_hugr(self) -> Result<Hugr, crate::hugr::ValidationError> {
+    fn finish_hugr(self) -> Result<Hugr, crate::hugr::ValidationError<Node>> {
         self.base.validate()?;
         Ok(self.base)
     }

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -99,7 +99,7 @@ impl DFGBuilder<Hugr> {
 }
 
 impl HugrBuilder for DFGBuilder<Hugr> {
-    fn finish_hugr(self) -> Result<Hugr, ValidationError> {
+    fn finish_hugr(self) -> Result<Hugr, ValidationError<Node>> {
         self.base.validate()?;
         Ok(self.base)
     }
@@ -306,7 +306,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>, T: From<BuildHandle<DfgID>>> SubContainer for
 }
 
 impl<T> HugrBuilder for DFGWrapper<Hugr, T> {
-    fn finish_hugr(self) -> Result<Hugr, ValidationError> {
+    fn finish_hugr(self) -> Result<Hugr, ValidationError<Node>> {
         self.0.finish_hugr()
     }
 }

--- a/hugr-core/src/builder/module.rs
+++ b/hugr-core/src/builder/module.rs
@@ -50,7 +50,7 @@ impl Default for ModuleBuilder<Hugr> {
 }
 
 impl HugrBuilder for ModuleBuilder<Hugr> {
-    fn finish_hugr(self) -> Result<Hugr, ValidationError> {
+    fn finish_hugr(self) -> Result<Hugr, ValidationError<Node>> {
         self.0.validate()?;
         Ok(self.0)
     }

--- a/hugr-core/src/builder/tail_loop.rs
+++ b/hugr-core/src/builder/tail_loop.rs
@@ -105,7 +105,7 @@ mod test {
     use super::*;
     #[test]
     fn basic_loop() -> Result<(), BuildError> {
-        let build_result: Result<Hugr, ValidationError> = {
+        let build_result: Result<Hugr, ValidationError<_>> = {
             let mut loop_b = TailLoopBuilder::new(vec![], vec![bool_t()], vec![usize_t()])?;
             let [i1] = loop_b.input_wires_arr();
             let const_wire = loop_b.add_load_value(ConstUsize::new(1));

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -33,6 +33,7 @@ use types_mut::{
 use derive_more::{Display, Error, From};
 
 use super::{Extension, ExtensionId, ExtensionRegistry, ExtensionSet};
+use crate::core::HugrNode;
 use crate::ops::constant::ValueName;
 use crate::ops::custom::OpaqueOpError;
 use crate::ops::{NamedOp, OpName, OpType, Value};
@@ -78,11 +79,11 @@ pub fn resolve_value_extensions(
 /// Errors that can occur during extension resolution.
 #[derive(Debug, Display, Clone, Error, From, PartialEq)]
 #[non_exhaustive]
-pub enum ExtensionResolutionError {
+pub enum ExtensionResolutionError<N: HugrNode = Node> {
     /// Could not resolve an opaque operation to an extension operation.
     #[display("Error resolving opaque operation: {_0}")]
     #[from]
-    OpaqueOpError(OpaqueOpError),
+    OpaqueOpError(OpaqueOpError<N>),
     /// An operation requires an extension that is not in the given registry.
     #[display(
         "{op}{} requires extension {missing_extension}, but it could not be found in the extension list used during resolution. The available extensions are: {}",
@@ -91,7 +92,7 @@ pub enum ExtensionResolutionError {
     )]
     MissingOpExtension {
         /// The node that requires the extension.
-        node: Option<Node>,
+        node: Option<N>,
         /// The operation that requires the extension.
         op: OpName,
         /// The missing extension
@@ -107,7 +108,7 @@ pub enum ExtensionResolutionError {
     )]
     MissingTypeExtension {
         /// The node that requires the extension.
-        node: Option<Node>,
+        node: Option<N>,
         /// The type that requires the extension.
         ty: TypeName,
         /// The missing extension
@@ -149,10 +150,10 @@ pub enum ExtensionResolutionError {
     },
 }
 
-impl ExtensionResolutionError {
+impl<N: HugrNode> ExtensionResolutionError<N> {
     /// Create a new error for missing operation extensions.
     pub fn missing_op_extension(
-        node: Option<Node>,
+        node: Option<N>,
         op: &OpType,
         missing_extension: &ExtensionId,
         extensions: &ExtensionRegistry,
@@ -167,7 +168,7 @@ impl ExtensionResolutionError {
 
     /// Create a new error for missing type extensions.
     pub fn missing_type_extension(
-        node: Option<Node>,
+        node: Option<N>,
         ty: &TypeName,
         missing_extension: &ExtensionId,
         extensions: &WeakExtensionRegistry,
@@ -184,7 +185,7 @@ impl ExtensionResolutionError {
 /// Errors that can occur when collecting extension requirements.
 #[derive(Debug, Display, Clone, Error, From, PartialEq)]
 #[non_exhaustive]
-pub enum ExtensionCollectionError {
+pub enum ExtensionCollectionError<N: HugrNode = Node> {
     /// An operation requires an extension that is not in the given registry.
     #[display(
         "{op}{} contains custom types for which have lost the reference to their defining extensions. Dropped extensions: {}",
@@ -193,7 +194,7 @@ pub enum ExtensionCollectionError {
     )]
     DroppedOpExtensions {
         /// The node that is missing extensions.
-        node: Option<Node>,
+        node: Option<N>,
         /// The operation that is missing extensions.
         op: OpName,
         /// The missing extensions.
@@ -212,10 +213,10 @@ pub enum ExtensionCollectionError {
     },
 }
 
-impl ExtensionCollectionError {
+impl<N: HugrNode> ExtensionCollectionError<N> {
     /// Create a new error when operation extensions have been dropped.
     pub fn dropped_op_extension(
-        node: Option<Node>,
+        node: Option<N>,
         op: &OpType,
         missing_extension: impl IntoIterator<Item = ExtensionId>,
     ) -> Self {

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -337,7 +337,7 @@ pub enum LoadHugrError {
     Load(#[from] serde_json::Error),
     /// Validation of the loaded Hugr failed.
     #[error(transparent)]
-    Validation(#[from] ValidationError),
+    Validation(#[from] ValidationError<Node>),
     /// Error when resolving extension operations and types.
     #[error(transparent)]
     Extension(#[from] ExtensionResolutionError),

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -25,7 +25,7 @@ use crate::types::{
     CustomType, FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature, Type, TypeBound, TypeRV,
     TypeRow,
 };
-use crate::{const_extension_ids, test_file, type_row, Direction, IncomingPort, Node};
+use crate::{const_extension_ids, test_file, type_row, Direction, Hugr, IncomingPort, Node};
 
 /// Creates a hugr with a single function definition that copies a bit `copies` times.
 ///
@@ -87,7 +87,7 @@ fn invalid_root() {
     b.set_parent(root, module);
     assert_matches!(
         b.validate(),
-        Err(ValidationError::RootNotRoot { node }) => assert_eq!(node, root)
+        Err(ValidationError::NoParent { node }) => assert_eq!(node, module)
     );
 
     // Fix the root
@@ -189,7 +189,7 @@ fn df_children_restrictions() {
     assert_matches!(
         b.validate(),
         Err(ValidationError::InvalidChildren { parent, source: ChildrenValidationError::IOSignatureMismatch { child, .. }, .. })
-            => {assert_eq!(parent, def); assert_eq!(child, output.into_portgraph())}
+            => {assert_eq!(parent, def); assert_eq!(child, output)}
     );
     b.replace_op(output, ops::Output::new(vec![bool_t(), bool_t()]));
 
@@ -198,7 +198,7 @@ fn df_children_restrictions() {
     assert_matches!(
         b.validate(),
         Err(ValidationError::InvalidChildren { parent, source: ChildrenValidationError::InternalIOChildren { child, .. }, .. })
-            => {assert_eq!(parent, def); assert_eq!(child, copy.into_portgraph())}
+            => {assert_eq!(parent, def); assert_eq!(child, copy)}
     );
 }
 
@@ -807,7 +807,7 @@ fn cfg_children_restrictions() {
     assert_matches!(
         b.validate(),
         Err(ValidationError::InvalidChildren { parent, source: ChildrenValidationError::InternalExitChildren { child, .. }, .. })
-            => {assert_eq!(parent, cfg); assert_eq!(child, exit2.into_portgraph())}
+            => {assert_eq!(parent, cfg); assert_eq!(child, exit2)}
     );
     b.remove_node(exit2);
 

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -24,6 +24,7 @@ use portgraph::render::{DotFormat, MermaidFormat};
 use portgraph::{LinkView, PortView};
 
 use super::internal::{HugrInternals, HugrMutInternals};
+use super::validate::ValidationContext;
 use super::{Hugr, HugrMut, Node, NodeMetadata, ValidationError};
 use crate::core::HugrNode;
 use crate::extension::ExtensionRegistry;
@@ -451,9 +452,12 @@ pub trait HugrView: HugrInternals {
     fn extensions(&self) -> &ExtensionRegistry;
 
     /// Check the validity of the underlying HUGR.
-    fn validate(&self) -> Result<(), ValidationError> {
-        #[allow(deprecated)]
-        self.base_hugr().validate()
+    fn validate(&self) -> Result<(), ValidationError<Self::Node>>
+    where
+        Self: Sized,
+    {
+        let mut validator = ValidationContext::new(self);
+        validator.validate()
     }
 
     /// Extracts a HUGR containing the parent node and all its descendants.

--- a/hugr-core/src/hugr/views/impls.rs
+++ b/hugr-core/src/hugr/views/impls.rs
@@ -70,7 +70,7 @@ macro_rules! hugr_view_methods {
                 fn static_targets(&self, node: Self::Node) -> Option<impl Iterator<Item = (Self::Node, crate::IncomingPort)>>;
                 fn value_types(&self, node: Self::Node, dir: crate::Direction) -> impl Iterator<Item = (crate::Port, crate::types::Type)>;
                 fn extensions(&self) -> &crate::extension::ExtensionRegistry;
-                fn validate(&self) -> Result<(), crate::hugr::ValidationError>;
+                fn validate(&self) -> Result<(), crate::hugr::ValidationError<Self::Node>>;
                 fn extract_hugr(&self, parent: Self::Node) -> (crate::Hugr, impl crate::hugr::views::ExtractionResult<Self::Node> + 'static);
             }
         }

--- a/hugr-core/src/hugr/views/rerooted.rs
+++ b/hugr-core/src/hugr/views/rerooted.rs
@@ -114,7 +114,7 @@ impl<H: HugrView> HugrView for Rerooted<H> {
                 fn static_targets(&self, node: Self::Node) -> Option<impl Iterator<Item = (Self::Node, crate::IncomingPort)>>;
                 fn value_types(&self, node: Self::Node, dir: crate::Direction) -> impl Iterator<Item = (crate::Port, crate::types::Type)>;
                 fn extensions(&self) -> &crate::extension::ExtensionRegistry;
-                fn validate(&self) -> Result<(), crate::hugr::ValidationError>;
+                fn validate(&self) -> Result<(), crate::hugr::ValidationError<Self::Node>>;
                 fn extract_hugr(&self, parent: Self::Node) -> (crate::Hugr, impl crate::hugr::views::ExtractionResult<Self::Node> + 'static);
         }
     }

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -18,12 +18,11 @@ use std::borrow::Cow;
 use crate::extension::simple_op::MakeExtensionOp;
 use crate::extension::{ExtensionId, ExtensionRegistry};
 use crate::types::{EdgeKind, Signature, Substitution};
-use crate::{Direction, OutgoingPort, Port};
+use crate::{Direction, Node, OutgoingPort, Port};
 use crate::{IncomingPort, PortIndex};
 use derive_more::Display;
 use handle::NodeHandle;
 use paste::paste;
-use portgraph::NodeIndex;
 
 use enum_dispatch::enum_dispatch;
 
@@ -298,7 +297,7 @@ impl OpType {
     /// Checks whether the operation can contain children nodes.
     #[inline]
     pub fn is_container(&self) -> bool {
-        self.validity_flags().allowed_children != OpTag::None
+        self.validity_flags::<Node>().allowed_children != OpTag::None
     }
 
     /// Cast to an extension operation.
@@ -491,16 +490,16 @@ impl OpParent for ExitBlock {}
 pub trait ValidateOp {
     /// Returns a set of flags describing the validity predicates for this operation.
     #[inline]
-    fn validity_flags(&self) -> validate::OpValidityFlags {
+    fn validity_flags<N: HugrNode>(&self) -> validate::OpValidityFlags<N> {
         Default::default()
     }
 
     /// Validate the ordered list of children.
     #[inline]
-    fn validate_op_children<'a>(
+    fn validate_op_children<'a, N: HugrNode>(
         &self,
-        _children: impl DoubleEndedIterator<Item = (NodeIndex, &'a OpType)>,
-    ) -> Result<(), validate::ChildrenValidationError> {
+        _children: impl DoubleEndedIterator<Item = (N, &'a OpType)>,
+    ) -> Result<(), validate::ChildrenValidationError<N>> {
         Ok(())
     }
 }

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -12,10 +12,11 @@ use {
     ::proptest_derive::Arbitrary,
 };
 
+use crate::core::HugrNode;
 use crate::extension::simple_op::MakeExtensionOp;
 use crate::extension::{ConstFoldResult, ExtensionId, OpDef, SignatureError};
 use crate::types::{type_param::TypeArg, Signature};
-use crate::{ops, IncomingPort, Node};
+use crate::{ops, IncomingPort};
 
 use super::dataflow::DataflowOpTrait;
 use super::tag::OpTag;
@@ -316,14 +317,14 @@ impl DataflowOpTrait for OpaqueOp {
 /// when trying to resolve the serialized names against a registry of known Extensions.
 #[derive(Clone, Debug, Error, PartialEq)]
 #[non_exhaustive]
-pub enum OpaqueOpError {
+pub enum OpaqueOpError<N: HugrNode> {
     /// The Extension was found but did not contain the expected OpDef
     #[error("Operation '{op}' in {node} not found in Extension {extension}. Available operations: {}",
             available_ops.iter().join(", ")
     )]
     OpNotFoundInExtension {
         /// The node where the error occurred.
-        node: Node,
+        node: N,
         /// The missing operation.
         op: OpName,
         /// The extension where the operation was expected.
@@ -335,7 +336,7 @@ pub enum OpaqueOpError {
     #[error("Conflicting signature: resolved {op} in extension {extension} to a concrete implementation which computed {computed} but stored signature was {stored}")]
     #[allow(missing_docs)]
     SignatureMismatch {
-        node: Node,
+        node: N,
         extension: ExtensionId,
         op: OpName,
         stored: Signature,
@@ -345,14 +346,14 @@ pub enum OpaqueOpError {
     #[error("Error in signature of operation '{name}' in {node}: {cause}")]
     #[allow(missing_docs)]
     SignatureError {
-        node: Node,
+        node: N,
         name: OpName,
         #[source]
         cause: SignatureError,
     },
     /// Unresolved operation encountered during validation.
     #[error("Unexpected unresolved opaque operation '{1}' in {0}, from Extension {2}.")]
-    UnresolvedOp(Node, OpName, ExtensionId),
+    UnresolvedOp(N, OpName, ExtensionId),
     /// Error updating the extension registry in the Hugr while resolving opaque ops.
     #[error("Error updating extension registry: {0}")]
     ExtensionRegistryError(#[from] crate::extension::ExtensionRegistryError),
@@ -367,6 +368,7 @@ mod test {
     use crate::extension::ExtensionRegistry;
     use crate::std_extensions::arithmetic::conversions::{self};
     use crate::std_extensions::STD_REG;
+    use crate::Node;
     use crate::{
         extension::{
             prelude::{bool_t, qb_t, usize_t},

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -9,7 +9,7 @@ use crate::envelope::{read_envelope, write_envelope, EnvelopeConfig, EnvelopeErr
 use crate::extension::resolution::ExtensionResolutionError;
 use crate::extension::{ExtensionId, ExtensionRegistry, PRELUDE_REGISTRY};
 use crate::hugr::{ExtensionError, HugrView, ValidationError};
-use crate::{Extension, Hugr};
+use crate::{Extension, Hugr, Node};
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 /// Package of module HUGRs.
@@ -291,7 +291,7 @@ pub enum PackageValidationError {
         available: Vec<ExtensionId>,
     },
     /// Error raised while validating the package hugrs.
-    Validation(ValidationError),
+    Validation(ValidationError<Node>),
 }
 
 #[cfg(test)]

--- a/hugr-core/src/std_extensions/ptr.rs
+++ b/hugr-core/src/std_extensions/ptr.rs
@@ -225,6 +225,7 @@ pub(crate) mod test {
     use crate::builder::DFGBuilder;
     use crate::extension::prelude::bool_t;
     use crate::ops::ExtensionOp;
+    use crate::HugrView;
     use crate::{
         builder::{Dataflow, DataflowHugr},
         std_extensions::arithmetic::int_types::INT_TYPES,

--- a/hugr-passes/src/dead_funcs.rs
+++ b/hugr-passes/src/dead_funcs.rs
@@ -128,7 +128,7 @@ impl ComposablePass for RemoveDeadFuncsPass {
 pub fn remove_dead_funcs(
     h: &mut impl HugrMut<Node = Node>,
     entry_points: impl IntoIterator<Item = Node>,
-) -> Result<(), ValidatePassError<RemoveDeadFuncsError>> {
+) -> Result<(), ValidatePassError<Node, RemoveDeadFuncsError>> {
     validate_if_test(
         RemoveDeadFuncsPass::default().with_module_entry_points(entry_points),
         h,

--- a/hugr-passes/src/monomorphize.rs
+++ b/hugr-passes/src/monomorphize.rs
@@ -34,7 +34,7 @@ use crate::ComposablePass;
 /// whenever the names of their parents are unique, but this is not guaranteed.
 pub fn monomorphize(
     hugr: &mut impl HugrMut<Node = Node>,
-) -> Result<(), ValidatePassError<Infallible>> {
+) -> Result<(), ValidatePassError<Node, Infallible>> {
     validate_if_test(MonomorphizePass, hugr)
 }
 


### PR DESCRIPTION
Removes the dependency on `base_hugr` when validating views.
Now the validation code runs directly on any given `HugrView`.

To make this work I had to add `<N: HugrNode>` parameters to multiple error types.
This makes sense, as now validating a non-`Node` hugr will return errors with the correct indices.

BREAKING CHANGE: Added node parameters to multiple error types, including the one returned by `HugrView::validate`.