### PR TITLE
feat!: Remove description on opaque ops.

### DIFF
--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -568,13 +568,7 @@ impl<'a> Context<'a> {
                 // to declare operations as a node, in which case the description will be attached
                 // to that node as metadata.
 
-                let optype = OpType::OpaqueOp(OpaqueOp::new(
-                    extension,
-                    name,
-                    String::default(),
-                    args,
-                    signature,
-                ));
+                let optype = OpType::OpaqueOp(OpaqueOp::new(extension, name, args, signature));
 
                 let node = self.make_node(node_id, optype, parent)?;
 

--- a/hugr-py/src/hugr/_serialization/ops.py
+++ b/hugr-py/src/hugr/_serialization/ops.py
@@ -498,7 +498,6 @@ class ExtensionOp(DataflowOp):
     extension: ExtensionId
     name: str
     signature: stys.FunctionType = Field(default_factory=stys.FunctionType.empty)
-    description: str = ""
     args: list[stys.TypeArg] = Field(default_factory=list)
 
     def insert_port_types(self, in_types: TypeRow, out_types: TypeRow) -> None:

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -315,7 +315,6 @@ class Custom(DataflowOp):
 
     op_name: str
     signature: tys.FunctionType = field(default_factory=tys.FunctionType.empty)
-    description: str = ""
     extension: tys.ExtensionId = ""
     args: list[tys.TypeArg] = field(default_factory=list)
 
@@ -325,7 +324,6 @@ class Custom(DataflowOp):
             extension=self.extension,
             name=self.op_name,
             signature=self.signature._to_serial(),
-            description=self.description,
             args=ser_it(self.args),
         )
 

--- a/specification/schema/hugr_schema_live.json
+++ b/specification/schema/hugr_schema_live.json
@@ -537,11 +537,6 @@
                 "signature": {
                     "$ref": "#/$defs/FunctionType"
                 },
-                "description": {
-                    "default": "",
-                    "title": "Description",
-                    "type": "string"
-                },
                 "args": {
                     "items": {
                         "$ref": "#/$defs/TypeArg"

--- a/specification/schema/hugr_schema_strict_live.json
+++ b/specification/schema/hugr_schema_strict_live.json
@@ -537,11 +537,6 @@
                 "signature": {
                     "$ref": "#/$defs/FunctionType"
                 },
-                "description": {
-                    "default": "",
-                    "title": "Description",
-                    "type": "string"
-                },
                 "args": {
                     "items": {
                         "$ref": "#/$defs/TypeArg"

--- a/specification/schema/testing_hugr_schema_live.json
+++ b/specification/schema/testing_hugr_schema_live.json
@@ -537,11 +537,6 @@
                 "signature": {
                     "$ref": "#/$defs/FunctionType"
                 },
-                "description": {
-                    "default": "",
-                    "title": "Description",
-                    "type": "string"
-                },
                 "args": {
                     "items": {
                         "$ref": "#/$defs/TypeArg"

--- a/specification/schema/testing_hugr_schema_strict_live.json
+++ b/specification/schema/testing_hugr_schema_strict_live.json
@@ -537,11 +537,6 @@
                 "signature": {
                     "$ref": "#/$defs/FunctionType"
                 },
-                "description": {
-                    "default": "",
-                    "title": "Description",
-                    "type": "string"
-                },
                 "args": {
                     "items": {
                         "$ref": "#/$defs/TypeArg"


### PR DESCRIPTION
This PR removes the description field on opaque operations. The description can and should be derived when resolving the operation; there is no need for every instance of an operation to carry its own individual copy of an operation's documentation.

BREAKING CHANGE:
- Removed `description` parameter from `OpaqueOp::new`.