### PR TITLE
feat: Add PinnedSubgraph

### DIFF
--- a/hugr-persistent/src/lib.rs
+++ b/hugr-persistent/src/lib.rs
@@ -70,6 +70,7 @@ mod parents_view;
 mod persistent_hugr;
 mod resolver;
 pub mod state_space;
+pub mod subgraph;
 mod trait_impls;
 pub mod walker;
 mod wire;
@@ -77,6 +78,7 @@ mod wire;
 pub use persistent_hugr::{Commit, PersistentHugr};
 pub use resolver::{PointerEqResolver, Resolver, SerdeHashResolver};
 pub use state_space::{CommitId, CommitStateSpace, InvalidCommit, PatchNode};
+pub use subgraph::PinnedSubgraph;
 pub use walker::Walker;
 pub use wire::PersistentWire;
 

--- a/hugr-persistent/src/state_space.rs
+++ b/hugr-persistent/src/state_space.rs
@@ -13,7 +13,7 @@ use hugr_core::{
             BoundaryPort,
             simple_replace::{BoundaryMode, InvalidReplacement},
         },
-        views::{InvalidSignature, sibling_subgraph::InvalidSubgraph},
+        views::InvalidSignature,
     },
     ops::OpType,
 };
@@ -23,7 +23,7 @@ use thiserror::Error;
 
 use crate::{
     Commit, PersistentHugr, PersistentReplacement, PointerEqResolver, Resolver,
-    find_conflicting_node, parents_view::ParentsView,
+    find_conflicting_node, parents_view::ParentsView, subgraph::InvalidPinnedSubgraph,
 };
 
 pub mod serial;
@@ -618,7 +618,7 @@ pub enum InvalidCommit {
 
     #[error("Invalid subgraph: {0}")]
     /// The subgraph of the replacement is not convex.
-    InvalidSubgraph(#[from] InvalidSubgraph<PatchNode>),
+    InvalidSubgraph(#[from] InvalidPinnedSubgraph),
 
     /// The replacement of the commit is invalid.
     #[error("Invalid replacement: {0}")]

--- a/hugr-persistent/src/subgraph.rs
+++ b/hugr-persistent/src/subgraph.rs
@@ -1,0 +1,224 @@
+use std::collections::BTreeSet;
+
+use hugr_core::{
+    IncomingPort, OutgoingPort,
+    hugr::views::{
+        SiblingSubgraph,
+        sibling_subgraph::{IncomingPorts, InvalidSubgraph, OutgoingPorts},
+    },
+};
+use itertools::Itertools;
+use thiserror::Error;
+
+use crate::{CommitId, PatchNode, PersistentHugr, PersistentWire, Resolver, Walker};
+
+/// A set of pinned nodes and wires between them, along with a fixed input
+/// and output boundary, simmilar to [`SiblingSubgraph`].
+///
+/// Unlike [`SiblingSubgraph`], subgraph validity (in particular convexity) is
+/// not checked (and cannot be checked), as the same [`PinnedSubgraph`] may
+/// represent [`SiblingSubgraph`]s in different HUGRs.
+///
+/// Obtain a valid [`SiblingSubgraph`] for a specific [`PersistentHugr`] by
+/// calling [`PinnedSubgraph::to_sibling_subgraph`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PinnedSubgraph {
+    /// The nodes of the induced subgraph.
+    nodes: BTreeSet<PatchNode>,
+    /// The input ports of the subgraph.
+    ///
+    /// Grouped by input parameter. Each port must be unique and belong to a
+    /// node in `nodes`.
+    inputs: Vec<Vec<(PatchNode, IncomingPort)>>,
+    /// The output ports of the subgraph.
+    ///
+    /// Repeated ports are allowed and correspond to copying the output. Every
+    /// port must belong to a node in `nodes`.
+    outputs: Vec<(PatchNode, OutgoingPort)>,
+    /// The commits that must be selected in the host for the subgraph to be
+    /// valid.
+    selected_commits: BTreeSet<CommitId>,
+}
+
+impl From<SiblingSubgraph<PatchNode>> for PinnedSubgraph {
+    fn from(subgraph: SiblingSubgraph<PatchNode>) -> Self {
+        Self {
+            inputs: subgraph.incoming_ports().clone(),
+            outputs: subgraph.outgoing_ports().clone(),
+            nodes: BTreeSet::from_iter(subgraph.nodes().iter().copied()),
+            selected_commits: BTreeSet::new(),
+        }
+    }
+}
+
+impl PinnedSubgraph {
+    /// Create a new subgraph from a set of pinned nodes and wires.
+    ///
+    /// All nodes must be pinned and all wires must be complete in the given
+    /// `walker`.
+    ///
+    /// Nodes that are not isolated, i.e. are attached to at least one wire in
+    /// `wires` will be added implicitly to the graph and do not need to be
+    /// explicitly listed in `nodes`.
+    pub fn try_from_pinned<R, Wires, Nodes>(
+        nodes: impl IntoIterator<IntoIter = Nodes>,
+        wires: impl IntoIterator<IntoIter = Wires>,
+        walker: &Walker<R>,
+    ) -> Result<Self, InvalidPinnedSubgraph>
+    where
+        R: Resolver,
+        Wires: Iterator<Item = PersistentWire> + Clone,
+        Nodes: Iterator<Item = PatchNode> + Clone,
+    {
+        let mut selected_commits = BTreeSet::new();
+        let host = walker.as_hugr_view();
+        let wires = wires.into_iter();
+        let nodes = nodes.into_iter();
+
+        for w in wires.clone() {
+            if !walker.is_complete(&w, None) {
+                return Err(InvalidPinnedSubgraph::IncompleteWire(w));
+            }
+            for id in w.owners() {
+                if host.contains_id(id) {
+                    selected_commits.insert(id);
+                } else {
+                    return Err(InvalidPinnedSubgraph::InvalidCommit(id));
+                }
+            }
+        }
+
+        if let Some(unpinned) = nodes.clone().find(|&n| !walker.is_pinned(n)) {
+            return Err(InvalidPinnedSubgraph::UnpinnedNode(unpinned));
+        }
+
+        let (inputs, outputs, all_nodes) = Self::compute_io_ports(nodes, wires, host);
+
+        Ok(Self {
+            selected_commits,
+            nodes: all_nodes,
+            inputs,
+            outputs,
+        })
+    }
+
+    /// Create a new subgraph from a set of complete wires in `walker`.
+    pub fn try_from_wires<R, Wires>(
+        wires: impl IntoIterator<IntoIter = Wires>,
+        walker: &Walker<R>,
+    ) -> Result<Self, InvalidPinnedSubgraph>
+    where
+        R: Resolver,
+        Wires: Iterator<Item = PersistentWire> + Clone,
+    {
+        Self::try_from_pinned(std::iter::empty(), wires, walker)
+    }
+
+    /// Compute the input and output ports for the given pinned nodes and wires.
+    ///
+    /// Return the input boundary ports, output boundary ports as well as the
+    /// set of all nodes in the subgraph.
+    pub fn compute_io_ports<R: Resolver>(
+        nodes: impl IntoIterator<Item = PatchNode>,
+        wires: impl IntoIterator<Item = PersistentWire>,
+        host: &PersistentHugr<R>,
+    ) -> (
+        IncomingPorts<PatchNode>,
+        OutgoingPorts<PatchNode>,
+        BTreeSet<PatchNode>,
+    ) {
+        let mut wire_ports_incoming = BTreeSet::new();
+        let mut wire_ports_outgoing = BTreeSet::new();
+
+        for w in wires {
+            wire_ports_incoming.extend(w.all_incoming_ports(host));
+            wire_ports_outgoing.extend(w.single_outgoing_port(host));
+        }
+
+        let mut all_nodes = BTreeSet::from_iter(nodes);
+        all_nodes.extend(wire_ports_incoming.iter().map(|&(n, _)| n));
+        all_nodes.extend(wire_ports_outgoing.iter().map(|&(n, _)| n));
+
+        // (in/out) boundary: all in/out ports on the nodes of the wire, minus ports
+        // that are part of the wires
+        let inputs = all_nodes
+            .iter()
+            .flat_map(|&n| host.input_value_ports(n))
+            .filter(|node_port| !wire_ports_incoming.contains(node_port))
+            .map(|np| vec![np])
+            .collect_vec();
+        let outputs = all_nodes
+            .iter()
+            .flat_map(|&n| host.output_value_ports(n))
+            .filter(|node_port| !wire_ports_outgoing.contains(node_port))
+            .collect_vec();
+
+        (inputs, outputs, all_nodes)
+    }
+
+    /// Convert the pinned subgraph to a [`SiblingSubgraph`] for the given
+    /// `host`.
+    ///
+    /// This will fail if any of the required selected commits are not in the
+    /// host, if any of the nodes are invalid in the host (e.g. deleted by
+    /// another commit in host), or if the subgraph is not convex.
+    pub fn to_sibling_subgraph<R>(
+        &self,
+        host: &PersistentHugr<R>,
+    ) -> Result<SiblingSubgraph<PatchNode>, InvalidPinnedSubgraph> {
+        if let Some(&unselected) = self
+            .selected_commits
+            .iter()
+            .find(|&&id| !host.contains_id(id))
+        {
+            return Err(InvalidPinnedSubgraph::InvalidCommit(unselected));
+        }
+
+        if let Some(invalid) = self.nodes.iter().find(|&&n| !host.contains_node(n)) {
+            return Err(InvalidPinnedSubgraph::InvalidNode(*invalid));
+        }
+
+        Ok(SiblingSubgraph::try_new(
+            self.inputs.clone(),
+            self.outputs.clone(),
+            host,
+        )?)
+    }
+
+    /// Iterate over all the commits required by this pinned subgraph.
+    pub fn selected_commits(&self) -> impl Iterator<Item = CommitId> + '_ {
+        self.selected_commits.iter().copied()
+    }
+
+    /// Iterate over all the nodes in this pinned subgraph.
+    pub fn nodes(&self) -> impl Iterator<Item = PatchNode> + '_ {
+        self.nodes.iter().copied()
+    }
+
+    /// Returns the computed [`IncomingPorts`] of the subgraph.
+    #[must_use]
+    pub fn incoming_ports(&self) -> &IncomingPorts<PatchNode> {
+        &self.inputs
+    }
+
+    /// Returns the computed [`OutgoingPorts`] of the subgraph.
+    #[must_use]
+    pub fn outgoing_ports(&self) -> &OutgoingPorts<PatchNode> {
+        &self.outputs
+    }
+}
+
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
+pub enum InvalidPinnedSubgraph {
+    #[error("Invalid subgraph: {0}")]
+    InvalidSubgraph(#[from] InvalidSubgraph<PatchNode>),
+    #[error("Invalid commit in host: {0}")]
+    InvalidCommit(CommitId),
+    #[error("Wire is not complete: {0:?}")]
+    IncompleteWire(PersistentWire),
+    #[error("Node is not pinned: {0}")]
+    UnpinnedNode(PatchNode),
+    #[error("Invalid node in host: {0}")]
+    InvalidNode(PatchNode),
+}

--- a/hugr-persistent/tests/persistent_walker_example.rs
+++ b/hugr-persistent/tests/persistent_walker_example.rs
@@ -5,11 +5,11 @@ use std::collections::{BTreeSet, VecDeque};
 use itertools::{Either, Itertools};
 
 use hugr_core::{
-    builder::{endo_sig, DFGBuilder, Dataflow, DataflowHugr},
+    Hugr, HugrView, IncomingPort, OutgoingPort, Port, PortIndex,
+    builder::{DFGBuilder, Dataflow, DataflowHugr, endo_sig},
     extension::prelude::qb_t,
     ops::OpType,
     types::EdgeKind,
-    Hugr, HugrView, IncomingPort, OutgoingPort, Port, PortIndex,
 };
 
 use hugr_persistent::{Commit, CommitStateSpace, PersistentWire, PinnedSubgraph, Walker};
@@ -23,10 +23,10 @@ use walker_example_extension::cz_gate;
 mod walker_example_extension {
     use std::sync::Arc;
 
+    use hugr_core::Extension;
     use hugr_core::extension::ExtensionId;
     use hugr_core::ops::{ExtensionOp, OpName};
     use hugr_core::types::{FuncValueType, PolyFuncTypeRV};
-    use hugr_core::Extension;
 
     use lazy_static::lazy_static;
     use semver::Version;


### PR DESCRIPTION
I've factored out the logic that computes the subgraph of a `PersistentHugr` when constructing a `SimpleReplacement` into a new type `PinnedSubgraph`. This is required so that commit factories in `tket2` are able to compute the matched subgraph and extract the matched subHUGRs.

This is very similar to `SiblingSubgraph`, with the nuance that the same subgraph can be applied to multiple `PersistentHugr`s, as long as they all share the same pinned nodes (in particular when the different `PersistentHugr`s stem from the different expansions of the same `Walker`). Conversions to and from `SiblingSubgraph`s are provided.