### PR TITLE
chore: Fix crate versions for release-plz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hugr"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-core"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 dependencies = [
  "cgmath",
  "cool_asserts",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-llvm"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 dependencies = [
  "anyhow",
  "delegate",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-model"
-version = "0.19.1"
+version = "0.20.0-rc.0"
 dependencies = [
  "base64",
  "bumpalo",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-passes"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 dependencies = [
  "ascent",
  "derive_more",

--- a/hugr-cli/CHANGELOG.md
+++ b/hugr-cli/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [0.20.0-rc.0](https://github.com/CQCL/hugr/compare/hugr-cli-v0.15.4...hugr-cli-v0.20.0-rc.0) - 2025-05-09
+
+### New Features
+
+- [**breaking**] Bump MSRV to 1.85 ([#2136](https://github.com/CQCL/hugr/pull/2136))
+- [**breaking**] Add Hugr entrypoints ([#2147](https://github.com/CQCL/hugr/pull/2147))
+- [**breaking**] Validate any HugrView, make errors generic ([#2155](https://github.com/CQCL/hugr/pull/2155))
+- [**breaking**] Only expose envelope serialization of hugrs and packages ([#2167](https://github.com/CQCL/hugr/pull/2167))
+
 ## [0.15.3](https://github.com/CQCL/hugr/compare/hugr-cli-v0.15.2...hugr-cli-v0.15.3) - 2025-04-02
 
 ### Documentation

--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-cli"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -19,7 +19,7 @@ bench = false
 clap = { workspace = true, features = ["derive", "cargo"] }
 clap-verbosity-flag.workspace = true
 derive_more = { workspace = true, features = ["display", "error", "from"] }
-hugr = { path = "../hugr", version = "0.15.4" }
+hugr = { path = "../hugr", version = "0.20.0-rc.0" }
 serde_json.workspace = true
 clio = { workspace = true, features = ["clap-parse"] }
 

--- a/hugr-core/CHANGELOG.md
+++ b/hugr-core/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [0.20.0-rc.0](https://github.com/CQCL/hugr/compare/hugr-core-v0.15.4...hugr-core-v0.20.0-rc.0) - 2025-05-09
+
+### Bug Fixes
+
+- [**breaking**] Don't expose `HugrMutInternals` ([#2071](https://github.com/CQCL/hugr/pull/2071))
+- `as_unary_option` indexing bug ([#2163](https://github.com/CQCL/hugr/pull/2163))
+- Skip phantom data for array value serialisation ([#2166](https://github.com/CQCL/hugr/pull/2166))
+- Remove deleted nodes from node_map in `SimpleReplacement` ([#2176](https://github.com/CQCL/hugr/pull/2176))
+
+### New Features
+
+- [**breaking**] Allow generic Nodes in HugrMut insert operations ([#2075](https://github.com/CQCL/hugr/pull/2075))
+- [**breaking**] Mark all Error enums as non_exhaustive ([#2056](https://github.com/CQCL/hugr/pull/2056))
+- Make NodeHandle generic ([#2092](https://github.com/CQCL/hugr/pull/2092))
+- [**breaking**] remove ExtensionValue ([#2093](https://github.com/CQCL/hugr/pull/2093))
+- [**breaking**] Hugrmut on generic nodes ([#2111](https://github.com/CQCL/hugr/pull/2111))
+- [**breaking**] Removed model_unstable feature flag ([#2120](https://github.com/CQCL/hugr/pull/2120))
+- [**breaking**] Remove `RootTagged` from the hugr view trait hierarchy ([#2122](https://github.com/CQCL/hugr/pull/2122))
+- [**breaking**] Split Rewrite trait into VerifyPatch and ApplyPatch ([#2070](https://github.com/CQCL/hugr/pull/2070))
+- [**breaking**] Bump MSRV to 1.85 ([#2136](https://github.com/CQCL/hugr/pull/2136))
+- [**breaking**] Cleanup core trait definitions ([#2126](https://github.com/CQCL/hugr/pull/2126))
+- [**breaking**] Removed runtime extension sets. ([#2145](https://github.com/CQCL/hugr/pull/2145))
+- [**breaking**] Accept outgoing ports in SimpleReplacement nu_out ([#2151](https://github.com/CQCL/hugr/pull/2151))
+- [**breaking**] Improved array lowering ([#2109](https://github.com/CQCL/hugr/pull/2109))
+- [**breaking**] Make `NamedOp` private. Add `MakeExtensionOp::name` and `MakeOpDef::opdef_name` ([#2138](https://github.com/CQCL/hugr/pull/2138))
+- InsertCut patch for inserting HUGR across edges. ([#2153](https://github.com/CQCL/hugr/pull/2153))
+- [**breaking**] Add Hugr entrypoints ([#2147](https://github.com/CQCL/hugr/pull/2147))
+- [**breaking**] Return a node mapping in HugrInternals::region_portgraph ([#2164](https://github.com/CQCL/hugr/pull/2164))
+- [**breaking**] Validate any HugrView, make errors generic ([#2155](https://github.com/CQCL/hugr/pull/2155))
+- Reimplement `insert_hugr` using only `HugrView` ([#2174](https://github.com/CQCL/hugr/pull/2174))
+- Only allow region containers as entrypoints ([#2173](https://github.com/CQCL/hugr/pull/2173))
+- Export and import entrypoints via metadata in `hugr-model`. ([#2172](https://github.com/CQCL/hugr/pull/2172))
+- [**breaking**] Only expose envelope serialization of hugrs and packages ([#2167](https://github.com/CQCL/hugr/pull/2167))
+
+### Refactor
+
+- do not use .portgraph in mermaid/graphviz ([#2177](https://github.com/CQCL/hugr/pull/2177))
+- [**breaking**] Removed global portgraph-related methods from `HugrInternals` ([#2180](https://github.com/CQCL/hugr/pull/2180))
+
 ## [0.15.4](https://github.com/CQCL/hugr/compare/hugr-core-v0.15.3...hugr-core-v0.15.4) - 2025-05-07
 
 ### New Features

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-core"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 
@@ -27,7 +27,7 @@ bench = false
 name = "model"
 
 [dependencies]
-hugr-model = { version = "0.19.1", path = "../hugr-model" }
+hugr-model = { version = "0.20.0-rc.0", path = "../hugr-model" }
 
 cgmath = { workspace = true, features = ["serde"] }
 delegate = { workspace = true }

--- a/hugr-llvm/CHANGELOG.md
+++ b/hugr-llvm/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.20.0-rc.0](https://github.com/CQCL/hugr/compare/hugr-llvm-v0.15.4...hugr-llvm-v0.20.0-rc.0) - 2025-05-09
+
+### Bug Fixes
+
+- Fix `inline_constant_functions` pass ([#2135](https://github.com/CQCL/hugr/pull/2135))
+
+### New Features
+
+- [**breaking**] Hugrmut on generic nodes ([#2111](https://github.com/CQCL/hugr/pull/2111))
+- [**breaking**] Remove `RootTagged` from the hugr view trait hierarchy ([#2122](https://github.com/CQCL/hugr/pull/2122))
+- [**breaking**] Bump MSRV to 1.85 ([#2136](https://github.com/CQCL/hugr/pull/2136))
+- [**breaking**] Cleanup core trait definitions ([#2126](https://github.com/CQCL/hugr/pull/2126))
+- [**breaking**] Removed runtime extension sets. ([#2145](https://github.com/CQCL/hugr/pull/2145))
+- [**breaking**] Improved array lowering ([#2109](https://github.com/CQCL/hugr/pull/2109))
+- [**breaking**] Make `NamedOp` private. Add `MakeExtensionOp::name` and `MakeOpDef::opdef_name` ([#2138](https://github.com/CQCL/hugr/pull/2138))
+- Make `hugr_llvm::extension::collections::array::build_array_alloc` public ([#2165](https://github.com/CQCL/hugr/pull/2165))
+- Add LLVM emission for prelude.noop ([#2160](https://github.com/CQCL/hugr/pull/2160))
+- [**breaking**] Add Hugr entrypoints ([#2147](https://github.com/CQCL/hugr/pull/2147))
+- [**breaking**] Return a node mapping in HugrInternals::region_portgraph ([#2164](https://github.com/CQCL/hugr/pull/2164))
+
 ## [0.15.4](https://github.com/CQCL/hugr/compare/hugr-llvm-v0.15.3...hugr-llvm-v0.15.4) - 2025-05-07
 
 ### New Features

--- a/hugr-llvm/Cargo.toml
+++ b/hugr-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-llvm"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 description = "A general and extensible crate for lowering HUGRs into LLVM IR"
 
 edition.workspace = true
@@ -26,7 +26,7 @@ workspace = true
 
 [dependencies]
 inkwell = { version = "0.6.0", default-features = false }
-hugr-core = { path = "../hugr-core", version = "0.15.4" }
+hugr-core = { path = "../hugr-core", version = "0.20.0-rc.0" }
 anyhow = "1.0.98"
 itertools.workspace = true
 delegate.workspace = true

--- a/hugr-model/CHANGELOG.md
+++ b/hugr-model/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.20.0-rc.0](https://github.com/CQCL/hugr/compare/hugr-model-v0.19.1...hugr-model-v0.20.0-rc.0) - 2025-05-09
+
+### New Features
+
+- [**breaking**] Mark all Error enums as non_exhaustive ([#2056](https://github.com/CQCL/hugr/pull/2056))
+- [**breaking**] Bump MSRV to 1.85 ([#2136](https://github.com/CQCL/hugr/pull/2136))
+- Export and import entrypoints via metadata in `hugr-model`. ([#2172](https://github.com/CQCL/hugr/pull/2172))
+
 ## [0.19.0](https://github.com/CQCL/hugr/compare/hugr-model-v0.18.1...hugr-model-v0.19.0) - 2025-05-07
 
 ### New Features

--- a/hugr-model/Cargo.toml
+++ b/hugr-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-model"
-version = "0.19.1"
+version = "0.20.0-rc.0"
 readme = "README.md"
 documentation = "https://docs.rs/hugr-model/"
 description = "Data model for Quantinuum's HUGR intermediate representation"

--- a/hugr-passes/CHANGELOG.md
+++ b/hugr-passes/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 
 
+## [0.20.0-rc.0](https://github.com/CQCL/hugr/compare/hugr-passes-v0.15.4...hugr-passes-v0.20.0-rc.0) - 2025-05-09
+
+### New Features
+
+- [**breaking**] Mark all Error enums as non_exhaustive ([#2056](https://github.com/CQCL/hugr/pull/2056))
+- [**breaking**] Handle CallIndirect in Dataflow Analysis ([#2059](https://github.com/CQCL/hugr/pull/2059))
+- [**breaking**] ComposablePass trait allowing sequencing and validation ([#1895](https://github.com/CQCL/hugr/pull/1895))
+- [**breaking**] ReplaceTypes: allow lowering ops into a Call to a function already in the Hugr ([#2094](https://github.com/CQCL/hugr/pull/2094))
+- [**breaking**] Hugrmut on generic nodes ([#2111](https://github.com/CQCL/hugr/pull/2111))
+- [**breaking**] Remove `RootTagged` from the hugr view trait hierarchy ([#2122](https://github.com/CQCL/hugr/pull/2122))
+- [**breaking**] Split Rewrite trait into VerifyPatch and ApplyPatch ([#2070](https://github.com/CQCL/hugr/pull/2070))
+- [**breaking**] Bump MSRV to 1.85 ([#2136](https://github.com/CQCL/hugr/pull/2136))
+- [**breaking**] Cleanup core trait definitions ([#2126](https://github.com/CQCL/hugr/pull/2126))
+- [**breaking**] Removed runtime extension sets. ([#2145](https://github.com/CQCL/hugr/pull/2145))
+- [**breaking**] Improved array lowering ([#2109](https://github.com/CQCL/hugr/pull/2109))
+- export mangle name function ([#2152](https://github.com/CQCL/hugr/pull/2152))
+- [**breaking**] Make `NamedOp` private. Add `MakeExtensionOp::name` and `MakeOpDef::opdef_name` ([#2138](https://github.com/CQCL/hugr/pull/2138))
+- [**breaking**] Add Hugr entrypoints ([#2147](https://github.com/CQCL/hugr/pull/2147))
+- [**breaking**] Return a node mapping in HugrInternals::region_portgraph ([#2164](https://github.com/CQCL/hugr/pull/2164))
+- [**breaking**] Validate any HugrView, make errors generic ([#2155](https://github.com/CQCL/hugr/pull/2155))
+- [**breaking**] Explicit hugr type param to ComposablePass ([#2179](https://github.com/CQCL/hugr/pull/2179))
+
+### Refactor
+
+- [**breaking**] Removed global portgraph-related methods from `HugrInternals` ([#2180](https://github.com/CQCL/hugr/pull/2180))
+
 ## [0.15.4](https://github.com/CQCL/hugr/compare/hugr-passes-v0.15.3...hugr-passes-v0.15.4) - 2025-05-07
 
 ### New Features

--- a/hugr-passes/Cargo.toml
+++ b/hugr-passes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-passes"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -19,7 +19,7 @@ workspace = true
 bench = false
 
 [dependencies]
-hugr-core = { path = "../hugr-core", version = "0.15.4" }
+hugr-core = { path = "../hugr-core", version = "0.20.0-rc.0" }
 portgraph = { workspace = true }
 ascent = { version = "0.8.0" }
 derive_more = { workspace = true, features = ["display", "error", "from"] }

--- a/hugr-py/Cargo.toml
+++ b/hugr-py/Cargo.toml
@@ -21,6 +21,8 @@ bench = false
 
 [dependencies]
 bumpalo = { workspace = true, features = ["collections"] }
-hugr-model = { version = "0.19", path = "../hugr-model", features = ["pyo3"] }
+hugr-model = { version = "0.20.0-rc.0", path = "../hugr-model", features = [
+    "pyo3",
+] }
 paste.workspace = true
 pyo3 = { workspace = true, features = ["extension-module", "abi3-py310"] }

--- a/hugr/CHANGELOG.md
+++ b/hugr/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [0.20.0-rc.0](https://github.com/CQCL/hugr/compare/hugr-v0.15.4...hugr-v0.20.0-rc.0) - 2025-05-09
+
+### Bug Fixes
+
+- [**breaking**] Don't expose `HugrMutInternals` ([#2071](https://github.com/CQCL/hugr/pull/2071))
+- `as_unary_option` indexing bug ([#2163](https://github.com/CQCL/hugr/pull/2163))
+- Skip phantom data for array value serialisation ([#2166](https://github.com/CQCL/hugr/pull/2166))
+- Remove deleted nodes from node_map in `SimpleReplacement` ([#2176](https://github.com/CQCL/hugr/pull/2176))
+
+### New Features
+
+- [**breaking**] Handle CallIndirect in Dataflow Analysis ([#2059](https://github.com/CQCL/hugr/pull/2059))
+- [**breaking**] ComposablePass trait allowing sequencing and validation ([#1895](https://github.com/CQCL/hugr/pull/1895))
+- [**breaking**] ReplaceTypes: allow lowering ops into a Call to a function already in the Hugr ([#2094](https://github.com/CQCL/hugr/pull/2094))
+- export mangle name function ([#2152](https://github.com/CQCL/hugr/pull/2152))
+- [**breaking**] Explicit hugr type param to ComposablePass ([#2179](https://github.com/CQCL/hugr/pull/2179))
+- [**breaking**] Allow generic Nodes in HugrMut insert operations ([#2075](https://github.com/CQCL/hugr/pull/2075))
+- [**breaking**] Mark all Error enums as non_exhaustive ([#2056](https://github.com/CQCL/hugr/pull/2056))
+- Make NodeHandle generic ([#2092](https://github.com/CQCL/hugr/pull/2092))
+- [**breaking**] remove ExtensionValue ([#2093](https://github.com/CQCL/hugr/pull/2093))
+- [**breaking**] Hugrmut on generic nodes ([#2111](https://github.com/CQCL/hugr/pull/2111))
+- [**breaking**] Cleanup core trait definitions ([#2126](https://github.com/CQCL/hugr/pull/2126))
+- [**breaking**] Accept outgoing ports in SimpleReplacement nu_out ([#2151](https://github.com/CQCL/hugr/pull/2151))
+- [**breaking**] Improved array lowering ([#2109](https://github.com/CQCL/hugr/pull/2109))
+- [**breaking**] Make `NamedOp` private. Add `MakeExtensionOp::name` and `MakeOpDef::opdef_name` ([#2138](https://github.com/CQCL/hugr/pull/2138))
+- InsertCut patch for inserting HUGR across edges. ([#2153](https://github.com/CQCL/hugr/pull/2153))
+- [**breaking**] Add Hugr entrypoints ([#2147](https://github.com/CQCL/hugr/pull/2147))
+- [**breaking**] Return a node mapping in HugrInternals::region_portgraph ([#2164](https://github.com/CQCL/hugr/pull/2164))
+- [**breaking**] Validate any HugrView, make errors generic ([#2155](https://github.com/CQCL/hugr/pull/2155))
+- Reimplement `insert_hugr` using only `HugrView` ([#2174](https://github.com/CQCL/hugr/pull/2174))
+- Only allow region containers as entrypoints ([#2173](https://github.com/CQCL/hugr/pull/2173))
+- Export and import entrypoints via metadata in `hugr-model`. ([#2172](https://github.com/CQCL/hugr/pull/2172))
+- [**breaking**] Removed model_unstable feature flag ([#2120](https://github.com/CQCL/hugr/pull/2120))
+- [**breaking**] Remove `RootTagged` from the hugr view trait hierarchy ([#2122](https://github.com/CQCL/hugr/pull/2122))
+- [**breaking**] Split Rewrite trait into VerifyPatch and ApplyPatch ([#2070](https://github.com/CQCL/hugr/pull/2070))
+- [**breaking**] Bump MSRV to 1.85 ([#2136](https://github.com/CQCL/hugr/pull/2136))
+- [**breaking**] Removed runtime extension sets. ([#2145](https://github.com/CQCL/hugr/pull/2145))
+- [**breaking**] Only expose envelope serialization of hugrs and packages ([#2167](https://github.com/CQCL/hugr/pull/2167))
+
+### Refactor
+
+- do not use .portgraph in mermaid/graphviz ([#2177](https://github.com/CQCL/hugr/pull/2177))
+- [**breaking**] Removed global portgraph-related methods from `HugrInternals` ([#2180](https://github.com/CQCL/hugr/pull/2180))
+
 ## [0.15.4](https://github.com/CQCL/hugr/compare/hugr-v0.15.3...hugr-v0.15.4) - 2025-05-07
 
 ### New Features

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr"
-version = "0.15.4"
+version = "0.20.0-rc.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 
@@ -30,10 +30,10 @@ llvm-test = ["hugr-llvm/llvm14-0", "hugr-llvm/test-utils"]
 zstd = ["hugr-core/zstd"]
 
 [dependencies]
-hugr-model = { path = "../hugr-model", version = "0.19.1" }
-hugr-core = { path = "../hugr-core", version = "0.15.4" }
-hugr-passes = { path = "../hugr-passes", version = "0.15.4" }
-hugr-llvm = { path = "../hugr-llvm", version = "0.15.4", optional = true }
+hugr-model = { path = "../hugr-model", version = "0.20.0-rc.0" }
+hugr-core = { path = "../hugr-core", version = "0.20.0-rc.0" }
+hugr-passes = { path = "../hugr-passes", version = "0.20.0-rc.0" }
+hugr-llvm = { path = "../hugr-llvm", version = "0.20.0-rc.0", optional = true }
 
 [dev-dependencies]
 lazy_static = { workspace = true }


### PR DESCRIPTION
`release-plz` doesn't like when the published crate version differs from the one in `Cargo.toml`, even when it's off-branch
https://github.com/CQCL/hugr/actions/runs/15017824492/job/42199778639

This PR updates the versions to the `0.20.0-rc.0` release candidate so the automation starts working again.