### PR TITLE
refactor!: remove deprecated runtime extension errors

### DIFF
--- a/hugr-core/src/envelope/package_json.rs
+++ b/hugr-core/src/envelope/package_json.rs
@@ -5,7 +5,6 @@ use std::io;
 
 use crate::extension::ExtensionRegistry;
 use crate::extension::resolution::ExtensionResolutionError;
-use crate::hugr::ExtensionError;
 use crate::package::Package;
 use crate::{Extension, Hugr};
 
@@ -65,8 +64,6 @@ pub enum PackageEncodingError {
     IOError(io::Error),
     /// Could not resolve the extension needed to encode the hugr.
     ExtensionResolution(ExtensionResolutionError),
-    /// Could not resolve the runtime extensions for the hugr.
-    RuntimeExtensionResolution(ExtensionError),
 }
 
 /// A private package structure implementing the serde traits.

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -21,7 +21,6 @@ use crate::types::EdgeKind;
 use crate::types::type_param::TypeParam;
 use crate::{Direction, Port};
 
-use super::ExtensionError;
 use super::internal::PortgraphNodeMap;
 use super::views::HugrView;
 
@@ -692,10 +691,6 @@ pub enum ValidationError<N: HugrNode> {
     /// There are invalid inter-graph edges.
     #[error(transparent)]
     InterGraphEdgeError(#[from] InterGraphEdgeError<N>),
-    /// There are errors in the extension deltas.
-    #[deprecated(note = "Never returned since hugr-core-v0.20.0")]
-    #[error(transparent)]
-    ExtensionError(#[from] ExtensionError),
     /// A node claims to still be awaiting extension inference. Perhaps it is not acted upon by inference.
     #[error(
         "{node} needs a concrete ExtensionSet - inference will provide this for Case/CFG/Conditional/DataflowBlock/DFG/TailLoop only"


### PR DESCRIPTION
BREAKING CHANGE: Unused errors to do with runtime extension requirement checking have been removed (deprecated in v0.20.0).