### PR TITLE
feat: Deprecate invalidation_set, add invalidated_nodes and SimpleReplacement::invalidation_set

### DIFF
--- a/hugr-core/src/hugr/patch/consts.rs
+++ b/hugr-core/src/hugr/patch/consts.rs
@@ -46,7 +46,10 @@ impl<N: HugrNode> PatchVerification for RemoveLoadConstant<N> {
         Ok(())
     }
 
-    fn invalidation_set(&self) -> impl Iterator<Item = N> {
+    fn invalidated_nodes(
+        &self,
+        _: &impl HugrView<Node = Self::Node>,
+    ) -> impl Iterator<Item = Self::Node> {
         iter::once(self.0)
     }
 }
@@ -93,7 +96,10 @@ impl<N: HugrNode> PatchVerification for RemoveConst<N> {
         Ok(())
     }
 
-    fn invalidation_set(&self) -> impl Iterator<Item = N> {
+    fn invalidated_nodes(
+        &self,
+        _: &impl HugrView<Node = Self::Node>,
+    ) -> impl Iterator<Item = Self::Node> {
         iter::once(self.0)
     }
 }
@@ -158,7 +164,7 @@ mod test {
 
         let remove_1 = RemoveLoadConstant(load_1_node);
         assert_eq!(
-            remove_1.invalidation_set().exactly_one().ok(),
+            remove_1.invalidated_nodes(&h).exactly_one().ok(),
             Some(load_1_node)
         );
 
@@ -166,7 +172,7 @@ mod test {
 
         let remove_con = RemoveConst(con_node);
         assert_eq!(
-            remove_con.invalidation_set().exactly_one().ok(),
+            remove_con.invalidated_nodes(&h).exactly_one().ok(),
             Some(con_node)
         );
 

--- a/hugr-core/src/hugr/patch/inline_call.rs
+++ b/hugr-core/src/hugr/patch/inline_call.rs
@@ -52,7 +52,7 @@ impl<N: HugrNode> PatchVerification for InlineCall<N> {
         Ok(())
     }
 
-    fn invalidation_set(&self) -> impl Iterator<Item = N> {
+    fn invalidated_nodes(&self, _: &impl HugrView<Node = N>) -> impl Iterator<Item = N> {
         Some(self.0).into_iter()
     }
 }

--- a/hugr-core/src/hugr/patch/inline_dfg.rs
+++ b/hugr-core/src/hugr/patch/inline_dfg.rs
@@ -4,7 +4,7 @@
 
 use super::{PatchHugrMut, PatchVerification};
 use crate::ops::handle::{DfgID, NodeHandle};
-use crate::{IncomingPort, Node, OutgoingPort, PortIndex};
+use crate::{HugrView, IncomingPort, Node, OutgoingPort, PortIndex};
 
 /// Structure identifying an `InlineDFG` rewrite from the spec
 pub struct InlineDFG(pub DfgID);
@@ -43,7 +43,10 @@ impl PatchVerification for InlineDFG {
         Ok(())
     }
 
-    fn invalidation_set(&self) -> impl Iterator<Item = Node> {
+    fn invalidated_nodes(
+        &self,
+        _: &impl HugrView<Node = Self::Node>,
+    ) -> impl Iterator<Item = Self::Node> {
         [self.0.node()].into_iter()
     }
 }

--- a/hugr-core/src/hugr/patch/insert_cut.rs
+++ b/hugr-core/src/hugr/patch/insert_cut.rs
@@ -118,7 +118,10 @@ impl<N: HugrNode> PatchVerification for InsertCut<N> {
     }
 
     #[inline]
-    fn invalidation_set(&self) -> impl Iterator<Item = N> {
+    fn invalidated_nodes(
+        &self,
+        _: &impl HugrView<Node = Self::Node>,
+    ) -> impl Iterator<Item = Self::Node> {
         iter::once(self.parent)
             .chain(self.targets.iter().map(|(n, _)| *n))
             .unique()
@@ -179,7 +182,7 @@ mod tests {
         let targets: Vec<_> = h.all_linked_inputs(i).collect();
         let inserter = InsertCut::new(h.entrypoint(), targets, replacement);
         assert_eq!(
-            inserter.invalidation_set().collect::<Vec<Node>>(),
+            inserter.invalidated_nodes(&h).collect::<Vec<Node>>(),
             vec![h.entrypoint(), o]
         );
 

--- a/hugr-core/src/hugr/patch/insert_identity.rs
+++ b/hugr-core/src/hugr/patch/insert_identity.rs
@@ -67,7 +67,10 @@ impl<N: HugrNode> PatchVerification for IdentityInsertion<N> {
     }
 
     #[inline]
-    fn invalidation_set(&self) -> impl Iterator<Item = N> {
+    fn invalidated_nodes(
+        &self,
+        _: &impl HugrView<Node = Self::Node>,
+    ) -> impl Iterator<Item = Self::Node> {
         iter::once(self.post_node)
     }
 }

--- a/hugr-core/src/hugr/patch/outline_cfg.rs
+++ b/hugr-core/src/hugr/patch/outline_cfg.rs
@@ -97,7 +97,10 @@ impl PatchVerification for OutlineCfg {
         Ok(())
     }
 
-    fn invalidation_set(&self) -> impl Iterator<Item = Node> {
+    fn invalidated_nodes(
+        &self,
+        _: &impl HugrView<Node = Self::Node>,
+    ) -> impl Iterator<Item = Self::Node> {
         self.blocks.iter().copied()
     }
 }

--- a/hugr-core/src/hugr/patch/replace.rs
+++ b/hugr-core/src/hugr/patch/replace.rs
@@ -320,7 +320,10 @@ impl<HostNode: HugrNode> PatchVerification for Replacement<HostNode> {
         Ok(())
     }
 
-    fn invalidation_set(&self) -> impl Iterator<Item = HostNode> {
+    fn invalidated_nodes(
+        &self,
+        _: &impl HugrView<Node = Self::Node>,
+    ) -> impl Iterator<Item = Self::Node> {
         self.removal.iter().copied()
     }
 }

--- a/hugr-core/src/hugr/patch/simple_replace.rs
+++ b/hugr-core/src/hugr/patch/simple_replace.rs
@@ -527,7 +527,10 @@ impl<HostNode: HugrNode> PatchVerification for SimpleReplacement<HostNode> {
     }
 
     #[inline]
-    fn invalidation_set(&self) -> impl Iterator<Item = HostNode> {
+    fn invalidated_nodes(
+        &self,
+        _: &impl HugrView<Node = Self::Node>,
+    ) -> impl Iterator<Item = Self::Node> {
         self.subgraph.nodes().iter().copied()
     }
 }
@@ -864,7 +867,7 @@ pub(in crate::hugr::patch) mod test {
 
         // Check invalidation set
         assert_eq!(
-            HashSet::<_>::from_iter(r.invalidation_set()),
+            HashSet::<_>::from_iter(r.invalidated_nodes(&h)),
             HashSet::<_>::from_iter([h_node_cx, h_node_h0, h_node_h1]),
         );
 

--- a/hugr-core/src/hugr/patch/simple_replace.rs
+++ b/hugr-core/src/hugr/patch/simple_replace.rs
@@ -516,6 +516,11 @@ impl<HostNode: HugrNode> SimpleReplacement<HostNode> {
         let subgraph = subgraph.map_nodes(node_map);
         SimpleReplacement::try_new(subgraph, new_host, replacement.clone())
     }
+
+    /// Allows to get the [Self::invalidated_nodes] without requiring a [HugrView].
+    pub fn invalidation_set(&self) -> impl Iterator<Item = HostNode> {
+        self.subgraph.nodes().iter().copied()
+    }
 }
 
 impl<HostNode: HugrNode> PatchVerification for SimpleReplacement<HostNode> {
@@ -531,7 +536,7 @@ impl<HostNode: HugrNode> PatchVerification for SimpleReplacement<HostNode> {
         &self,
         _: &impl HugrView<Node = Self::Node>,
     ) -> impl Iterator<Item = Self::Node> {
-        self.subgraph.nodes().iter().copied()
+        self.invalidation_set()
     }
 }
 

--- a/hugr-persistent/src/persistent_hugr.rs
+++ b/hugr-persistent/src/persistent_hugr.rs
@@ -97,7 +97,9 @@ impl Commit {
 
     /// Get the set of nodes invalidated by the patch in `self`.
     pub fn invalidation_set(&self) -> impl Iterator<Item = PatchNode> + '_ {
-        self.replacement().into_iter().flat_map(|r| r.invalidation_set())
+        self.replacement()
+            .into_iter()
+            .flat_map(|r| r.invalidation_set())
     }
 
     /// Get the set of nodes deleted by applying `self`.

--- a/hugr-persistent/src/persistent_hugr.rs
+++ b/hugr-persistent/src/persistent_hugr.rs
@@ -170,7 +170,8 @@ impl<'a> From<&'a RelRc<CommitData, ()>> for &'a Commit {
 /// [`PersistentHugr`] implements [`HugrView`], so that it can used as
 /// a drop-in substitute for a Hugr wherever read-only access is required. It
 /// does not implement [`HugrMut`](hugr_core::hugr::hugrmut::HugrMut), however.
-/// Mutations must be performed by applying patches (see [`PatchVerification`]
+/// Mutations must be performed by applying patches (see
+/// [`PatchVerification`](hugr_core::hugr::patch::PatchVerification)
 /// and [`Patch`]). Currently, only [`SimpleReplacement`] patches are supported.
 /// You can use [`Self::add_replacement`] to add a patch to `self`, or use the
 /// aforementioned patch traits.

--- a/hugr-persistent/src/persistent_hugr.rs
+++ b/hugr-persistent/src/persistent_hugr.rs
@@ -7,7 +7,7 @@ use delegate::delegate;
 use derive_more::derive::From;
 use hugr_core::{
     Hugr, HugrView, IncomingPort, Node, OutgoingPort, Port, SimpleReplacement,
-    hugr::patch::{Patch, PatchVerification, simple_replace},
+    hugr::patch::{Patch, simple_replace},
 };
 use itertools::{Either, Itertools};
 use relrc::RelRc;
@@ -97,9 +97,7 @@ impl Commit {
 
     /// Get the set of nodes invalidated by the patch in `self`.
     pub fn invalidation_set(&self) -> impl Iterator<Item = PatchNode> + '_ {
-        self.replacement()
-            .into_iter()
-            .flat_map(|r| r.invalidation_set())
+        self.replacement().into_iter().flat_map(|r| r.invalidation_set())
     }
 
     /// Get the set of nodes deleted by applying `self`.


### PR DESCRIPTION
Currently a Patch(Verification) has to report its `invalidation_set` without being able to see the Hugr on which it will act (and without being able to verify itself against that Hugr - well the set is meaningless if it doesn't verify/apply, but nonetheless). This would be really useful in #2290 for one...

So, this PR adds a new method `invalidated_nodes` which is like `invalidation_set` but takes an `&impl HugrView`; and deprecates the old `invalidation_set`.

Annoyingly deprecating a method in a trait doesn't flag up *implementations* of the method, only calls to it. So the breaking change follow-up to remove invalidation_set (and *require* an implementation of invalidated_nodes) will be significantly breaking. (If we didn't have the default now, this would be breaking and the follow-up still too, however).

For `SimpleReplacement` I've added the method but outside the trait, for use in PersistentHugr. (It looks a little odd but the deprecation warning kicks in only if you call the trait method, and the non-trait method seems to be preferred when both are in scope.)