### PR TITLE
feat!: Better error reporting in `hugr-cli`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
 name = "hugr-cli"
 version = "0.20.1"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "assert_fs",
  "clap",
@@ -1234,6 +1235,9 @@ dependencies = [
  "rstest",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1896,6 +1900,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2031,12 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -2811,6 +2831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3010,6 +3039,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,7 +3164,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3135,6 +3186,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3280,6 +3357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,6 +3499,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,6 +3522,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -22,6 +22,10 @@ derive_more = { workspace = true, features = ["display", "error", "from"] }
 hugr = { path = "../hugr", version = "0.20.1" }
 serde_json.workspace = true
 clio = { workspace = true, features = ["clap-parse"] }
+anyhow.workspace = true
+thiserror.workspace = true
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["fmt"] }
 
 [lints]
 workspace = true

--- a/hugr-cli/src/extensions.rs
+++ b/hugr-cli/src/extensions.rs
@@ -1,4 +1,5 @@
 //! Dump standard extensions in serialized form.
+use anyhow::Result;
 use clap::Parser;
 use hugr::extension::ExtensionRegistry;
 use std::{io::Write, path::PathBuf};
@@ -25,7 +26,7 @@ impl ExtArgs {
     /// Write out the standard extensions in serialized form.
     /// Qualified names of extensions used to generate directories under the specified output directory.
     /// E.g. extension "foo.bar.baz" will be written to "OUTPUT/foo/bar/baz.json".
-    pub fn run_dump(&self, registry: &ExtensionRegistry) {
+    pub fn run_dump(&self, registry: &ExtensionRegistry) -> Result<()> {
         let base_dir = &self.outdir;
 
         for ext in registry {
@@ -35,15 +36,17 @@ impl ExtArgs {
             }
             path.set_extension("json");
 
-            std::fs::create_dir_all(path.clone().parent().unwrap()).unwrap();
+            std::fs::create_dir_all(path.clone().parent().unwrap())?;
             // file buffer
-            let mut file = std::fs::File::create(&path).unwrap();
+            let mut file = std::fs::File::create(&path)?;
 
-            serde_json::to_writer_pretty(&mut file, &ext).unwrap();
+            serde_json::to_writer_pretty(&mut file, &ext)?;
 
             // write newline, for pre-commit end of file check that edits the file to
             // add newlines if missing.
-            file.write_all(b"\n").unwrap();
+            file.write_all(b"\n")?;
         }
+
+        Ok(())
     }
 }

--- a/hugr-cli/src/hugr_io.rs
+++ b/hugr-cli/src/hugr_io.rs
@@ -7,7 +7,6 @@ use hugr::package::Package;
 use hugr::{Extension, Hugr};
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
-use tracing::instrument;
 
 use crate::CliError;
 

--- a/hugr-cli/src/hugr_io.rs
+++ b/hugr-cli/src/hugr_io.rs
@@ -7,6 +7,7 @@ use hugr::package::Package;
 use hugr::{Extension, Hugr};
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
+use tracing::instrument;
 
 use crate::CliError;
 

--- a/hugr-cli/src/lib.rs
+++ b/hugr-cli/src/lib.rs
@@ -57,11 +57,11 @@
 //! ```
 
 use clap::{Parser, crate_version};
-use clap_verbosity_flag::log::Level;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use hugr::envelope::EnvelopeError;
 use hugr::package::PackageValidationError;
 use std::ffi::OsString;
+use thiserror::Error;
 
 pub mod extensions;
 pub mod hugr_io;
@@ -73,8 +73,19 @@ pub mod validate;
 #[clap(version = crate_version!(), long_about = None)]
 #[clap(about = "HUGR CLI tools.")]
 #[group(id = "hugr")]
+pub struct CliArgs {
+    /// The command to be run.
+    #[command(subcommand)]
+    pub command: CliCommand,
+    /// Verbosity.
+    #[command(flatten)]
+    pub verbose: Verbosity<InfoLevel>,
+}
+
+/// The CLI subcommands.
+#[derive(Debug, clap::Subcommand)]
 #[non_exhaustive]
-pub enum CliArgs {
+pub enum CliCommand {
     /// Validate and visualize a HUGR file.
     Validate(validate::ValArgs),
     /// Write standard extensions out in serialized form.
@@ -87,40 +98,24 @@ pub enum CliArgs {
 }
 
 /// Error type for the CLI.
-#[derive(Debug, derive_more::Display, derive_more::Error, derive_more::From)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum CliError {
     /// Error reading input.
-    #[display("Error reading from path: {_0}")]
-    InputFile(std::io::Error),
+    #[error("Error reading from path.")]
+    InputFile(#[from] std::io::Error),
     /// Error parsing input.
-    #[display("Error parsing package: {_0}")]
-    Parse(serde_json::Error),
-    #[display("Error validating HUGR: {_0}")]
+    #[error("Error parsing package.")]
+    Parse(#[from] serde_json::Error),
+    #[error("Error validating HUGR.")]
     /// Errors produced by the `validate` subcommand.
-    Validate(PackageValidationError),
-    #[display("Error decoding HUGR envelope: {_0}")]
+    Validate(#[from] PackageValidationError),
+    #[error("Error decoding HUGR envelope.")]
     /// Errors produced by the `validate` subcommand.
-    Envelope(EnvelopeError),
+    Envelope(#[from] EnvelopeError),
     /// Pretty error when the user passes a non-envelope file.
-    #[display(
+    #[error(
         "Input file is not a HUGR envelope. Invalid magic number.\n\nUse `--hugr-json` to read a raw HUGR JSON file instead."
     )]
     NotAnEnvelope,
-}
-
-/// Other arguments affecting the HUGR CLI runtime.
-#[derive(Parser, Debug)]
-pub struct OtherArgs {
-    /// Verbosity.
-    #[command(flatten)]
-    pub verbose: Verbosity<InfoLevel>,
-}
-
-impl OtherArgs {
-    /// Test whether a `level` message should be output.
-    #[must_use]
-    pub fn verbosity(&self, level: Level) -> bool {
-        self.verbose.log_level_filter() >= level
-    }
 }

--- a/hugr-cli/src/main.rs
+++ b/hugr-cli/src/main.rs
@@ -1,73 +1,65 @@
 //! Validate serialized HUGR on the command line
 
+use std::ffi::OsString;
+
+use anyhow::{Result, bail};
 use clap::Parser as _;
+use clap_verbosity_flag::VerbosityFilter;
+use hugr_cli::{CliArgs, CliCommand};
+use tracing::{instrument, metadata::LevelFilter};
 
-use hugr_cli::{CliArgs, mermaid, validate};
+#[instrument(err(Debug))]
+fn main() -> Result<()> {
+    let cli_args = CliArgs::parse();
 
-use clap_verbosity_flag::log::Level;
+    let level = match cli_args.verbose.filter() {
+        VerbosityFilter::Off => LevelFilter::OFF,
+        VerbosityFilter::Error => LevelFilter::ERROR,
+        VerbosityFilter::Warn => LevelFilter::WARN,
+        VerbosityFilter::Info => LevelFilter::INFO,
+        VerbosityFilter::Debug => LevelFilter::DEBUG,
+        VerbosityFilter::Trace => LevelFilter::TRACE,
+    };
+    tracing_subscriber::fmt().with_max_level(level).init();
 
-fn main() {
-    match CliArgs::parse() {
-        CliArgs::Validate(args) => run_validate(args),
-        CliArgs::GenExtensions(args) => args.run_dump(&hugr::std_extensions::STD_REG),
-        CliArgs::Mermaid(args) => run_mermaid(args),
-        CliArgs::External(args) => {
-            // External subcommand support: invoke `hugr-<subcommand>`
-            if args.is_empty() {
-                eprintln!("No external subcommand specified.");
-                std::process::exit(1);
-            }
-            let subcmd = args[0].to_string_lossy();
-            let exe = format!("hugr-{}", subcmd);
-            let rest: Vec<_> = args[1..]
-                .iter()
-                .map(|s| s.to_string_lossy().to_string())
-                .collect();
-            match std::process::Command::new(&exe).args(&rest).status() {
-                Ok(status) => {
-                    if !status.success() {
-                        std::process::exit(status.code().unwrap_or(1));
-                    }
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    eprintln!(
-                        "error: no such subcommand: '{subcmd}'.\nCould not find '{exe}' in PATH."
-                    );
-                    std::process::exit(1);
-                }
-                Err(e) => {
-                    eprintln!("error: failed to invoke '{exe}': {e}");
-                    std::process::exit(1);
-                }
+    match cli_args.command {
+        CliCommand::Validate(mut args) => args.run()?,
+        CliCommand::GenExtensions(args) => args.run_dump(&hugr::std_extensions::STD_REG)?,
+        CliCommand::Mermaid(mut args) => args.run_print()?,
+        CliCommand::External(args) => run_external(args)?,
+        _ => bail!("Unknown command"),
+    };
+
+    Ok(())
+}
+
+fn run_external(args: Vec<OsString>) -> Result<()> {
+    // External subcommand support: invoke `hugr-<subcommand>`
+    if args.is_empty() {
+        eprintln!("No external subcommand specified.");
+        std::process::exit(1);
+    }
+    let subcmd = args[0].to_string_lossy();
+    let exe = format!("hugr-{}", subcmd);
+    let rest: Vec<_> = args[1..]
+        .iter()
+        .map(|s| s.to_string_lossy().to_string())
+        .collect();
+    match std::process::Command::new(&exe).args(&rest).status() {
+        Ok(status) => {
+            if !status.success() {
+                std::process::exit(status.code().unwrap_or(1));
             }
         }
-        _ => {
-            eprintln!("Unknown command");
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("error: no such subcommand: '{subcmd}'.\nCould not find '{exe}' in PATH.");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("error: failed to invoke '{exe}': {e}");
             std::process::exit(1);
         }
     }
-}
 
-/// Run the `validate` subcommand.
-fn run_validate(mut args: validate::ValArgs) {
-    let result = args.run();
-
-    if let Err(e) = result {
-        if args.verbosity(Level::Error) {
-            eprintln!("{e}");
-        }
-        std::process::exit(1);
-    }
-}
-
-/// Run the `mermaid` subcommand.
-fn run_mermaid(mut args: mermaid::MermaidArgs) {
-    let result = args.run_print();
-
-    if let Err(e) = result {
-        if args.other_args.verbosity(Level::Error) {
-            eprintln!("{e}");
-        }
-        std::process::exit(1);
-    }
+    Ok(())
 }

--- a/hugr-cli/src/mermaid.rs
+++ b/hugr-cli/src/mermaid.rs
@@ -1,6 +1,7 @@
 //! Render mermaid diagrams.
 use std::io::Write;
 
+use crate::CliError;
 use crate::hugr_io::HugrInputArgs;
 use anyhow::Result;
 use clap::Parser;
@@ -45,7 +46,7 @@ impl MermaidArgs {
         let package = self.input_args.get_package()?;
 
         if self.validate {
-            package.validate()?;
+            package.validate().map_err(CliError::Validate)?;
         }
 
         for hugr in package.modules {

--- a/hugr-cli/src/mermaid.rs
+++ b/hugr-cli/src/mermaid.rs
@@ -1,14 +1,12 @@
 //! Render mermaid diagrams.
 use std::io::Write;
 
+use crate::hugr_io::HugrInputArgs;
+use anyhow::Result;
 use clap::Parser;
-use clap_verbosity_flag::log::Level;
 use clio::Output;
 use hugr::HugrView;
 use hugr::package::PackageValidationError;
-
-use crate::OtherArgs;
-use crate::hugr_io::HugrInputArgs;
 
 /// Dump the standard extensions.
 #[derive(Parser, Debug)]
@@ -30,15 +28,11 @@ pub struct MermaidArgs {
     /// Output file '-' for stdout
     #[clap(long, short, value_parser, default_value = "-")]
     output: Output,
-
-    /// Additional arguments
-    #[command(flatten)]
-    pub other_args: OtherArgs,
 }
 
 impl MermaidArgs {
     /// Write the mermaid diagram to the output.
-    pub fn run_print(&mut self) -> Result<(), crate::CliError> {
+    pub fn run_print(&mut self) -> Result<()> {
         if self.input_args.hugr_json {
             self.run_print_hugr()
         } else {
@@ -47,7 +41,7 @@ impl MermaidArgs {
     }
 
     /// Write the mermaid diagram for a HUGR envelope.
-    pub fn run_print_envelope(&mut self) -> Result<(), crate::CliError> {
+    pub fn run_print_envelope(&mut self) -> Result<()> {
         let package = self.input_args.get_package()?;
 
         if self.validate {
@@ -61,7 +55,7 @@ impl MermaidArgs {
     }
 
     /// Write the mermaid diagram for a legacy HUGR json.
-    pub fn run_print_hugr(&mut self) -> Result<(), crate::CliError> {
+    pub fn run_print_hugr(&mut self) -> Result<()> {
         let hugr = self.input_args.get_hugr()?;
 
         if self.validate {
@@ -71,11 +65,5 @@ impl MermaidArgs {
 
         writeln!(self.output, "{}", hugr.mermaid_string())?;
         Ok(())
-    }
-
-    /// Test whether a `level` message should be output.
-    #[must_use]
-    pub fn verbosity(&self, level: Level) -> bool {
-        self.other_args.verbosity(level)
     }
 }

--- a/hugr-cli/src/validate.rs
+++ b/hugr-cli/src/validate.rs
@@ -6,6 +6,7 @@ use hugr::HugrView;
 use hugr::package::PackageValidationError;
 use tracing::info;
 
+use crate::CliError;
 use crate::hugr_io::HugrInputArgs;
 
 /// Validate and visualise a HUGR file.
@@ -29,10 +30,11 @@ impl ValArgs {
         if self.input_args.hugr_json {
             let hugr = self.input_args.get_hugr()?;
             hugr.validate()
-                .map_err(PackageValidationError::Validation)?;
+                .map_err(PackageValidationError::Validation)
+                .map_err(CliError::Validate)?;
         } else {
             let package = self.input_args.get_package()?;
-            package.validate()?;
+            package.validate().map_err(CliError::Validate)?;
         };
 
         info!("{VALID_PRINT}");

--- a/hugr-core/src/package.rs
+++ b/hugr-core/src/package.rs
@@ -1,6 +1,5 @@
 //! Bundles of hugr modules along with the extension required to load them.
 
-use derive_more::{Display, Error, From};
 use std::io;
 
 use crate::envelope::{EnvelopeConfig, EnvelopeError, read_envelope, write_envelope};
@@ -8,6 +7,7 @@ use crate::extension::ExtensionRegistry;
 use crate::hugr::{HugrView, ValidationError};
 use crate::std_extensions::STD_REG;
 use crate::{Hugr, Node};
+use thiserror::Error;
 
 #[derive(Debug, Default, Clone, PartialEq)]
 /// Package of module HUGRs.
@@ -131,11 +131,12 @@ impl AsRef<[Hugr]> for Package {
 }
 
 /// Error raised while validating a package.
-#[derive(Debug, Display, From, Error)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
+#[error("Package validation error.")]
 pub enum PackageValidationError {
     /// Error raised while validating the package hugrs.
-    Validation(ValidationError<Node>),
+    Validation(#[from] ValidationError<Node>),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR streamlines the error reporting in `hugr-cli`, displaying error source trails and setting up the tracing crate. For that, some error trait implementations were migrated to `thiserror`. The PR also simplifies the `clap` structures by pulling out the verbosity level from the individual commands. The commands should use tracing macros instead of relying on filtering for verbosity themselves.

BREAKING CHANGE: Reorganised `clap` commands and errors in `hugr-cli` which is only visible when it is used as a library.