### PR TITLE
test: Enable model-exts for python roundtrip tests

### DIFF
--- a/hugr-py/tests/conftest.py
+++ b/hugr-py/tests/conftest.py
@@ -187,9 +187,11 @@ def validate(
         "json": EnvelopeConfig.TEXT,
         "model-exts": EnvelopeConfig.BINARY,
     }
-    # TODO: "model-exts" comes with its own variety of errors.
-    # Fix them and add it to the list of write formats.
-    WRITE_FORMATS = ["json"]
+    # Envelope formats used when exporting test hugrs.
+    WRITE_FORMATS = ["json", "model-exts"]
+    # Envelope formats used as target for `hugr convert` before loading back the
+    # test hugrs.
+    #
     # Model envelopes cannot currently be loaded from python.
     # TODO: Add model envelope loading to python, and add it to the list.
     LOAD_FORMATS = ["json"]


### PR DESCRIPTION
~Blocked by https://github.com/CQCL/hugr/issues/2454~
~Blocked by https://github.com/CQCL/hugr/issues/2464~
~Blocked by #2466~