### PR TITLE
fix: DeadFuncElimPass/CallGraph w/ non-module entrypoint

### DIFF
--- a/hugr-passes/src/call_graph.rs
+++ b/hugr-passes/src/call_graph.rs
@@ -48,19 +48,20 @@ impl<N: HugrNode> CallGraph<N> {
     /// Makes a new `CallGraph` for a Hugr.
     pub fn new(hugr: &impl HugrView<Node = N>) -> Self {
         let mut g = Graph::default();
-        let non_func_root =
-            (!hugr.get_optype(hugr.entrypoint()).is_module()).then_some(hugr.entrypoint());
-        let node_to_g = hugr
+        let mut node_to_g = hugr
             .children(hugr.module_root())
             .filter_map(|n| {
                 let weight = match hugr.get_optype(n) {
                     OpType::FuncDecl(_) => CallGraphNode::FuncDecl(n),
                     OpType::FuncDefn(_) => CallGraphNode::FuncDefn(n),
-                    _ => (Some(n) == non_func_root).then_some(CallGraphNode::NonFuncRoot)?,
+                    _ => return None,
                 };
                 Some((n, g.add_node(weight)))
             })
             .collect::<HashMap<_, _>>();
+        if !hugr.entrypoint_optype().is_module() && !node_to_g.contains_key(&hugr.entrypoint()) {
+            node_to_g.insert(hugr.entrypoint(), g.add_node(CallGraphNode::NonFuncRoot));
+        }
         for (func, cg_node) in &node_to_g {
             traverse(hugr, *cg_node, *func, &mut g, &node_to_g);
         }

--- a/hugr-passes/src/dead_funcs.rs
+++ b/hugr-passes/src/dead_funcs.rs
@@ -174,12 +174,15 @@ mod test {
         let f_inp = fm.input_wires();
         let fm = fm.finish_with_outputs(f_inp)?;
         let mut m = hb.define_function("main", Signature::new_endo(usize_t()))?;
-        let mc = m.call(fm.handle(), &[], m.input_wires())?;
-        let m = m.finish_with_outputs(mc.outputs())?;
+        let m_in = m.input_wires();
+        let mut dfg = m.dfg_builder(Signature::new_endo(usize_t()), m_in)?;
+        let c = dfg.call(fm.handle(), &[], dfg.input_wires())?;
+        let dfg = dfg.finish_with_outputs(c.outputs()).unwrap();
+        m.finish_with_outputs(dfg.outputs())?;
 
         let mut hugr = hb.finish_hugr()?;
         if use_hugr_entrypoint {
-            hugr.set_entrypoint(m.node());
+            hugr.set_entrypoint(dfg.node());
         }
 
         let avail_funcs = hugr


### PR DESCRIPTION
#2336 tried to update DeadFuncElimPass wrt. entrypoint, but managed to break it by searching for the entrypoint only among the module-root's children; if the entrypoint is deeper, this meant it was never scanned or included in the CallGraph.

This fixes that by scanning the entrypoint separately. Note this produces two nodes in the callgraph: one for whatever function contains the entrypoint; and one for the entrypoint. The former will have outgoing edges to all the same targets as the latter, possibly plus some more. (One could argue the function containing the entrypoint should "call" the entrypoint, but this is not a proper call, so, no.)