### PR TITLE
fix: Fixed bug in python model export name mangling.

### DIFF
--- a/hugr-py/src/hugr/model/export.py
+++ b/hugr-py/src/hugr/model/export.py
@@ -539,7 +539,7 @@ class ModelExport:
             case _:
                 return None
 
-        return _mangle_name(node, name)
+        return _mangle_name(func_node, name)
 
     def find_const_input(self, node: Node) -> model.Term | None:
         """Find and export the constant that a node is connected to, if any."""


### PR DESCRIPTION
This PR fixes a bug in the Python model export: `Call` nodes referred to themselves instead of the function to be called.