### PR TITLE
perf(py): mutable `Node` to avoid linear update cost

### DIFF
--- a/hugr-py/src/hugr/build/dfg.py
+++ b/hugr-py/src/hugr/build/dfg.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -230,8 +230,8 @@ class DfBase(ParentBuilder[DP], DefinitionBuilder, AbstractContextManager):
         """
         new_n = self.hugr.add_node(op, self.parent_node, metadata=metadata)
         self._wire_up(new_n, args)
-
-        return replace(new_n, _num_out_ports=op.num_out)
+        new_n._num_out_ports = op.num_out
+        return new_n
 
     def add(self, com: ops.Command, *, metadata: dict[str, Any] | None = None) -> Node:
         """Add a command (holding a dataflow operation and the incoming wires)

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable, Iterator, Mapping
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from queue import Queue
 from typing import (
     TYPE_CHECKING,
@@ -290,7 +290,8 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         else:
             node = Node(len(self._nodes), {})
             self._nodes.append(node_data)
-        node = replace(node, _num_out_ports=num_outs, _metadata=node_data.metadata)
+        node._num_out_ports = num_outs
+        node._metadata = node_data.metadata
         if parent:
             self[parent].children.append(node)
 
@@ -322,11 +323,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             self[node]._num_inps = num_inps
         if num_outs is not None:
             self[node]._num_outs = num_outs
-            node = replace(node, _num_out_ports=num_outs)
-            parent = self[node].parent
-            if parent is not None:
-                pos = self[parent].children.index(node)
-                self[parent].children[pos] = node
+            node._num_out_ports = num_outs
 
         if node.idx == self.entrypoint.idx:
             self.entrypoint = node
@@ -412,7 +409,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         weight, self._nodes[node.idx] = self._nodes[node.idx], None
 
         # Free up the metadata dictionary
-        node = replace(node, _metadata={})
+        node._metadata = {}
 
         self._free_nodes.append(node)
         return weight

--- a/hugr-py/src/hugr/hugr/node_port.py
+++ b/hugr-py/src/hugr/hugr/node_port.py
@@ -147,7 +147,7 @@ class ToNode(Wire, Protocol):
         return self.to_node()._metadata
 
 
-@dataclass(frozen=True, eq=True, order=True)
+@dataclass(eq=True, order=True)
 class Node(ToNode):
     """Node in hierarchical :class:`Hugr <hugr.hugr.Hugr>` graph,
     with globally unique index.
@@ -223,6 +223,9 @@ class Node(ToNode):
 
     def __repr__(self) -> str:
         return f"Node({self.idx})"
+
+    def __hash__(self) -> int:
+        return hash(self.idx)
 
 
 P = TypeVar("P", InPort, OutPort)


### PR DESCRIPTION
`list.index` call to update parent was very costly for nodes with many children. This was only necessary because Node was frozen, this can be avoided with a custom hash.