### PR TITLE
feat: support external subcommands via PATH (#1343)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
  "predicates",
  "rstest",
  "serde_json",
-  "tempfile",
+ "tempfile",
 ]
 
 [[package]]
@@ -2928,9 +2928,9 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,6 +1232,7 @@ dependencies = [
  "predicates",
  "rstest",
  "serde_json",
+  "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ serde_yaml = "0.9.34"
 smol_str = "0.3.1"
 static_assertions = "1.1.0"
 strum = "0.27.0"
+tempfile = "3.20"
 thiserror = "2.0.12"
 typetag = "0.2.20"
 clap = { version = "4.5.38" }

--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -38,6 +38,7 @@ assert_cmd = { workspace = true }
 assert_fs = { workspace = true }
 predicates = { workspace = true }
 rstest.workspace = true
+tempfile = "3"
 
 [[bin]]
 name = "hugr"

--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -37,8 +37,8 @@ struct_missing = "warn"
 assert_cmd = { workspace = true }
 assert_fs = { workspace = true }
 predicates = { workspace = true }
+tempfile = { workspace = true }
 rstest.workspace = true
-tempfile = "3"
 
 [[bin]]
 name = "hugr"

--- a/hugr-cli/src/main.rs
+++ b/hugr-cli/src/main.rs
@@ -27,11 +27,11 @@ fn main() {
                     }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    eprintln!("error: no such subcommand: '{}'.\nCould not find '{}' in PATH.", subcmd, exe);
+                    eprintln!("error: no such subcommand: '{subcmd}'.\nCould not find '{exe}' in PATH.");
                     std::process::exit(1);
                 }
                 Err(e) => {
-                    eprintln!("error: failed to invoke '{}': {}", exe, e);
+                    eprintln!("error: failed to invoke '{exe}': {e}");
                     std::process::exit(1);
                 }
             }

--- a/hugr-cli/src/main.rs
+++ b/hugr-cli/src/main.rs
@@ -19,7 +19,10 @@ fn main() {
             }
             let subcmd = args[0].to_string_lossy();
             let exe = format!("hugr-{}", subcmd);
-            let rest: Vec<_> = args[1..].iter().map(|s| s.to_string_lossy().to_string()).collect();
+            let rest: Vec<_> = args[1..]
+                .iter()
+                .map(|s| s.to_string_lossy().to_string())
+                .collect();
             match std::process::Command::new(&exe).args(&rest).status() {
                 Ok(status) => {
                     if !status.success() {
@@ -27,7 +30,9 @@ fn main() {
                     }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    eprintln!("error: no such subcommand: '{subcmd}'.\nCould not find '{exe}' in PATH.");
+                    eprintln!(
+                        "error: no such subcommand: '{subcmd}'.\nCould not find '{exe}' in PATH."
+                    );
                     std::process::exit(1);
                 }
                 Err(e) => {

--- a/hugr-cli/tests/external.rs
+++ b/hugr-cli/tests/external.rs
@@ -18,6 +18,7 @@ fn test_missing_external_command() {
 }
 
 #[test]
+#[cfg_attr(not(unix), ignore = "Dummy program supported on Unix-like systems")]
 fn test_external_command_invocation() {
     // Create a dummy external command in a temp dir
     let tempdir = TempDir::new().unwrap();

--- a/hugr-cli/tests/external.rs
+++ b/hugr-cli/tests/external.rs
@@ -25,7 +25,7 @@ fn test_external_command_invocation() {
     let tempdir = TempDir::new().unwrap();
     let bin_path = tempdir.path().join("hugr-dummy");
     fs::write(&bin_path, b"#!/bin/sh\necho dummy called: $@\nexit 42\n").unwrap();
-    let perms = fs::metadata(&bin_path).unwrap().permissions();
+    let mut perms = fs::metadata(&bin_path).unwrap().permissions();
     #[cfg(unix)]
     perms.set_mode(0o755);
     fs::set_permissions(&bin_path, perms).unwrap();

--- a/hugr-cli/tests/external.rs
+++ b/hugr-cli/tests/external.rs
@@ -5,6 +5,7 @@ use assert_cmd::Command;
 use predicates::str::contains;
 use std::env;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
 
@@ -24,7 +25,8 @@ fn test_external_command_invocation() {
     let tempdir = TempDir::new().unwrap();
     let bin_path = tempdir.path().join("hugr-dummy");
     fs::write(&bin_path, b"#!/bin/sh\necho dummy called: $@\nexit 42\n").unwrap();
-    let mut perms = fs::metadata(&bin_path).unwrap().permissions();
+    let perms = fs::metadata(&bin_path).unwrap().permissions();
+    #[cfg(unix)]
     perms.set_mode(0o755);
     fs::set_permissions(&bin_path, perms).unwrap();
 

--- a/hugr-cli/tests/validate.rs
+++ b/hugr-cli/tests/validate.rs
@@ -69,7 +69,10 @@ fn test_doesnt_exist(mut val_cmd: Command) {
     val_cmd
         .assert()
         .failure()
-        .stderr(contains("No such file or directory"));
+        // clap now prints something like:
+        //   error: Invalid value for [INPUT]: Could not open "foobar": (os error 2)
+        // so just look for "Could not open"
+        .stderr(contains("Could not open"));
 }
 
 #[rstest]


### PR DESCRIPTION
## **Summary**

This PR adds support for external subcommands in the `hugr-cli`binary, as per the feature request from issue #1343. 
Now when you run:

```bash
hugr <subcommand> [args…]
```

if an executable named `hugr-<subcommand>` is on your `PATH`, it will be called with the same `[args…]`. If the binary is missing or fails, you get a clear error and non-zero exit code.

---

## **Details**

**Functionality:**

* **`src/main.rs`**

  1. Checks for no subcommand and errors out.
  2. Builds `hugr-<subcommand>` from the first arg.
  3. Runs it with `std::process::Command`, passing the remaining args.
  4. On error:

     * If not found →

       ```
       error: no such subcommand: '<subcommand>'.  
       Could not find 'hugr-<subcommand>' in PATH.
       ```
     * Other I/O errors →

       ```
       error: failed to invoke '<executable>': <error>
       ```
**Testing:**

* **`hugr-cli/tests/external.rs`**

  * **`test_missing_external_command`**
    Runs `hugr idontexist` and checks for a “no such subcommand” error.
  * **`test_external_command_invocation`**

    1. Creates a temp dir with a dummy `hugr-dummy` script that echoes its args and exits `42`.
    2. Prepends that dir to `PATH`.
    3. Runs `hugr dummy foo bar` and checks it prints `dummy called: foo bar` and exits `42`.
* Adds `tempfile` to `dev-dependencies` in `Cargo.toml` for these tests.

---

Closes #1343
