### PR TITLE
fix: Fixed two bugs in import/export of function operations

### DIFF
--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -966,8 +966,10 @@ impl<'a> Context<'a> {
         node_data: &'a table::Node<'a>,
         parent: Node,
     ) -> Result<Node, ImportError> {
-        if let Some([_, _]) = self.match_symbol(operation, model::CORE_CALL_INDIRECT)? {
-            let signature = self.get_node_signature(node_id)?;
+        if let Some([inputs, outputs]) = self.match_symbol(operation, model::CORE_CALL_INDIRECT)? {
+            let inputs = self.import_type_row(inputs)?;
+            let outputs = self.import_type_row(outputs)?;
+            let signature = Signature::new(inputs, outputs);
             let optype = OpType::CallIndirect(CallIndirect { signature });
             let node = self.make_node(node_id, optype, parent)?;
             return Ok(node);

--- a/hugr-py/src/hugr/model/export.py
+++ b/hugr-py/src/hugr/model/export.py
@@ -213,7 +213,8 @@ class ModelExport:
                 )
 
             case LoadFunc() as op:
-                signature = op.instantiation.to_model()
+                signature = op.outer_signature().to_model()
+                instantiation = op.instantiation.to_model()
                 func_args = cast(
                     list[model.Term], [type.to_model() for type in op.type_args]
                 )
@@ -227,10 +228,10 @@ class ModelExport:
 
                 return model.Node(
                     operation=model.CustomOp(
-                        model.Apply("core.load_const", [signature, func])
+                        model.Apply("core.load_const", [instantiation, func])
                     ),
                     signature=signature,
-                    inputs=inputs,
+                    inputs=[],
                     outputs=outputs,
                     meta=meta,
                 )


### PR DESCRIPTION
This PR fixes two bugs: The first bug exported the type `LoadFunc` nodes incorrectly from Python. The second imported the type of `core.call_indirect` operations incorrectly.