### PR TITLE
feat(persistent): Add serialisation for CommitStateSpace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,6 +1351,7 @@ dependencies = [
  "delegate",
  "derive_more 1.0.0",
  "hugr-core",
+ "insta",
  "itertools 0.14.0",
  "lazy_static",
  "petgraph 0.8.1",
@@ -1358,7 +1359,11 @@ dependencies = [
  "relrc",
  "rstest",
  "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
  "thiserror 2.0.12",
+ "wyhash",
 ]
 
 [[package]]
@@ -1602,7 +1607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -2429,7 +2434,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
 ]
 
@@ -2440,7 +2445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2454,12 +2459,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2468,7 +2479,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2580,6 +2591,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "petgraph 0.8.1",
+ "serde",
  "thiserror 1.0.69",
 ]
 
@@ -3840,6 +3852,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wyhash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca4d373340c479fd1e779f7a763acee85da3e423b1a9a9acccf97babcc92edbb"
+dependencies = [
+ "rand_core 0.9.3",
+]
 
 [[package]]
 name = "wyz"

--- a/hugr-persistent/Cargo.toml
+++ b/hugr-persistent/Cargo.toml
@@ -11,14 +11,18 @@ license.workspace = true
 name = "persistent_walker_example"
 
 [dependencies]
-relrc = { workspace = true, features = ["petgraph"] }
 hugr-core.path = "../hugr-core"
+
 delegate.workspace = true
 derive_more.workspace = true
 itertools.workspace = true
 petgraph.workspace = true
 portgraph.workspace = true
+relrc = { workspace = true, features = ["petgraph", "serde"] }
+serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
+wyhash = "0.6.0"
 
 [lints]
 workspace = true
@@ -27,3 +31,5 @@ workspace = true
 rstest.workspace = true
 lazy_static.workspace = true
 semver.workspace = true
+serde_with.workspace = true
+insta.workspace = true

--- a/hugr-persistent/src/lib.rs
+++ b/hugr-persistent/src/lib.rs
@@ -72,7 +72,7 @@ mod trait_impls;
 pub mod walker;
 
 pub use persistent_hugr::{Commit, PersistentHugr};
-pub use resolver::PointerEqResolver;
+pub use resolver::{PointerEqResolver, SerdeHashResolver};
 pub use state_space::{CommitId, CommitStateSpace, InvalidCommit, PatchNode};
 pub use walker::{PinnedWire, Walker};
 

--- a/hugr-persistent/src/parents_view.rs
+++ b/hugr-persistent/src/parents_view.rs
@@ -23,7 +23,10 @@ pub(crate) struct ParentsView<'a> {
 }
 
 impl<'a> ParentsView<'a> {
-    pub(crate) fn from_commit(commit_id: CommitId, state_space: &'a CommitStateSpace) -> Self {
+    pub(crate) fn from_commit<R>(
+        commit_id: CommitId,
+        state_space: &'a CommitStateSpace<R>,
+    ) -> Self {
         let mut hugrs = BTreeMap::new();
         for parent in state_space.parents(commit_id) {
             hugrs.insert(parent, state_space.commit_hugr(parent));

--- a/hugr-persistent/src/state_space.rs
+++ b/hugr-persistent/src/state_space.rs
@@ -10,19 +10,23 @@ use hugr_core::{
     ops::OpType,
 };
 use itertools::Itertools;
-use relrc::{HistoryGraph, RelRc};
+use relrc::{EquivalenceResolver, HistoryGraph, RelRc};
 use thiserror::Error;
 
 use crate::{
-    Commit, PersistentHugr, PersistentReplacement, PointerEqResolver, find_conflicting_node,
-    parents_view::ParentsView,
+    Commit, PersistentHugr, PersistentReplacement, PointerEqResolver, SerdeHashResolver,
+    find_conflicting_node, parents_view::ParentsView,
 };
+
+mod serial;
 
 /// A copyable handle to a [`Commit`] vertex within a [`CommitStateSpace`]
 pub type CommitId = relrc::NodeId;
 
 /// A HUGR node within a commit of the commit state space
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Hash)]
+#[derive(
+    Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub struct PatchNode(pub CommitId, pub Node);
 
 impl std::fmt::Display for PatchNode {
@@ -59,24 +63,25 @@ pub(crate) enum CommitData {
 /// same subgraph. Use [`Self::try_extract_hugr`] to get a [`PersistentHugr`]
 /// with a set of compatible commits.
 #[derive(Clone, Debug)]
-pub struct CommitStateSpace {
+pub struct CommitStateSpace<R = PointerEqResolver> {
     /// A set of commits with directed (acyclic) dependencies between them.
     ///
     /// Each commit is stored as a [`RelRc`].
-    graph: HistoryGraph<CommitData, (), PointerEqResolver>,
+    pub(super) graph: HistoryGraph<CommitData, (), R>,
     /// The unique root of the commit graph.
     ///
     /// The only commit in the graph with variant [`CommitData::Base`]. All
     /// other commits are [`CommitData::Replacement`]s, and are descendants
     /// of this.
-    base_commit: CommitId,
+    pub(super) base_commit: CommitId,
 }
 
-impl CommitStateSpace {
+#[allow(private_bounds)]
+impl<R: Default + EquivalenceResolver<CommitData, ()>> CommitStateSpace<R> {
     /// Create a new commit state space with a single base commit.
     pub fn with_base(hugr: Hugr) -> Self {
         let commit = RelRc::new(CommitData::Base(hugr));
-        let graph = HistoryGraph::new([commit.clone()], PointerEqResolver);
+        let graph = HistoryGraph::new([commit.clone()], R::default());
         let base_commit = graph
             .all_node_ids()
             .exactly_one()
@@ -92,7 +97,7 @@ impl CommitStateSpace {
     pub fn try_from_commits(
         commits: impl IntoIterator<Item = Commit>,
     ) -> Result<Self, InvalidCommit> {
-        let graph = HistoryGraph::new(commits.into_iter().map_into(), PointerEqResolver);
+        let graph = HistoryGraph::new(commits.into_iter().map_into(), R::default());
         let base_commits = graph
             .all_node_ids()
             .filter(|&id| matches!(graph.get_node(id).value(), CommitData::Base(_)))
@@ -116,18 +121,6 @@ impl CommitStateSpace {
         self.try_add_commit(commit)
     }
 
-    /// Add a set of commits to the state space.
-    ///
-    /// Commits must be valid replacement commits or coincide with the existing
-    /// base commit.
-    pub fn extend(&mut self, commits: impl IntoIterator<Item = Commit>) {
-        // TODO: make this more efficient
-        for commit in commits {
-            self.try_add_commit(commit)
-                .expect("invalid commit in extend");
-        }
-    }
-
     /// Add a commit (and all its ancestors) to the state space.
     ///
     /// Returns an [`InvalidCommit::NonUniqueBase`] error if the commit is a
@@ -141,14 +134,16 @@ impl CommitStateSpace {
         Ok(self.graph.insert_node(commit))
     }
 
-    /// Check if `commit` is in the commit state space.
-    pub fn contains(&self, commit: &Commit) -> bool {
-        self.graph.contains(commit.as_relrc())
-    }
-
-    /// Check if `commit_id` is in the commit state space.
-    pub fn contains_id(&self, commit_id: CommitId) -> bool {
-        self.graph.contains_id(commit_id)
+    /// Add a set of commits to the state space.
+    ///
+    /// Commits must be valid replacement commits or coincide with the existing
+    /// base commit.
+    pub fn extend(&mut self, commits: impl IntoIterator<Item = Commit>) {
+        // TODO: make this more efficient
+        for commit in commits {
+            self.try_add_commit(commit)
+                .expect("invalid commit in extend");
+        }
     }
 
     /// Extract a `PersistentHugr` from this state space, consisting of
@@ -162,7 +157,7 @@ impl CommitStateSpace {
     pub fn try_extract_hugr(
         &self,
         commits: impl IntoIterator<Item = CommitId>,
-    ) -> Result<PersistentHugr, InvalidCommit> {
+    ) -> Result<PersistentHugr<R>, InvalidCommit> {
         // Define commits as the set of all ancestors of the given commits
         let all_commit_ids = get_all_ancestors(&self.graph, commits);
 
@@ -185,12 +180,24 @@ impl CommitStateSpace {
         let commits = all_commit_ids
             .into_iter()
             .map(|id| self.get_commit(id).as_relrc().clone());
-        let subgraph = HistoryGraph::new(commits, PointerEqResolver);
+        let subgraph = HistoryGraph::new(commits, R::default());
 
         Ok(PersistentHugr::from_state_space_unsafe(Self {
             graph: subgraph,
             base_commit: self.base_commit,
         }))
+    }
+}
+
+impl<R> CommitStateSpace<R> {
+    /// Check if `commit` is in the commit state space.
+    pub fn contains(&self, commit: &Commit) -> bool {
+        self.graph.contains(commit.as_relrc())
+    }
+
+    /// Check if `commit_id` is in the commit state space.
+    pub fn contains_id(&self, commit_id: CommitId) -> bool {
+        self.graph.contains_id(commit_id)
     }
 
     /// Get the base commit ID.
@@ -254,7 +261,7 @@ impl CommitStateSpace {
         }
     }
 
-    pub(crate) fn as_history_graph(&self) -> &HistoryGraph<CommitData, (), PointerEqResolver> {
+    pub(crate) fn as_history_graph(&self) -> &HistoryGraph<CommitData, (), R> {
         &self.graph
     }
 
@@ -394,7 +401,7 @@ impl CommitStateSpace {
 
 // The subset of HugrView methods that can be implemented on CommitStateSpace
 // by simplify delegating to the patches' respective HUGRs
-impl CommitStateSpace {
+impl<R> CommitStateSpace<R> {
     /// Get the type of the operation at `node`.
     pub fn get_optype(&self, PatchNode(commit_id, node): PatchNode) -> &OpType {
         let hugr = self.commit_hugr(commit_id);

--- a/hugr-persistent/src/state_space/serial.rs
+++ b/hugr-persistent/src/state_space/serial.rs
@@ -1,7 +1,7 @@
 use relrc::serialization::SerializedHistoryGraph;
 
 use super::*;
-use crate::hugr::patch::simple_replace::serial::SerialSimpleReplacement;
+use hugr_core::hugr::patch::simple_replace::serial::SerialSimpleReplacement;
 
 /// Serialized format for [`PersistentReplacement`]
 pub type SerialPersistentReplacement<H> = SerialSimpleReplacement<H, PatchNode>;
@@ -53,26 +53,26 @@ impl<H: Into<Hugr>> From<SerialCommitData<H>> for CommitData {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SerialCommitStateSpace<H> {
     /// The serialized history graph containing commit data
-    pub graph: SerializedHistoryGraph<SerialCommitData<H>, (), PointerEqResolver>,
+    pub graph: SerializedHistoryGraph<SerialCommitData<H>, (), SerdeHashResolver<H>>,
     /// The base commit ID
     pub base_commit: CommitId,
 }
 
-impl CommitStateSpace {
+impl<H: Into<Hugr> + From<Hugr> + serde::Serialize> CommitStateSpace<SerdeHashResolver<H>> {
     /// Create a new [`CommitStateSpace`] from its serialized format
-    pub fn from_serial<H: Into<Hugr> + Clone>(value: SerialCommitStateSpace<H>) -> Self {
+    pub fn from_serial(value: SerialCommitStateSpace<H>) -> Self {
         let SerialCommitStateSpace { graph, base_commit } = value;
 
         // Deserialize the SerializedHistoryGraph into a HistoryGraph with CommitData
         let graph = graph.map_nodes(|n| CommitData::from_serial(n));
-        let graph = HistoryGraph::try_from_serialized(graph, PointerEqResolver)
+        let graph = HistoryGraph::try_from_serialized(graph, SerdeHashResolver::default())
             .expect("failed to deserialize history graph");
 
         Self { graph, base_commit }
     }
 
     /// Convert a [`CommitStateSpace`] into its serialized format
-    pub fn into_serial<H: From<Hugr>>(self) -> SerialCommitStateSpace<H> {
+    pub fn into_serial(self) -> SerialCommitStateSpace<H> {
         let Self { graph, base_commit } = self;
         let graph = graph.to_serialized();
         let graph = graph.map_nodes(|n| n.into_serial());
@@ -80,7 +80,7 @@ impl CommitStateSpace {
     }
 
     /// Create a serialized format from a reference to [`CommitStateSpace`]
-    pub fn to_serial<H>(&self) -> SerialCommitStateSpace<H>
+    pub fn to_serial(&self) -> SerialCommitStateSpace<H>
     where
         H: From<Hugr>,
     {
@@ -94,13 +94,17 @@ impl CommitStateSpace {
     }
 }
 
-impl<H: From<Hugr>> From<CommitStateSpace> for SerialCommitStateSpace<H> {
-    fn from(value: CommitStateSpace) -> Self {
+impl<H: Into<Hugr> + From<Hugr> + serde::Serialize> From<CommitStateSpace<SerdeHashResolver<H>>>
+    for SerialCommitStateSpace<H>
+{
+    fn from(value: CommitStateSpace<SerdeHashResolver<H>>) -> Self {
         value.into_serial()
     }
 }
 
-impl<H: Clone + Into<Hugr>> From<SerialCommitStateSpace<H>> for CommitStateSpace {
+impl<H: Into<Hugr> + From<Hugr> + serde::Serialize> From<SerialCommitStateSpace<H>>
+    for CommitStateSpace<SerdeHashResolver<H>>
+{
     fn from(value: SerialCommitStateSpace<H>) -> Self {
         CommitStateSpace::from_serial(value)
     }
@@ -109,13 +113,12 @@ impl<H: Clone + Into<Hugr>> From<SerialCommitStateSpace<H>> for CommitStateSpace
 #[cfg(test)]
 mod tests {
     use derive_more::derive::Into;
+    use hugr_core::envelope::serde_with::AsStringEnvelope;
     use rstest::rstest;
     use serde_with::serde_as;
 
     use super::*;
-    use crate::{
-        envelope::serde_with::AsStringEnvelope, hugr::persistent::tests::test_state_space,
-    };
+    use crate::tests::test_state_space;
 
     #[serde_as]
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, From, Into)]
@@ -126,19 +129,22 @@ mod tests {
 
     #[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
     #[rstest]
-    fn test_serialize_state_space(test_state_space: (CommitStateSpace, [CommitId; 4])) {
+    fn test_serialize_state_space(
+        test_state_space: (
+            CommitStateSpace<SerdeHashResolver<WrappedHugr>>,
+            [CommitId; 4],
+        ),
+    ) {
         let (state_space, _) = test_state_space;
-        let serialized = state_space.to_serial::<WrappedHugr>();
+        let serialized = state_space.to_serial();
 
-        let deser = CommitStateSpace::from_serial(serialized);
-        let _serialized_2 = deser.to_serial::<WrappedHugr>();
+        let deser = CommitStateSpace::from_serial(serialized.clone());
+        let serialized_2 = deser.to_serial();
 
-        // TODO: add this once PointerEqResolver is replaced by a deterministic resolver
-        // insta::assert_snapshot!(serde_json::to_string_pretty(&serialized).unwrap());
-        // see https://github.com/CQCL/hugr/issues/2299
-        // assert_eq!(
-        //     serde_json::to_string(&serialized),
-        //     serde_json::to_string(&serialized_2)
-        // );
+        insta::assert_snapshot!(serde_json::to_string_pretty(&serialized).unwrap());
+        assert_eq!(
+            serde_json::to_string(&serialized).unwrap(),
+            serde_json::to_string(&serialized_2).unwrap()
+        );
     }
 }

--- a/hugr-persistent/src/state_space/snapshots/hugr_persistent__state_space__serial__tests__serialize_state_space.snap
+++ b/hugr-persistent/src/state_space/snapshots/hugr_persistent__state_space__serial__tests__serialize_state_space.snap
@@ -1,0 +1,244 @@
+---
+source: hugr-persistent/src/state_space/serial.rs
+expression: "serde_json::to_string_pretty(&serialized).unwrap()"
+---
+{
+  "graph": {
+    "nodes": {
+      "16b2e9a04376ba38": {
+        "value": {
+          "Replacement": {
+            "subgraph": {
+              "nodes": [
+                [
+                  "881c0aa6a9d30735",
+                  8
+                ]
+              ],
+              "inputs": [
+                [
+                  [
+                    [
+                      "881c0aa6a9d30735",
+                      8
+                    ],
+                    {
+                      "index": 0
+                    }
+                  ]
+                ]
+              ],
+              "outputs": [
+                [
+                  [
+                    "881c0aa6a9d30735",
+                    8
+                  ],
+                  {
+                    "index": 0
+                  }
+                ]
+              ]
+            },
+            "replacement": {
+              "hugr": "HUGRiHJv?@{\"modules\":[{\"version\":\"live\",\"nodes\":[{\"parent\":0,\"op\":\"Module\"},{\"parent\":0,\"op\":\"FuncDefn\",\"name\":\"main\",\"signature\":{\"params\":[],\"body\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}},{\"parent\":1,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"DFG\",\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}},{\"parent\":4,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Extension\",\"extension\":\"logic\",\"name\":\"Not\",\"args\":[],\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}},{\"parent\":4,\"op\":\"Extension\",\"extension\":\"logic\",\"name\":\"Not\",\"args\":[],\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}],\"edges\":[[[2,0],[4,0]],[[4,0],[3,0]],[[5,0],[7,0]],[[7,0],[8,0]],[[8,0],[6,0]]],\"metadata\":[null,null,null,null,null,null,null,null,null],\"encoder\":\"hugr-rs v0.20.1\",\"entrypoint\":4}],\"extensions\":[]}"
+            }
+          }
+        },
+        "incoming": [
+          [
+            "881c0aa6a9d30735",
+            null
+          ]
+        ]
+      },
+      "4acf96da371e3962": {
+        "value": {
+          "Replacement": {
+            "subgraph": {
+              "nodes": [
+                [
+                  "881c0aa6a9d30735",
+                  7
+                ],
+                [
+                  "881c0aa6a9d30735",
+                  9
+                ]
+              ],
+              "inputs": [
+                [
+                  [
+                    [
+                      "881c0aa6a9d30735",
+                      7
+                    ],
+                    {
+                      "index": 0
+                    }
+                  ]
+                ],
+                [
+                  [
+                    [
+                      "881c0aa6a9d30735",
+                      9
+                    ],
+                    {
+                      "index": 1
+                    }
+                  ]
+                ]
+              ],
+              "outputs": [
+                [
+                  [
+                    "881c0aa6a9d30735",
+                    9
+                  ],
+                  {
+                    "index": 0
+                  }
+                ]
+              ]
+            },
+            "replacement": {
+              "hugr": "HUGRiHJv?@{\"modules\":[{\"version\":\"live\",\"nodes\":[{\"parent\":0,\"op\":\"Module\"},{\"parent\":0,\"op\":\"FuncDefn\",\"name\":\"main\",\"signature\":{\"params\":[],\"body\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}},{\"parent\":1,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"DFG\",\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}},{\"parent\":4,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Extension\",\"extension\":\"logic\",\"name\":\"Xor\",\"args\":[],\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}],\"edges\":[[[2,0],[4,0]],[[2,1],[4,1]],[[4,0],[3,0]],[[5,0],[7,0]],[[5,1],[7,1]],[[7,0],[6,0]]],\"metadata\":[null,null,null,null,null,null,null,null],\"encoder\":\"hugr-rs v0.20.1\",\"entrypoint\":4}],\"extensions\":[]}"
+            }
+          }
+        },
+        "incoming": [
+          [
+            "881c0aa6a9d30735",
+            null
+          ]
+        ]
+      },
+      "601f9f872992eda5": {
+        "value": {
+          "Replacement": {
+            "subgraph": {
+              "nodes": [
+                [
+                  "881c0aa6a9d30735",
+                  9
+                ],
+                [
+                  "8ac2181d41d63052",
+                  8
+                ]
+              ],
+              "inputs": [
+                [
+                  [
+                    [
+                      "8ac2181d41d63052",
+                      8
+                    ],
+                    {
+                      "index": 0
+                    }
+                  ]
+                ],
+                [
+                  [
+                    [
+                      "881c0aa6a9d30735",
+                      9
+                    ],
+                    {
+                      "index": 1
+                    }
+                  ]
+                ]
+              ],
+              "outputs": [
+                [
+                  [
+                    "881c0aa6a9d30735",
+                    9
+                  ],
+                  {
+                    "index": 0
+                  }
+                ]
+              ]
+            },
+            "replacement": {
+              "hugr": "HUGRiHJv?@{\"modules\":[{\"version\":\"live\",\"nodes\":[{\"parent\":0,\"op\":\"Module\"},{\"parent\":0,\"op\":\"FuncDefn\",\"name\":\"main\",\"signature\":{\"params\":[],\"body\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}},{\"parent\":1,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"DFG\",\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}},{\"parent\":4,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Extension\",\"extension\":\"logic\",\"name\":\"Xor\",\"args\":[],\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}],\"edges\":[[[2,0],[4,0]],[[2,1],[4,1]],[[4,0],[3,0]],[[5,0],[7,0]],[[5,1],[7,1]],[[7,0],[6,0]]],\"metadata\":[null,null,null,null,null,null,null,null],\"encoder\":\"hugr-rs v0.20.1\",\"entrypoint\":4}],\"extensions\":[]}"
+            }
+          }
+        },
+        "incoming": [
+          [
+            "881c0aa6a9d30735",
+            null
+          ],
+          [
+            "8ac2181d41d63052",
+            null
+          ]
+        ]
+      },
+      "881c0aa6a9d30735": {
+        "value": {
+          "Base": {
+            "hugr": "HUGRiHJv?@{\"modules\":[{\"version\":\"live\",\"nodes\":[{\"parent\":0,\"op\":\"Module\"},{\"parent\":0,\"op\":\"FuncDefn\",\"name\":\"main\",\"signature\":{\"params\":[],\"body\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}},{\"parent\":1,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"DFG\",\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}},{\"parent\":4,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Extension\",\"extension\":\"logic\",\"name\":\"Not\",\"args\":[],\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}},{\"parent\":4,\"op\":\"Extension\",\"extension\":\"logic\",\"name\":\"Not\",\"args\":[],\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}},{\"parent\":4,\"op\":\"Extension\",\"extension\":\"logic\",\"name\":\"And\",\"args\":[],\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2},{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}],\"edges\":[[[2,0],[4,0]],[[2,1],[4,1]],[[4,0],[3,0]],[[5,0],[7,0]],[[5,1],[8,0]],[[7,0],[9,0]],[[8,0],[9,1]],[[9,0],[6,0]]],\"metadata\":[null,null,null,null,null,null,null,null,null,null],\"encoder\":\"hugr-rs v0.20.1\",\"entrypoint\":4}],\"extensions\":[]}"
+          }
+        },
+        "incoming": []
+      },
+      "8ac2181d41d63052": {
+        "value": {
+          "Replacement": {
+            "subgraph": {
+              "nodes": [
+                [
+                  "881c0aa6a9d30735",
+                  7
+                ]
+              ],
+              "inputs": [
+                [
+                  [
+                    [
+                      "881c0aa6a9d30735",
+                      7
+                    ],
+                    {
+                      "index": 0
+                    }
+                  ]
+                ]
+              ],
+              "outputs": [
+                [
+                  [
+                    "881c0aa6a9d30735",
+                    7
+                  ],
+                  {
+                    "index": 0
+                  }
+                ]
+              ]
+            },
+            "replacement": {
+              "hugr": "HUGRiHJv?@{\"modules\":[{\"version\":\"live\",\"nodes\":[{\"parent\":0,\"op\":\"Module\"},{\"parent\":0,\"op\":\"FuncDefn\",\"name\":\"main\",\"signature\":{\"params\":[],\"body\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}},{\"parent\":1,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":1,\"op\":\"DFG\",\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}},{\"parent\":4,\"op\":\"Input\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Output\",\"types\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]},{\"parent\":4,\"op\":\"Extension\",\"extension\":\"logic\",\"name\":\"Not\",\"args\":[],\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}},{\"parent\":4,\"op\":\"Extension\",\"extension\":\"logic\",\"name\":\"Not\",\"args\":[],\"signature\":{\"input\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}],\"output\":[{\"t\":\"Sum\",\"s\":\"Unit\",\"size\":2}]}}],\"edges\":[[[2,0],[4,0]],[[4,0],[3,0]],[[5,0],[7,0]],[[7,0],[8,0]],[[8,0],[6,0]]],\"metadata\":[null,null,null,null,null,null,null,null,null],\"encoder\":\"hugr-rs v0.20.1\",\"entrypoint\":4}],\"extensions\":[]}"
+            }
+          }
+        },
+        "incoming": [
+          [
+            "881c0aa6a9d30735",
+            null
+          ]
+        ]
+      }
+    },
+    "resolver_id": {
+      "id": "SerdeHashResolver"
+    }
+  },
+  "base_commit": "881c0aa6a9d30735"
+}

--- a/hugr-persistent/src/tests.rs
+++ b/hugr-persistent/src/tests.rs
@@ -8,9 +8,13 @@ use hugr_core::{
     ops::handle::NodeHandle,
     std_extensions::logic::LogicOp,
 };
+use relrc::EquivalenceResolver;
 use rstest::*;
 
-use crate::{Commit, CommitStateSpace, PatchNode, state_space::CommitId};
+use crate::{
+    Commit, CommitStateSpace, PatchNode,
+    state_space::{CommitData, CommitId},
+};
 
 /// Creates a simple test Hugr with a DFG that contains a small boolean circuit
 ///
@@ -201,10 +205,11 @@ fn create_not_and_to_xor_replacement(hugr: &Hugr) -> SimpleReplacement {
 /// - `commit1` and `commit2` are disjoint with `commit4` (i.e. compatible),
 /// - `commit2` depends on `commit1`
 #[fixture]
-pub(crate) fn test_state_space() -> (CommitStateSpace, [CommitId; 4]) {
+pub(crate) fn test_state_space<R: Default + EquivalenceResolver<CommitData, ()>>()
+-> (CommitStateSpace<R>, [CommitId; 4]) {
     let (base_hugr, [not0_node, not1_node, _and_node]) = simple_hugr();
 
-    let mut state_space = CommitStateSpace::with_base(base_hugr);
+    let mut state_space = CommitStateSpace::<R>::with_base(base_hugr);
 
     // Create first replacement (replace NOT0 with two NOT gates)
     let replacement1 = create_double_not_replacement(state_space.base_hugr(), not0_node);

--- a/hugr-persistent/src/trait_impls.rs
+++ b/hugr-persistent/src/trait_impls.rs
@@ -37,7 +37,7 @@ impl Patch<PersistentHugr> for PersistentReplacement {
     }
 }
 
-impl HugrInternals for PersistentHugr {
+impl<R> HugrInternals for PersistentHugr<R> {
     type RegionPortgraph<'p>
         = portgraph::MultiPortGraph
     where
@@ -71,7 +71,7 @@ impl HugrInternals for PersistentHugr {
 // the whole extracted HUGR in memory. We are currently prioritizing correctness
 // and clarity over performance and will optimise some of these operations in
 // the future as bottlenecks are encountered. (see #2248)
-impl HugrView for PersistentHugr {
+impl<R> HugrView for PersistentHugr<R> {
     fn entrypoint(&self) -> Self::Node {
         // The entrypoint remains unchanged throughout the patch history, and is
         // found in the base hugr.


### PR DESCRIPTION
This PR adds serialisation for the `CommitStateSpace` type, following the pattern of #2300. To make the serialisation/deserialisation deterministic, a new `Resolver` is introduced.

Resolvers define a notion of equivalence between commits in the state space. The simplest resolver is `PointerEqResolver`, which considers commits to be equivalent if they point to the same data in memory. The "key" to that commit is the memory pointer, and so is non-deterministic.

The new resolver determines commit equivalence by computing a hash of the serialised data. This is not very efficient and will have to be improved in the future, but it is correct and convenient to use for the time being. For this purpose, a fast, reproducible and platform-independent hash is used (`wyhash`).

To accomodate multiple resolves, `CommitStateSpace` and `PersistentHugr` had to be made generic over the resolver type.

Closes #2299