### PR TITLE
docs: Hide hugr-persistent docs

### DIFF
--- a/hugr-persistent/src/lib.rs
+++ b/hugr-persistent/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(hidden)] // TODO: remove when stable
+
 //! Persistent data structure for HUGR mutations.
 //!
 //! This crate provides a persistent data structure [`PersistentHugr`] that

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -141,7 +141,7 @@ pub use hugr_passes as algorithms;
 pub use hugr_llvm as llvm;
 
 #[cfg(feature = "persistent_unstable")]
-#[doc(inline)]
+#[doc(hidden)] // TODO: remove when stable
 pub use hugr_persistent as persistent;
 
 // Modules with hand-picked re-exports.


### PR DESCRIPTION
As discussed, I am hiding all docs related to `hugr-persistent`, so that future breaking changes won't trip up the changelog generation.