### PR TITLE
feat!: Return a node mapping in HugrInternals::region_portgraph

### DIFF
--- a/hugr-core/src/hugr/internal.rs
+++ b/hugr-core/src/hugr/internal.rs
@@ -46,7 +46,7 @@ pub trait HugrInternals {
     // when doing so we are unable to restrict the type to implement petgraph's
     // traits over references (e.g. `&MyGraph : IntoNodeIdentifiers`, which is
     // needed if we want to use petgraph's algorithms on the region graph).
-    // This won't be solvable until we don't do the big petgraph refactor -.-
+    // This won't be solvable until we do the big petgraph refactor -.-
     // In the meantime, just wrap the portgraph in a `FlatRegion` as needed.
     fn region_portgraph(
         &self,

--- a/hugr-core/src/hugr/internal.rs
+++ b/hugr-core/src/hugr/internal.rs
@@ -24,19 +24,37 @@ pub trait HugrInternals {
     where
         Self: 'p;
 
+    /// The portgraph graph structure returned by [`HugrInternals::region_portgraph`].
+    type RegionPortgraph<'p>: LinkView<LinkEndpoint: Eq> + Clone + 'p
+    where
+        Self: 'p;
+
     /// The type of nodes in the Hugr.
     type Node: Copy + Ord + std::fmt::Debug + std::fmt::Display + std::hash::Hash;
+
+    /// A mapping between HUGR nodes and portgraph nodes in the graph returned by
+    /// [`HugrInternals::region_portgraph`].
+    type RegionPortgraphNodes: PortgraphNodeMap<Self::Node>;
 
     /// Returns a reference to the underlying portgraph.
     fn portgraph(&self) -> Self::Portgraph<'_>;
 
-    /// Returns a flat portgraph view of a region in the HUGR.
-    ///
-    /// This is a subgraph of [`HugrInternals::portgraph`], with a flat hierarchy.
+    /// Returns a flat portgraph view of a region in the HUGR, and a mapping between
+    /// HUGR nodes and portgraph nodes in the graph.
+    //
+    // NOTE: Ideally here we would just return `Self::RegionPortgraph<'_>`, but
+    // when doing so we are unable to restrict the type to implement petgraph's
+    // traits over references (e.g. `&MyGraph : IntoNodeIdentifiers`, which is
+    // needed if we want to use petgraph's algorithms on the region graph).
+    // This won't be solvable until we don't do the big petgraph refactor -.-
+    // In the meantime, just wrap the portgraph in a `FlatRegion` as needed.
     fn region_portgraph(
         &self,
         parent: Self::Node,
-    ) -> portgraph::view::FlatRegion<'_, impl LinkView<LinkEndpoint: Eq> + Clone + '_>;
+    ) -> (
+        portgraph::view::FlatRegion<'_, Self::RegionPortgraph<'_>>,
+        Self::RegionPortgraphNodes,
+    );
 
     /// Returns the portgraph [Hierarchy](portgraph::Hierarchy) of the graph
     /// returned by [`HugrInternals::portgraph`].
@@ -65,13 +83,55 @@ pub trait HugrInternals {
     fn base_hugr(&self) -> &Hugr;
 }
 
+/// A map between hugr nodes and portgraph nodes in the graph returned by
+/// [`HugrInternals::region_portgraph`].
+pub trait PortgraphNodeMap<N>: Clone + Sized + std::fmt::Debug {
+    /// Returns the portgraph index of a HUGR node in the associated region
+    /// graph.
+    ///
+    /// If the node is not in the region, the result is undefined.
+    fn to_portgraph(&self, node: N) -> portgraph::NodeIndex;
+
+    /// Returns the HUGR node for a portgraph node in the associated region
+    /// graph.
+    ///
+    /// If the node is not in the region, the result is undefined.
+    #[allow(clippy::wrong_self_convention)]
+    fn from_portgraph(&self, node: portgraph::NodeIndex) -> N;
+}
+
+/// An identity map between HUGR nodes and portgraph nodes.
+#[derive(
+    Copy, Clone, Debug, Default, Eq, PartialEq, Hash, PartialOrd, Ord, derive_more::Display,
+)]
+pub struct DefaultPGNodeMap;
+
+impl PortgraphNodeMap<Node> for DefaultPGNodeMap {
+    #[inline]
+    fn to_portgraph(&self, node: Node) -> portgraph::NodeIndex {
+        node.into_portgraph()
+    }
+
+    #[inline]
+    fn from_portgraph(&self, node: portgraph::NodeIndex) -> Node {
+        node.into()
+    }
+}
+
 impl HugrInternals for Hugr {
     type Portgraph<'p>
         = &'p MultiPortGraph
     where
         Self: 'p;
 
+    type RegionPortgraph<'p>
+        = &'p MultiPortGraph
+    where
+        Self: 'p;
+
     type Node = Node;
+
+    type RegionPortgraphNodes = DefaultPGNodeMap;
 
     #[inline]
     fn portgraph(&self) -> Self::Portgraph<'_> {
@@ -82,10 +142,14 @@ impl HugrInternals for Hugr {
     fn region_portgraph(
         &self,
         parent: Self::Node,
-    ) -> portgraph::view::FlatRegion<'_, impl LinkView<LinkEndpoint: Eq> + Clone + '_> {
+    ) -> (
+        portgraph::view::FlatRegion<'_, Self::RegionPortgraph<'_>>,
+        Self::RegionPortgraphNodes,
+    ) {
         let pg = self.portgraph();
         let root = self.to_portgraph_node(parent);
-        portgraph::view::FlatRegion::new_without_root(pg, &self.hierarchy, root)
+        let region = portgraph::view::FlatRegion::new_without_root(pg, &self.hierarchy, root);
+        (region, DefaultPGNodeMap)
     }
 
     #[inline]

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -86,7 +86,7 @@ impl<'a> ValidationContext<'a> {
     /// The results of this computation should be cached in `self.dominators`.
     /// We don't do it here to avoid mutable borrows.
     fn compute_dominator(&self, parent: Node) -> Dominators<portgraph::NodeIndex> {
-        let region = self.hugr.region_portgraph(parent);
+        let (region, _) = self.hugr.region_portgraph(parent);
         let entry_node = self.hugr.children(parent).next().unwrap();
         dominators::simple_fast(&region, entry_node.into_portgraph())
     }
@@ -357,7 +357,7 @@ impl<'a> ValidationContext<'a> {
             return Ok(());
         };
 
-        let region = self.hugr.region_portgraph(parent);
+        let (region, _) = self.hugr.region_portgraph(parent);
         let postorder = Topo::new(&region);
         let nodes_visited = postorder
             .iter(&region)

--- a/hugr-core/src/hugr/views/impls.rs
+++ b/hugr-core/src/hugr/views/impls.rs
@@ -12,7 +12,7 @@ macro_rules! hugr_internal_methods {
         delegate::delegate! {
             to ({let $arg=self; $e}) {
                 fn portgraph(&self) -> Self::Portgraph<'_>;
-                fn region_portgraph(&self, parent: Self::Node) -> portgraph::view::FlatRegion<'_, impl portgraph::view::LinkView<LinkEndpoint: Eq> + Clone + '_>;
+                fn region_portgraph(&self, parent: Self::Node) -> (portgraph::view::FlatRegion<'_, Self::RegionPortgraph<'_>>, Self::RegionPortgraphNodes);
                 fn hierarchy(&self) -> &portgraph::Hierarchy;
                 fn to_portgraph_node(&self, node: impl crate::ops::handle::NodeHandle<Self::Node>) -> portgraph::NodeIndex;
                 fn from_portgraph_node(&self, index: portgraph::NodeIndex) -> Self::Node;
@@ -135,7 +135,15 @@ impl<T: HugrView> HugrInternals for &T {
         = T::Portgraph<'p>
     where
         Self: 'p;
+
+    type RegionPortgraph<'p>
+        = T::RegionPortgraph<'p>
+    where
+        Self: 'p;
+
     type Node = T::Node;
+
+    type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
     hugr_internal_methods! {this, *this}
 }
@@ -149,7 +157,15 @@ impl<T: HugrView> HugrInternals for &mut T {
         = T::Portgraph<'p>
     where
         Self: 'p;
+
+    type RegionPortgraph<'p>
+        = T::RegionPortgraph<'p>
+    where
+        Self: 'p;
+
     type Node = T::Node;
+
+    type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
     hugr_internal_methods! {this, &**this}
 }
@@ -169,7 +185,15 @@ impl<T: HugrView> HugrInternals for Rc<T> {
         = T::Portgraph<'p>
     where
         Self: 'p;
+
+    type RegionPortgraph<'p>
+        = T::RegionPortgraph<'p>
+    where
+        Self: 'p;
+
     type Node = T::Node;
+
+    type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
     hugr_internal_methods! {this, this.as_ref()}
 }
@@ -183,7 +207,15 @@ impl<T: HugrView> HugrInternals for Arc<T> {
         = T::Portgraph<'p>
     where
         Self: 'p;
+
+    type RegionPortgraph<'p>
+        = T::RegionPortgraph<'p>
+    where
+        Self: 'p;
+
     type Node = T::Node;
+
+    type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
     hugr_internal_methods! {this, this.as_ref()}
 }
@@ -197,7 +229,15 @@ impl<T: HugrView> HugrInternals for Box<T> {
         = T::Portgraph<'p>
     where
         Self: 'p;
+
+    type RegionPortgraph<'p>
+        = T::RegionPortgraph<'p>
+    where
+        Self: 'p;
+
     type Node = T::Node;
+
+    type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
     hugr_internal_methods! {this, this.as_ref()}
 }
@@ -217,7 +257,15 @@ impl<T: HugrView + ToOwned> HugrInternals for Cow<'_, T> {
         = T::Portgraph<'p>
     where
         Self: 'p;
+
+    type RegionPortgraph<'p>
+        = T::RegionPortgraph<'p>
+    where
+        Self: 'p;
+
     type Node = T::Node;
+
+    type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
     hugr_internal_methods! {this, this.as_ref()}
 }

--- a/hugr-core/src/hugr/views/rerooted.rs
+++ b/hugr-core/src/hugr/views/rerooted.rs
@@ -41,7 +41,15 @@ impl<H: HugrView> HugrInternals for Rerooted<H> {
         = H::Portgraph<'p>
     where
         Self: 'p;
+
+    type RegionPortgraph<'p>
+        = H::RegionPortgraph<'p>
+    where
+        Self: 'p;
+
     type Node = H::Node;
+
+    type RegionPortgraphNodes = H::RegionPortgraphNodes;
 
     super::impls::hugr_internal_methods! {this, &this.hugr}
 }

--- a/hugr-llvm/src/emit/ops.rs
+++ b/hugr-llvm/src/emit/ops.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, Result};
+use hugr_core::hugr::internal::PortgraphNodeMap;
 use hugr_core::ops::{
     constant::Sum, Call, CallIndirect, Case, Conditional, Const, ExtensionOp, Input, LoadConstant,
     LoadFunction, OpTag, OpTrait, OpType, Output, Tag, TailLoop, Value, CFG,
@@ -70,10 +71,10 @@ where
         debug_assert!(i.out_value_types().count() == self.inputs.as_ref().unwrap().len());
         debug_assert!(o.in_value_types().count() == self.outputs.as_ref().unwrap().len());
 
-        let region_graph = node.hugr().region_portgraph(node.node());
+        let (region_graph, node_map) = node.hugr().region_portgraph(node.node());
         let topo = Topo::new(&region_graph);
         for n in topo.iter(&region_graph) {
-            let node = node.hugr().fat_optype(node.hugr().from_portgraph_node(n));
+            let node = node.hugr().fat_optype(node_map.from_portgraph(n));
             let inputs_rmb = context.node_ins_rmb(node)?;
             let inputs = inputs_rmb.read(context.builder(), [])?;
             let outputs = context.node_outs_rmb(node)?.promise();


### PR DESCRIPTION
Closes #2158

Annoyingly, we still need to return a `FlatRegion` (or some other concrete wrapper) here so that _references_ to the graph implements some of petgraph's traits (like `IntoNodeIdentifiers`) which are normally implemented for `&'_ G`. There's no way to write that in a GAT constraint :/
We'll have to wait for the big petgraph rewrite to clean that.

BREAKING CHANGE: `HugrInternals::region_portgraph` now also returns a node mapping between hugr and portgraph nodes