### PR TITLE
refactor: tidies to PersistentHugr

### DIFF
--- a/hugr-core/src/hugr/persistent.rs
+++ b/hugr-core/src/hugr/persistent.rs
@@ -474,10 +474,8 @@ impl PersistentHugr {
             let commit_id = out_node.0;
 
             let is_input = || {
-                let Some(repl) = self.replacement(commit_id) else {
-                    return false;
-                };
-                repl.get_replacement_io()[0] == out_node.1
+                self.replacement(commit_id)
+                    .is_some_and(|repl| repl.get_replacement_io()[0] == out_node.1)
             };
             if let Some(deleted_by) = self.find_deleting_commit(out_node) {
                 (out_node, out_port) = self

--- a/hugr-core/src/hugr/persistent.rs
+++ b/hugr-core/src/hugr/persistent.rs
@@ -573,11 +573,11 @@ impl PersistentHugr {
                     if Some(in_node) == curr_repl_out {
                         None
                     } else {
-                        let other_deleted_by =
-                            self.find_deleting_commit(PatchNode(commit_id, in_node))?;
-                        // (out_node, out_port) -> (in_node, in_port) is a boundary edge
-                        // into the child commit `other_deleted_by`
-                        (Some(other_deleted_by) != out_deleted_by).then_some(other_deleted_by)
+                        self.find_deleting_commit(PatchNode(commit_id, in_node))
+                            .filter(|other_deleted_by|
+                                // (out_node, out_port) -> (in_node, in_port) is a boundary edge
+                                // into the child commit `other_deleted_by`
+                                (Some(other_deleted_by) != out_deleted_by.as_ref()))
                     }
                 })
                 .collect();

--- a/hugr-core/src/hugr/persistent.rs
+++ b/hugr-core/src/hugr/persistent.rs
@@ -752,34 +752,5 @@ fn find_conflicting_node<'a>(
     })
 }
 
-/// A wrapper around a boolean that implements `Extend<V>`. The boolean
-/// is true if a non-empty iterator was appended to `self`.
-#[derive(Debug, Copy, Clone, Default)]
-struct IteratorNonEmpty(bool);
-
-impl<V> Extend<V> for IteratorNonEmpty {
-    fn extend<T: IntoIterator<Item = V>>(&mut self, iter: T) {
-        self.0 |= iter.into_iter().next().is_some();
-    }
-}
-
 #[cfg(test)]
 mod tests;
-
-#[cfg(test)]
-mod test_iterator_non_empty {
-    use super::IteratorNonEmpty;
-
-    use rstest::rstest;
-
-    #[rstest]
-    #[case(vec![])]
-    #[case(vec![1])]
-    #[case(vec![1, 2, 3])]
-    fn test_extend(#[case] input: Vec<i32>) {
-        let expected = !input.is_empty();
-        let mut res = IteratorNonEmpty::default();
-        res.extend(input);
-        assert_eq!(res.0, expected);
-    }
-}

--- a/hugr-core/src/hugr/persistent.rs
+++ b/hugr-core/src/hugr/persistent.rs
@@ -473,10 +473,6 @@ impl PersistentHugr {
         loop {
             let commit_id = out_node.0;
 
-            let is_input = || {
-                self.replacement(commit_id)
-                    .is_some_and(|repl| repl.get_replacement_io()[0] == out_node.1)
-            };
             if let Some(deleted_by) = self.find_deleting_commit(out_node) {
                 (out_node, out_port) = self
                     .state_space
@@ -492,7 +488,10 @@ impl PersistentHugr {
                         })
                         .expect("out_node is connected to output node (which is never deleted)")
                 };
-            } else if is_input() {
+            } else if self
+                .replacement(commit_id)
+                .is_some_and(|repl| repl.get_replacement_io()[0] == out_node.1)
+            {
                 // out_node is an input node
                 (out_node, out_port) = self
                     .as_state_space()

--- a/hugr-core/src/hugr/persistent.rs
+++ b/hugr-core/src/hugr/persistent.rs
@@ -569,16 +569,13 @@ impl PersistentHugr {
 
             let deleted_by_child: BTreeSet<_> = hugr
                 .linked_inputs(out_node.1, out_port)
+                .filter(|(in_node, _)| Some(in_node) != curr_repl_out.as_ref())
                 .filter_map(|(in_node, _)| {
-                    if Some(in_node) == curr_repl_out {
-                        None
-                    } else {
-                        self.find_deleting_commit(PatchNode(commit_id, in_node))
-                            .filter(|other_deleted_by|
+                    self.find_deleting_commit(PatchNode(commit_id, in_node))
+                        .filter(|other_deleted_by|
                                 // (out_node, out_port) -> (in_node, in_port) is a boundary edge
                                 // into the child commit `other_deleted_by`
                                 (Some(other_deleted_by) != out_deleted_by.as_ref()))
-                    }
                 })
                 .collect();
 


### PR DESCRIPTION
I mistakenly made these as comments on #2168 because GitHub's "show changes from last review" includes changes merged in from main - the code I was commenting on actually went into main as part of #2202 . So, nothing major, but separating out.