### PR TITLE
chore!: Remove deprecated definitions

### DIFF
--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -164,17 +164,6 @@ pub enum EnvelopeError {
     #[display("Zstd compression is not supported. This requires the 'zstd' feature for `hugr`.")]
     #[from(ignore)]
     ZstdUnsupported,
-    /// Tried to encode a package with multiple HUGRs, when only 1 was expected.
-    #[display(
-            "Packages with multiple HUGRs are currently unsupported. Tried to encode {count} HUGRs, when 1 was expected."
-        )]
-    #[from(ignore)]
-    /// Deprecated: Packages with multiple HUGRs is a legacy feature that is no longer supported.
-    #[deprecated(since = "0.15.2", note = "Multiple HUGRs are supported via packages.")]
-    MultipleHugrs {
-        /// The number of HUGRs in the package.
-        count: usize,
-    },
     /// JSON serialization error.
     SerdeError {
         /// The source error.

--- a/hugr-llvm/src/extension/collections/array.rs
+++ b/hugr-llvm/src/extension/collections/array.rs
@@ -892,7 +892,9 @@ mod test {
     use hugr_core::extension::prelude::either_type;
     use hugr_core::ops::Tag;
     use hugr_core::std_extensions::collections::array::op_builder::build_all_array_ops;
-    use hugr_core::std_extensions::collections::array::{self, array_type, ArrayRepeat, ArrayScan};
+    use hugr_core::std_extensions::collections::array::{
+        self, array_type, ArrayOpBuilder, ArrayRepeat, ArrayScan,
+    };
     use hugr_core::std_extensions::STD_REG;
     use hugr_core::types::Type;
     use hugr_core::{
@@ -919,7 +921,7 @@ mod test {
         check_emission,
         emit::test::SimpleHugrConfig,
         test::{exec_ctx, llvm_ctx, TestContext},
-        utils::{ArrayOpBuilder, IntOpBuilder, LogicOpBuilder},
+        utils::{IntOpBuilder, LogicOpBuilder},
     };
 
     #[rstest]

--- a/hugr-llvm/src/extension/int.rs
+++ b/hugr-llvm/src/extension/int.rs
@@ -1114,31 +1114,7 @@ fn emit_const_int<'c, H: HugrView<Node = Node>>(
     Ok(ty.const_int(k.value_u(), false).as_basic_value_enum())
 }
 
-/// Populates a [CodegenExtsBuilder] with all extensions needed to lower int
-/// ops, types, and constants.
-///
-/// Any ops that panic will do so using [DefaultPreludeCodegen].
-#[deprecated]
-pub fn add_int_extensions<'a, H: HugrView<Node = Node> + 'a>(
-    cem: CodegenExtsBuilder<'a, H>,
-) -> CodegenExtsBuilder<'a, H> {
-    cem.add_extension(IntCodegenExtension(DefaultPreludeCodegen))
-}
-
 impl<'a, H: HugrView<Node = Node> + 'a> CodegenExtsBuilder<'a, H> {
-    /// Populates a [CodegenExtsBuilder] with all extensions needed to lower int
-    /// ops, types, and constants.
-    ///
-    /// Any ops that panic will do so using [DefaultPreludeCodegen].
-    ///
-    /// # Deprecated
-    ///
-    /// This method is deprecated in favor of [Self::add_default_int_extensions].
-    #[deprecated]
-    pub fn add_int_extensions(self) -> Self {
-        self.add_default_int_extensions()
-    }
-
     /// Populates a [CodegenExtsBuilder] with all extensions needed to lower int
     /// ops, types, and constants.
     ///

--- a/hugr-llvm/src/utils.rs
+++ b/hugr-llvm/src/utils.rs
@@ -1,15 +1,11 @@
 //! Module for utilities that do not depend on LLVM. These are candidates for
 //! upstreaming.
-#[deprecated(note = "This module is deprecated and will be removed in a future release.")]
-pub mod array_op_builder;
 pub mod fat;
 pub mod inline_constant_functions;
 pub mod int_op_builder;
 pub mod logic_op_builder;
 pub mod type_map;
 
-#[deprecated(note = "Import from hugr_core::std_extensions::collections::array.")]
-pub use hugr_core::std_extensions::collections::array::ArrayOpBuilder;
 pub use inline_constant_functions::inline_constant_functions;
 pub use int_op_builder::IntOpBuilder;
 pub use logic_op_builder::LogicOpBuilder;

--- a/hugr-llvm/src/utils/array_op_builder.rs
+++ b/hugr-llvm/src/utils/array_op_builder.rs
@@ -1,2 +1,0 @@
-#[deprecated(note = "Import from hugr_core::std_extensions::collections::array.")]
-pub use hugr_core::std_extensions::collections::array::op_builder::*;

--- a/hugr-passes/src/dataflow.rs
+++ b/hugr-passes/src/dataflow.rs
@@ -13,7 +13,6 @@ pub use partial_value::{AbstractValue, AsConcrete, LoadedFunction, PartialSum, P
 
 use hugr_core::ops::constant::OpaqueValue;
 use hugr_core::ops::{ExtensionOp, Value};
-use hugr_core::types::TypeArg;
 use hugr_core::Hugr;
 
 /// Clients of the dataflow framework (particular analyses, such as constant folding)
@@ -71,18 +70,6 @@ pub trait ConstLoader<V> {
     /// Produces an abstract value from a Hugr in a [Value::Function], if possible.
     /// The default just returns `None`, which will be interpreted as [PartialValue::Top].
     fn value_from_const_hugr(&self, _loc: ConstLocation<Self::Node>, _h: &Hugr) -> Option<V> {
-        None
-    }
-
-    /// Produces an abstract value from a [FuncDefn] or [FuncDecl] node
-    /// (that has been loaded via a [LoadFunction]), if possible.
-    /// The default just returns `None`, which will be interpreted as [PartialValue::Top].
-    ///
-    /// [FuncDefn]: hugr_core::ops::FuncDefn
-    /// [FuncDecl]: hugr_core::ops::FuncDecl
-    /// [LoadFunction]: hugr_core::ops::LoadFunction
-    #[deprecated(note = "Automatically handled by Datalog, implementation will be ignored")]
-    fn value_from_function(&self, _node: Self::Node, _type_args: &[TypeArg]) -> Option<V> {
         None
     }
 }

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -18,13 +18,6 @@ pub mod merge_bbs;
 mod monomorphize;
 pub mod untuple;
 
-// TODO: Deprecated re-export. Remove on a breaking release.
-#[deprecated(
-    since = "0.14.1",
-    note = "Use `hugr_passes::RemoveDeadFuncsPass` instead."
-)]
-#[allow(deprecated)]
-pub use monomorphize::remove_polyfuncs;
 pub use monomorphize::{mangle_name, monomorphize, MonomorphizePass};
 pub mod replace_types;
 pub use replace_types::ReplaceTypes;

--- a/hugr-passes/src/monomorphize.rs
+++ b/hugr-passes/src/monomorphize.rs
@@ -10,7 +10,7 @@ use hugr_core::{
     Node,
 };
 
-use hugr_core::hugr::{hugrmut::HugrMut, Hugr, HugrView, OpType};
+use hugr_core::hugr::{hugrmut::HugrMut, HugrView, OpType};
 use itertools::Itertools as _;
 
 use crate::composable::{validate_if_test, ValidatePassError};
@@ -36,40 +36,6 @@ pub fn monomorphize(
     hugr: &mut impl HugrMut<Node = Node>,
 ) -> Result<(), ValidatePassError<Infallible>> {
     validate_if_test(MonomorphizePass, hugr)
-}
-
-/// Removes any polymorphic [FuncDefn]s from the Hugr. Note that if these have
-/// calls from *monomorphic* code, this will make the Hugr invalid (call [monomorphize]
-/// first).
-///
-/// Deprecated: use [crate::remove_dead_funcs] instead.
-#[deprecated(
-    since = "0.14.1",
-    note = "Use hugr_passes::RemoveDeadFuncsPass instead"
-)]
-pub fn remove_polyfuncs(mut h: Hugr) -> Hugr {
-    #[allow(deprecated)] // we are in a deprecated function, so remove both at same time
-    remove_polyfuncs_ref(&mut h);
-    h
-}
-
-#[deprecated(
-    since = "0.14.1",
-    note = "Use hugr_passes::RemoveDeadFuncsPass instead"
-)]
-fn remove_polyfuncs_ref(h: &mut impl HugrMut<Node = Node>) {
-    let mut pfs_to_delete = Vec::new();
-    let mut to_scan = Vec::from_iter(h.children(h.entrypoint()));
-    while let Some(n) = to_scan.pop() {
-        if is_polymorphic_funcdefn(h.get_optype(n)) {
-            pfs_to_delete.push(n)
-        } else {
-            to_scan.extend(h.children(n));
-        }
-    }
-    for n in pfs_to_delete {
-        h.remove_subtree(n);
-    }
 }
 
 fn is_polymorphic(fd: &FuncDefn) -> bool {
@@ -243,10 +209,8 @@ fn instantiate(
 /// Replaces calls to polymorphic functions with calls to new monomorphic
 /// instantiations of the polymorphic ones.
 ///
-/// If the Hugr is [Module](OpType::Module)-rooted,
-/// * then the original polymorphic [FuncDefn]s are left untouched (including Calls inside them)
-///     - call [remove_polyfuncs] when no other Hugr will be linked in that might instantiate these
-/// * else, the originals are removed (they are invisible from outside the Hugr).
+/// The original polymorphic [FuncDefn]s are left untouched (including Calls inside them).
+/// Call [crate::remove_dead_funcs] to remove them.
 ///
 /// If the Hugr is [FuncDefn](OpType::FuncDefn)-rooted with polymorphic
 /// signature then the HUGR will not be modified.
@@ -268,10 +232,6 @@ impl ComposablePass for MonomorphizePass {
         // If the root is a polymorphic function, then there are no external calls, so nothing to do
         if !is_polymorphic_funcdefn(h.get_optype(root)) {
             mono_scan(h, root, None, &mut HashMap::new());
-            if !h.get_optype(root).is_module() {
-                #[allow(deprecated)] // TODO remove in next breaking release and update docs
-                remove_polyfuncs_ref(h);
-            }
         }
         Ok(())
     }
@@ -578,14 +538,15 @@ mod test {
                 &mangle_name(&pf2_name, &[TypeArg::BoundedNat { n: 4 }, arr2u().into()]), // from pf1<4>
                 &mangle_name(&pf2_name, &[TypeArg::BoundedNat { n: 2 }, usize_t().into()]), // from both pf1<4> and <5>
                 &mangle_inner_func(&pf2_name, "get_usz"),
-                "mainish"
+                &pf2_name,
+                "mainish",
+                "pf1"
             ]
             .into_iter()
             .sorted()
             .collect_vec()
         );
         for (n, fd) in funcs.into_values() {
-            assert!(!is_polymorphic(fd));
             if n == mono_hugr.entrypoint() {
                 assert_eq!(fd.name, "mainish");
             } else {
@@ -633,7 +594,6 @@ mod test {
         let mono_hugr = hugr;
 
         let mut funcs = list_funcs(&mono_hugr);
-        assert!(funcs.values().all(|(_, fd)| !is_polymorphic(fd)));
         #[allow(clippy::unnecessary_to_owned)] // It is necessary
         let (m, _) = funcs.remove(&"id2".to_string()).unwrap();
         assert_eq!(m, mono.handle().node());


### PR DESCRIPTION
Closes #2117.
Some remaining deprecations will be removed by the other open PRs. 

BREAKING CHANGE: Removed `EnvelopeError::MultipleHugrs`
BREAKING CHANGE: Removed `add_int_extension` alias in `hugr_llvm::extension`
BREAKING CHANGE: Removed re-export of `ArrayOpBuilder` in `hugr_llvm`
BREAKING CHANGE: Removed unused `ConstLoader::value_from_function` in `hugr_passes`
BREAKING CHANGE: `Monomorphize` pass in `hugr_passes` no longer removes the poly functions.