### PR TITLE
feat: Add boundary edge traversal in SimpleReplacement

### DIFF
--- a/hugr-core/src/hugr/patch/port_types.rs
+++ b/hugr-core/src/hugr/patch/port_types.rs
@@ -10,7 +10,7 @@ use derive_more::From;
 ///
 /// This is used to represent boundary edges that will be added between the host
 /// and replacement graphs when applying a rewrite.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum BoundaryPort<HostNode, P> {
     /// A port in the host graph.
     Host(HostNode, P),
@@ -19,11 +19,11 @@ pub enum BoundaryPort<HostNode, P> {
 }
 
 /// A port in the host graph.
-#[derive(Debug, Clone, Copy, From, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, From, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HostPort<N, P>(pub N, pub P);
 
 /// A port in the replacement graph.
-#[derive(Debug, Clone, Copy, From, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, From, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReplacementPort<P>(pub Node, pub P);
 
 impl<HostNode: Copy, P> BoundaryPort<HostNode, P> {

--- a/hugr-core/src/hugr/patch/port_types.rs
+++ b/hugr-core/src/hugr/patch/port_types.rs
@@ -8,9 +8,9 @@ use derive_more::From;
 
 /// A port in either the host or replacement graph.
 ///
-/// This is used to represent boundary edges that will be added between the host and
-/// replacement graphs when applying a rewrite.
-#[derive(Debug, Clone, Copy)]
+/// This is used to represent boundary edges that will be added between the host
+/// and replacement graphs when applying a rewrite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BoundaryPort<HostNode, P> {
     /// A port in the host graph.
     Host(HostNode, P),
@@ -19,7 +19,7 @@ pub enum BoundaryPort<HostNode, P> {
 }
 
 /// A port in the host graph.
-#[derive(Debug, Clone, Copy, From)]
+#[derive(Debug, Clone, Copy, From, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HostPort<N, P>(pub N, pub P);
 
 /// A port in the replacement graph.
@@ -28,11 +28,28 @@ pub struct ReplacementPort<P>(pub Node, pub P);
 
 impl<HostNode: Copy, P> BoundaryPort<HostNode, P> {
     /// Maps a boundary port according to the insertion mapping.
-    /// Host ports are unchanged, while Replacement ports are mapped according to the `index_map`.
+    /// Host ports are unchanged, while Replacement ports are mapped according
+    /// to the `index_map`.
     pub fn map_replacement(self, index_map: &HashMap<Node, HostNode>) -> (HostNode, P) {
         match self {
             BoundaryPort::Host(node, port) => (node, port),
             BoundaryPort::Replacement(node, port) => (*index_map.get(&node).unwrap(), port),
+        }
+    }
+
+    /// Returns the replacement port if this is a replacement port.
+    pub fn as_replacement(self) -> Option<(Node, P)> {
+        match self {
+            BoundaryPort::Replacement(node, port) => Some((node, port)),
+            BoundaryPort::Host(_, _) => None,
+        }
+    }
+
+    /// Returns the host port if this is a host port.
+    pub fn as_host(self) -> Option<(HostNode, P)> {
+        match self {
+            BoundaryPort::Host(node, port) => Some((node, port)),
+            BoundaryPort::Replacement(_, _) => None,
         }
     }
 }

--- a/hugr-core/src/hugr/patch/simple_replace.rs
+++ b/hugr-core/src/hugr/patch/simple_replace.rs
@@ -653,9 +653,6 @@ pub(in crate::hugr::patch) mod test {
     use crate::extension::prelude::{bool_t, qb_t};
     use crate::hugr::patch::simple_replace::Outcome;
     use crate::hugr::patch::{BoundaryPort, HostPort, PatchVerification, ReplacementPort};
-    use crate::hugr::views::sibling_subgraph::tests::{
-        build_3not_hugr, build_hugr_classical, build_multiport_hugr,
-    };
     use crate::hugr::views::{HugrView, SiblingSubgraph};
     use crate::hugr::{Hugr, HugrMut, Patch};
     use crate::ops::OpTag;

--- a/hugr-core/src/hugr/patch/simple_replace.rs
+++ b/hugr-core/src/hugr/patch/simple_replace.rs
@@ -129,16 +129,15 @@ impl<HostNode: HugrNode> SimpleReplacement<HostNode> {
         &self,
         port: impl Into<HostPort<HostNode, IncomingPort>>,
         host: &impl HugrView<Node = HostNode>,
-    ) -> BoundaryPort<HostNode, OutgoingPort> {
+    ) -> Option<BoundaryPort<HostNode, OutgoingPort>> {
         let HostPort(node, port) = port.into();
         let pos = self
             .subgraph
             .outgoing_ports()
             .iter()
-            .position(move |&(n, p)| host.linked_inputs(n, p).contains(&(node, port)))
-            .expect("valid incoming output port");
+            .position(move |&(n, p)| host.linked_inputs(n, p).contains(&(node, port)))?;
 
-        self.linked_replacement_output_by_position(pos, host)
+        Some(self.linked_replacement_output_by_position(pos, host))
     }
 
     /// The outgoing port linked to the i-th output boundary edge of `subgraph`.
@@ -186,13 +185,10 @@ impl<HostNode: HugrNode> SimpleReplacement<HostNode> {
     ) -> impl Iterator<Item = HostPort<HostNode, IncomingPort>> {
         let ReplacementPort(node, port) = port.into();
         let [_, repl_out] = self.get_replacement_io();
-        let mut positions = self
+        let positions = self
             .replacement
             .linked_inputs(node, port)
-            .filter_map(move |(n, p)| (n == repl_out).then_some(p.index()))
-            .peekable();
-
-        assert!(positions.peek().is_some(), "not a boundary port");
+            .filter_map(move |(n, p)| (n == repl_out).then_some(p.index()));
 
         positions
             .map(|pos| self.subgraph.outgoing_ports()[pos])
@@ -1156,7 +1152,10 @@ pub(in crate::hugr::patch) mod test {
 
         // Test linked_replacement_output with empty replacement
         let replacement_output = (0..4)
-            .map(|i| repl.linked_replacement_output((out, IncomingPort::from(i)), &hugr))
+            .map(|i| {
+                repl.linked_replacement_output((out, IncomingPort::from(i)), &hugr)
+                    .unwrap()
+            })
             .collect_vec();
 
         assert_eq!(
@@ -1198,7 +1197,10 @@ pub(in crate::hugr::patch) mod test {
         );
 
         let replacement_output = (0..4)
-            .map(|i| repl.linked_replacement_output((out, IncomingPort::from(i)), &hugr))
+            .map(|i| {
+                repl.linked_replacement_output((out, IncomingPort::from(i)), &hugr)
+                    .unwrap()
+            })
             .collect_vec();
 
         assert_eq!(
@@ -1249,7 +1251,10 @@ pub(in crate::hugr::patch) mod test {
         );
 
         let replacement_output = (0..4)
-            .map(|i| repl.linked_replacement_output((out, IncomingPort::from(i)), &hugr))
+            .map(|i| {
+                repl.linked_replacement_output((out, IncomingPort::from(i)), &hugr)
+                    .unwrap()
+            })
             .collect_vec();
 
         assert_eq!(


### PR DESCRIPTION
I believe these methods finally expose the "right" way to think of the boundary between a replacement and its subgraph, in particular this won't be broken as we extend `SiblingSubgraph` to express more types of subgraphs (see issue #2212).

The idea is simple: for any replacement, there must be links between ports that are just outside the `subgraph` in host, and ports that are linked to the input and output nodes of the `replacement`. These links are precisely the edges that will need to be added when the replacement is applied, between the existing host HUGR and the newly added nodes of the `replacement`. Specifically these edges link:
- outgoing ports in `host` that are "just before the subgraph" (i.e. ports linked to an incoming port of `subgraph`) to incoming ports in `replacement` that are linked to the input node, and
- incoming ports in `host` that are "just after the subgraph" (i.e. ports linked to an outgoing port of `subgraph`) to outgoing ports in `replacement` that are linked to the output node.