### PR TITLE
chore: Setup hugr-persistent for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ pretty = "0.12.4"
 pretty_assertions = "1.4.1"
 zstd = "0.13.2"
 relrc = "0.4.6"
+wyhash = "0.6.0"
 
 # These public dependencies usually require breaking changes downstream, so we
 # try to be as permissive as possible.

--- a/hugr-persistent/CHANGELOG.md
+++ b/hugr-persistent/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/hugr-persistent/Cargo.toml
+++ b/hugr-persistent/Cargo.toml
@@ -1,20 +1,25 @@
 [package]
 name = "hugr-persistent"
 version = "0.1.0"
-rust-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+readme = "README.md"
+documentation = "https://docs.rs/hugr-persistent/"
+homepage = { workspace = true }
+repository = { workspace = true }
+description = "Persistent IR structure for Quantinuum's HUGR"
+keywords = ["Quantum", "Quantinuum"]
+categories = ["compilers", "ir"]
 
 [[test]]
 name = "persistent_walker_example"
 
 [dependencies]
-hugr-core.path = "../hugr-core"
+hugr-core = { path = "../hugr-core", version = "0.21.0" }
 
+derive_more = { workspace = true, features = ["display", "error", "from"] }
 delegate.workspace = true
-derive_more.workspace = true
 itertools.workspace = true
 petgraph.workspace = true
 portgraph.workspace = true
@@ -22,10 +27,13 @@ relrc = { workspace = true, features = ["petgraph", "serde"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-wyhash = "0.6.0"
+wyhash.workspace = true
 
 [lints]
 workspace = true
+
+[lib]
+bench = false
 
 [dev-dependencies]
 rstest.workspace = true

--- a/hugr-persistent/README.md
+++ b/hugr-persistent/README.md
@@ -1,0 +1,59 @@
+![](/hugr/assets/hugr_logo.svg)
+
+# hugr-persistent
+
+[![build_status][]](https://github.com/CQCL/hugr/actions)
+[![crates][]](https://crates.io/crates/hugr-persistent)
+[![msrv][]](https://github.com/CQCL/hugr)
+[![codecov][]](https://codecov.io/gh/CQCL/hugr)
+
+The Hierarchical Unified Graph Representation (HUGR, pronounced _hugger_) is the
+common representation of quantum circuits and operations in the Quantinuum
+ecosystem.
+
+It provides a high-fidelity representation of operations, that facilitates
+compilation and encodes runnable programs.
+
+The HUGR specification is [here](https://github.com/CQCL/hugr/blob/main/specification/hugr.md).
+
+## Overview
+
+This crate provides a persistent data structure for HUGR mutations; mutations to
+the data are stored persistently as a set of `Commit`s along with the
+dependencies between them.
+
+As a result of persistency, the entire mutation history of a HUGR can be
+traversed and references to previous versions of the data remain valid even
+as the HUGR graph is "mutated" by applying patches: the patches are in
+effect added to the history as new commits.
+
+## Usage
+
+Add the dependency to your project:
+
+```bash
+cargo add hugr-persistent
+```
+
+Please read the [API documentation here][].
+
+## Recent Changes
+
+See [CHANGELOG][] for a list of changes. The minimum supported rust
+version will only change on major releases.
+
+## Development
+
+See [DEVELOPMENT.md](https://github.com/CQCL/hugr/blob/main/DEVELOPMENT.md) for instructions on setting up the development environment.
+
+## License
+
+This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http://www.apache.org/licenses/LICENSE-2.0).
+
+  [API documentation here]: https://docs.rs/hugr-persistent/
+  [build_status]: https://github.com/CQCL/hugr/actions/workflows/ci-rs.yml/badge.svg?branch=main
+  [msrv]: https://img.shields.io/crates/msrv/hugr-persistent
+  [crates]: https://img.shields.io/crates/v/hugr-persistent
+  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/hugr?logo=codecov
+  [LICENSE]: https://github.com/CQCL/hugr/blob/main/LICENCE
+  [CHANGELOG]: https://github.com/CQCL/hugr/blob/main/hugr-persistent/CHANGELOG.md

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -69,3 +69,8 @@ version_group = "hugr"
 name = "hugr-llvm"
 release = true
 version_group = "hugr"
+
+[[package]]
+name = "hugr-persistent"
+# TODO: Remove after the first release has been manually created.
+release = false


### PR DESCRIPTION
Some last config and metadata updates before we publish the crate (required to publish `hugr 0.21`).

The bot does not have permissions to create new crates, so I'll do it manually.