### PR TITLE
feat: Symbol applications can leave out prefixes of wildcards.

### DIFF
--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -1586,6 +1586,9 @@ impl<'a> Context<'a> {
             return Ok(None);
         }
 
+        // We allow the match even if the symbol is applied to fewer arguments
+        // than parameters. In that case, the arguments are padded with wildcards
+        // at the beginning.
         if args.len() > N {
             return Ok(None);
         }

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -1586,7 +1586,18 @@ impl<'a> Context<'a> {
             return Ok(None);
         }
 
-        Ok((*args).try_into().ok())
+        if args.len() > N {
+            return Ok(None);
+        }
+
+        let result = std::array::from_fn(|i| {
+            (i + args.len())
+                .checked_sub(N)
+                .map(|i| args[i])
+                .unwrap_or_default()
+        });
+
+        Ok(Some(result))
     }
 
     fn expect_symbol<const N: usize>(

--- a/hugr-core/tests/snapshots/model__roundtrip_call.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_call.snap
@@ -48,7 +48,7 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-call
       (core.fn
         []
         [(core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])]))
-    ((core.load_const _ example.caller) [] [%0]
+    ((core.load_const example.caller) [] [%0]
       (signature
         (core.fn
           []

--- a/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_cfg.snap
@@ -28,7 +28,7 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cfg.
             (core.fn [(core.ctrl [?0])] [(core.ctrl [?0]) (core.ctrl [?0])]))
           (dfg [%4] [%5]
             (signature (core.fn [?0] [(core.adt [[?0] [?0]])]))
-            ((core.make_adt _ _ 0) [%4] [%5]
+            ((core.make_adt 0) [%4] [%5]
               (signature (core.fn [?0] [(core.adt [[?0] [?0]])])))))))))
 
 (define-func example.cfg_order (param ?0 core.type) (core.fn [?0] [?0])
@@ -42,11 +42,11 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cfg.
           (signature (core.fn [(core.ctrl [?0])] [(core.ctrl [?0])]))
           (dfg [%4] [%5]
             (signature (core.fn [?0] [(core.adt [[?0]])]))
-            ((core.make_adt _ _ 0) [%4] [%5]
+            ((core.make_adt 0) [%4] [%5]
               (signature (core.fn [?0] [(core.adt [[?0]])])))))
         (block [%6] [%3]
           (signature (core.fn [(core.ctrl [?0])] [(core.ctrl [?0])]))
           (dfg [%7] [%8]
             (signature (core.fn [?0] [(core.adt [[?0]])]))
-            ((core.make_adt _ _ 0) [%7] [%8]
+            ((core.make_adt 0) [%7] [%8]
               (signature (core.fn [?0] [(core.adt [[?0]])])))))))))

--- a/hugr-core/tests/snapshots/model__roundtrip_const.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_const.snap
@@ -31,9 +31,9 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
 (define-func example.bools (core.fn [] [(core.adt [[] []]) (core.adt [[] []])])
   (dfg [] [%0 %1]
     (signature (core.fn [] [(core.adt [[] []]) (core.adt [[] []])]))
-    ((core.load_const _ (core.const.adt [[] []] _ 0 [])) [] [%0]
+    ((core.load_const (core.const.adt [[] []] _ 0 [])) [] [%0]
       (signature (core.fn [] [(core.adt [[] []])])))
-    ((core.load_const _ (core.const.adt [[] []] _ 1 [])) [] [%1]
+    ((core.load_const (core.const.adt [[] []] _ 1 [])) [] [%1]
       (signature (core.fn [] [(core.adt [[] []])])))))
 
 (define-func
@@ -51,7 +51,6 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
            [[(collections.array.array 5 (arithmetic.int.types.int 6))
              arithmetic.float.types.float64]])]))
     ((core.load_const
-        _
         (core.const.adt
           [[(collections.array.array 5 (arithmetic.int.types.int 6))
             arithmetic.float.types.float64]]
@@ -80,10 +79,9 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cons
       (core.fn
         []
         [arithmetic.float.types.float64 arithmetic.float.types.float64]))
-    ((core.load_const _ (arithmetic.float.const_f64 1.0)) [] [%0]
+    ((core.load_const (arithmetic.float.const_f64 1.0)) [] [%0]
       (signature (core.fn [] [arithmetic.float.types.float64])))
     ((core.load_const
-        _
         (compat.const_json
           arithmetic.float.types.float64
           "{\"c\":\"ConstUnknown\",\"v\":{\"value\":1.0}}"))

--- a/hugr-core/tests/snapshots/model__roundtrip_entrypoint.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_entrypoint.snap
@@ -46,5 +46,5 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-entr
           (signature (core.fn [(core.ctrl [])] [(core.ctrl [])]))
           (dfg [] [%2]
             (signature (core.fn [] [(core.adt [[]])]))
-            ((core.make_adt _ _ 0) [] [%2]
+            ((core.make_adt 0) [] [%2]
               (signature (core.fn [] [(core.adt [[]])])))))))))

--- a/hugr-core/tests/snapshots/model__roundtrip_loop.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_loop.snap
@@ -21,5 +21,5 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-loop
       (signature (core.fn [?0] [?0]))
       (dfg [%2] [%3]
         (signature (core.fn [?0] [(core.adt [[?0] [?0]])]))
-        ((core.make_adt _ _ 0) [%2] [%3]
+        ((core.make_adt 0) [%2] [%3]
           (signature (core.fn [?0] [(core.adt [[?0] [?0]])])))))))

--- a/hugr-model/src/v0/table/mod.rs
+++ b/hugr-model/src/v0/table/mod.rs
@@ -97,10 +97,16 @@ impl<'a> Module<'a> {
     }
 
     /// Return the term data for a given term id.
+    ///
+    /// Returns [`Term::Wildcard`] when the term id is invalid.
     #[inline]
     #[must_use]
     pub fn get_term(&self, term_id: TermId) -> Option<&Term<'a>> {
-        self.terms.get(term_id.index())
+        if term_id.is_valid() {
+            self.terms.get(term_id.index())
+        } else {
+            Some(&Term::Wildcard)
+        }
     }
 
     /// Return a mutable reference to the term data for a given term id.
@@ -405,6 +411,12 @@ macro_rules! define_index {
                 Self(index as u32)
             }
 
+            /// Returns whether the index is valid.
+            #[inline]
+            #[must_use] pub fn is_valid(self) -> bool {
+                self.0 < u32::MAX
+            }
+
             /// Returns the index as a `usize` to conveniently use it as a slice index.
             #[inline]
             #[must_use] pub fn index(self) -> usize {
@@ -423,30 +435,36 @@ macro_rules! define_index {
                 unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const Self, slice.len()) }
             }
         }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self(u32::MAX)
+            }
+        }
     };
 }
 
 define_index! {
     /// Id of a node in a hugr graph.
-    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct NodeId(pub u32);
 }
 
 define_index! {
     /// Index of a link in a hugr graph.
-    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct LinkIndex(pub u32);
 }
 
 define_index! {
     /// Id of a region in a hugr graph.
-    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct RegionId(pub u32);
 }
 
 define_index! {
     /// Id of a term in a hugr graph.
-    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+    #[derive(Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct TermId(pub u32);
 }
 

--- a/hugr-model/tests/fixtures/model-cfg.edn
+++ b/hugr-model/tests/fixtures/model-cfg.edn
@@ -15,7 +15,7 @@
                         (signature (core.fn [(core.ctrl [?a])] [(core.ctrl [?a]) (core.ctrl [?a])]))
                         (dfg [%5] [%6]
                              (signature (core.fn [?a] [(core.adt [[?a] [?a]])]))
-                             ((core.make_adt _ _ 0) [%5] [%6]
+                             ((core.make_adt 0) [%5] [%6]
                                                     (signature (core.fn [?a] [(core.adt [[?a] [?a]])])))))))))
 
 (define-func example.cfg_order

--- a/hugr-model/tests/fixtures/model-const.edn
+++ b/hugr-model/tests/fixtures/model-const.edn
@@ -7,9 +7,9 @@
            [(core.adt [[] []]) (core.adt [[] []])])
   (dfg [] [%false %true]
        (signature (core.fn [] [(core.adt [[] []]) (core.adt [[] []])]))
-       ((core.load_const _ (core.const.adt _ _ 0 (tuple))) [] [%false]
+       ((core.load_const (core.const.adt 0 (tuple))) [] [%false]
                                                                (signature (core.fn [] [(core.adt [[] []])])))
-       ((core.load_const _ (core.const.adt _ _ 1 (tuple))) [] [%true]
+       ((core.load_const (core.const.adt 1 (tuple))) [] [%true]
                                                                (signature (core.fn [] [(core.adt [[] []])])))))
 
 (define-func example.make-pair
@@ -25,10 +25,8 @@
      [(core.adt
        [[(collections.array.array 5 (arithmetic.int.types.int 6))
          arithmetic.float.types.float64]])]))
-   ((core.load_const _
+   ((core.load_const
                      (core.const.adt
-                      _
-                      _
                       0
                       (tuple (collections.array.const
                               5
@@ -52,12 +50,12 @@
            [arithmetic.float.types.float64])
   (dfg [] [%0 %1]
        (signature (core.fn [] [arithmetic.float.types.float64 arithmetic.float.types.float64]))
-       ((core.load_const _
+       ((core.load_const
                          (compat.const_json arithmetic.float.types.float64 "{\"c\":\"ConstF64\",\"v\":{\"value\":1.0}}"))
         [] [%0]
         (signature (core.fn [] [arithmetic.float.types.float64])))
     ; The following const is to test that import/export can deal with unknown constants.
-       ((core.load_const _
+       ((core.load_const
                          (compat.const_json arithmetic.float.types.float64 "{\"c\":\"ConstUnknown\",\"v\":{\"value\":1.0}}"))
         [] [%1]
         (signature (core.fn [] [arithmetic.float.types.float64])))))

--- a/hugr-model/tests/fixtures/model-loop.edn
+++ b/hugr-model/tests/fixtures/model-loop.edn
@@ -11,5 +11,5 @@
                   (signature (core.fn [?a] [?a]))
                   (dfg [%2] [%3]
                        (signature (core.fn [?a] [(core.adt [[?a] [?a]])]))
-                       ((core.make_adt _ _ 0) [%2] [%3]
+                       ((core.make_adt 0) [%2] [%3]
                                               (signature (core.fn [?a] [(core.adt [[?a] [?a]])])))))))


### PR DESCRIPTION
Symbols in `hugr-model` such as functions or constructors can have parameters whose value can be inferred from context. So far it was already possible to pass wildcard terms to these parameters to indicate that they should be inferred. Noticing that redundant parameters often form a prefix of a symbol's parameter list, this PR adds the ability to apply a symbol with fewer arguments than it has parameters, automatically padding the arguments with wildcards in the front.