### PR TITLE
feat: Use hugr-model as default binary encoding

### DIFF
--- a/hugr-core/src/envelope/header.rs
+++ b/hugr-core/src/envelope/header.rs
@@ -33,10 +33,22 @@ pub(super) struct EnvelopeHeader {
 pub enum EnvelopeFormat {
     /// `hugr-model` v0 binary capnproto message.
     Model = 1,
-    /// `hugr-model` v0 binary capnproto message followed by a json-encoded [crate::extension::ExtensionRegistry].
-    //
-    // This is a temporary format required until the model adds support for extensions.
+    /// `hugr-model` v0 binary capnproto message followed by a json-encoded
+    /// [crate::extension::ExtensionRegistry].
+    ///
+    /// This is a temporary format required until the model adds support for
+    /// extensions.
     ModelWithExtensions = 2,
+    /// Human-readable S-expression encoding using [`hugr_model::v0`].
+    ///
+    /// Uses a printable ascii value as the discriminant so the envelope can be
+    /// read as text.
+    ///
+    /// :caution: This format does not yet support extension encoding, so it should
+    /// be avoided.
+    //
+    // TODO: Update comment once extension encoding is supported.
+    ModelText = 40, // '(' in ascii
     /// Json-encoded [crate::package::Package]
     ///
     /// Uses a printable ascii value as the discriminant so the envelope can be
@@ -58,7 +70,7 @@ impl EnvelopeFormat {
     /// If the format is a model format, returns its version number.
     pub fn model_version(self) -> Option<u32> {
         match self {
-            Self::Model | Self::ModelWithExtensions => Some(0),
+            Self::Model | Self::ModelWithExtensions | Self::ModelText => Some(0),
             _ => None,
         }
     }
@@ -67,7 +79,7 @@ impl EnvelopeFormat {
     ///
     /// If true, the encoded envelope can be read as text.
     pub fn ascii_printable(self) -> bool {
-        matches!(self, Self::PackageJson)
+        matches!(self, Self::PackageJson | Self::ModelText)
     }
 }
 
@@ -116,8 +128,8 @@ impl EnvelopeConfig {
     /// If the `zstd` feature is enabled, this will use zstd compression.
     pub const fn binary() -> Self {
         Self {
-            format: EnvelopeFormat::Model,
-            zstd: None,
+            format: EnvelopeFormat::ModelWithExtensions,
+            zstd: Some(ZstdConfig::default_level()),
         }
     }
 }
@@ -137,6 +149,11 @@ pub struct ZstdConfig {
 }
 
 impl ZstdConfig {
+    /// Create a new zstd configuration with default compression level.
+    pub const fn default_level() -> Self {
+        Self { level: None }
+    }
+
     /// Returns the zstd compression level to pass to the zstd library.
     ///
     /// Uses [zstd::DEFAULT_COMPRESSION_LEVEL] if the level is not set.
@@ -224,6 +241,7 @@ mod tests {
     #[rstest]
     #[case(EnvelopeFormat::Model)]
     #[case(EnvelopeFormat::ModelWithExtensions)]
+    #[case(EnvelopeFormat::ModelText)]
     #[case(EnvelopeFormat::PackageJson)]
     fn header_round_trip(#[case] format: EnvelopeFormat) {
         // With zstd compression

--- a/hugr-model/src/v0/ast/mod.rs
+++ b/hugr-model/src/v0/ast/mod.rs
@@ -34,6 +34,7 @@ mod python;
 mod resolve;
 mod view;
 
+pub use parse::ParseError;
 pub use resolve::ResolveError;
 
 /// A package in the hugr AST.


### PR DESCRIPTION
This is an experimental feature that'll be included in the `hugr 0.20.0-rc.0` release candidate for testing