### PR TITLE
fix: Panic when an extension name is too long.

### DIFF
--- a/hugr-core/src/hugr/ident.rs
+++ b/hugr-core/src/hugr/ident.rs
@@ -56,7 +56,7 @@ impl IdentList {
     /// ```
     pub fn split_last(&self) -> Option<(IdentList, SmolStr)> {
         let (prefix, suffix) = self.0.rsplit_once('.')?;
-        let prefix = Self::new_unchecked(prefix);
+        let prefix = Self(SmolStr::new(prefix));
         let suffix = suffix.into();
         Some((prefix, suffix))
     }


### PR DESCRIPTION
This PR fixes a bug that led to a panic in import when the name of an extension exceeded 23 bytes.

This was caused by a misreading of `IdentList::new_unchecked`: this method not only avoids checking the identifier for validity but also assumes that the input will fit into the 23 byte inline capacity of a `SmolStr`.