### PR TITLE
feat: Reimplement `insert_hugr` using only `HugrView`

### DIFF
--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -135,6 +135,16 @@ impl Hugr {
             .ok_or(HugrError::UnsupportedEntrypoint { op: op_name })
     }
 
+    /// Reserves enough capacity to insert at least the given number of
+    /// additional nodes and links.
+    ///
+    /// This method does not take into account already allocated free space left
+    /// after node removals, and may overallocate capacity.
+    pub fn reserve(&mut self, nodes: usize, links: usize) {
+        let ports = links * 2;
+        self.graph.reserve(nodes, ports);
+    }
+
     /// Load a Hugr from a json reader.
     ///
     /// Validates the Hugr against the provided extension registry, ensuring all

--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -428,7 +428,7 @@ impl HugrMut for Hugr {
         root: Self::Node,
         other: &H,
     ) -> InsertionResult<H::Node, Self::Node> {
-        let node_map = insert_hugr_internal(self, &other, other.entry_descendants(), |&n| {
+        let node_map = insert_hugr_internal(self, other, other.entry_descendants(), |&n| {
             if n == other.entrypoint() {
                 Some(root)
             } else {
@@ -462,7 +462,7 @@ impl HugrMut for Hugr {
         other: &H,
         subgraph: &SiblingSubgraph<H::Node>,
     ) -> HashMap<H::Node, Self::Node> {
-        let node_map = insert_hugr_internal(self, &other, subgraph.nodes().iter().cloned(), |_| {
+        let node_map = insert_hugr_internal(self, other, subgraph.nodes().iter().cloned(), |_| {
             Some(root)
         });
         // Update the optypes and metadata, copying them from the other graph.


### PR DESCRIPTION
Removes another use of `HugrInternals::portgraph`