### PR TITLE
feat(core): builder pattern for EnvelopeConfig

### DIFF
--- a/hugr-core/src/envelope/header.rs
+++ b/hugr-core/src/envelope/header.rs
@@ -95,7 +95,7 @@ impl EnvelopeFormat {
 }
 
 /// Configuration for encoding an envelope.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct EnvelopeConfig {
     /// The format to use for the payload.
@@ -105,21 +105,9 @@ pub struct EnvelopeConfig {
     pub zstd: Option<ZstdConfig>,
 }
 
-impl Default for EnvelopeConfig {
-    fn default() -> Self {
-        let format = Default::default();
-        let zstd = if cfg!(feature = "zstd") {
-            Some(ZstdConfig::default())
-        } else {
-            None
-        };
-        Self { format, zstd }
-    }
-}
-
 impl EnvelopeConfig {
     /// Create a new envelope configuration with the specified format.
-    /// `zstd` compression is set to default.
+    /// `zstd` compression is set to default value `None`.
     pub fn new(format: EnvelopeFormat) -> Self {
         Self {
             format,

--- a/hugr-core/src/envelope/header.rs
+++ b/hugr-core/src/envelope/header.rs
@@ -107,7 +107,7 @@ pub struct EnvelopeConfig {
 
 impl EnvelopeConfig {
     /// Create a new envelope configuration with the specified format.
-    /// `zstd` compression is set to default value `None`.
+    /// `zstd` compression is disabled by default.
     pub fn new(format: EnvelopeFormat) -> Self {
         Self {
             format,

--- a/hugr-core/src/envelope/header.rs
+++ b/hugr-core/src/envelope/header.rs
@@ -118,6 +118,28 @@ impl Default for EnvelopeConfig {
 }
 
 impl EnvelopeConfig {
+    /// Create a new envelope configuration with the specified format.
+    /// `zstd` compression is set to default.
+    pub fn new(format: EnvelopeFormat) -> Self {
+        Self {
+            format,
+            ..Default::default()
+        }
+    }
+
+    /// Set the zstd compression configuration for the envelope.
+    pub fn with_zstd(self, zstd: ZstdConfig) -> Self {
+        Self {
+            zstd: Some(zstd),
+            ..self
+        }
+    }
+
+    /// Disable zstd compression in the envelope configuration.
+    pub fn disable_compression(self) -> Self {
+        Self { zstd: None, ..self }
+    }
+
     /// Create a new envelope header with the specified configuration.
     pub(super) fn make_header(&self) -> EnvelopeHeader {
         EnvelopeHeader {
@@ -162,6 +184,12 @@ pub struct ZstdConfig {
 }
 
 impl ZstdConfig {
+    /// Create a new zstd configuration with the specified compression level.
+    pub fn new(level: u8) -> Self {
+        Self {
+            level: NonZeroU8::new(level),
+        }
+    }
     /// Create a new zstd configuration with default compression level.
     #[must_use]
     pub const fn default_level() -> Self {

--- a/hugr/benches/benchmarks/hugr.rs
+++ b/hugr/benches/benchmarks/hugr.rs
@@ -19,9 +19,7 @@ trait Serializer {
 struct JsonSer;
 impl Serializer for JsonSer {
     fn serialize(&self, hugr: &Hugr) -> Vec<u8> {
-        let mut cfg = EnvelopeConfig::default();
-        cfg.format = EnvelopeFormat::PackageJson;
-        cfg.zstd = None;
+        let cfg = EnvelopeConfig::new(EnvelopeFormat::PackageJson).disable_compression();
 
         let mut bytes = Vec::new();
         hugr.store(&mut bytes, cfg).unwrap();
@@ -36,9 +34,8 @@ struct CapnpSer;
 
 impl Serializer for CapnpSer {
     fn serialize(&self, hugr: &Hugr) -> Vec<u8> {
-        let mut cfg = EnvelopeConfig::default();
-        cfg.format = EnvelopeFormat::ModelWithExtensions;
-        cfg.zstd = Some(Default::default());
+        let cfg =
+            EnvelopeConfig::new(EnvelopeFormat::ModelWithExtensions).with_zstd(Default::default());
 
         let mut bytes = Vec::new();
         hugr.store(&mut bytes, cfg).unwrap();


### PR DESCRIPTION
non exhaustive structs require constructors to be usable outside the crate