### PR TITLE
feat!: Rename 'Any' type bound to 'Linear'

### DIFF
--- a/hugr-core/src/builder/module.rs
+++ b/hugr-core/src/builder/module.rs
@@ -220,7 +220,7 @@ mod test {
             let mut module_builder = ModuleBuilder::new();
 
             let qubit_state_type =
-                module_builder.add_alias_declare("qubit_state", TypeBound::Any)?;
+                module_builder.add_alias_declare("qubit_state", TypeBound::Linear)?;
 
             let f_build = module_builder.define_function(
                 "main",

--- a/hugr-core/src/extension/declarative/types.rs
+++ b/hugr-core/src/extension/declarative/types.rs
@@ -100,7 +100,7 @@ impl From<TypeDefBoundDeclaration> for TypeDefBound {
                 bound: TypeBound::Copyable,
             },
             TypeDefBoundDeclaration::Any => Self::Explicit {
-                bound: TypeBound::Any,
+                bound: TypeBound::Linear,
             },
         }
     }

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -656,7 +656,7 @@ pub(super) mod test {
         const OP_NAME: OpName = OpName::new_inline("Reverse");
 
         let ext = Extension::try_new_test_arc(EXT_ID, |ext, extension_ref| {
-            const TP: TypeParam = TypeParam::RuntimeType(TypeBound::Any);
+            const TP: TypeParam = TypeParam::RuntimeType(TypeBound::Linear);
             let list_of_var =
                 Type::new_extension(list_def.instantiate(vec![TypeArg::new_var_use(0, TP)])?);
             let type_scheme = PolyFuncTypeRV::new(vec![TP], Signature::new_endo(vec![list_of_var]));
@@ -702,13 +702,13 @@ pub(super) mod test {
                 &self,
                 arg_values: &[TypeArg],
             ) -> Result<PolyFuncTypeRV, SignatureError> {
-                const TP: TypeParam = TypeParam::RuntimeType(TypeBound::Any);
+                const TP: TypeParam = TypeParam::RuntimeType(TypeBound::Linear);
                 let [TypeArg::BoundedNat(n)] = arg_values else {
                     return Err(SignatureError::InvalidTypeArgs);
                 };
                 let n = *n as usize;
                 let tvs: Vec<Type> = (0..n)
-                    .map(|_| Type::new_var_use(0, TypeBound::Any))
+                    .map(|_| Type::new_var_use(0, TypeBound::Linear))
                     .collect();
                 Ok(PolyFuncTypeRV::new(
                     vec![TP.clone()],
@@ -752,9 +752,9 @@ pub(super) mod test {
 
             // quick sanity check that we are validating the args - note changed bound:
             assert_eq!(
-                def.validate_args(&args, &[TypeBound::Any.into()]),
+                def.validate_args(&args, &[TypeBound::Linear.into()]),
                 Err(SignatureError::TypeVarDoesNotMatchDeclaration {
-                    actual: TypeBound::Any.into(),
+                    actual: TypeBound::Linear.into(),
                     cached: TypeBound::Copyable.into()
                 })
             );
@@ -791,8 +791,8 @@ pub(super) mod test {
                 "SimpleOp".into(),
                 String::new(),
                 PolyFuncTypeRV::new(
-                    vec![TypeBound::Any.into()],
-                    Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
+                    vec![TypeBound::Linear.into()],
+                    Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Linear)]),
                 ),
                 extension_ref,
             )?;
@@ -807,7 +807,7 @@ pub(super) mod test {
                 def.compute_signature(&[arg.clone()]),
                 Err(SignatureError::TypeArgMismatch(
                     TermTypeError::TypeMismatch {
-                        type_: TypeBound::Any.into(),
+                        type_: TypeBound::Linear.into(),
                         term: arg,
                     }
                 ))

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -110,10 +110,10 @@ lazy_static! {
                     PANIC_OP_ID,
                     "Panic with input error".to_string(),
                     PolyFuncTypeRV::new(
-                        [TypeParam::new_list_type(TypeBound::Any), TypeParam::new_list_type(TypeBound::Any)],
+                        [TypeParam::new_list_type(TypeBound::Linear), TypeParam::new_list_type(TypeBound::Linear)],
                         FuncValueType::new(
-                            vec![TypeRV::new_extension(error_type.clone()), TypeRV::new_row_var_use(0, TypeBound::Any)],
-                            vec![TypeRV::new_row_var_use(1, TypeBound::Any)],
+                            vec![TypeRV::new_extension(error_type.clone()), TypeRV::new_row_var_use(0, TypeBound::Linear)],
+                            vec![TypeRV::new_row_var_use(1, TypeBound::Linear)],
                         ),
                     ),
                     extension_ref,
@@ -124,10 +124,10 @@ lazy_static! {
                 EXIT_OP_ID,
                 "Exit with input error".to_string(),
                 PolyFuncTypeRV::new(
-                    [TypeParam::new_list_type(TypeBound::Any), TypeParam::new_list_type(TypeBound::Any)],
+                    [TypeParam::new_list_type(TypeBound::Linear), TypeParam::new_list_type(TypeBound::Linear)],
                     FuncValueType::new(
-                        vec![TypeRV::new_extension(error_type), TypeRV::new_row_var_use(0, TypeBound::Any)],
-                        vec![TypeRV::new_row_var_use(1, TypeBound::Any)],
+                        vec![TypeRV::new_extension(error_type), TypeRV::new_row_var_use(0, TypeBound::Linear)],
+                        vec![TypeRV::new_row_var_use(1, TypeBound::Linear)],
                     ),
                 ),
                 extension_ref,
@@ -160,7 +160,7 @@ pub(crate) fn qb_custom_t(extension_ref: &Weak<Extension>) -> CustomType {
         TypeName::new_inline("qubit"),
         vec![],
         PRELUDE_ID,
-        TypeBound::Any,
+        TypeBound::Linear,
         extension_ref,
     )
 }
@@ -626,10 +626,10 @@ impl MakeOpDef for TupleOpDef {
     }
 
     fn init_signature(&self, _extension_ref: &Weak<Extension>) -> SignatureFunc {
-        let rv = TypeRV::new_row_var_use(0, TypeBound::Any);
+        let rv = TypeRV::new_row_var_use(0, TypeBound::Linear);
         let tuple_type = TypeRV::new_tuple(vec![rv.clone()]);
 
-        let param = TypeParam::new_list_type(TypeBound::Any);
+        let param = TypeParam::new_list_type(TypeBound::Linear);
         match self {
             TupleOpDef::MakeTuple => {
                 PolyFuncTypeRV::new([param], FuncValueType::new(rv, tuple_type))
@@ -800,8 +800,8 @@ impl MakeOpDef for NoopDef {
     }
 
     fn init_signature(&self, _extension_ref: &Weak<Extension>) -> SignatureFunc {
-        let tv = Type::new_var_use(0, TypeBound::Any);
-        PolyFuncType::new([TypeBound::Any.into()], Signature::new_endo(tv)).into()
+        let tv = Type::new_var_use(0, TypeBound::Linear);
+        PolyFuncType::new([TypeBound::Linear.into()], Signature::new_endo(tv)).into()
     }
 
     fn description(&self) -> String {
@@ -912,8 +912,8 @@ impl MakeOpDef for BarrierDef {
 
     fn init_signature(&self, _extension_ref: &Weak<Extension>) -> SignatureFunc {
         PolyFuncTypeRV::new(
-            vec![TypeParam::new_list_type(TypeBound::Any)],
-            FuncValueType::new_endo(TypeRV::new_row_var_use(0, TypeBound::Any)),
+            vec![TypeParam::new_list_type(TypeBound::Linear)],
+            FuncValueType::new_endo(TypeRV::new_row_var_use(0, TypeBound::Linear)),
         )
         .into()
     }

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -333,7 +333,7 @@ fn resolve_custom_const(#[case] custom_const: impl CustomConst) {
 #[rstest]
 fn resolve_call() {
     let dummy_fn_sig = PolyFuncType::new(
-        vec![TypeParam::RuntimeType(TypeBound::Any)],
+        vec![TypeParam::RuntimeType(TypeBound::Linear)],
         Signature::new(vec![], vec![bool_t()]),
     );
 

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -34,7 +34,7 @@ impl TypeDefBound {
     #[must_use]
     pub fn any() -> Self {
         TypeDefBound::Explicit {
-            bound: TypeBound::Any,
+            bound: TypeBound::Linear,
         }
     }
 
@@ -142,7 +142,7 @@ impl TypeDef {
                 let args: Vec<_> = args.iter().collect();
                 if indices.is_empty() {
                     // Assume most general case
-                    return TypeBound::Any;
+                    return TypeBound::Linear;
                 }
                 least_upper_bound(indices.iter().map(|i| {
                     let ta = args.get(*i);

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -443,7 +443,7 @@ fn serialize_types_roundtrip() {
 #[case(bool_t())]
 #[case(usize_t())]
 #[case(INT_TYPES[2].clone())]
-#[case(Type::new_alias(crate::ops::AliasDecl::new("t", TypeBound::Any)))]
+#[case(Type::new_alias(crate::ops::AliasDecl::new("t", TypeBound::Linear)))]
 #[case(Type::new_var_use(2, TypeBound::Copyable))]
 #[case(Type::new_tuple(vec![bool_t(),qb_t()]))]
 #[case(Type::new_sum([vec![bool_t(),qb_t()], vec![Type::new_unit_sum(4)]]))]
@@ -477,9 +477,9 @@ fn polyfunctype1() -> PolyFuncType {
 }
 
 fn polyfunctype2() -> PolyFuncTypeRV {
-    let tv0 = TypeRV::new_row_var_use(0, TypeBound::Any);
+    let tv0 = TypeRV::new_row_var_use(0, TypeBound::Linear);
     let tv1 = TypeRV::new_row_var_use(1, TypeBound::Copyable);
-    let params = [TypeBound::Any, TypeBound::Copyable].map(TypeParam::new_list_type);
+    let params = [TypeBound::Linear, TypeBound::Copyable].map(TypeParam::new_list_type);
     let inputs = vec![
         TypeRV::new_function(FuncValueType::new(tv0.clone(), tv1.clone())),
         tv0,
@@ -496,11 +496,11 @@ fn polyfunctype2() -> PolyFuncTypeRV {
 #[case(polyfunctype1())]
 #[case(PolyFuncType::new([TypeParam::StringType], Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Copyable)])))]
 #[case(PolyFuncType::new([TypeBound::Copyable.into()], Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Copyable)])))]
-#[case(PolyFuncType::new([TypeParam::new_list_type(TypeBound::Any)], Signature::new_endo(type_row![])))]
-#[case(PolyFuncType::new([TypeParam::new_tuple_type([TypeBound::Any.into(), TypeParam::bounded_nat_type(2.try_into().unwrap())])], Signature::new_endo(type_row![])))]
+#[case(PolyFuncType::new([TypeParam::new_list_type(TypeBound::Linear)], Signature::new_endo(type_row![])))]
+#[case(PolyFuncType::new([TypeParam::new_tuple_type([TypeBound::Linear.into(), TypeParam::bounded_nat_type(2.try_into().unwrap())])], Signature::new_endo(type_row![])))]
 #[case(PolyFuncType::new(
-    [TypeParam::new_list_type(TypeBound::Any)],
-    Signature::new_endo(Type::new_tuple(TypeRV::new_row_var_use(0, TypeBound::Any)))))]
+    [TypeParam::new_list_type(TypeBound::Linear)],
+    Signature::new_endo(Type::new_tuple(TypeRV::new_row_var_use(0, TypeBound::Linear)))))]
 fn roundtrip_polyfunctype_fixedlen(#[case] poly_func_type: PolyFuncType) {
     check_testing_roundtrip(poly_func_type);
 }
@@ -509,11 +509,11 @@ fn roundtrip_polyfunctype_fixedlen(#[case] poly_func_type: PolyFuncType) {
 #[case(FuncValueType::new_endo(type_row![]).into())]
 #[case(PolyFuncTypeRV::new([TypeParam::StringType], FuncValueType::new_endo(vec![Type::new_var_use(0, TypeBound::Copyable)])))]
 #[case(PolyFuncTypeRV::new([TypeBound::Copyable.into()], FuncValueType::new_endo(vec![Type::new_var_use(0, TypeBound::Copyable)])))]
-#[case(PolyFuncTypeRV::new([TypeParam::new_list_type(TypeBound::Any)], FuncValueType::new_endo(type_row![])))]
-#[case(PolyFuncTypeRV::new([TypeParam::new_tuple_type([TypeBound::Any.into(), TypeParam::bounded_nat_type(2.try_into().unwrap())])], FuncValueType::new_endo(type_row![])))]
+#[case(PolyFuncTypeRV::new([TypeParam::new_list_type(TypeBound::Linear)], FuncValueType::new_endo(type_row![])))]
+#[case(PolyFuncTypeRV::new([TypeParam::new_tuple_type([TypeBound::Linear.into(), TypeParam::bounded_nat_type(2.try_into().unwrap())])], FuncValueType::new_endo(type_row![])))]
 #[case(PolyFuncTypeRV::new(
-    [TypeParam::new_list_type(TypeBound::Any)],
-    FuncValueType::new_endo(TypeRV::new_row_var_use(0, TypeBound::Any))))]
+    [TypeParam::new_list_type(TypeBound::Linear)],
+    FuncValueType::new_endo(TypeRV::new_row_var_use(0, TypeBound::Linear))))]
 #[case(polyfunctype2())]
 fn roundtrip_polyfunctype_varlen(#[case] poly_func_type: PolyFuncTypeRV) {
     check_testing_roundtrip(poly_func_type);
@@ -524,7 +524,7 @@ fn roundtrip_polyfunctype_varlen(#[case] poly_func_type: PolyFuncTypeRV) {
 #[case(ops::FuncDefn::new("polyfunc1", polyfunctype1()))]
 #[case(ops::FuncDecl::new("polyfunc2", polyfunctype1()))]
 #[case(ops::AliasDefn { name: "aliasdefn".into(), definition: Type::new_unit_sum(4)})]
-#[case(ops::AliasDecl { name: "aliasdecl".into(), bound: TypeBound::Any})]
+#[case(ops::AliasDecl { name: "aliasdecl".into(), bound: TypeBound::Linear})]
 #[case(ops::Const::new(Value::false_val()))]
 #[case(ops::Const::new(Value::function(crate::builder::test::simple_dfg_hugr()).unwrap()))]
 #[case(ops::Input::new(vec![Type::new_var_use(3,TypeBound::Copyable)]))]

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -320,7 +320,7 @@ fn invalid_types() {
         "MyContainer",
         vec![usize_t().into()],
         EXT_ID,
-        TypeBound::Any,
+        TypeBound::Linear,
         &Arc::downgrade(&ext),
     ));
     let mut hugr = identity_hugr_with_type(valid.clone()).0;
@@ -332,7 +332,7 @@ fn invalid_types() {
         "MyContainer",
         vec![valid.clone().into()],
         EXT_ID,
-        TypeBound::Any,
+        TypeBound::Linear,
         &Arc::downgrade(&ext),
     );
     assert_eq!(
@@ -354,7 +354,7 @@ fn invalid_types() {
         validate_to_sig_error(bad_bound.clone()),
         SignatureError::WrongBound {
             actual: TypeBound::Copyable,
-            expected: TypeBound::Any
+            expected: TypeBound::Linear
         }
     );
 
@@ -363,14 +363,14 @@ fn invalid_types() {
         "MyContainer",
         vec![Type::new_extension(bad_bound).into()],
         EXT_ID,
-        TypeBound::Any,
+        TypeBound::Linear,
         &Arc::downgrade(&ext),
     );
     assert_eq!(
         validate_to_sig_error(nested),
         SignatureError::WrongBound {
             actual: TypeBound::Copyable,
-            expected: TypeBound::Any
+            expected: TypeBound::Linear
         }
     );
 
@@ -378,7 +378,7 @@ fn invalid_types() {
         "MyContainer",
         vec![usize_t().into(), 3u64.into()],
         EXT_ID,
-        TypeBound::Any,
+        TypeBound::Linear,
         &Arc::downgrade(&ext),
     );
     assert_eq!(
@@ -393,8 +393,8 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
     let f = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
-            [TypeBound::Any.into()],
-            Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
+            [TypeBound::Linear.into()],
+            Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Linear)]),
         ),
     )?;
     let [w] = f.input_wires_arr();
@@ -403,8 +403,8 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
     let f = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
-            [TypeBound::Any.into()],
-            Signature::new_endo(vec![Type::new_var_use(1, TypeBound::Any)]),
+            [TypeBound::Linear.into()],
+            Signature::new_endo(vec![Type::new_var_use(1, TypeBound::Linear)]),
         ),
     )?;
     let [w] = f.input_wires_arr();
@@ -413,7 +413,7 @@ fn typevars_declared() -> Result<(), Box<dyn std::error::Error>> {
     let f = FunctionBuilder::new(
         "myfunc",
         PolyFuncType::new(
-            [TypeBound::Any.into()],
+            [TypeBound::Linear.into()],
             Signature::new_endo(vec![Type::new_var_use(1, TypeBound::Copyable)]),
         ),
     )?;
@@ -486,10 +486,10 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub(crate) fn extension_with_eval_parallel() -> Arc<Extension> {
-    let rowp = TypeParam::new_list_type(TypeBound::Any);
+    let rowp = TypeParam::new_list_type(TypeBound::Linear);
     Extension::new_test_arc(EXT_ID, |ext, extension_ref| {
-        let inputs = TypeRV::new_row_var_use(0, TypeBound::Any);
-        let outputs = TypeRV::new_row_var_use(1, TypeBound::Any);
+        let inputs = TypeRV::new_row_var_use(0, TypeBound::Linear);
+        let outputs = TypeRV::new_row_var_use(1, TypeBound::Linear);
         let evaled_fn = TypeRV::new_function(FuncValueType::new(inputs.clone(), outputs.clone()));
         let pf = PolyFuncTypeRV::new(
             [rowp.clone(), rowp.clone()],
@@ -498,7 +498,7 @@ pub(crate) fn extension_with_eval_parallel() -> Arc<Extension> {
         ext.add_op("eval".into(), String::new(), pf, extension_ref)
             .unwrap();
 
-        let rv = |idx| TypeRV::new_row_var_use(idx, TypeBound::Any);
+        let rv = |idx| TypeRV::new_row_var_use(idx, TypeBound::Linear);
         let pf = PolyFuncTypeRV::new(
             [rowp.clone(), rowp.clone(), rowp.clone(), rowp.clone()],
             Signature::new(
@@ -548,13 +548,13 @@ fn list1ty(t: TypeRV) -> Term {
 #[test]
 fn row_variables() -> Result<(), Box<dyn std::error::Error>> {
     let e = extension_with_eval_parallel();
-    let tv = TypeRV::new_row_var_use(0, TypeBound::Any);
+    let tv = TypeRV::new_row_var_use(0, TypeBound::Linear);
     let inner_ft = Type::new_function(FuncValueType::new_endo(tv.clone()));
     let ft_usz = Type::new_function(FuncValueType::new_endo(vec![tv.clone(), usize_t().into()]));
     let mut fb = FunctionBuilder::new(
         "id",
         PolyFuncType::new(
-            [TypeParam::new_list_type(TypeBound::Any)],
+            [TypeParam::new_list_type(TypeBound::Linear)],
             Signature::new(inner_ft.clone(), ft_usz),
         ),
     )?;
@@ -582,8 +582,8 @@ fn test_polymorphic_load() -> Result<(), Box<dyn std::error::Error>> {
     let id = m.declare(
         "id",
         PolyFuncType::new(
-            vec![TypeBound::Any.into()],
-            Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
+            vec![TypeBound::Linear.into()],
+            Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Linear)]),
         ),
     )?;
     let sig = Signature::new(

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -1203,7 +1203,7 @@ impl<'a> Context<'a> {
 
     /// Import a [`Term`] from a term that represents a static type or value.
     fn import_term(&mut self, term_id: table::TermId) -> Result<Term, ImportError> {
-        self.import_term_with_bound(term_id, TypeBound::Any)
+        self.import_term_with_bound(term_id, TypeBound::Linear)
     }
 
     fn import_term_with_bound(
@@ -1542,7 +1542,7 @@ impl<'a> Context<'a> {
                     }
                 }
                 table::Term::Var(table::VarId(_, index)) => {
-                    let var = RV::try_from_rv(RowVariable(*index as _, TypeBound::Any))
+                    let var = RV::try_from_rv(RowVariable(*index as _, TypeBound::Linear))
                         .map_err(|_| error_invalid!("expected a closed list"))?;
                     types.push(TypeBase::new(TypeEnum::RowVar(var)));
                 }
@@ -1796,7 +1796,7 @@ impl LocalVar {
     pub fn new(r#type: table::TermId) -> Self {
         Self {
             r#type,
-            bound: TypeBound::Any,
+            bound: TypeBound::Linear,
         }
     }
 }

--- a/hugr-core/src/ops/controlflow.rs
+++ b/hugr-core/src/ops/controlflow.rs
@@ -359,7 +359,7 @@ mod test {
     #[test]
     fn test_subst_dataflow_block() {
         use crate::ops::OpTrait;
-        let tv0 = Type::new_var_use(0, TypeBound::Any);
+        let tv0 = Type::new_var_use(0, TypeBound::Linear);
         let dfb = DataflowBlock {
             inputs: vec![usize_t(), tv0.clone()].into(),
             other_outputs: vec![tv0.clone()].into(),
@@ -375,10 +375,14 @@ mod test {
 
     #[test]
     fn test_subst_conditional() {
-        let tv1 = Type::new_var_use(1, TypeBound::Any);
+        let tv1 = Type::new_var_use(1, TypeBound::Linear);
         let cond = Conditional {
             sum_rows: vec![usize_t().into(), tv1.clone().into()],
-            other_inputs: vec![Type::new_tuple(TypeRV::new_row_var_use(0, TypeBound::Any))].into(),
+            other_inputs: vec![Type::new_tuple(TypeRV::new_row_var_use(
+                0,
+                TypeBound::Linear,
+            ))]
+            .into(),
             outputs: vec![usize_t(), tv1].into(),
         };
         let cond2 = cond.substitute(&Substitution::new(&[

--- a/hugr-core/src/std_extensions/collections/array.rs
+++ b/hugr-core/src/std_extensions/collections/array.rs
@@ -96,7 +96,7 @@ lazy_static! {
         Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
             extension.add_type(
                     ARRAY_TYPENAME,
-                    vec![ TypeParam::max_nat_type(), TypeBound::Any.into()],
+                    vec![ TypeParam::max_nat_type(), TypeBound::Linear.into()],
                     "Fixed-length array".into(),
                     // Default array is linear, even if the elements are copyable
                     TypeDefBound::any(),

--- a/hugr-core/src/std_extensions/collections/array/array_conversion.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_conversion.rs
@@ -76,9 +76,9 @@ impl<AK: ArrayKind, const DIR: Direction, OtherAK: ArrayKind>
 {
     /// To avoid recursion when defining the extension, take the type definition as an argument.
     fn signature_from_def(&self, array_def: &TypeDef) -> SignatureFunc {
-        let params = vec![TypeParam::max_nat_type(), TypeBound::Any.into()];
+        let params = vec![TypeParam::max_nat_type(), TypeBound::Linear.into()];
         let size = TypeArg::new_var_use(0, TypeParam::max_nat_type());
-        let element_ty = Type::new_var_use(1, TypeBound::Any);
+        let element_ty = Type::new_var_use(1, TypeBound::Linear);
 
         let this_ty = AK::instantiate_ty(array_def, size.clone(), element_ty.clone())
             .expect("Array type instantiation failed");

--- a/hugr-core/src/std_extensions/collections/array/array_op.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_op.rs
@@ -72,9 +72,9 @@ impl<AK: ArrayKind> SignatureFromArgs for GenericArrayOpDef<AK> {
         let [TypeArg::BoundedNat(n)] = *arg_values else {
             return Err(SignatureError::InvalidTypeArgs);
         };
-        let elem_ty_var = Type::new_var_use(0, TypeBound::Any);
+        let elem_ty_var = Type::new_var_use(0, TypeBound::Linear);
         let array_ty = AK::ty(n, elem_ty_var.clone());
-        let params = vec![TypeBound::Any.into()];
+        let params = vec![TypeBound::Linear.into()];
         let poly_func_ty = match self {
             GenericArrayOpDef::new_array => PolyFuncTypeRV::new(
                 params,
@@ -140,10 +140,10 @@ impl<AK: ArrayKind> GenericArrayOpDef<AK> {
             (*self).into()
         } else {
             let size_var = TypeArg::new_var_use(0, TypeParam::max_nat_type());
-            let elem_ty_var = Type::new_var_use(1, TypeBound::Any);
+            let elem_ty_var = Type::new_var_use(1, TypeBound::Linear);
             let array_ty = AK::instantiate_ty(array_def, size_var.clone(), elem_ty_var.clone())
                 .expect("Array type instantiation failed");
-            let standard_params = vec![TypeParam::max_nat_type(), TypeBound::Any.into()];
+            let standard_params = vec![TypeParam::max_nat_type(), TypeBound::Linear.into()];
 
             // We can assume that the prelude has ben loaded at this point,
             // since it doesn't depend on the array extension.
@@ -184,9 +184,9 @@ impl<AK: ArrayKind> GenericArrayOpDef<AK> {
                     )
                 }
                 discard_empty => PolyFuncTypeRV::new(
-                    vec![TypeBound::Any.into()],
+                    vec![TypeBound::Linear.into()],
                     FuncValueType::new(
-                        AK::instantiate_ty(array_def, 0, Type::new_var_use(0, TypeBound::Any))
+                        AK::instantiate_ty(array_def, 0, Type::new_var_use(0, TypeBound::Linear))
                             .expect("Array type instantiation failed"),
                         type_row![],
                     ),

--- a/hugr-core/src/std_extensions/collections/array/array_repeat.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_repeat.rs
@@ -52,9 +52,9 @@ impl<AK: ArrayKind> FromStr for GenericArrayRepeatDef<AK> {
 impl<AK: ArrayKind> GenericArrayRepeatDef<AK> {
     /// To avoid recursion when defining the extension, take the type definition as an argument.
     fn signature_from_def(&self, array_def: &TypeDef) -> SignatureFunc {
-        let params = vec![TypeParam::max_nat_type(), TypeBound::Any.into()];
+        let params = vec![TypeParam::max_nat_type(), TypeBound::Linear.into()];
         let n = TypeArg::new_var_use(0, TypeParam::max_nat_type());
-        let t = Type::new_var_use(1, TypeBound::Any);
+        let t = Type::new_var_use(1, TypeBound::Linear);
         let func = Type::new_function(Signature::new(vec![], vec![t.clone()]));
         let array_ty =
             AK::instantiate_ty(array_def, n, t).expect("Array type instantiation failed");

--- a/hugr-core/src/std_extensions/collections/array/array_scan.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_scan.rs
@@ -57,14 +57,14 @@ impl<AK: ArrayKind> GenericArrayScanDef<AK> {
         // array<N, T1>, (T1, *A -> T2, *A), *A, -> array<N, T2>, *A
         let params = vec![
             TypeParam::max_nat_type(),
-            TypeBound::Any.into(),
-            TypeBound::Any.into(),
-            TypeParam::new_list_type(TypeBound::Any),
+            TypeBound::Linear.into(),
+            TypeBound::Linear.into(),
+            TypeParam::new_list_type(TypeBound::Linear),
         ];
         let n = TypeArg::new_var_use(0, TypeParam::max_nat_type());
-        let t1 = Type::new_var_use(1, TypeBound::Any);
-        let t2 = Type::new_var_use(2, TypeBound::Any);
-        let s = TypeRV::new_row_var_use(3, TypeBound::Any);
+        let t1 = Type::new_var_use(1, TypeBound::Linear);
+        let t2 = Type::new_var_use(2, TypeBound::Linear);
+        let s = TypeRV::new_row_var_use(3, TypeBound::Linear);
         PolyFuncTypeRV::new(
             params,
             FuncTypeBase::<RowVariable>::new(

--- a/hugr-core/src/std_extensions/collections/borrow_array.rs
+++ b/hugr-core/src/std_extensions/collections/borrow_array.rs
@@ -139,13 +139,13 @@ impl BArrayUnsafeOpDef {
 
     fn signature_from_def(&self, def: &TypeDef, _: &sync::Weak<Extension>) -> SignatureFunc {
         let size_var = TypeArg::new_var_use(0, TypeParam::max_nat_type());
-        let elem_ty_var = Type::new_var_use(1, TypeBound::Any);
+        let elem_ty_var = Type::new_var_use(1, TypeBound::Linear);
         let array_ty: Type = def
             .instantiate(vec![size_var, elem_ty_var.clone().into()])
             .unwrap()
             .into();
 
-        let params = vec![TypeParam::max_nat_type(), TypeBound::Any.into()];
+        let params = vec![TypeParam::max_nat_type(), TypeBound::Linear.into()];
 
         let usize_t: Type = usize_t();
 
@@ -293,7 +293,7 @@ lazy_static! {
         Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
             extension.add_type(
                     BORROW_ARRAY_TYPENAME,
-                    vec![ TypeParam::max_nat_type(), TypeBound::Any.into()],
+                    vec![ TypeParam::max_nat_type(), TypeBound::Linear.into()],
                     "Fixed-length borrow array".into(),
                     // Borrow array is linear, even if the elements are copyable.
                     TypeDefBound::any(),

--- a/hugr-core/src/std_extensions/collections/list.rs
+++ b/hugr-core/src/std_extensions/collections/list.rs
@@ -167,7 +167,7 @@ pub enum ListOp {
 
 impl ListOp {
     /// Type parameter used in the list types.
-    const TP: TypeParam = TypeParam::RuntimeType(TypeBound::Any);
+    const TP: TypeParam = TypeParam::RuntimeType(TypeBound::Linear);
 
     /// Instantiate a list operation with an `element_type`.
     #[must_use]
@@ -181,7 +181,7 @@ impl ListOp {
     /// Compute the signature of the operation, given the list type definition.
     fn compute_signature(self, list_type_def: &TypeDef) -> SignatureFunc {
         use ListOp::{get, insert, length, pop, push, set};
-        let e = Type::new_var_use(0, TypeBound::Any);
+        let e = Type::new_var_use(0, TypeBound::Linear);
         let l = self.list_type(list_type_def, 0);
         match self {
             pop => self

--- a/hugr-core/src/std_extensions/collections/value_array.rs
+++ b/hugr-core/src/std_extensions/collections/value_array.rs
@@ -102,7 +102,7 @@ lazy_static! {
         Extension::new_arc(EXTENSION_ID, VERSION, |extension, extension_ref| {
             extension.add_type(
                     VALUE_ARRAY_TYPENAME,
-                    vec![ TypeParam::max_nat_type(), TypeBound::Any.into()],
+                    vec![ TypeParam::max_nat_type(), TypeBound::Linear.into()],
                     "Fixed-length value array".into(),
                     // Value arrays are copyable iff their elements are
                     TypeDefBound::from_params(vec![1]),

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -192,10 +192,10 @@ pub(crate) mod test {
     #[test]
     fn test_opaque() -> Result<(), SignatureError> {
         let list_def = list::EXTENSION.get_type(&list::LIST_TYPENAME).unwrap();
-        let tyvar = TypeArg::new_var_use(0, TypeBound::Any.into());
+        let tyvar = TypeArg::new_var_use(0, TypeBound::Linear.into());
         let list_of_var = Type::new_extension(list_def.instantiate([tyvar.clone()])?);
         let list_len = PolyFuncTypeBase::new_validated(
-            [TypeBound::Any.into()],
+            [TypeBound::Linear.into()],
             Signature::new(vec![list_of_var], vec![usize_t()]),
         )?;
 
@@ -216,8 +216,8 @@ pub(crate) mod test {
     #[test]
     fn test_mismatched_args() -> Result<(), SignatureError> {
         let size_var = TypeArg::new_var_use(0, TypeParam::max_nat_type());
-        let ty_var = TypeArg::new_var_use(1, TypeBound::Any.into());
-        let type_params = [TypeParam::max_nat_type(), TypeBound::Any.into()];
+        let ty_var = TypeArg::new_var_use(1, TypeBound::Linear.into());
+        let type_params = [TypeParam::max_nat_type(), TypeBound::Linear.into()];
 
         // Valid schema...
         let good_array = array_type_parametric(size_var.clone(), ty_var.clone())?;
@@ -252,7 +252,7 @@ pub(crate) mod test {
             "array",
             [ty_var, size_var],
             array::EXTENSION_ID,
-            TypeBound::Any,
+            TypeBound::Linear,
             &Arc::downgrade(&array::EXTENSION),
         ));
         let bad_ts =
@@ -271,7 +271,7 @@ pub(crate) mod test {
         for decl in [
             Term::new_list_type(Term::max_nat_type()),
             Term::StringType,
-            Term::new_tuple_type([TypeBound::Any.into(), Term::max_nat_type()]),
+            Term::new_tuple_type([TypeBound::Linear.into(), Term::max_nat_type()]),
         ] {
             let invalid_ts = PolyFuncTypeBase::new_validated([decl.clone()], body_type.clone());
             assert_eq!(
@@ -324,7 +324,7 @@ pub(crate) mod test {
                     TYPE_NAME,
                     [TypeArg::new_var_use(0, tp)],
                     EXT_ID,
-                    TypeBound::Any,
+                    TypeBound::Linear,
                     &Arc::downgrade(&ext),
                 ))),
             )
@@ -351,13 +351,13 @@ pub(crate) mod test {
         decl_accepts_rejects_var(
             TypeBound::Copyable.into(),
             &[TypeBound::Copyable.into()],
-            &[TypeBound::Any.into()],
+            &[TypeBound::Linear.into()],
         )?;
 
         decl_accepts_rejects_var(
             Term::new_list_type(TypeBound::Copyable),
             &[Term::new_list_type(TypeBound::Copyable)],
-            &[Term::new_list_type(TypeBound::Any)],
+            &[Term::new_list_type(TypeBound::Linear)],
         )?;
 
         decl_accepts_rejects_var(
@@ -373,7 +373,7 @@ pub(crate) mod test {
         Ok(())
     }
 
-    const TP_ANY: TypeParam = TypeParam::RuntimeType(TypeBound::Any);
+    const TP_ANY: TypeParam = TypeParam::RuntimeType(TypeBound::Linear);
     #[test]
     fn row_variables_bad_schema() {
         // Mismatched TypeBound (Copyable vs Any)
@@ -393,7 +393,7 @@ pub(crate) mod test {
         // Declared as row variable, used as type variable
         let e = PolyFuncTypeBase::new_validated(
             [decl.clone()],
-            Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Any)]),
+            Signature::new_endo(vec![Type::new_var_use(0, TypeBound::Linear)]),
         )
         .unwrap_err();
         assert_matches!(e, SignatureError::TypeVarDoesNotMatchDeclaration { actual, cached } => {
@@ -404,7 +404,7 @@ pub(crate) mod test {
 
     #[test]
     fn row_variables() {
-        let rty = TypeRV::new_row_var_use(0, TypeBound::Any);
+        let rty = TypeRV::new_row_var_use(0, TypeBound::Linear);
         let pf = PolyFuncTypeBase::new_validated(
             [TypeParam::new_list_type(TP_ANY)],
             FuncValueType::new(

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -70,7 +70,7 @@ pub type TypeParam = Term;
 pub enum Term {
     /// The type of runtime types.
     #[display("Type{}", match _0 {
-        TypeBound::Any => String::new(),
+        TypeBound::Linear => String::new(),
         _ => format!("[{_0}]")
     })]
     RuntimeType(TypeBound),
@@ -896,7 +896,7 @@ mod test {
         check(usize_t(), &TypeBound::Copyable.into()).unwrap();
         let seq_param = TypeParam::new_list_type(TypeBound::Copyable);
         check(usize_t(), &seq_param).unwrap_err();
-        check_seq(&[usize_t()], &TypeBound::Any.into()).unwrap_err();
+        check_seq(&[usize_t()], &TypeBound::Linear.into()).unwrap_err();
 
         // Into a list of type, we can fit a single row var
         check(rowvar(0, TypeBound::Copyable), &seq_param).unwrap();
@@ -905,17 +905,17 @@ mod test {
         check_seq(&[rowvar(0, TypeBound::Copyable)], &seq_param).unwrap();
         check_seq(
             &[
-                rowvar(1, TypeBound::Any),
+                rowvar(1, TypeBound::Linear),
                 usize_t().into(),
                 rowvar(0, TypeBound::Copyable),
             ],
-            &TypeParam::new_list_type(TypeBound::Any),
+            &TypeParam::new_list_type(TypeBound::Linear),
         )
         .unwrap();
         // Next one fails because a list of Eq is required
         check_seq(
             &[
-                rowvar(1, TypeBound::Any),
+                rowvar(1, TypeBound::Linear),
                 usize_t().into(),
                 rowvar(0, TypeBound::Copyable),
             ],
@@ -957,8 +957,8 @@ mod test {
         )
         .unwrap_err(); // Wrong way around
         let two_types = TypeParam::new_tuple_type(Term::new_list([
-            TypeBound::Any.into(),
-            TypeBound::Any.into(),
+            TypeBound::Linear.into(),
+            TypeBound::Linear.into(),
         ]));
         check(TypeArg::new_var_use(0, two_types.clone()), &two_types).unwrap();
         // not a Row Var which could have any number of elems
@@ -973,7 +973,7 @@ mod test {
 
         // Now say a row variable referring to *that* row was used
         // to instantiate an outer "row parameter" (list of type).
-        let outer_param = Term::new_list_type(TypeBound::Any);
+        let outer_param = Term::new_list_type(TypeBound::Linear);
         let outer_arg = Term::new_list([
             TypeRV::new_row_var_use(0, TypeBound::Copyable).into(),
             usize_t().into(),
@@ -992,7 +992,7 @@ mod test {
 
     #[test]
     fn subst_list_list() {
-        let outer_param = Term::new_list_type(Term::new_list_type(TypeBound::Any));
+        let outer_param = Term::new_list_type(Term::new_list_type(TypeBound::Linear));
         let row_var_decl = Term::new_list_type(TypeBound::Copyable);
         let row_var_use = Term::new_var_use(0, row_var_decl.clone());
         let good_arg = Term::new_list([
@@ -1013,7 +1013,7 @@ mod test {
             Err(TermTypeError::TypeMismatch {
                 term: usize_t().into(),
                 // The error reports the type expected for each element of the list:
-                type_: TypeParam::new_list_type(TypeBound::Any)
+                type_: TypeParam::new_list_type(TypeBound::Linear)
             })
         );
 

--- a/hugr-passes/src/const_fold/test.rs
+++ b/hugr-passes/src/const_fold/test.rs
@@ -1591,7 +1591,7 @@ fn test_module() -> Result<(), Box<dyn std::error::Error>> {
     // Define a top-level constant, (only) the second of which can be removed
     let c7 = mb.add_constant(Value::from(ConstInt::new_u(5, 7)?));
     let c17 = mb.add_constant(Value::from(ConstInt::new_u(5, 17)?));
-    let ad1 = mb.add_alias_declare("unused", TypeBound::Any)?;
+    let ad1 = mb.add_alias_declare("unused", TypeBound::Linear)?;
     let ad2 = mb.add_alias_def("unused2", INT_TYPES[3].clone())?;
     let mut main = mb.define_function(
         "main",

--- a/hugr-passes/src/monomorphize.rs
+++ b/hugr-passes/src/monomorphize.rs
@@ -548,8 +548,8 @@ mod test {
                     .define_function(
                         "foo",
                         PolyFuncType::new(
-                            [TypeBound::Any.into()],
-                            Signature::new_endo(Type::new_var_use(0, TypeBound::Any)),
+                            [TypeBound::Linear.into()],
+                            Signature::new_endo(Type::new_var_use(0, TypeBound::Linear)),
                         ),
                     )
                     .unwrap();

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -654,7 +654,7 @@ mod test {
                 let pv_of_var = ext
                     .add_type(
                         PACKED_VEC.into(),
-                        vec![TypeBound::Any.into()],
+                        vec![TypeBound::Linear.into()],
                         String::new(),
                         TypeDefBound::from_params(vec![0]),
                         w,
@@ -669,7 +669,7 @@ mod test {
                         vec![TypeBound::Copyable.into()],
                         Signature::new(
                             vec![pv_of_var.into(), i64_t()],
-                            Type::new_var_use(0, TypeBound::Any),
+                            Type::new_var_use(0, TypeBound::Linear),
                         ),
                     ),
                     w,
@@ -747,9 +747,9 @@ mod test {
         let c_int = Type::from(coln.instantiate([i64_t().into()]).unwrap());
         let c_bool = Type::from(coln.instantiate([bool_t().into()]).unwrap());
         let mut mb = ModuleBuilder::new();
-        let sig = Signature::new_endo(Type::new_var_use(0, TypeBound::Any));
+        let sig = Signature::new_endo(Type::new_var_use(0, TypeBound::Linear));
         let fb = mb
-            .define_function("id", PolyFuncType::new([TypeBound::Any.into()], sig))
+            .define_function("id", PolyFuncType::new([TypeBound::Linear.into()], sig))
             .unwrap();
         let inps = fb.input_wires();
         let id = fb.finish_with_outputs(inps).unwrap();
@@ -966,8 +966,8 @@ mod test {
             IdentList::new_unchecked("NoBoundsCheck"),
             Version::new(0, 0, 0),
             |e, w| {
-                let params = vec![TypeBound::Any.into()];
-                let tv = Type::new_var_use(0, TypeBound::Any);
+                let params = vec![TypeBound::Linear.into()];
+                let tv = Type::new_var_use(0, TypeBound::Linear);
                 let list_of_var = list_type(tv.clone());
                 e.add_op(
                     READ.into(),

--- a/hugr-passes/src/replace_types/linearize.rs
+++ b/hugr-passes/src/replace_types/linearize.rs
@@ -15,7 +15,7 @@ use super::{NodeTemplate, ParametricType, handlers::linearize_value_array};
 /// Trait for things that know how to wire up linear outports to other than one
 /// target.  Used to restore Hugr validity when a [`ReplaceTypes`](super::ReplaceTypes)
 /// results in types of such outports changing from [Copyable] to linear (i.e.
-/// [`hugr_core::types::TypeBound::Any`]).
+/// [`hugr_core::types::TypeBound::Linear`]).
 ///
 /// Note that this is not really effective before [monomorphization]: if a
 /// function polymorphic over a [Copyable] becomes called with a

--- a/hugr-py/src/hugr/_serialization/tys.py
+++ b/hugr-py/src/hugr/_serialization/tys.py
@@ -412,15 +412,15 @@ class PolyFuncType(BaseType):
 
 class TypeBound(Enum):
     Copyable = "C"
-    Any = "A"
+    Linear = "A"
 
     @staticmethod
     def join(*bs: TypeBound) -> TypeBound:
         """Computes the least upper bound for a sequence of bounds."""
         res = TypeBound.Copyable
         for b in bs:
-            if b == TypeBound.Any:
-                return TypeBound.Any
+            if b == TypeBound.Linear:
+                return TypeBound.Linear
             if res == TypeBound.Copyable:
                 res = b
         return res
@@ -429,8 +429,8 @@ class TypeBound(Enum):
         match self:
             case TypeBound.Copyable:
                 return "Copyable"
-            case TypeBound.Any:
-                return "Any"
+            case TypeBound.Linear:
+                return "Linear"
 
 
 class Opaque(BaseType):

--- a/hugr-py/src/hugr/std/collections/array.py
+++ b/hugr-py/src/hugr/std/collections/array.py
@@ -54,7 +54,7 @@ class Array(tys.ExtType):
         return None
 
     def type_bound(self) -> tys.TypeBound:
-        return tys.TypeBound.Any
+        return tys.TypeBound.Linear
 
 
 @dataclass

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -68,7 +68,7 @@ class Type(Protocol):
             >>> Tuple(Bool, Bool).type_bound()
             <TypeBound.Copyable: 'C'>
             >>> Tuple(Qubit, Bool).type_bound()
-            <TypeBound.Any: 'A'>
+            <TypeBound.Linear: 'A'>
         """
         ...  # pragma: no cover
 
@@ -820,7 +820,7 @@ class Opaque(Type):
 @dataclass
 class _QubitDef(Type):
     def type_bound(self) -> TypeBound:
-        return TypeBound.Any
+        return TypeBound.Linear
 
     def _to_serial(self) -> stys.Qubit:
         return stys.Qubit()

--- a/hugr-py/tests/test_custom.py
+++ b/hugr-py/tests/test_custom.py
@@ -139,7 +139,7 @@ _LIST_T = STRINGLY_EXT.add_type_def(
     ext.TypeDef(
         "List",
         description="A list of elements.",
-        params=[tys.TypeTypeParam(tys.TypeBound.Any)],
+        params=[tys.TypeTypeParam(tys.TypeBound.Linear)],
         bound=ext.FromParamsBound([0]),
     )
 )

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -233,8 +233,8 @@ def test_poly_function(direct_call: bool) -> None:
     f_id = mod.declare_function(
         "id",
         tys.PolyFuncType(
-            [tys.TypeTypeParam(tys.TypeBound.Any)],
-            tys.FunctionType.endo([tys.Variable(0, tys.TypeBound.Any)]),
+            [tys.TypeTypeParam(tys.TypeBound.Linear)],
+            tys.FunctionType.endo([tys.Variable(0, tys.TypeBound.Linear)]),
         ),
     )
 

--- a/hugr-py/tests/test_ops.py
+++ b/hugr-py/tests/test_ops.py
@@ -59,7 +59,7 @@ from hugr.val import TRUE
         (FuncDecl("bar", PolyFuncType.empty()), "FuncDecl(bar)"),
         (Const(TRUE), "Const(TRUE)"),
         (Noop(), "Noop"),
-        (AliasDecl("baz", TypeBound.Any), "AliasDecl(baz)"),
+        (AliasDecl("baz", TypeBound.Linear), "AliasDecl(baz)"),
         (AliasDefn("baz", Bool), "AliasDefn(baz)"),
     ],
 )

--- a/hugr-py/tests/test_tys.py
+++ b/hugr-py/tests/test_tys.py
@@ -90,15 +90,15 @@ def test_tys_sum_str(ty: Type, string: str, repr_str: str):
 @pytest.mark.parametrize(
     ("param", "string"),
     [
-        (TypeTypeParam(TypeBound.Any), "Any"),
+        (TypeTypeParam(TypeBound.Linear), "Linear"),
         (BoundedNatParam(3), "Nat(3)"),
         (BoundedNatParam(None), "Nat"),
         (StringParam(), "String"),
         (FloatParam(), "Float"),
         (BytesParam(), "Bytes"),
         (
-            TupleParam([TypeTypeParam(TypeBound.Any), BoundedNatParam(3)]),
-            "(Any, Nat(3))",
+            TupleParam([TypeTypeParam(TypeBound.Linear), BoundedNatParam(3)]),
+            "(Linear, Nat(3))",
         ),
         (ListParam(StringParam()), "[String]"),
     ],
@@ -136,7 +136,7 @@ def test_args_str(arg: TypeArg, string: str):
         (Array(Bool, 3), "array<3, Type(Bool)>"),
         (StaticArray(Bool), "static_array<Type(Bool)>"),
         (ValueArray(Bool, 3), "value_array<3, Type(Bool)>"),
-        (Variable(2, TypeBound.Any), "$2"),
+        (Variable(2, TypeBound.Linear), "$2"),
         (RowVariable(4, TypeBound.Copyable), "$4"),
         (USize(), "USize"),
         (INT_T, "int<5>"),
@@ -145,10 +145,10 @@ def test_args_str(arg: TypeArg, string: str):
         (FunctionType([Bool, Qubit], [Qubit, Bool]), "Bool, Qubit -> Qubit, Bool"),
         (
             PolyFuncType(
-                [TypeTypeParam(TypeBound.Any), BoundedNatParam(7)],
+                [TypeTypeParam(TypeBound.Linear), BoundedNatParam(7)],
                 FunctionType([_int_tv(1)], [Variable(0, TypeBound.Copyable)]),
             ),
-            "∀ Any, Nat(7). int<$1> -> $0",
+            "∀ Linear, Nat(7). int<$1> -> $0",
         ),
     ],
 )
@@ -179,12 +179,12 @@ def test_array():
     ls = Array(Bool, 3)
     assert ls.ty == Bool
     assert ls.size == 3
-    assert ls.type_bound() == TypeBound.Any
+    assert ls.type_bound() == TypeBound.Linear
 
     ls = Array(ty_var, len_var)
     assert ls.ty == ty_var
     assert ls.size is None
-    assert ls.type_bound() == TypeBound.Any
+    assert ls.type_bound() == TypeBound.Linear
 
     ar_val = ArrayVal([val.TRUE, val.FALSE], Bool)
     assert ar_val.v == [val.TRUE, val.FALSE]
@@ -192,7 +192,7 @@ def test_array():
 
 
 def test_value_array():
-    ty_var = Variable(0, TypeBound.Any)
+    ty_var = Variable(0, TypeBound.Linear)
     len_var = VariableArg(1, BoundedNatParam())
 
     ls = ValueArray(Bool, 3)
@@ -203,7 +203,7 @@ def test_value_array():
     ls = ValueArray(ty_var, len_var)
     assert ls.ty == ty_var
     assert ls.size is None
-    assert ls.type_bound() == TypeBound.Any
+    assert ls.type_bound() == TypeBound.Linear
 
     ar_val = ValueArrayVal([val.TRUE, val.FALSE], Bool)
     assert ar_val.v == [val.TRUE, val.FALSE]

--- a/hugr/benches/benchmarks/types.rs
+++ b/hugr/benches/benchmarks/types.rs
@@ -13,7 +13,7 @@ fn make_complex_type() -> Type {
     let int = usize_t();
     let q_register = Type::new_tuple(vec![qb; 8]);
     let b_register = Type::new_tuple(vec![int; 8]);
-    let q_alias = Type::new_alias(AliasDecl::new("QReg", TypeBound::Any));
+    let q_alias = Type::new_alias(AliasDecl::new("QReg", TypeBound::Linear));
     let sum = Type::new_sum([q_register, q_alias]);
     Type::new_function(Signature::new(vec![sum], vec![b_register]))
 }

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -824,7 +824,7 @@ copied or discarded (multiple or 0 links from on output port respectively):
   allows multiple (or 0) outgoing edges from an outport; also these types can
   be sent down `Const` edges.
 
-Note that all dataflow inputs (`Value`, `Const` and `Function`) always require a single connection, regardless of whether the type is `AnyType` or `Copyable`.
+Note that all dataflow inputs (`Value`, `Const` and `Function`) always require a single connection, regardless of whether the type is `Linear` or `Copyable`.
 
 **Rows** The `#` is a *row* which is a sequence of zero or more types. Types in the row can optionally be given names in metadata i.e. this does not affect behaviour of the HUGR. When writing literal types, we use `#` to distinguish between tuples and rows, e.g. `(int<1>,int<2>)` is a tuple while `Sum(#(int<1>),#(int<2>))` contains two rows.
 
@@ -890,7 +890,7 @@ TypeArg ::= Type(Type) -- could be a variable of kind Type, or contain variable(
 
 For example, a Function node declaring a `TypeParam::Opaque("Array", [5, TypeArg::Type(Type::Opaque("usize"))])`
 means that any `Call` to it must statically provide a *value* that is an array of 5 `usize`s;
-or a Function node declaring a `TypeParam::BoundedUSize(5)` and a `TypeParam::Type(Any)` requires two TypeArgs,
+or a Function node declaring a `TypeParam::BoundedUSize(5)` and a `TypeParam::Type(Linear)` requires two TypeArgs,
 firstly a non-negative integer less than 5, secondly a type (which might be from an extension, e.g. `usize`).
 
 Given TypeArgs, the body of the Function node's type can be converted to a monomorphic signature by substitution,


### PR DESCRIPTION
Closes #1356 

The bound is still encoded as "A", so this doesn't break serialization.

BREAKING CHANGE: Renamed the `Any` type bound to `Linear`