### PR TITLE
chore: Fix new rust lints

### DIFF
--- a/hugr-cli/src/main.rs
+++ b/hugr-cli/src/main.rs
@@ -47,7 +47,7 @@ fn run_external(args: Vec<OsString>) -> Result<()> {
         std::process::exit(1);
     }
     let subcmd = args[0].to_string_lossy();
-    let exe = format!("hugr-{}", subcmd);
+    let exe = format!("hugr-{subcmd}");
     let rest: Vec<_> = args[1..]
         .iter()
         .map(|s| s.to_string_lossy().to_string())

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -421,7 +421,7 @@ pub trait HugrView: HugrInternals {
         let config = match RenderConfig::try_from(formatter) {
             Ok(config) => config,
             Err(e) => {
-                panic!("Unsupported format option: {}", e);
+                panic!("Unsupported format option: {e}");
             }
         };
         #[allow(deprecated)]

--- a/hugr-persistent/src/state_space.rs
+++ b/hugr-persistent/src/state_space.rs
@@ -31,7 +31,7 @@ pub struct PatchNode(pub CommitId, pub Node);
 
 impl std::fmt::Display for PatchNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/hugr-persistent/src/tests.rs
+++ b/hugr-persistent/src/tests.rs
@@ -427,8 +427,7 @@ fn test_try_add_replacement(test_state_space: (CommitStateSpace, [CommitId; 4]))
         let result = persistent_hugr.try_add_replacement(repl4.clone());
         assert!(
             result.is_ok(),
-            "[commit1, commit2] + [commit4] are compatible. Got {:?}",
-            result
+            "[commit1, commit2] + [commit4] are compatible. Got {result:?}"
         );
         let hugr = persistent_hugr.to_hugr();
         let exp_hugr = state_space
@@ -444,8 +443,7 @@ fn test_try_add_replacement(test_state_space: (CommitStateSpace, [CommitId; 4]))
         let result = persistent_hugr.try_add_replacement(repl3.clone());
         assert!(
             result.is_err(),
-            "[commit1, commit2] + [commit3] are incompatible. Got {:?}",
-            result
+            "[commit1, commit2] + [commit3] are incompatible. Got {result:?}"
         );
     }
 }

--- a/hugr-persistent/src/trait_impls.rs
+++ b/hugr-persistent/src/trait_impls.rs
@@ -256,7 +256,7 @@ impl<R> HugrView for PersistentHugr<R> {
                 // replace node labels with patch node IDs
                 let node_labels_map: HashMap<_, _> = node_map
                     .into_iter()
-                    .map(|(k, v)| (v, format!("{:?}", k)))
+                    .map(|(k, v)| (v, format!("{k:?}")))
                     .collect();
                 NodeLabel::Custom(node_labels_map)
             }

--- a/hugr-persistent/src/walker.rs
+++ b/hugr-persistent/src/walker.rs
@@ -481,8 +481,7 @@ mod tests {
                 .collect::<BTreeSet<_>>();
             assert!(
                 exp_options.remove(&commit_ids),
-                "{:?} not an expected set of commit IDs (or duplicate)",
-                commit_ids
+                "{commit_ids:?} not an expected set of commit IDs (or duplicate)"
             );
 
             // new wire is complete (and thus cannot be expanded)
@@ -512,8 +511,7 @@ mod tests {
 
         assert!(
             exp_options.is_empty(),
-            "missing expected options: {:?}",
-            exp_options
+            "missing expected options: {exp_options:?}"
         );
     }
 


### PR DESCRIPTION
Fixes the new lints in rust/clippy 1.88

Inlines variables in `format!` strings to follow the [new lint](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args).
Most of these were already fixed on the edition update PR #2195.