### PR TITLE
feat: ReplaceTypes allows linearizing inside Op replacements

### DIFF
--- a/hugr-passes/src/linearize_array.rs
+++ b/hugr-passes/src/linearize_array.rs
@@ -114,7 +114,7 @@ impl Default for LinearizeArrayPass {
                 )))
             },
         );
-        pass.linearizer()
+        pass.linearizer_mut()
             .register_callback(array_type_def(), copy_discard_array);
         Self(pass)
     }
@@ -139,7 +139,7 @@ impl LinearizeArrayPass {
     /// Allows to configure how to clone and discard arrays that are nested
     /// inside opaque extension values.
     pub fn linearizer(&mut self) -> &mut DelegatingLinearizer {
-        self.0.linearizer()
+        self.0.linearizer_mut()
     }
 }
 

--- a/hugr-passes/src/linearize_array.rs
+++ b/hugr-passes/src/linearize_array.rs
@@ -53,9 +53,9 @@ impl Default for LinearizeArrayPass {
             Ok(Some(ArrayValue::new(ty, contents).into()))
         });
         for op_def in ArrayOpDef::iter() {
-            pass.replace_parametrized_op(
+            pass.replace_parametrized_op_with(
                 value_array::EXTENSION.get_op(&op_def.opdef_id()).unwrap(),
-                move |args| {
+                move |args, _| {
                     // `get` is only allowed for copyable elements. Assuming the Hugr was
                     // valid when we started, the only way for the element to become linear
                     // is if it used to contain nested `value_array`s. In that case, we
@@ -76,38 +76,38 @@ impl Default for LinearizeArrayPass {
                 },
             );
         }
-        pass.replace_parametrized_op(
+        pass.replace_parametrized_op_with(
             value_array::EXTENSION.get_op(&ARRAY_REPEAT_OP_ID).unwrap(),
-            |args| {
+            |args, _| {
                 Some(NodeTemplate::SingleOp(
                     ArrayRepeatDef::new().instantiate(args).unwrap().into(),
                 ))
             },
         );
-        pass.replace_parametrized_op(
+        pass.replace_parametrized_op_with(
             value_array::EXTENSION.get_op(&ARRAY_SCAN_OP_ID).unwrap(),
-            |args| {
+            |args, _| {
                 Some(NodeTemplate::SingleOp(
                     ArrayScanDef::new().instantiate(args).unwrap().into(),
                 ))
             },
         );
-        pass.replace_parametrized_op(
+        pass.replace_parametrized_op_with(
             value_array::EXTENSION
                 .get_op(&VArrayFromArrayDef::new().opdef_id())
                 .unwrap(),
-            |args| {
+            |args, _| {
                 let array_ty = array_type_parametric(args[0].clone(), args[1].clone()).unwrap();
                 Some(NodeTemplate::SingleOp(
                     Noop::new(array_ty).to_extension_op().unwrap().into(),
                 ))
             },
         );
-        pass.replace_parametrized_op(
+        pass.replace_parametrized_op_with(
             value_array::EXTENSION
                 .get_op(&VArrayToArrayDef::new().opdef_id())
                 .unwrap(),
-            |args| {
+            |args, _| {
                 let array_ty = array_type_parametric(args[0].clone(), args[1].clone()).unwrap();
                 Some(NodeTemplate::SingleOp(
                     Noop::new(array_ty).to_extension_op().unwrap().into(),

--- a/hugr-passes/src/linearize_array.rs
+++ b/hugr-passes/src/linearize_array.rs
@@ -70,26 +70,26 @@ impl Default for LinearizeArrayPass {
                         "Cannot linearise arrays in this Hugr: \
                             Contains a `get` operation on nested value arrays"
                     );
-                    Some(NodeTemplate::SingleOp(
+                    Ok(Some(NodeTemplate::SingleOp(
                         op_def.instantiate(args).unwrap().into(),
-                    ))
+                    )))
                 },
             );
         }
         pass.replace_parametrized_op_with(
             value_array::EXTENSION.get_op(&ARRAY_REPEAT_OP_ID).unwrap(),
             |args, _| {
-                Some(NodeTemplate::SingleOp(
+                Ok(Some(NodeTemplate::SingleOp(
                     ArrayRepeatDef::new().instantiate(args).unwrap().into(),
-                ))
+                )))
             },
         );
         pass.replace_parametrized_op_with(
             value_array::EXTENSION.get_op(&ARRAY_SCAN_OP_ID).unwrap(),
             |args, _| {
-                Some(NodeTemplate::SingleOp(
+                Ok(Some(NodeTemplate::SingleOp(
                     ArrayScanDef::new().instantiate(args).unwrap().into(),
-                ))
+                )))
             },
         );
         pass.replace_parametrized_op_with(
@@ -98,9 +98,9 @@ impl Default for LinearizeArrayPass {
                 .unwrap(),
             |args, _| {
                 let array_ty = array_type_parametric(args[0].clone(), args[1].clone()).unwrap();
-                Some(NodeTemplate::SingleOp(
+                Ok(Some(NodeTemplate::SingleOp(
                     Noop::new(array_ty).to_extension_op().unwrap().into(),
-                ))
+                )))
             },
         );
         pass.replace_parametrized_op_with(
@@ -109,9 +109,9 @@ impl Default for LinearizeArrayPass {
                 .unwrap(),
             |args, _| {
                 let array_ty = array_type_parametric(args[0].clone(), args[1].clone()).unwrap();
-                Some(NodeTemplate::SingleOp(
+                Ok(Some(NodeTemplate::SingleOp(
                     Noop::new(array_ty).to_extension_op().unwrap().into(),
-                ))
+                )))
             },
         );
         pass.linearizer()

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -326,6 +326,12 @@ impl ReplaceTypes {
         self.param_types.insert(src.into(), Arc::new(dest_fn));
     }
 
+    /// Deprecated + Renamed to [Self::linearizer_mut]
+    #[deprecated(note = "Use linearizer_mut")]
+    pub fn linearizer(&mut self) -> &mut DelegatingLinearizer {
+        self.linearizer_mut()
+    }
+
     /// Allows to configure how to deal with types/wires that were [Copyable]
     /// but have become linear as a result of type-changing. Specifically,
     /// the [Linearizer] is used whenever lowering produces an outport which both
@@ -335,7 +341,7 @@ impl ReplaceTypes {
     ///
     /// [Copyable]: hugr_core::types::TypeBound::Copyable
     /// [`array`]: hugr_core::std_extensions::collections::array::array_type
-    pub fn linearizer(&mut self) -> &mut DelegatingLinearizer {
+    pub fn linearizer_mut(&mut self) -> &mut DelegatingLinearizer {
         &mut self.linearize
     }
 

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -327,9 +327,14 @@ impl ReplaceTypes {
     }
 
     /// Deprecated + Renamed to [Self::linearizer_mut]
-    #[deprecated(note = "Use linearizer_mut")]
+    #[deprecated(note = "Use linearizer_mut")] // When removed, rename get_linearizer to linearizer
     pub fn linearizer(&mut self) -> &mut DelegatingLinearizer {
         self.linearizer_mut()
+    }
+
+    /// Allows access to the [Linearizer], e.g. for building [NodeTemplate::CompoundOp]s
+    pub fn get_linearizer(&self) -> &DelegatingLinearizer {
+        &self.linearize
     }
 
     /// Allows to configure how to deal with types/wires that were [Copyable]

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -185,7 +185,10 @@ impl ReplacementOptions {
     /// Specifies that the replacement should be processed by the same [ReplaceTypes].
     /// This increases compositionality (in that replacements for different ops do not
     /// need to account for each other), but would lead to an infinite loop if e.g.
-    /// changing an op for a DFG containing an instance of the same op.
+    /// changing an op for a DFG containing an instance of the same op. Also, note
+    /// that if the recursive processing changes the signature of the replacement,
+    /// this may break surrounding wires (e.g. from [Input] or to [Output] nodes)
+    /// because types are not subject to recursive replacement.
     pub fn with_recursive_replacement(mut self, rec: bool) -> Self {
         self.process_recursive = rec;
         self

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -403,10 +403,7 @@ impl ReplaceTypes {
         src: &OpDef,
         dest_fn: impl Fn(&[TypeArg]) -> Option<NodeTemplate> + 'static,
     ) {
-        self.param_ops.insert(
-            src.into(),
-            (Arc::new(dest_fn), ReplacementOptions::default()),
-        );
+        self.replace_parametrized_op_with(src, dest_fn, ReplacementOptions::default())
     }
 
     /// Configures this instance to change occurrences of a parametrized op `src`

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -748,7 +748,7 @@ mod test {
                     .into(),
             ),
         );
-        lw.replace_parametrized_op(ext.get_op(READ).unwrap().as_ref(), |type_args| {
+        lw.replace_parametrized_op_with(ext.get_op(READ).unwrap().as_ref(), |type_args, _| {
             Some(NodeTemplate::CompoundOp(Box::new(
                 lowered_read(just_elem_type(type_args).clone(), DFGBuilder::new)
                     .finish_hugr()
@@ -1028,9 +1028,9 @@ mod test {
             option_contents(just_elem_type(args)).map(list_type)
         });
         // and read<option<x>> to get<x> - the latter has the expected option<x> return type
-        lowerer.replace_parametrized_op(
+        lowerer.replace_parametrized_op_with(
             e.get_op(READ).unwrap().as_ref(),
-            Box::new(|args: &[TypeArg]| {
+            |args: &[TypeArg], _| {
                 option_contents(just_elem_type(args)).map(|elem| {
                     NodeTemplate::SingleOp(
                         ListOp::get
@@ -1040,7 +1040,7 @@ mod test {
                             .into(),
                     )
                 })
-            }),
+            },
         );
         assert!(lowerer.run(&mut h).unwrap());
         // list<usz>      -> read<usz>      -> usz just becomes list<qb> -> read<qb> -> qb
@@ -1134,7 +1134,7 @@ mod test {
             .inserted_entrypoint;
 
         let mut lw = lowerer(&e);
-        lw.replace_parametrized_op(e.get_op(READ).unwrap().as_ref(), move |args| {
+        lw.replace_parametrized_op_with(e.get_op(READ).unwrap().as_ref(), move |args, _| {
             Some(NodeTemplate::Call(read_func, args.to_owned()))
         });
         lw.run(&mut h).unwrap();

--- a/hugr-passes/src/replace_types/linearize.rs
+++ b/hugr-passes/src/replace_types/linearize.rs
@@ -55,7 +55,7 @@ pub trait Linearizer {
         let (tgt_node, tgt_inport) = if targets.len() == 1 {
             *targets.first().unwrap()
         } else {
-            // Fail fast if the edges are nonlocal. (TODO transform to local edges!)
+            // Fail fast if the edges are nonlocal.
             let src_parent = hugr
                 .get_parent(src.node())
                 .expect("Root node cannot have out edges");
@@ -147,7 +147,8 @@ pub enum LinearizeError {
         sig: Option<Box<Signature>>,
     },
     #[error(
-        "Cannot add nonlocal edge for linear type from {src} (with parent {src_parent}) to {tgt} (with parent {tgt_parent})"
+        "Cannot add nonlocal edge for linear type from {src} (with parent {src_parent}) to {tgt} (with parent {tgt_parent}).
+  Try using LocalizeEdges pass first."
     )]
     NoLinearNonLocalEdges {
         src: Node,

--- a/hugr-passes/src/replace_types/linearize.rs
+++ b/hugr-passes/src/replace_types/linearize.rs
@@ -455,7 +455,7 @@ mod test {
         let usize_custom_t = usize_t().as_extension().unwrap().clone();
         lowerer.replace_type(usize_custom_t, Type::new_extension(lin_custom_t.clone()));
         lowerer
-            .linearizer()
+            .linearizer_mut()
             .register_simple(
                 lin_custom_t,
                 NodeTemplate::SingleOp(copy_op.into()),
@@ -577,7 +577,7 @@ mod test {
         let opdef = e.get_op("copy").unwrap();
         let opdef2 = opdef.clone();
         lowerer
-            .linearizer()
+            .linearizer_mut()
             .register_callback(lin_t_def, move |args, num_outs, _| {
                 assert!(args.is_empty());
                 Ok(NodeTemplate::SingleOp(
@@ -639,7 +639,7 @@ mod test {
         let mut replacer = ReplaceTypes::default();
         replacer.replace_type(usize_t().as_extension().unwrap().clone(), lin_t.clone());
 
-        let bad_copy = replacer.linearizer().register_simple(
+        let bad_copy = replacer.linearizer_mut().register_simple(
             lin_ct.clone(),
             NodeTemplate::SingleOp(copy3.clone()),
             NodeTemplate::SingleOp(discard.clone().into()),
@@ -654,7 +654,7 @@ mod test {
             })
         );
 
-        let bad_discard = replacer.linearizer().register_simple(
+        let bad_discard = replacer.linearizer_mut().register_simple(
             lin_ct.clone(),
             NodeTemplate::SingleOp(copy2.into()),
             NodeTemplate::SingleOp(copy3.clone()),
@@ -671,7 +671,7 @@ mod test {
 
         // Try parametrized instead, but this version always returns 3 outports
         replacer
-            .linearizer()
+            .linearizer_mut()
             .register_callback(ext.get_type(LIN_T).unwrap(), move |_args, _, _| {
                 Ok(NodeTemplate::SingleOp(copy3.clone()))
             });
@@ -699,7 +699,7 @@ mod test {
         let (e, mut lowerer) = ext_lowerer();
 
         lowerer
-            .linearizer()
+            .linearizer_mut()
             .register_callback(value_array_type_def(), linearize_value_array);
         let lin_t = Type::from(e.get_type(LIN_T).unwrap().instantiate([]).unwrap());
         let opt_lin_ty = Type::from(option_type(lin_t.clone()));
@@ -817,7 +817,7 @@ mod test {
 
         let mut lower_discard_to_call = ReplaceTypes::default();
         lower_discard_to_call
-            .linearizer()
+            .linearizer_mut()
             .register_simple(
                 lin_ct.clone(),
                 NodeTemplate::Call(backup.entrypoint(), vec![]), // Arbitrary, unused

--- a/hugr-passes/src/replace_types/linearize.rs
+++ b/hugr-passes/src/replace_types/linearize.rs
@@ -52,8 +52,6 @@ pub trait Linearizer {
         src: Wire,
         targets: &[(Node, IncomingPort)],
     ) -> Result<(), LinearizeError> {
-        let sig = hugr.signature(src.node()).unwrap();
-        let typ = sig.port_type(src.source()).unwrap();
         let (tgt_node, tgt_inport) = if targets.len() == 1 {
             *targets.first().unwrap()
         } else {
@@ -74,7 +72,8 @@ pub trait Linearizer {
                     tgt_parent,
                 });
             }
-            let typ = typ.clone(); // Stop borrowing hugr in order to add_hugr to it
+            let sig = hugr.signature(src.node()).unwrap();
+            let typ = sig.port_type(src.source()).unwrap().clone();
             let copy_discard_op = self
                 .copy_discard_op(&typ, targets.len())?
                 .add_hugr(hugr, src_parent)

--- a/hugr-passes/src/replace_types/linearize.rs
+++ b/hugr-passes/src/replace_types/linearize.rs
@@ -876,7 +876,7 @@ mod test {
             },
         );
         let drop_op = drop_ext.get_op("drop").unwrap();
-        lowerer.replace_parametrized_op(drop_op, |args| {
+        lowerer.replace_parametrized_op_recursive(drop_op, |args| {
             let [TypeArg::Runtime(ty)] = args else {
                 panic!("Expected just one type")
             };
@@ -886,7 +886,6 @@ mod test {
             std::mem::swap(&mut h, dfb.hugr_mut());
             Some(NodeTemplate::CompoundOp(Box::new(h)))
         });
-        lowerer.process_replacements(true);
 
         let build_hugr = |ty: Type| {
             let mut dfb = DFGBuilder::new(Signature::new(ty.clone(), vec![])).unwrap();


### PR DESCRIPTION
* Add `replace_parametrized_op_with` and `replace_op_with` which allow specifying a ReplacementOptions struct
* For now, ReplacementOptions has only one option, to allow running the linearizer on all outports of the replacement
* Test demonstrates - of course the replacement Hugr is invalid (unconnected port) before linearization.