### PR TITLE
fix!: Use unique region_portgraph in convexity check

### DIFF
--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -178,13 +178,12 @@ impl<N: HugrNode> SiblingSubgraph<N> {
         inputs: IncomingPorts<N>,
         outputs: OutgoingPorts<N>,
         hugr: &H,
-        checker: &impl ConvexChecker,
+        checker: &TopoConvexChecker<H>,
     ) -> Result<Self, InvalidSubgraph<N>> {
-        let parent = pick_parent(hugr, &inputs, &outputs)?;
-        let (region, node_map) = hugr.region_portgraph(parent);
+        let (region, node_map) = checker.region_portgraph();
 
         // Ordering of the edges here is preserved and becomes ordering of the signature.
-        let boundary = make_boundary::<H>(&region, &node_map, &inputs, &outputs);
+        let boundary = make_boundary::<H>(&region, node_map, &inputs, &outputs);
         let subpg = Subgraph::new_subgraph(region, boundary);
         let nodes = subpg
             .nodes_iter()
@@ -242,10 +241,10 @@ impl<N: HugrNode> SiblingSubgraph<N> {
     ///
     /// Refer to [`SiblingSubgraph::try_from_nodes`] for the full
     /// documentation.
-    pub fn try_from_nodes_with_checker<'c, 'h: 'c>(
+    pub fn try_from_nodes_with_checker<H: HugrView<Node = N>>(
         nodes: impl Into<Vec<N>>,
-        hugr: &'h impl HugrView<Node = N>,
-        checker: &impl ConvexChecker,
+        hugr: &H,
+        checker: &TopoConvexChecker<H>,
     ) -> Result<Self, InvalidSubgraph<N>> {
         let nodes = nodes.into();
 
@@ -608,6 +607,12 @@ impl<'g, Base: HugrView> TopoConvexChecker<'g, Base> {
         portgraph::view::FlatRegion<'g, Base::RegionPortgraph<'g>>,
     > {
         &self.init_checker().0
+    }
+
+    /// Return the portgraph and node map on which convexity queries are performed.
+    fn region_portgraph(&self) -> (CheckerRegion<'g, Base>, &Base::RegionPortgraphNodes) {
+        let (checker, node_map) = self.init_checker();
+        (checker.graph(), node_map)
     }
 
     /// Returns the node map from the region to the base HUGR.


### PR DESCRIPTION
Previously, `region_portgraph` was called twice: once to construct the convexity checker (e.g. in `try_from_nodes`), and once to actually construct the subgraph (in `try_new_with_checker`). As a result, if the results from `region_portgraph` were not deterministic, the checker would not be valid and the convexity check might fail. I've had to narrow down the argument type, but there is currently only one type of convexity checker used, so this should not impact anyone.

BREAKING CHANGE: `SiblingSubgraph` only accepts `TopoConvexChecker` as convexity checker type
