### PR TITLE
feat!: Hide FuncDefn/cl fields, add accessors and ::new(...)

### DIFF
--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -398,8 +398,8 @@ pub trait Dataflow: Container {
         let func_node = fid.node();
         let func_op = self.hugr().get_optype(func_node);
         let func_sig = match func_op {
-            OpType::FuncDefn(ops::FuncDefn { signature, .. })
-            | OpType::FuncDecl(ops::FuncDecl { signature, .. }) => signature.clone(),
+            OpType::FuncDefn(fd) => fd.signature().clone(),
+            OpType::FuncDecl(fd) => fd.signature().clone(),
             _ => {
                 return Err(BuildError::UnexpectedType {
                     node: func_node,
@@ -614,8 +614,8 @@ pub trait Dataflow: Container {
         let hugr = self.hugr();
         let def_op = hugr.get_optype(function.node());
         let type_scheme = match def_op {
-            OpType::FuncDefn(ops::FuncDefn { signature, .. })
-            | OpType::FuncDecl(ops::FuncDecl { signature, .. }) => signature.clone(),
+            OpType::FuncDefn(fd) => fd.signature().clone(),
+            OpType::FuncDecl(fd) => fd.signature().clone(),
             _ => {
                 return Err(BuildError::UnexpectedType {
                     node: function.node(),

--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -96,10 +96,7 @@ pub trait Container {
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
         let signature: PolyFuncType = signature.into();
         let body = signature.body().clone();
-        let f_node = self.add_child_node(ops::FuncDefn {
-            name: name.into(),
-            signature,
-        });
+        let f_node = self.add_child_node(ops::FuncDefn::new(name, signature));
 
         // Add the extensions used by the function types.
         self.use_extensions(

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -184,7 +184,7 @@ impl FunctionBuilder<Hugr> {
         });
 
         // Update the inner input node
-        let types = new_optype.signature.body().input.clone();
+        let types = new_optype.signature().body().input.clone();
         self.hugr_mut().replace_op(inp_node, Input { types });
         let mut new_port = self.hugr_mut().add_ports(inp_node, Direction::Outgoing, 1);
         let new_port = new_port.next().unwrap();
@@ -219,7 +219,7 @@ impl FunctionBuilder<Hugr> {
         });
 
         // Update the inner input node
-        let types = new_optype.signature.body().output.clone();
+        let types = new_optype.signature().body().output.clone();
         self.hugr_mut().replace_op(out_node, Output { types });
         let mut new_port = self.hugr_mut().add_ports(out_node, Direction::Incoming, 1);
         let new_port = new_port.next().unwrap();
@@ -254,7 +254,7 @@ impl FunctionBuilder<Hugr> {
         let ops::OpType::FuncDefn(fd) = self.hugr_mut().optype_mut(parent) else {
             panic!("FunctionBuilder node must be a FuncDefn")
         };
-        fd.signature = f(fd.inner_signature().into_owned()).into();
+        *fd.signature_mut() = f(fd.inner_signature().into_owned()).into();
         &*fd
     }
 }

--- a/hugr-core/src/builder/module.rs
+++ b/hugr-core/src/builder/module.rs
@@ -80,7 +80,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
             .clone();
         let body = signature.body().clone();
         self.hugr_mut()
-            .replace_op(f_node, ops::FuncDefn { name, signature });
+            .replace_op(f_node, ops::FuncDefn::new(name, signature));
 
         let db = DFGBuilder::create_with_io(self.hugr_mut(), f_node, body)?;
         Ok(FunctionBuilder::from_dfg_builder(db))

--- a/hugr-core/src/builder/module.rs
+++ b/hugr-core/src/builder/module.rs
@@ -69,18 +69,19 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         f_id: &FuncID<false>,
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
         let f_node = f_id.node();
-        let ops::FuncDecl { signature, name } = self
-            .hugr()
-            .get_optype(f_node)
-            .as_func_decl()
-            .ok_or(BuildError::UnexpectedType {
-                node: f_node,
-                op_desc: "crate::ops::OpType::FuncDecl",
-            })?
-            .clone();
-        let body = signature.body().clone();
+        let decl =
+            self.hugr()
+                .get_optype(f_node)
+                .as_func_decl()
+                .ok_or(BuildError::UnexpectedType {
+                    node: f_node,
+                    op_desc: "crate::ops::OpType::FuncDecl",
+                })?;
+        let name = decl.func_name().clone();
+        let sig = decl.signature.clone();
+        let body = sig.body().clone();
         self.hugr_mut()
-            .replace_op(f_node, ops::FuncDefn::new(name, signature));
+            .replace_op(f_node, ops::FuncDefn::new(name, sig));
 
         let db = DFGBuilder::create_with_io(self.hugr_mut(), f_node, body)?;
         Ok(FunctionBuilder::from_dfg_builder(db))
@@ -99,10 +100,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
     ) -> Result<FuncID<false>, BuildError> {
         let body = signature.body().clone();
         // TODO add param names to metadata
-        let declare_n = self.add_child_node(ops::FuncDecl {
-            signature,
-            name: name.into(),
-        });
+        let declare_n = self.add_child_node(ops::FuncDecl::new(name, signature));
 
         // Add the extensions used by the function types.
         self.use_extensions(

--- a/hugr-core/src/builder/module.rs
+++ b/hugr-core/src/builder/module.rs
@@ -78,7 +78,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
                     op_desc: "crate::ops::OpType::FuncDecl",
                 })?;
         let name = decl.func_name().clone();
-        let sig = decl.signature.clone();
+        let sig = decl.signature().clone();
         let body = sig.body().clone();
         self.hugr_mut()
             .replace_op(f_node, ops::FuncDefn::new(name, sig));

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -223,7 +223,7 @@ impl<'a> Context<'a> {
     /// one of those operations.
     fn get_func_name(&self, func_node: Node) -> Option<&'a str> {
         match self.hugr.get_optype(func_node) {
-            OpType::FuncDecl(func_decl) => Some(&func_decl.name),
+            OpType::FuncDecl(func_decl) => Some(func_decl.func_name()),
             OpType::FuncDefn(func_defn) => Some(func_defn.func_name()),
             _ => None,
         }
@@ -258,7 +258,7 @@ impl<'a> Context<'a> {
         // We record the name of the symbol defined by the node, if any.
         let symbol = match optype {
             OpType::FuncDefn(func_defn) => Some(func_defn.func_name().as_str()),
-            OpType::FuncDecl(func_decl) => Some(func_decl.name.as_str()),
+            OpType::FuncDecl(func_decl) => Some(func_decl.func_name().as_str()),
             OpType::AliasDecl(alias_decl) => Some(alias_decl.name.as_str()),
             OpType::AliasDefn(alias_defn) => Some(alias_defn.name.as_str()),
             _ => None,

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -224,7 +224,7 @@ impl<'a> Context<'a> {
     fn get_func_name(&self, func_node: Node) -> Option<&'a str> {
         match self.hugr.get_optype(func_node) {
             OpType::FuncDecl(func_decl) => Some(&func_decl.name),
-            OpType::FuncDefn(func_defn) => Some(&func_defn.name),
+            OpType::FuncDefn(func_defn) => Some(func_defn.func_name()),
             _ => None,
         }
     }
@@ -257,7 +257,7 @@ impl<'a> Context<'a> {
 
         // We record the name of the symbol defined by the node, if any.
         let symbol = match optype {
-            OpType::FuncDefn(func_defn) => Some(func_defn.name.as_str()),
+            OpType::FuncDefn(func_defn) => Some(func_defn.func_name().as_str()),
             OpType::FuncDecl(func_decl) => Some(func_decl.name.as_str()),
             OpType::AliasDecl(alias_decl) => Some(alias_decl.name.as_str()),
             OpType::AliasDefn(alias_defn) => Some(alias_defn.name.as_str()),

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -328,7 +328,7 @@ impl<'a> Context<'a> {
 
             OpType::FuncDefn(func) => self.with_local_scope(node_id, |this| {
                 let name = this.get_func_name(node).unwrap();
-                let symbol = this.export_poly_func_type(name, &func.signature);
+                let symbol = this.export_poly_func_type(name, func.signature());
                 regions = this.bump.alloc_slice_copy(&[this.export_dfg(
                     node,
                     model::ScopeClosure::Closed,
@@ -339,7 +339,7 @@ impl<'a> Context<'a> {
 
             OpType::FuncDecl(func) => self.with_local_scope(node_id, |this| {
                 let name = this.get_func_name(node).unwrap();
-                let symbol = this.export_poly_func_type(name, &func.signature);
+                let symbol = this.export_poly_func_type(name, func.signature());
                 table::Operation::DeclareFunc(symbol)
             }),
 

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -42,8 +42,12 @@ pub(crate) fn collect_op_types_extensions(
             }
             collect_signature_exts(&ext.signature(), &mut used, &mut missing);
         }
-        OpType::FuncDefn(f) => collect_signature_exts(f.signature.body(), &mut used, &mut missing),
-        OpType::FuncDecl(f) => collect_signature_exts(f.signature.body(), &mut used, &mut missing),
+        OpType::FuncDefn(f) => {
+            collect_signature_exts(f.signature().body(), &mut used, &mut missing)
+        }
+        OpType::FuncDecl(f) => {
+            collect_signature_exts(f.signature().body(), &mut used, &mut missing)
+        }
         OpType::Const(c) => collect_value_exts(&c.value, &mut used, &mut missing),
         OpType::Input(inp) => collect_type_row_exts(&inp.types, &mut used, &mut missing),
         OpType::Output(out) => collect_type_row_exts(&out.types, &mut used, &mut missing),

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -35,10 +35,20 @@ pub fn resolve_op_types_extensions(
             resolve_signature_exts(node, ext.signature_mut(), extensions, used_extensions)?;
         }
         OpType::FuncDefn(f) => {
-            resolve_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?;
+            resolve_signature_exts(
+                node,
+                f.signature_mut().body_mut(),
+                extensions,
+                used_extensions,
+            )?;
         }
         OpType::FuncDecl(f) => {
-            resolve_signature_exts(node, f.signature.body_mut(), extensions, used_extensions)?;
+            resolve_signature_exts(
+                node,
+                f.signature_mut().body_mut(),
+                extensions,
+                used_extensions,
+            )?;
         }
         OpType::Const(c) => resolve_value_exts(node, &mut c.value, extensions, used_extensions)?,
         OpType::Input(inp) => {

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -443,13 +443,7 @@ fn make_module_hugr(root_op: OpType, nodes: usize, ports: usize) -> Option<Hugr>
         let dataflow_inputs = signature.input_count();
         let dataflow_outputs = signature.output_count();
 
-        let func = hugr.add_node_with_parent(
-            module,
-            ops::FuncDefn {
-                name: "main".into(),
-                signature: signature.clone().into(),
-            },
-        );
+        let func = hugr.add_node_with_parent(module, ops::FuncDefn::new("main", signature.clone()));
         let inp = hugr.add_node_with_parent(
             func,
             ops::Input {

--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -630,10 +630,10 @@ mod test {
         // Start a main function with two nat inputs.
         let f: Node = hugr.add_node_with_parent(
             module,
-            ops::FuncDefn {
-                name: "main".into(),
-                signature: Signature::new(vec![usize_t()], vec![usize_t(), usize_t()]).into(),
-            },
+            ops::FuncDefn::new(
+                "main",
+                Signature::new(usize_t(), vec![usize_t(), usize_t()]),
+            ),
         );
 
         {
@@ -676,13 +676,8 @@ mod test {
         hugr.use_extension(PRELUDE.to_owned());
         let root = hugr.entrypoint();
         let [foo, bar] = ["foo", "bar"].map(|name| {
-            let fd = hugr.add_node_with_parent(
-                root,
-                FuncDefn {
-                    name: name.to_string(),
-                    signature: Signature::new_endo(usize_t()).into(),
-                },
-            );
+            let fd = hugr
+                .add_node_with_parent(root, FuncDefn::new(name, Signature::new_endo(usize_t())));
             let inp = hugr.add_node_with_parent(fd, Input::new(usize_t()));
             let out = hugr.add_node_with_parent(fd, Output::new(usize_t()));
             hugr.connect(inp, 0, out, 0);

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -506,7 +506,7 @@ fn roundtrip_polyfunctype_varlen(#[case] poly_func_type: PolyFuncTypeRV) {
 
 #[rstest]
 #[case(ops::Module::new())]
-#[case(ops::FuncDefn { name: "polyfunc1".into(), signature: polyfunctype1()})]
+#[case(ops::FuncDefn::new("polyfunc1", polyfunctype1()))]
 #[case(ops::FuncDecl { name: "polyfunc2".into(), signature: polyfunctype1()})]
 #[case(ops::AliasDefn { name: "aliasdefn".into(), definition: Type::new_unit_sum(4)})]
 #[case(ops::AliasDecl { name: "aliasdecl".into(), bound: TypeBound::Any})]

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -507,7 +507,7 @@ fn roundtrip_polyfunctype_varlen(#[case] poly_func_type: PolyFuncTypeRV) {
 #[rstest]
 #[case(ops::Module::new())]
 #[case(ops::FuncDefn::new("polyfunc1", polyfunctype1()))]
-#[case(ops::FuncDecl { name: "polyfunc2".into(), signature: polyfunctype1()})]
+#[case(ops::FuncDecl::new("polyfunc2", polyfunctype1()))]
 #[case(ops::AliasDefn { name: "aliasdefn".into(), definition: Type::new_unit_sum(4)})]
 #[case(ops::AliasDecl { name: "aliasdecl".into(), bound: TypeBound::Any})]
 #[case(ops::Const::new(Value::false_val()))]

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -16,7 +16,7 @@ use crate::ops::custom::{ExtensionOp, OpaqueOpError};
 use crate::ops::validate::{
     ChildrenEdgeData, ChildrenValidationError, EdgeValidationError, OpValidityFlags,
 };
-use crate::ops::{FuncDefn, NamedOp, OpName, OpTag, OpTrait, OpType, ValidateOp};
+use crate::ops::{NamedOp, OpName, OpTag, OpTrait, OpType, ValidateOp};
 use crate::types::EdgeKind;
 use crate::types::type_param::TypeParam;
 use crate::{Direction, Port};

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -580,8 +580,8 @@ impl<'a, H: HugrView> ValidationContext<'a, H> {
 
         // For FuncDefn's, only the type variables declared by the FuncDefn can be referred to by nodes
         // inside the function. (The same would be true for FuncDecl's, but they have no child nodes.)
-        let var_decls = if let OpType::FuncDefn(FuncDefn { signature, .. }) = op_type {
-            signature.params()
+        let var_decls = if let OpType::FuncDefn(fd) = op_type {
+            fd.signature().params()
         } else {
             var_decls
         };

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -129,13 +129,7 @@ fn children_restrictions() {
 
     // Add a definition without children
     let def_sig = Signature::new(vec![bool_t()], vec![bool_t(), bool_t()]);
-    let new_def = b.add_node_with_parent(
-        root,
-        ops::FuncDefn {
-            signature: def_sig.into(),
-            name: "main".into(),
-        },
-    );
+    let new_def = b.add_node_with_parent(root, ops::FuncDefn::new("main", def_sig));
     assert_matches!(
         b.validate(),
         Err(ValidationError::ContainerWithoutChildren { node, .. }) => assert_eq!(node, new_def)
@@ -314,10 +308,7 @@ fn identity_hugr_with_type(t: Type) -> (Hugr, Node) {
 
     let def = b.add_node_with_parent(
         b.entrypoint(),
-        ops::FuncDefn {
-            name: "main".into(),
-            signature: Signature::new(row.clone(), row.clone()).into(),
-        },
+        ops::FuncDefn::new("main", Signature::new_endo(row.clone())),
     );
 
     let input = b.add_node_with_parent(def, ops::Input::new(row.clone()));

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -31,11 +31,8 @@ use crate::{Direction, Hugr, IncomingPort, Node, const_extension_ids, test_file,
 ///
 /// Returns the hugr and the node index of the definition.
 fn make_simple_hugr(copies: usize) -> (Hugr, Node) {
-    let def_op: OpType = ops::FuncDefn {
-        name: "main".into(),
-        signature: Signature::new(vec![bool_t()], vec![bool_t(); copies]).into(),
-    }
-    .into();
+    let def_op: OpType =
+        ops::FuncDefn::new("main", Signature::new(bool_t(), vec![bool_t(); copies])).into();
 
     let mut b = Hugr::default();
     let root = b.entrypoint();

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -363,8 +363,8 @@ pub trait HugrView: HugrInternals {
     /// a [`FuncDecl`][crate::ops::FuncDecl] or [`FuncDefn`][crate::ops::FuncDefn].
     fn poly_func_type(&self) -> Option<PolyFuncType> {
         match self.entrypoint_optype() {
-            OpType::FuncDecl(decl) => Some(decl.signature.clone()),
-            OpType::FuncDefn(defn) => Some(defn.signature.clone()),
+            OpType::FuncDecl(decl) => Some(decl.signature().clone()),
+            OpType::FuncDefn(defn) => Some(defn.signature().clone()),
             _ => None,
         }
     }

--- a/hugr-core/src/hugr/views/render.rs
+++ b/hugr-core/src/hugr/views/render.rs
@@ -41,7 +41,7 @@ pub(super) fn node_style(
     fn node_name(h: &Hugr, n: NodeIndex) -> String {
         match h.get_optype(n.into()) {
             OpType::FuncDecl(f) => format!("FuncDecl: \"{}\"", f.name),
-            OpType::FuncDefn(f) => format!("FuncDefn: \"{}\"", f.name),
+            OpType::FuncDefn(f) => format!("FuncDefn: \"{}\"", f.func_name()),
             op => op.name().to_string(),
         }
     }

--- a/hugr-core/src/hugr/views/render.rs
+++ b/hugr-core/src/hugr/views/render.rs
@@ -40,7 +40,7 @@ pub(super) fn node_style(
 ) -> Box<dyn FnMut(NodeIndex) -> NodeStyle + '_> {
     fn node_name(h: &Hugr, n: NodeIndex) -> String {
         match h.get_optype(n.into()) {
-            OpType::FuncDecl(f) => format!("FuncDecl: \"{}\"", f.name),
+            OpType::FuncDecl(f) => format!("FuncDecl: \"{}\"", f.func_name()),
             OpType::FuncDefn(f) => format!("FuncDefn: \"{}\"", f.func_name()),
             op => op.name().to_string(),
         }

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -1211,7 +1211,7 @@ mod tests {
         let func =
             SiblingSubgraph::try_new_dataflow_subgraph::<_, FuncID<true>>(&func_graph).unwrap();
         let func_defn = hugr.get_optype(func_root).as_func_defn().unwrap();
-        assert_eq!(func_defn.signature, func.signature(&func_graph).into());
+        assert_eq!(func_defn.signature(), &func.signature(&func_graph).into());
     }
 
     #[test]

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -408,10 +408,7 @@ impl<'a> Context<'a> {
 
             table::Operation::DefineFunc(symbol) => {
                 self.import_poly_func_type(node_id, *symbol, |ctx, signature| {
-                    let optype = OpType::FuncDefn(FuncDefn {
-                        name: symbol.name.to_string(),
-                        signature,
-                    });
+                    let optype = OpType::FuncDefn(FuncDefn::new(symbol.name, signature));
 
                     let node = ctx.make_node(node_id, optype, parent)?;
 

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -424,10 +424,7 @@ impl<'a> Context<'a> {
 
             table::Operation::DeclareFunc(symbol) => {
                 self.import_poly_func_type(node_id, *symbol, |ctx, signature| {
-                    let optype = OpType::FuncDecl(FuncDecl {
-                        name: symbol.name.to_string(),
-                        signature,
-                    });
+                    let optype = OpType::FuncDecl(FuncDecl::new(symbol.name, signature));
 
                     let node = ctx.make_node(node_id, optype, parent)?;
 

--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -53,7 +53,6 @@ impl OpTrait for Module {
 /// Children nodes are the body of the definition.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(Arbitrary))]
-#[non_exhaustive]
 pub struct FuncDefn {
     /// Name of function
     #[cfg_attr(test, proptest(strategy = "any_nonempty_string()"))]

--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -77,8 +77,8 @@ impl FuncDefn {
     }
 
     /// Sets the name of the function (as per [Self::func_name])
-    pub fn set_func_name(&mut self, name: String) {
-        self.name = name
+    pub fn func_name_mut(&mut self) -> &mut String {
+        &mut self.name
     }
 }
 

--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -73,7 +73,7 @@ impl FuncDefn {
         &self.name
     }
 
-    /// Mutable access to the name of the function (as per [Self::func_name])
+    /// Allows mutating the name of the function (as per [Self::func_name])
     pub fn func_name_mut(&mut self) -> &mut String {
         &mut self.name
     }
@@ -139,7 +139,7 @@ impl FuncDecl {
         &self.name
     }
 
-    /// Mutable access to the name of the function (as per [Self::func_name])
+    /// Allows mutating the name of the function (as per [Self::func_name])
     pub fn func_name_mut(&mut self) -> &mut String {
         &mut self.name
     }

--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -68,12 +68,12 @@ impl FuncDefn {
         }
     }
 
-    /// The name of the function (not, the name of the Op)
+    /// The name of the function (not the name of the Op)
     pub fn func_name(&self) -> &String {
         &self.name
     }
 
-    /// Sets the name of the function (as per [Self::func_name])
+    /// Mutable access to the name of the function (as per [Self::func_name])
     pub fn func_name_mut(&mut self) -> &mut String {
         &mut self.name
     }
@@ -134,9 +134,14 @@ impl FuncDecl {
         }
     }
 
-    /// The name of the function (not, the name of the Op)
+    /// The name of the function (not the name of the Op)
     pub fn func_name(&self) -> &String {
         &self.name
+    }
+
+    /// Mutable access to the name of the function (as per [Self::func_name])
+    pub fn func_name_mut(&mut self) -> &mut String {
+        &mut self.name
     }
 
     /// Gets the signature of the function

--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -54,11 +54,9 @@ impl OpTrait for Module {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct FuncDefn {
-    /// Name of function
     #[cfg_attr(test, proptest(strategy = "any_nonempty_string()"))]
     name: String,
-    /// Signature of the function
-    pub signature: PolyFuncType,
+    signature: PolyFuncType,
 }
 
 impl FuncDefn {
@@ -78,6 +76,16 @@ impl FuncDefn {
     /// Sets the name of the function (as per [Self::func_name])
     pub fn func_name_mut(&mut self) -> &mut String {
         &mut self.name
+    }
+
+    /// Gets the signature of the function
+    pub fn signature(&self) -> &PolyFuncType {
+        &self.signature
+    }
+
+    /// Allows mutating the signature of the function
+    pub fn signature_mut(&mut self) -> &mut PolyFuncType {
+        &mut self.signature
     }
 }
 
@@ -112,11 +120,9 @@ impl OpTrait for FuncDefn {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct FuncDecl {
-    /// Name of function
     #[cfg_attr(test, proptest(strategy = "any_nonempty_string()"))]
     name: String,
-    /// Signature of the function
-    pub signature: PolyFuncType,
+    signature: PolyFuncType,
 }
 
 impl FuncDecl {
@@ -131,6 +137,16 @@ impl FuncDecl {
     /// The name of the function (not, the name of the Op)
     pub fn func_name(&self) -> &String {
         &self.name
+    }
+
+    /// Gets the signature of the function
+    pub fn signature(&self) -> &PolyFuncType {
+        &self.signature
+    }
+
+    /// Allows mutating the signature of the function
+    pub fn signature_mut(&mut self) -> &mut PolyFuncType {
+        &mut self.signature
     }
 }
 

--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -53,12 +53,23 @@ impl OpTrait for Module {
 /// Children nodes are the body of the definition.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(Arbitrary))]
+#[non_exhaustive]
 pub struct FuncDefn {
     /// Name of function
     #[cfg_attr(test, proptest(strategy = "any_nonempty_string()"))]
     pub name: String,
     /// Signature of the function
     pub signature: PolyFuncType,
+}
+
+impl FuncDefn {
+    /// Create a new instance with the given name and signature
+    pub fn new(name: impl Into<String>, signature: impl Into<PolyFuncType>) -> Self {
+        Self {
+            name: name.into(),
+            signature: signature.into(),
+        }
+    }
 }
 
 impl_op_name!(FuncDefn);

--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -57,7 +57,7 @@ impl OpTrait for Module {
 pub struct FuncDefn {
     /// Name of function
     #[cfg_attr(test, proptest(strategy = "any_nonempty_string()"))]
-    pub name: String,
+    name: String,
     /// Signature of the function
     pub signature: PolyFuncType,
 }
@@ -69,6 +69,16 @@ impl FuncDefn {
             name: name.into(),
             signature: signature.into(),
         }
+    }
+
+    /// The name of the function (not, the name of the Op)
+    pub fn func_name(&self) -> &String {
+        &self.name
+    }
+
+    /// Sets the name of the function (as per [Self::func_name])
+    pub fn set_func_name(&mut self, name: String) {
+        self.name = name
     }
 }
 

--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -115,9 +115,24 @@ impl OpTrait for FuncDefn {
 pub struct FuncDecl {
     /// Name of function
     #[cfg_attr(test, proptest(strategy = "any_nonempty_string()"))]
-    pub name: String,
+    name: String,
     /// Signature of the function
     pub signature: PolyFuncType,
+}
+
+impl FuncDecl {
+    /// Create a new instance with the given name and signature
+    pub fn new(name: impl Into<String>, signature: impl Into<PolyFuncType>) -> Self {
+        Self {
+            name: name.into(),
+            signature: signature.into(),
+        }
+    }
+
+    /// The name of the function (not, the name of the Op)
+    pub fn func_name(&self) -> &String {
+        &self.name
+    }
 }
 
 impl_op_name!(FuncDecl);

--- a/hugr-llvm/src/emit.rs
+++ b/hugr-llvm/src/emit.rs
@@ -147,7 +147,7 @@ impl<'c, 'a, H> EmitModuleContext<'c, 'a, H> {
     where
         H: HugrView<Node = Node>,
     {
-        self.get_hugr_func_impl(&node.name, node.node(), &node.signature)
+        self.get_hugr_func_impl(node.func_name(), node.node(), &node.signature)
     }
 
     /// Adds or gets the [`FunctionValue`] in the [Module] corresponding to the given [`FuncDecl`].

--- a/hugr-llvm/src/emit.rs
+++ b/hugr-llvm/src/emit.rs
@@ -147,7 +147,7 @@ impl<'c, 'a, H> EmitModuleContext<'c, 'a, H> {
     where
         H: HugrView<Node = Node>,
     {
-        self.get_hugr_func_impl(node.func_name(), node.node(), &node.signature)
+        self.get_hugr_func_impl(node.func_name(), node.node(), node.signature())
     }
 
     /// Adds or gets the [`FunctionValue`] in the [Module] corresponding to the given [`FuncDecl`].
@@ -160,7 +160,7 @@ impl<'c, 'a, H> EmitModuleContext<'c, 'a, H> {
     where
         H: HugrView<Node = Node>,
     {
-        self.get_hugr_func_impl(node.func_name(), node.node(), &node.signature)
+        self.get_hugr_func_impl(node.func_name(), node.node(), node.signature())
     }
 
     /// Adds or get the [`FunctionValue`] in the [Module] with the given symbol
@@ -333,7 +333,7 @@ impl<'c, 'a, H: HugrView<Node = Node>> EmitHugr<'c, 'a, H> {
         }
         let func = self.module_context.get_func_defn(node)?;
         let mut func_ctx = EmitFuncContext::new(self.module_context, func)?;
-        let ret_rmb = func_ctx.new_row_mail_box(node.signature.body().output.iter(), "ret")?;
+        let ret_rmb = func_ctx.new_row_mail_box(node.signature().body().output.iter(), "ret")?;
         ops::emit_dataflow_parent(
             &mut func_ctx,
             EmitOpArgs {

--- a/hugr-llvm/src/emit.rs
+++ b/hugr-llvm/src/emit.rs
@@ -160,7 +160,7 @@ impl<'c, 'a, H> EmitModuleContext<'c, 'a, H> {
     where
         H: HugrView<Node = Node>,
     {
-        self.get_hugr_func_impl(&node.name, node.node(), &node.signature)
+        self.get_hugr_func_impl(node.func_name(), node.node(), &node.signature)
     }
 
     /// Adds or get the [`FunctionValue`] in the [Module] with the given symbol

--- a/hugr-llvm/src/utils/inline_constant_functions.rs
+++ b/hugr-llvm/src/utils/inline_constant_functions.rs
@@ -61,10 +61,7 @@ fn inline_constant_functions_impl(hugr: &mut impl HugrMut<Node = Node>) -> Resul
                 ))?
                 .into_owned()
                 .into();
-            let func_defn = FuncDefn {
-                name: const_fn_name(konst_n),
-                signature: polysignature.clone(),
-            };
+            let func_defn = FuncDefn::new(const_fn_name(konst_n), polysignature.clone());
             func_hugr.replace_op(func_hugr.entrypoint(), func_defn);
             let func_node = hugr
                 .insert_hugr(hugr.entrypoint(), func_hugr)

--- a/hugr-passes/src/dead_funcs.rs
+++ b/hugr-passes/src/dead_funcs.rs
@@ -182,7 +182,7 @@ mod test {
             .filter_map(|n| {
                 hugr.get_optype(n)
                     .as_func_defn()
-                    .map(|fd| (fd.name.clone(), n))
+                    .map(|fd| (fd.func_name().clone(), n))
             })
             .collect::<HashMap<_, _>>();
 
@@ -197,7 +197,11 @@ mod test {
 
         let remaining_funcs = hugr
             .nodes()
-            .filter_map(|n| hugr.get_optype(n).as_func_defn().map(|fd| fd.name.as_str()))
+            .filter_map(|n| {
+                hugr.get_optype(n)
+                    .as_func_defn()
+                    .map(|fd| fd.func_name().as_str())
+            })
             .sorted()
             .collect_vec();
         assert_eq!(remaining_funcs, retained_funcs);

--- a/hugr-passes/src/monomorphize.rs
+++ b/hugr-passes/src/monomorphize.rs
@@ -138,12 +138,8 @@ fn instantiate(
         let outer_name = h.get_optype(poly_func).as_func_defn().unwrap().name.clone();
         let mut to_scan = Vec::from_iter(h.children(poly_func));
         while let Some(n) = to_scan.pop() {
-            if let OpType::FuncDefn(fd) = h.get_optype(n) {
-                let fd = FuncDefn {
-                    name: mangle_inner_func(&outer_name, &fd.name),
-                    signature: fd.signature.clone(),
-                };
-                h.replace_op(n, fd);
+            if let OpType::FuncDefn(fd) = h.optype_mut(n) {
+                fd.name = mangle_inner_func(&outer_name, &fd.name);
                 h.move_after_sibling(n, poly_func);
             } else {
                 to_scan.extend(h.children(n));
@@ -161,13 +157,7 @@ fn instantiate(
         &h.get_optype(poly_func).as_func_defn().unwrap().name,
         &type_args,
     );
-    let mono_tgt = h.add_node_after(
-        poly_func,
-        FuncDefn {
-            name,
-            signature: mono_sig.into(),
-        },
-    );
+    let mono_tgt = h.add_node_after(poly_func, FuncDefn::new(name, mono_sig));
     // Insert BEFORE we scan (in case of recursion), hence we cannot use Entry::or_insert
     ve.insert(mono_tgt);
     // Now make the instantiation

--- a/hugr-passes/src/monomorphize.rs
+++ b/hugr-passes/src/monomorphize.rs
@@ -39,7 +39,7 @@ pub fn monomorphize(
 }
 
 fn is_polymorphic(fd: &FuncDefn) -> bool {
-    !fd.signature.params().is_empty()
+    !fd.signature().params().is_empty()
 }
 
 fn is_polymorphic_funcdefn(t: &OpType) -> bool {
@@ -116,7 +116,7 @@ fn mono_scan(
         let new_tgt = instantiate(h, tgt, type_args.clone(), mono_sig.clone(), cache);
         let fn_out = {
             let func = h.get_optype(new_tgt).as_func_defn().unwrap();
-            debug_assert_eq!(func.signature, mono_sig.into());
+            debug_assert_eq!(func.signature(), &mono_sig.into());
             h.get_optype(new_tgt).static_output_port().unwrap()
         };
         h.disconnect(ch, fn_inp); // No-op if copying+substituting

--- a/hugr-passes/src/monomorphize.rs
+++ b/hugr-passes/src/monomorphize.rs
@@ -144,7 +144,7 @@ fn instantiate(
         let mut to_scan = Vec::from_iter(h.children(poly_func));
         while let Some(n) = to_scan.pop() {
             if let OpType::FuncDefn(fd) = h.optype_mut(n) {
-                fd.set_func_name(mangle_inner_func(&outer_name, fd.func_name()));
+                *fd.func_name_mut() = mangle_inner_func(&outer_name, fd.func_name());
                 h.move_after_sibling(n, poly_func);
             } else {
                 to_scan.extend(h.children(n));

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -159,8 +159,8 @@ fn call<H: HugrView<Node = Node>>(
     type_args: Vec<TypeArg>,
 ) -> Result<Call, BuildError> {
     let func_sig = match h.get_optype(func) {
-        OpType::FuncDecl(fd) => fd.signature.clone(),
-        OpType::FuncDefn(fd) => fd.signature.clone(),
+        OpType::FuncDecl(fd) => fd.signature().clone(),
+        OpType::FuncDefn(fd) => fd.signature().clone(),
         _ => {
             return Err(BuildError::UnexpectedType {
                 node: func,
@@ -393,8 +393,8 @@ impl ReplaceTypes {
         n: Node,
     ) -> Result<bool, ReplaceTypesError> {
         match hugr.optype_mut(n) {
-            OpType::FuncDefn(FuncDefn { signature, .. })
-            | OpType::FuncDecl(FuncDecl { signature, .. }) => signature.body_mut().transform(self),
+            OpType::FuncDefn(fd) => fd.signature_mut().body_mut().transform(self),
+            OpType::FuncDecl(fd) => fd.signature_mut().body_mut().transform(self),
             OpType::LoadConstant(LoadConstant { datatype: ty })
             | OpType::AliasDefn(AliasDefn { definition: ty, .. }) => ty.transform(self),
 

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -66,6 +66,8 @@ impl NodeTemplate {
     ///    * has a [`signature`] which the type-args of the [`Self::Call`] do not match
     ///
     /// [`signature`]: hugr_core::types::PolyFuncType
+    /// [`FuncDecl`]: hugr_core::ops::FuncDecl
+    /// [`FuncDefn`]: hugr_core::ops::FuncDefn
     pub fn add_hugr(
         self,
         hugr: &mut impl HugrMut<Node = Node>,

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -19,8 +19,7 @@ use hugr_core::ops::constant::{OpaqueValue, Sum};
 use hugr_core::ops::handle::{DataflowOpID, FuncID};
 use hugr_core::ops::{
     AliasDefn, CFG, Call, CallIndirect, Case, Conditional, Const, DFG, DataflowBlock, ExitBlock,
-    ExtensionOp, FuncDecl, FuncDefn, Input, LoadConstant, LoadFunction, OpTrait, OpType, Output,
-    Tag, TailLoop, Value,
+    ExtensionOp, Input, LoadConstant, LoadFunction, OpTrait, OpType, Output, Tag, TailLoop, Value,
 };
 use hugr_core::types::{
     ConstTypeError, CustomType, Signature, Transformable, Type, TypeArg, TypeEnum, TypeRow,


### PR DESCRIPTION
Accessors ::func_name, ::func_name_mut, ::signature, ::signature_mut.

Constructor ::new takes name + sig using `impl Into`.

BREAKING CHANGE: construction, destruction, and field access should use new methods