### PR TITLE
chore: remove unused smolstr dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,6 @@ dependencies = [
  "hugr-model",
  "paste",
  "pyo3",
- "smol_str",
 ]
 
 [[package]]

--- a/hugr-py/Cargo.toml
+++ b/hugr-py/Cargo.toml
@@ -24,4 +24,3 @@ bumpalo = { workspace = true, features = ["collections"] }
 hugr-model = { version = "0.19", path = "../hugr-model", features = ["pyo3"] }
 paste.workspace = true
 pyo3 = { workspace = true, features = ["extension-module", "abi3-py310"] }
-smol_str.workspace = true


### PR DESCRIPTION
the others found by cargo-machete were bogus