### PR TITLE
fix(py): deprecate extensions sets in values

### DIFF
--- a/hugr-py/src/hugr/_serialization/ops.py
+++ b/hugr-py/src/hugr/_serialization/ops.py
@@ -16,7 +16,6 @@ from . import tys as stys
 from .tys import (
     ConfiguredBaseModel,
     ExtensionId,
-    ExtensionSet,
     FunctionType,
     PolyFuncType,
     SumType,
@@ -109,7 +108,6 @@ class CustomValue(BaseValue):
     """An extension constant value, that can check it is of a given [CustomType]."""
 
     v: Literal["Extension"] = Field(default="Extension", title="ValueTag")
-    extensions: ExtensionSet
     typ: Type
     value: CustomConst
 
@@ -118,7 +116,6 @@ class CustomValue(BaseValue):
             name=self.value.c,
             typ=self.typ.deserialize(),
             val=self.value.v,
-            extensions=self.extensions,
         )
 
 

--- a/hugr-py/src/hugr/std/collections/array.py
+++ b/hugr-py/src/hugr/std/collections/array.py
@@ -75,9 +75,7 @@ class ArrayVal(val.ExtensionValue):
         vs = [v._to_serial_root() for v in self.v]
         element_ty = self.ty.ty._to_serial_root()
         serial_val = {"values": vs, "typ": element_ty}
-        return val.Extension(
-            name, typ=self.ty, val=serial_val, extensions=[EXTENSION.name]
-        )
+        return val.Extension(name, typ=self.ty, val=serial_val)
 
     def __str__(self) -> str:
         return f"array({comma_sep_str(self.v)})"

--- a/hugr-py/src/hugr/std/collections/list.py
+++ b/hugr-py/src/hugr/std/collections/list.py
@@ -52,9 +52,7 @@ class ListVal(val.ExtensionValue):
         vs = [v._to_serial_root() for v in self.v]
         element_ty = self.ty.ty._to_serial_root()
         serial_val = {"values": vs, "typ": element_ty}
-        return val.Extension(
-            name, typ=self.ty, val=serial_val, extensions=[EXTENSION.name]
-        )
+        return val.Extension(name, typ=self.ty, val=serial_val)
 
     def __str__(self) -> str:
         return f"[{comma_sep_str(self.v)}]"

--- a/hugr-py/src/hugr/std/collections/static_array.py
+++ b/hugr-py/src/hugr/std/collections/static_array.py
@@ -57,9 +57,7 @@ class StaticArrayVal(val.ExtensionValue):
             },
             "name": self.name,
         }
-        return val.Extension(
-            "StaticArrayValue", typ=self.ty, val=serial_val, extensions=[EXTENSION.name]
-        )
+        return val.Extension("StaticArrayValue", typ=self.ty, val=serial_val)
 
     def __str__(self) -> str:
         return f"static_array({comma_sep_str(self.v)})"

--- a/hugr-py/src/hugr/std/collections/value_array.py
+++ b/hugr-py/src/hugr/std/collections/value_array.py
@@ -75,9 +75,7 @@ class ValueArrayVal(val.ExtensionValue):
         vs = [v._to_serial_root() for v in self.v]
         element_ty = self.ty.ty._to_serial_root()
         serial_val = {"values": vs, "typ": element_ty}
-        return val.Extension(
-            name, typ=self.ty, val=serial_val, extensions=[EXTENSION.name]
-        )
+        return val.Extension(name, typ=self.ty, val=serial_val)
 
     def __str__(self) -> str:
         return f"value_array({comma_sep_str(self.v)})"

--- a/hugr-py/src/hugr/std/float.py
+++ b/hugr-py/src/hugr/std/float.py
@@ -25,9 +25,7 @@ class FloatVal(val.ExtensionValue):
     def to_value(self) -> val.Extension:
         name = "ConstF64"
         payload = {"value": self.v}
-        return val.Extension(
-            name, typ=FLOAT_T, val=payload, extensions=[FLOAT_TYPES_EXTENSION.name]
-        )
+        return val.Extension(name, typ=FLOAT_T, val=payload)
 
     def __str__(self) -> str:
         return f"{self.v}"

--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -66,7 +66,6 @@ class IntVal(val.ExtensionValue):
             name,
             typ=int_t(self.width),
             val=payload,
-            extensions=[INT_TYPES_EXTENSION.name],
         )
 
     def __str__(self) -> str:

--- a/hugr-py/src/hugr/std/prelude.py
+++ b/hugr-py/src/hugr/std/prelude.py
@@ -27,7 +27,6 @@ class StringVal(val.ExtensionValue):
             name,
             typ=STRING_T,
             val=payload,
-            extensions=[PRELUDE_EXTENSION.name],
         )
 
     def __str__(self) -> str:

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -317,6 +317,8 @@ class Extension(Value):
     typ: tys.Type
     #: Value payload.
     val: Any
+
+    #: Extension set. Deprecated, no longer used. Will be removed in hugr v0.13.
     extensions: tys.ExtensionSet = field(default_factory=tys.ExtensionSet)
 
     def type_(self) -> tys.Type:
@@ -326,7 +328,6 @@ class Extension(Value):
         return sops.CustomValue(
             typ=self.typ._to_serial_root(),
             value=sops.CustomConst(c=self.name, v=self.val),
-            extensions=self.extensions,
         )
 
     def to_model(self) -> model.Term:

--- a/hugr-py/tests/serialization/test_extension.py
+++ b/hugr-py/tests/serialization/test_extension.py
@@ -98,7 +98,6 @@ def test_extension():
         version=SemanticVersion(0, 1, 0),
         name="ext",
         types={"foo": type_def},
-        values={},
         operations={"New": op_def},
     )
 
@@ -119,7 +118,6 @@ def test_package():
         version=SemanticVersion(0, 1, 0),
         name="ext",
         types={},
-        values={},
         operations={},
     )
     ext_load = Extension.model_validate_json(EXAMPLE)

--- a/specification/schema/hugr_schema_live.json
+++ b/specification/schema/hugr_schema_live.json
@@ -338,13 +338,6 @@
                     "title": "ValueTag",
                     "type": "string"
                 },
-                "extensions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Extensions",
-                    "type": "array"
-                },
                 "typ": {
                     "$ref": "#/$defs/Type"
                 },
@@ -353,7 +346,6 @@
                 }
             },
             "required": [
-                "extensions",
                 "typ",
                 "value"
             ],

--- a/specification/schema/hugr_schema_strict_live.json
+++ b/specification/schema/hugr_schema_strict_live.json
@@ -338,13 +338,6 @@
                     "title": "ValueTag",
                     "type": "string"
                 },
-                "extensions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Extensions",
-                    "type": "array"
-                },
                 "typ": {
                     "$ref": "#/$defs/Type"
                 },
@@ -353,7 +346,6 @@
                 }
             },
             "required": [
-                "extensions",
                 "typ",
                 "value"
             ],

--- a/specification/schema/testing_hugr_schema_live.json
+++ b/specification/schema/testing_hugr_schema_live.json
@@ -338,13 +338,6 @@
                     "title": "ValueTag",
                     "type": "string"
                 },
-                "extensions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Extensions",
-                    "type": "array"
-                },
                 "typ": {
                     "$ref": "#/$defs/Type"
                 },
@@ -353,7 +346,6 @@
                 }
             },
             "required": [
-                "extensions",
                 "typ",
                 "value"
             ],

--- a/specification/schema/testing_hugr_schema_strict_live.json
+++ b/specification/schema/testing_hugr_schema_strict_live.json
@@ -338,13 +338,6 @@
                     "title": "ValueTag",
                     "type": "string"
                 },
-                "extensions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Extensions",
-                    "type": "array"
-                },
                 "typ": {
                     "$ref": "#/$defs/Type"
                 },
@@ -353,7 +346,6 @@
                 }
             },
             "required": [
-                "extensions",
                 "typ",
                 "value"
             ],


### PR DESCRIPTION
This was missed in #1906 

It was detected downstream when tket2 generated HUGRs could not be read in.
We need round trip tests that go Python -> serialised -> rust -> deserialized -> Python, might need a special binding in the validation code to do this.
