### PR TITLE
feat: Hugr::store_with_exts and auto-include in serde_as

### DIFF
--- a/hugr-core/src/envelope/serde_with.rs
+++ b/hugr-core/src/envelope/serde_with.rs
@@ -16,7 +16,9 @@ use crate::std_extensions::STD_REG;
 /// storing it as a string.
 ///
 /// Note that only PRELUDE extensions are used to decode the package's content.
-/// Additional extensions should be included in the serialized envelope.
+/// When serializing a HUGR, any additional extensions required to load the
+/// it are embedded in the envelope. Packages should manually add any required
+/// extensions before serializing.
 ///
 /// # Examples
 ///
@@ -186,8 +188,20 @@ macro_rules! impl_serde_as_string_envelope {
             where
                 S: serde::Serializer,
             {
+                // Include any additional extension required to load the HUGR in the envelope.
+                let extensions: &$crate::extension::ExtensionRegistry = $extension_reg;
+                let mut extra_extensions = $crate::extension::ExtensionRegistry::default();
+                for ext in $crate::hugr::views::HugrView::extensions(source).iter() {
+                    if !extensions.contains(ext.name()) {
+                        extra_extensions.register_updated(ext.clone());
+                    }
+                }
+
                 let str = source
-                    .store_str($crate::envelope::EnvelopeConfig::text())
+                    .store_str_with_exts(
+                        $crate::envelope::EnvelopeConfig::text(),
+                        &extra_extensions,
+                    )
                     .map_err(serde::ser::Error::custom)?;
                 serializer.collect_str(&str)
             }

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -57,6 +57,12 @@ impl Package {
     }
 
     /// Read a Package from a HUGR envelope.
+    ///
+    /// To load a Package, all the extensions used in its definition must be
+    /// available. The Envelope may include some of the extensions, but any
+    /// additional extensions must be provided in the `extensions` parameter. If
+    /// `extensions` is `None`, the default [`crate::std_extensions::STD_REG`]
+    /// is used.
     pub fn load(
         reader: impl io::BufRead,
         extensions: Option<&ExtensionRegistry>,
@@ -70,6 +76,12 @@ impl Package {
     ///
     /// Note that not all envelopes are valid strings. In the general case,
     /// it is recommended to use `Package::load` with a bytearray instead.
+    ///
+    /// To load a Package, all the extensions used in its definition must be
+    /// available. The Envelope may include some of the extensions, but any
+    /// additional extensions must be provided in the `extensions` parameter. If
+    /// `extensions` is `None`, the default [`crate::std_extensions::STD_REG`]
+    /// is used.
     pub fn load_str(
         envelope: impl AsRef<str>,
         extensions: Option<&ExtensionRegistry>,
@@ -78,6 +90,10 @@ impl Package {
     }
 
     /// Store the Package in a HUGR envelope.
+    ///
+    /// The Envelope will embed the definitions of the extensions in
+    /// [`Package::extensions`]. Any other extension used in the definition must
+    /// be passed to [`Package::load`] to load back the package.
     pub fn store(
         &self,
         writer: impl io::Write,
@@ -91,6 +107,10 @@ impl Package {
     /// Note that not all envelopes are valid strings. In the general case,
     /// it is recommended to use `Package::store` with a bytearray instead.
     /// See [`EnvelopeFormat::ascii_printable`][crate::envelope::EnvelopeFormat::ascii_printable].
+    ///
+    /// The Envelope will embed the definitions of the extensions in
+    /// [`Package::extensions`]. Any other extension used in the definition must
+    /// be passed to [`Package::load_str`] to load back the package.
     pub fn store_str(&self, config: EnvelopeConfig) -> Result<String, EnvelopeError> {
         if !config.format.ascii_printable() {
             return Err(EnvelopeError::NonASCIIFormat {


### PR DESCRIPTION
Closes #2279

This mostly expands the docs on the current behaviour, adds a `Hugr::store_with_exts` call to manually include extensions in the envelope, and auto-includes extra extensions in the `AsStringEnvelope` helper.