### PR TITLE
feat: Export macro for hugr serde wrappers with custom extensions

### DIFF
--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -166,6 +166,21 @@ impl Hugr {
     }
 }
 
+/// Deerialize the HUGR using a serde decoder.
+///
+/// This API is unstable API and will be removed in the future.
+#[deprecated(
+    since = "0.20.0",
+    note = "This API is unstable and will be removed in the future.
+            Use `Hugr::load` or the `AsStringEnvelope` adaptor instead."
+)]
+pub fn serde_deserialize_hugr<'de, D>(deserializer: D) -> Result<Hugr, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Hugr::serde_deserialize(deserializer)
+}
+
 impl TryFrom<&Hugr> for SerHugrLatest {
     type Error = HUGRSerializationError;
 

--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -174,6 +174,7 @@ impl Hugr {
     note = "This API is unstable and will be removed in the future.
             Use `Hugr::load` or the `AsStringEnvelope` adaptor instead."
 )]
+#[doc(hidden)]
 pub fn serde_deserialize_hugr<'de, D>(deserializer: D) -> Result<Hugr, D::Error>
 where
     D: Deserializer<'de>,


### PR DESCRIPTION
The `AsStringEnvelope` wrapper works well enough, but doesn't allow defining which extension sets to use when loading the Package/Hugrs.

Unfortunately, there is no way to define custom extension registers due to the way in which `serde_with` works.
The solution here is to add a public macro that implements the required traits.

This is needed for the ECC sets definition in `tket2`, which encode hugrs containing tket2-extension operations inside a serde struct.