### PR TITLE
fix: StaticArrayVal payload encoding, improve roundtrip checker

### DIFF
--- a/hugr-py/src/hugr/std/collections/static_array.py
+++ b/hugr-py/src/hugr/std/collections/static_array.py
@@ -55,8 +55,8 @@ class StaticArrayVal(val.ExtensionValue):
         # into specialized `Value`s).
         serial_val = {
             "value": {
-                "values": [v._to_serial_root().model_dump_json() for v in self.v],
-                "typ": self.ty.ty._to_serial_root().model_dump_json(),
+                "values": [v._to_serial_root() for v in self.v],
+                "typ": self.ty.ty._to_serial_root(),
             },
             "name": self.name,
         }


### PR DESCRIPTION
The eager encoding of `StaticArrayVal`'s payload caused the nested values to be encoded as _escaped_ strings, causing errors on the rust decoder.

This PR rollbacks the changes to `StaticArrayVal` done in #2436 and adds a better workaround in the roundtrip test instead.