### PR TITLE
chore: require docstrings in hugr-passes

### DIFF
--- a/hugr-passes/src/call_graph.rs
+++ b/hugr-passes/src/call_graph.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 //! Data structure for call graphs of a Hugr
 use std::collections::HashMap;
 

--- a/hugr-passes/src/const_fold.rs
+++ b/hugr-passes/src/const_fold.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 //! Constant-folding pass.
 //! An (example) use of the [dataflow analysis framework](super::dataflow).
 

--- a/hugr-passes/src/dataflow.rs
+++ b/hugr-passes/src/dataflow.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 //! Dataflow analysis of Hugrs.
 
 mod datalog;

--- a/hugr-passes/src/dead_funcs.rs
+++ b/hugr-passes/src/dead_funcs.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 //! Pass for removing statically-unreachable functions from a Hugr
 
 use std::collections::HashSet;

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -1,5 +1,4 @@
 //! Compilation passes acting on the HUGR program representation.
-#![expect(missing_docs)] // TODO: Fix...
 
 pub mod call_graph;
 pub mod composable;

--- a/hugr-passes/src/lower.rs
+++ b/hugr-passes/src/lower.rs
@@ -1,3 +1,5 @@
+//! Passes to lower operations in a HUGR.
+
 use hugr_core::{
     Hugr, Node,
     hugr::{hugrmut::HugrMut, views::SiblingSubgraph},

--- a/hugr-passes/src/non_local.rs
+++ b/hugr-passes/src/non_local.rs
@@ -1,6 +1,5 @@
 //! This module provides functions for finding non-local edges
 //! in a Hugr and converting them to local edges.
-#![warn(missing_docs)]
 use itertools::Itertools as _;
 
 use hugr_core::{

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::type_complexity)]
-#![warn(missing_docs)]
 //! Replace types with other types across the Hugr. See [`ReplaceTypes`] and [Linearizer].
 //!
 use std::borrow::Cow;


### PR DESCRIPTION
`missing_docs` is still allowed in `hugr-llvm`
https://github.com/CQCL/hugr/blob/7902ebcf47c427dc2fc9ed74f81b78254c0724b5/hugr-llvm/src/lib.rs#L64