### PR TITLE
feat: Type of constants in `core` `Term`s.

### DIFF
--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -1021,6 +1021,10 @@ impl<'a> Context<'a> {
             }
             Term::Variable(v) => self.export_type_arg_var(v),
             Term::StaticType => self.make_term_apply(model::CORE_STATIC, &[]),
+            Term::Const(ty) => {
+                let ty = self.export_type(ty);
+                self.make_term_apply(model::CORE_CONST, &[ty])
+            }
         }
     }
 

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -1021,7 +1021,7 @@ impl<'a> Context<'a> {
             }
             Term::Variable(v) => self.export_type_arg_var(v),
             Term::StaticType => self.make_term_apply(model::CORE_STATIC, &[]),
-            Term::Const(ty) => {
+            Term::ConstType(ty) => {
                 let ty = self.export_type(ty);
                 self.make_term_apply(model::CORE_CONST, &[ty])
             }

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -217,7 +217,7 @@ pub(super) fn collect_term_exts(
 ) {
     match term {
         Term::Runtime(ty) => collect_type_exts(ty, used_extensions, missing_extensions),
-        Term::Const(ty) => collect_type_exts(ty, used_extensions, missing_extensions),
+        Term::ConstType(ty) => collect_type_exts(ty, used_extensions, missing_extensions),
         Term::List(elems) => {
             for elem in elems.iter() {
                 collect_term_exts(elem, used_extensions, missing_extensions);

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -217,6 +217,7 @@ pub(super) fn collect_term_exts(
 ) {
     match term {
         Term::Runtime(ty) => collect_type_exts(ty, used_extensions, missing_extensions),
+        Term::Const(ty) => collect_type_exts(ty, used_extensions, missing_extensions),
         Term::List(elems) => {
             for elem in elems.iter() {
                 collect_term_exts(elem, used_extensions, missing_extensions);

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -222,7 +222,7 @@ pub(super) fn resolve_term_exts(
 ) -> Result<(), ExtensionResolutionError> {
     match term {
         Term::Runtime(ty) => resolve_type_exts(node, ty, extensions, used_extensions)?,
-        Term::Const(ty) => resolve_type_exts(node, ty, extensions, used_extensions)?,
+        Term::ConstType(ty) => resolve_type_exts(node, ty, extensions, used_extensions)?,
         Term::List(children)
         | Term::ListConcat(children)
         | Term::Tuple(children)

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -222,6 +222,7 @@ pub(super) fn resolve_term_exts(
 ) -> Result<(), ExtensionResolutionError> {
     match term {
         Term::Runtime(ty) => resolve_type_exts(node, ty, extensions, used_extensions)?,
+        Term::Const(ty) => resolve_type_exts(node, ty, extensions, used_extensions)?,
         Term::List(children)
         | Term::ListConcat(children)
         | Term::Tuple(children)

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -1325,8 +1325,11 @@ impl<'a> Context<'a> {
                 return Ok(Term::StaticType);
             }
 
-            if let Some([]) = self.match_symbol(term_id, model::CORE_CONST)? {
-                return Err(error_unsupported!("`{}`", model::CORE_CONST));
+            if let Some([ty]) = self.match_symbol(term_id, model::CORE_CONST)? {
+                let ty = self
+                    .import_type(ty)
+                    .map_err(|err| error_context!(err, "type of a constant"))?;
+                return Ok(TypeParam::new_const(ty));
             }
 
             if let Some([item_type]) = self.match_symbol(term_id, model::CORE_LIST_TYPE)? {

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -1155,7 +1155,8 @@ pub(super) mod proptest_utils {
             | TypeParamSer::String
             | TypeParamSer::Bytes
             | TypeParamSer::Float
-            | TypeParamSer::StaticType => true,
+            | TypeParamSer::StaticType
+            | TypeParamSer::Const { .. } => true,
             TypeParamSer::List { param } => term_is_serde_type_param(&param),
             TypeParamSer::Tuple { params } => {
                 match &params {

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -1156,7 +1156,7 @@ pub(super) mod proptest_utils {
             | TypeParamSer::Bytes
             | TypeParamSer::Float
             | TypeParamSer::StaticType
-            | TypeParamSer::Const { .. } => true,
+            | TypeParamSer::ConstType { .. } => true,
             TypeParamSer::List { param } => term_is_serde_type_param(&param),
             TypeParamSer::Tuple { params } => {
                 match &params {

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -79,6 +79,7 @@ pub(super) enum TypeParamSer {
     StaticType,
     List { param: Box<Term> },
     Tuple { params: ArrayOrTermSer },
+    Const { ty: Type },
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -136,6 +137,7 @@ impl From<Term> for TermSer {
             Term::BytesType => TermSer::TypeParam(TypeParamSer::Bytes),
             Term::FloatType => TermSer::TypeParam(TypeParamSer::Float),
             Term::ListType(param) => TermSer::TypeParam(TypeParamSer::List { param }),
+            Term::Const(ty) => TermSer::TypeParam(TypeParamSer::Const { ty: *ty }),
             Term::Runtime(ty) => TermSer::TypeArg(TypeArgSer::Type { ty }),
             Term::TupleType(params) => TermSer::TypeParam(TypeParamSer::Tuple {
                 params: (*params).into(),
@@ -165,6 +167,7 @@ impl From<TermSer> for Term {
                 TypeParamSer::Float => Term::FloatType,
                 TypeParamSer::List { param } => Term::ListType(param),
                 TypeParamSer::Tuple { params } => Term::TupleType(Box::new(params.into())),
+                TypeParamSer::Const { ty } => Term::Const(Box::new(ty)),
             },
             TermSer::TypeArg(arg) => match arg {
                 TypeArgSer::Type { ty } => Term::Runtime(ty),

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -79,7 +79,7 @@ pub(super) enum TypeParamSer {
     StaticType,
     List { param: Box<Term> },
     Tuple { params: ArrayOrTermSer },
-    Const { ty: Type },
+    ConstType { ty: Type },
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -137,7 +137,7 @@ impl From<Term> for TermSer {
             Term::BytesType => TermSer::TypeParam(TypeParamSer::Bytes),
             Term::FloatType => TermSer::TypeParam(TypeParamSer::Float),
             Term::ListType(param) => TermSer::TypeParam(TypeParamSer::List { param }),
-            Term::Const(ty) => TermSer::TypeParam(TypeParamSer::Const { ty: *ty }),
+            Term::ConstType(ty) => TermSer::TypeParam(TypeParamSer::ConstType { ty: *ty }),
             Term::Runtime(ty) => TermSer::TypeArg(TypeArgSer::Type { ty }),
             Term::TupleType(params) => TermSer::TypeParam(TypeParamSer::Tuple {
                 params: (*params).into(),
@@ -167,7 +167,7 @@ impl From<TermSer> for Term {
                 TypeParamSer::Float => Term::FloatType,
                 TypeParamSer::List { param } => Term::ListType(param),
                 TypeParamSer::Tuple { params } => Term::TupleType(Box::new(params.into())),
-                TypeParamSer::Const { ty } => Term::Const(Box::new(ty)),
+                TypeParamSer::ConstType { ty } => Term::ConstType(Box::new(ty)),
             },
             TermSer::TypeArg(arg) => match arg {
                 TypeArgSer::Type { ty } => Term::Runtime(ty),

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -179,7 +179,7 @@ impl Term {
         Self::TupleType(Box::new(item_types.into()))
     }
 
-    /// Creates a new [`Term::Const`] from a runtime type.
+    /// Creates a new [`Term::ConstType`] from a runtime type.
     pub fn new_const(ty: impl Into<Type>) -> Self {
         Self::ConstType(Box::new(ty.into()))
     }

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -142,8 +142,8 @@ pub enum Term {
 
     /// The type of constants for a runtime type.
     ///
-    /// A constant is a compile time description of a runtime value. The runtime
-    /// value is constructed when the constant is loaded.
+    /// A constant is a compile time description of how to produce a runtime value.
+    /// The runtime value is constructed when the constant is loaded.
     ///
     /// Constants are distinct from the runtime values that they describe. In
     /// particular, as part of the term language, constants can be freely copied

--- a/hugr-core/tests/snapshots/model__roundtrip_const.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_const.snap
@@ -98,6 +98,7 @@ expression: ast
       (signature (core.fn [] [arithmetic.float.types.float64])))))
 
 (declare-func
+  public
   example.const_as_param
   (param ?0 (core.const arithmetic.float.types.float64))
   (core.fn [] [?0]))

--- a/hugr-core/tests/snapshots/model__roundtrip_const.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_const.snap
@@ -20,6 +20,8 @@ expression: ast
 
 (import arithmetic.int.types.int)
 
+(import core.const)
+
 (import collections.array.const)
 
 (import arithmetic.float.types.float64)
@@ -94,3 +96,8 @@ expression: ast
           "{\"c\":\"ConstUnknown\",\"v\":{\"value\":1.0}}"))
       [] [%1]
       (signature (core.fn [] [arithmetic.float.types.float64])))))
+
+(declare-func
+  example.const_as_param
+  (param ?0 (core.const arithmetic.float.types.float64))
+  (core.fn [] [?0]))

--- a/hugr-core/tests/snapshots/model__roundtrip_const.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_const.snap
@@ -101,4 +101,4 @@ expression: ast
   public
   example.const_as_param
   (param ?0 (core.const arithmetic.float.types.float64))
-  (core.fn [] [?0]))
+  (core.fn [] [arithmetic.float.types.float64]))

--- a/hugr-model/tests/fixtures/model-const.edn
+++ b/hugr-model/tests/fixtures/model-const.edn
@@ -60,6 +60,6 @@
         [] [%1]
         (signature (core.fn [] [arithmetic.float.types.float64])))))
 
-(declare-func example.const_as_param
+(declare-func public example.const_as_param
   (param ?c (core.const arithmetic.float.types.float64))
   (core.fn [] [?c]))

--- a/hugr-model/tests/fixtures/model-const.edn
+++ b/hugr-model/tests/fixtures/model-const.edn
@@ -59,3 +59,7 @@
                          (compat.const_json arithmetic.float.types.float64 "{\"c\":\"ConstUnknown\",\"v\":{\"value\":1.0}}"))
         [] [%1]
         (signature (core.fn [] [arithmetic.float.types.float64])))))
+
+(declare-func example.const_as_param
+  (param ?c (core.const arithmetic.float.types.float64))
+  (core.fn [] [?c]))

--- a/hugr-model/tests/fixtures/model-const.edn
+++ b/hugr-model/tests/fixtures/model-const.edn
@@ -62,4 +62,4 @@
 
 (declare-func public example.const_as_param
   (param ?c (core.const arithmetic.float.types.float64))
-  (core.fn [] [?c]))
+  (core.fn [] [arithmetic.float.types.float64]))

--- a/hugr-py/src/hugr/_serialization/tys.py
+++ b/hugr-py/src/hugr/_serialization/tys.py
@@ -126,7 +126,7 @@ class TupleParam(BaseTypeParam):
 
 
 class ConstParam(BaseTypeParam):
-    tp: Literal["Const"] = "Const"
+    tp: Literal["ConstType"] = "ConstType"
     ty: Type
 
     def deserialize(self) -> tys.ConstParam:

--- a/hugr-py/src/hugr/_serialization/tys.py
+++ b/hugr-py/src/hugr/_serialization/tys.py
@@ -125,6 +125,14 @@ class TupleParam(BaseTypeParam):
         return tys.TupleParam(params=deser_it(self.params))
 
 
+class ConstParam(BaseTypeParam):
+    tp: Literal["Const"] = "Const"
+    ty: Type
+
+    def deserialize(self) -> tys.ConstParam:
+        return tys.ConstParam(ty=self.ty.deserialize())
+
+
 class TypeParam(RootModel):
     """A type parameter."""
 
@@ -135,7 +143,8 @@ class TypeParam(RootModel):
         | FloatParam
         | BytesParam
         | ListParam
-        | TupleParam,
+        | TupleParam
+        | ConstParam,
         WrapValidator(_json_custom_error_validator),
     ] = Field(discriminator="tp")
 

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -218,6 +218,23 @@ class TupleParam(TypeParam):
         return model.Apply("core.tuple", [item_types])
 
 
+@dataclass(frozen=True)
+class ConstParam(TypeParam):
+    """Type parameter which requires a constant value."""
+
+    ty: Type
+
+    def _to_serial(self) -> stys.ConstParam:
+        return stys.ConstParam(ty=self.ty._to_serial_root())
+
+    def __str__(self) -> str:
+        return f"Const({self.ty!s})"
+
+    def to_model(self) -> model.Term:
+        ty = cast(model.Term, self.ty.to_model())
+        return model.Apply("core.const", [ty])
+
+
 # ------------------------------------------
 # --------------- TypeArg ------------------
 # ------------------------------------------

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -292,6 +292,20 @@ def test_literals() -> None:
     validate(mod.hugr)
 
 
+def test_const_type() -> None:
+    mod = Module()
+
+    mod.declare_function(
+        "const_type",
+        tys.PolyFuncType(
+            [tys.ConstParam(tys.Qubit)],
+            tys.FunctionType([], [tys.Qubit]),
+        ),
+    )
+
+    validate(mod.hugr)
+
+
 @pytest.mark.parametrize("direct_call", [True, False])
 def test_mono_function(direct_call: bool) -> None:
     mod = Module()

--- a/hugr-py/tests/test_tys.py
+++ b/hugr-py/tests/test_tys.py
@@ -17,6 +17,7 @@ from hugr.tys import (
     BoundedNatParam,
     BytesArg,
     BytesParam,
+    ConstParam,
     Either,
     ExtType,
     FloatArg,
@@ -102,6 +103,7 @@ def test_tys_sum_str(ty: Type, string: str, repr_str: str):
             "(Linear, Nat(3))",
         ),
         (ListParam(StringParam()), "[String]"),
+        (ConstParam(Qubit), "Const(Qubit)"),
     ],
 )
 def test_params_str(param: TypeParam, string: str):

--- a/specification/schema/hugr_schema_live.json
+++ b/specification/schema/hugr_schema_live.json
@@ -349,8 +349,8 @@
             "additionalProperties": true,
             "properties": {
                 "tp": {
-                    "const": "Const",
-                    "default": "Const",
+                    "const": "ConstType",
+                    "default": "ConstType",
                     "title": "Tp",
                     "type": "string"
                 },
@@ -1806,7 +1806,7 @@
                 "mapping": {
                     "BoundedNat": "#/$defs/BoundedNatParam",
                     "Bytes": "#/$defs/BytesParam",
-                    "Const": "#/$defs/ConstParam",
+                    "ConstType": "#/$defs/ConstParam",
                     "Float": "#/$defs/FloatParam",
                     "List": "#/$defs/ListParam",
                     "String": "#/$defs/StringParam",

--- a/specification/schema/hugr_schema_live.json
+++ b/specification/schema/hugr_schema_live.json
@@ -345,6 +345,25 @@
             "title": "Const",
             "type": "object"
         },
+        "ConstParam": {
+            "additionalProperties": true,
+            "properties": {
+                "tp": {
+                    "const": "Const",
+                    "default": "Const",
+                    "title": "Tp",
+                    "type": "string"
+                },
+                "ty": {
+                    "$ref": "#/$defs/Type"
+                }
+            },
+            "required": [
+                "ty"
+            ],
+            "title": "ConstParam",
+            "type": "object"
+        },
         "CustomConst": {
             "additionalProperties": true,
             "properties": {
@@ -1787,6 +1806,7 @@
                 "mapping": {
                     "BoundedNat": "#/$defs/BoundedNatParam",
                     "Bytes": "#/$defs/BytesParam",
+                    "Const": "#/$defs/ConstParam",
                     "Float": "#/$defs/FloatParam",
                     "List": "#/$defs/ListParam",
                     "String": "#/$defs/StringParam",
@@ -1816,6 +1836,9 @@
                 },
                 {
                     "$ref": "#/$defs/TupleParam"
+                },
+                {
+                    "$ref": "#/$defs/ConstParam"
                 }
             ],
             "required": [

--- a/specification/schema/hugr_schema_strict_live.json
+++ b/specification/schema/hugr_schema_strict_live.json
@@ -349,8 +349,8 @@
             "additionalProperties": false,
             "properties": {
                 "tp": {
-                    "const": "Const",
-                    "default": "Const",
+                    "const": "ConstType",
+                    "default": "ConstType",
                     "title": "Tp",
                     "type": "string"
                 },
@@ -1806,7 +1806,7 @@
                 "mapping": {
                     "BoundedNat": "#/$defs/BoundedNatParam",
                     "Bytes": "#/$defs/BytesParam",
-                    "Const": "#/$defs/ConstParam",
+                    "ConstType": "#/$defs/ConstParam",
                     "Float": "#/$defs/FloatParam",
                     "List": "#/$defs/ListParam",
                     "String": "#/$defs/StringParam",

--- a/specification/schema/hugr_schema_strict_live.json
+++ b/specification/schema/hugr_schema_strict_live.json
@@ -345,6 +345,25 @@
             "title": "Const",
             "type": "object"
         },
+        "ConstParam": {
+            "additionalProperties": false,
+            "properties": {
+                "tp": {
+                    "const": "Const",
+                    "default": "Const",
+                    "title": "Tp",
+                    "type": "string"
+                },
+                "ty": {
+                    "$ref": "#/$defs/Type"
+                }
+            },
+            "required": [
+                "ty"
+            ],
+            "title": "ConstParam",
+            "type": "object"
+        },
         "CustomConst": {
             "additionalProperties": false,
             "properties": {
@@ -1787,6 +1806,7 @@
                 "mapping": {
                     "BoundedNat": "#/$defs/BoundedNatParam",
                     "Bytes": "#/$defs/BytesParam",
+                    "Const": "#/$defs/ConstParam",
                     "Float": "#/$defs/FloatParam",
                     "List": "#/$defs/ListParam",
                     "String": "#/$defs/StringParam",
@@ -1816,6 +1836,9 @@
                 },
                 {
                     "$ref": "#/$defs/TupleParam"
+                },
+                {
+                    "$ref": "#/$defs/ConstParam"
                 }
             ],
             "required": [

--- a/specification/schema/testing_hugr_schema_live.json
+++ b/specification/schema/testing_hugr_schema_live.json
@@ -349,8 +349,8 @@
             "additionalProperties": true,
             "properties": {
                 "tp": {
-                    "const": "Const",
-                    "default": "Const",
+                    "const": "ConstType",
+                    "default": "ConstType",
                     "title": "Tp",
                     "type": "string"
                 },
@@ -1884,7 +1884,7 @@
                 "mapping": {
                     "BoundedNat": "#/$defs/BoundedNatParam",
                     "Bytes": "#/$defs/BytesParam",
-                    "Const": "#/$defs/ConstParam",
+                    "ConstType": "#/$defs/ConstParam",
                     "Float": "#/$defs/FloatParam",
                     "List": "#/$defs/ListParam",
                     "String": "#/$defs/StringParam",

--- a/specification/schema/testing_hugr_schema_live.json
+++ b/specification/schema/testing_hugr_schema_live.json
@@ -345,6 +345,25 @@
             "title": "Const",
             "type": "object"
         },
+        "ConstParam": {
+            "additionalProperties": true,
+            "properties": {
+                "tp": {
+                    "const": "Const",
+                    "default": "Const",
+                    "title": "Tp",
+                    "type": "string"
+                },
+                "ty": {
+                    "$ref": "#/$defs/Type"
+                }
+            },
+            "required": [
+                "ty"
+            ],
+            "title": "ConstParam",
+            "type": "object"
+        },
         "CustomConst": {
             "additionalProperties": true,
             "properties": {
@@ -1865,6 +1884,7 @@
                 "mapping": {
                     "BoundedNat": "#/$defs/BoundedNatParam",
                     "Bytes": "#/$defs/BytesParam",
+                    "Const": "#/$defs/ConstParam",
                     "Float": "#/$defs/FloatParam",
                     "List": "#/$defs/ListParam",
                     "String": "#/$defs/StringParam",
@@ -1894,6 +1914,9 @@
                 },
                 {
                     "$ref": "#/$defs/TupleParam"
+                },
+                {
+                    "$ref": "#/$defs/ConstParam"
                 }
             ],
             "required": [

--- a/specification/schema/testing_hugr_schema_strict_live.json
+++ b/specification/schema/testing_hugr_schema_strict_live.json
@@ -349,8 +349,8 @@
             "additionalProperties": false,
             "properties": {
                 "tp": {
-                    "const": "Const",
-                    "default": "Const",
+                    "const": "ConstType",
+                    "default": "ConstType",
                     "title": "Tp",
                     "type": "string"
                 },
@@ -1884,7 +1884,7 @@
                 "mapping": {
                     "BoundedNat": "#/$defs/BoundedNatParam",
                     "Bytes": "#/$defs/BytesParam",
-                    "Const": "#/$defs/ConstParam",
+                    "ConstType": "#/$defs/ConstParam",
                     "Float": "#/$defs/FloatParam",
                     "List": "#/$defs/ListParam",
                     "String": "#/$defs/StringParam",

--- a/specification/schema/testing_hugr_schema_strict_live.json
+++ b/specification/schema/testing_hugr_schema_strict_live.json
@@ -345,6 +345,25 @@
             "title": "Const",
             "type": "object"
         },
+        "ConstParam": {
+            "additionalProperties": false,
+            "properties": {
+                "tp": {
+                    "const": "Const",
+                    "default": "Const",
+                    "title": "Tp",
+                    "type": "string"
+                },
+                "ty": {
+                    "$ref": "#/$defs/Type"
+                }
+            },
+            "required": [
+                "ty"
+            ],
+            "title": "ConstParam",
+            "type": "object"
+        },
         "CustomConst": {
             "additionalProperties": false,
             "properties": {
@@ -1865,6 +1884,7 @@
                 "mapping": {
                     "BoundedNat": "#/$defs/BoundedNatParam",
                     "Bytes": "#/$defs/BytesParam",
+                    "Const": "#/$defs/ConstParam",
                     "Float": "#/$defs/FloatParam",
                     "List": "#/$defs/ListParam",
                     "String": "#/$defs/StringParam",
@@ -1894,6 +1914,9 @@
                 },
                 {
                     "$ref": "#/$defs/TupleParam"
+                },
+                {
+                    "$ref": "#/$defs/ConstParam"
                 }
             ],
             "required": [


### PR DESCRIPTION
This PR adds a `Term::Const` variant, representing the type of constants for a given runtime type. This corresponds to the `core.const` type in `hugr-model`.

Closes #2304.