### PR TITLE
feat: Inline calls to functions not on cycles in the call graph

### DIFF
--- a/hugr-passes/src/call_graph.rs
+++ b/hugr-passes/src/call_graph.rs
@@ -5,6 +5,7 @@ use hugr_core::{HugrView, Node, core::HugrNode, ops::OpType};
 use petgraph::Graph;
 
 /// Weight for an edge in a [`CallGraph`]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CallGraphEdge<N = Node> {
     /// Edge corresponds to a [Call](OpType::Call) node (specified) in the Hugr
     Call(N),

--- a/hugr-passes/src/inline_funcs.rs
+++ b/hugr-passes/src/inline_funcs.rs
@@ -1,8 +1,9 @@
-/// Pass to inline calls to selected functions in a Hugr.
+//! Contains a pass to inline calls to selected functions in a Hugr.
 use std::collections::{HashSet, VecDeque};
 
 use hugr_core::hugr::hugrmut::HugrMut;
 use hugr_core::hugr::patch::inline_call::{InlineCall, InlineCallError};
+use itertools::Itertools;
 use petgraph::algo::tarjan_scc;
 
 use crate::call_graph::{CallGraph, CallGraphNode};
@@ -24,6 +25,9 @@ pub enum InlineAllError<N> {
 /// may be created as a result of inlining and so may not have existed in the input
 /// Hugr).
 ///
+/// If `target_funcs` is empty, rather than inlining no functions, inline all
+/// possible functions (i.e. all that are part of a cycle).
+///
 /// # Errors
 ///
 /// [InlineAllError::FunctionOnCycle] if any element of `target_funcs` is in a cycle
@@ -33,25 +37,34 @@ pub enum InlineAllError<N> {
 /// [FuncDefn]: hugr_core::ops::FuncDefn
 pub fn inline_acyclic<H: HugrMut>(
     h: &mut H,
-    cg: CallGraph<H::Node>,
     target_funcs: HashSet<H::Node>, // If empty, inline ALL
-    filt_func: impl Fn(H::Node, H::Node) -> bool,
+    filt_func: impl Fn(&H, H::Node, H::Node) -> bool,
 ) -> Result<(), InlineAllError<H::Node>> {
+    let cg = CallGraph::new(&*h);
     let g = cg.graph();
-    let sccs = tarjan_scc(g)
+    let sccs = tarjan_scc(g);
+    let sccs = sccs
         .into_iter()
-        .map(|ns| {
-            ns.into_iter()
-                .map(|n| {
-                    let CallGraphNode::FuncDefn(fd) = g.node_weight(n).unwrap() else {
-                        panic!("Expected only FuncDefns in sccs")
-                    };
-                    *fd
-                })
-                .collect::<Vec<_>>()
+        .filter_map(|ns| {
+            if let Ok(n) = ns.iter().exactly_one() {
+                if g.edges_connecting(*n, *n).next().is_none() {
+                    return None; // A 1-node SCC might be a cycle, but this is just a node.
+                }
+            }
+            Some(
+                ns.into_iter()
+                    .map(|n| {
+                        let CallGraphNode::FuncDefn(fd) = g.node_weight(n).unwrap() else {
+                            panic!("Expected only FuncDefns in sccs")
+                        };
+                        *fd
+                    })
+                    .collect::<Vec<_>>(),
+            )
         })
         .collect::<Vec<_>>();
     let all_sccs: HashSet<_> = sccs.iter().cloned().flatten().collect();
+    eprintln!("ALAN {all_sccs:?}");
     let target_funcs = if target_funcs.is_empty() {
         h.children(h.module_root())
             .filter(|n| !all_sccs.contains(n))
@@ -66,7 +79,11 @@ pub fn inline_acyclic<H: HugrMut>(
     while let Some(n) = q.pop_front() {
         if h.get_optype(n).is_call() {
             if let Some(t) = h.static_source(n) {
-                if target_funcs.contains(&t) && filt_func(n, t) {
+                if target_funcs.contains(&t) && filt_func(&h, n, t) {
+                    eprintln!(
+                        "ALAN inlining call {n} to {t}=={}",
+                        h.get_optype(t).as_func_defn().unwrap().func_name()
+                    );
                     h.apply_patch(InlineCall::new(n)).unwrap();
                 }
             }
@@ -75,4 +92,146 @@ pub fn inline_acyclic<H: HugrMut>(
         q.extend(h.children(n));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashSet;
+
+    use petgraph::visit::EdgeRef;
+
+    use hugr_core::HugrView;
+    use hugr_core::builder::{Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder};
+    use hugr_core::{Hugr, extension::prelude::qb_t, types::Signature};
+    use rstest::rstest;
+
+    use crate::call_graph::{CallGraph, CallGraphNode};
+    use crate::inline_funcs::{InlineAllError, inline_acyclic};
+
+    ///          /->-\
+    /// main -> f     g -> a -> b
+    ///        / \-<-/
+    ///       /
+    ///       \-> c -> d
+    fn test_hugr() -> Hugr {
+        let sig = || Signature::new_endo(qb_t());
+        let mut mb = ModuleBuilder::new();
+        let b = {
+            let fb = mb.define_function("b", sig()).unwrap();
+            let ins = fb.input_wires();
+            fb.finish_with_outputs(ins).unwrap()
+        };
+        let a = {
+            let mut fb = mb.define_function("a", sig()).unwrap();
+            let ins = fb.input_wires();
+            let res = fb.call(b.handle(), &[], ins).unwrap().outputs();
+            fb.finish_with_outputs(res).unwrap()
+        };
+        let d = {
+            let fb = mb.define_function("d", sig()).unwrap();
+            let ins = fb.input_wires();
+            fb.finish_with_outputs(ins).unwrap()
+        };
+        let c = {
+            let mut fb = mb.define_function("c", sig()).unwrap();
+            let ins = fb.input_wires();
+            let res = fb.call(d.handle(), &[], ins).unwrap().outputs();
+            fb.finish_with_outputs(res).unwrap()
+        };
+        let f = mb.declare("f", sig().into()).unwrap();
+        let g = {
+            let mut fb = mb.define_function("g", sig()).unwrap();
+            let ins = fb.input_wires();
+            let c1 = fb.call(&f, &[], ins).unwrap();
+            let c2 = fb.call(a.handle(), &[], c1.outputs()).unwrap();
+            fb.finish_with_outputs(c2.outputs()).unwrap()
+        };
+        let _f = {
+            let mut fb = mb.define_declaration(&f).unwrap();
+            let ins = fb.input_wires();
+            let c1 = fb.call(g.handle(), &[], ins).unwrap();
+            let c2 = fb.call(c.handle(), &[], c1.outputs()).unwrap();
+            fb.finish_with_outputs(c2.outputs()).unwrap()
+        };
+        mb.finish_hugr().unwrap()
+    }
+
+    fn find_func<H: HugrView>(h: &H, name: &str) -> H::Node {
+        h.children(h.module_root())
+            .find(|n| {
+                h.get_optype(*n)
+                    .as_func_defn()
+                    .is_some_and(|fd| fd.func_name() == name)
+            })
+            .unwrap()
+    }
+
+    #[rstest]
+    #[case(["f"], "f")]
+    #[case(["g", "a", "b", "d"], "g")]
+    fn test_cycles(
+        #[case] funcs: impl IntoIterator<Item = &'static str>,
+        #[case] exp_err: &'static str,
+    ) {
+        let h = test_hugr();
+        let target_funcs = funcs.into_iter().map(|name| find_func(&h, name)).collect();
+        let mut h2 = h.clone();
+        let r = inline_acyclic(&mut h2, target_funcs, |_, _, _| panic!());
+        assert_eq!(h, h2); // Did nothing
+        let Err(InlineAllError::FunctionOnCycle(tgt, scc)) = r else {
+            panic!()
+        };
+        assert_eq!(
+            h.get_optype(tgt).as_func_defn().unwrap().func_name(),
+            exp_err
+        );
+        let [f, g] = ["f", "g"].map(|n| find_func(&h, n));
+        assert_eq!(HashSet::from([f, g]), HashSet::from_iter(scc));
+    }
+
+    #[rstest]
+    #[case([], ["a", "b", "c", "d"], [("f", vec!["g"]), ("g", vec!["f"]), ("c", vec![]), ("a", vec![])])]
+    #[case(["a", "c"], ["a", "c"], [("f", vec!["g", "d"]), ("g", vec!["f", "b"]), ("c", vec!["d"]), ("a", vec!["b"])])]
+    fn test_inline(
+        #[case] req: impl IntoIterator<Item = &'static str>,
+        #[case] check_not_called: impl IntoIterator<Item = &'static str>,
+        #[case] check_calls: impl IntoIterator<Item = (&'static str, Vec<&'static str>)>,
+    ) {
+        let mut h = test_hugr();
+        let target_funcs = req.into_iter().map(|name| find_func(&h, name)).collect();
+        inline_acyclic(&mut h, target_funcs, |_, _, _| true).unwrap();
+        let cg = CallGraph::new(&h);
+        for fname in check_not_called {
+            let fnode = find_func(&h, fname);
+            let fnode = cg.node_index(fnode).unwrap();
+            assert_eq!(
+                None,
+                cg.graph()
+                    .edges_directed(fnode, petgraph::Direction::Incoming)
+                    .next()
+            );
+        }
+        for (fname, tgts) in check_calls {
+            let fnode = find_func(&h, fname);
+            let fnode = cg.node_index(fnode).unwrap();
+            assert_eq!(
+                cg.graph()
+                    .edges_directed(fnode, petgraph::Direction::Outgoing)
+                    .map(|e| {
+                        let Some(CallGraphNode::FuncDefn(fd)) = cg.graph().node_weight(e.target())
+                        else {
+                            panic!()
+                        };
+
+                        match h.get_optype(*fd) {
+                            hugr_core::ops::OpType::FuncDefn(fd) => fd.func_name().as_str(),
+                            o => panic!("Expected funcdefn, got {o}"),
+                        }
+                    })
+                    .collect::<HashSet<_>>(),
+                HashSet::from_iter(tgts),
+                "Calls from {fname}"
+            );
+        }
+    }
 }

--- a/hugr-passes/src/inline_funcs.rs
+++ b/hugr-passes/src/inline_funcs.rs
@@ -1,0 +1,74 @@
+use std::collections::{HashMap, HashSet};
+
+use hugr_core::hugr::{hugrmut::HugrMut, patch::inline_call::InlineCall};
+use petgraph::{Direction, algo::tarjan_scc, visit::EdgeRef};
+
+use crate::call_graph::{CallGraph, CallGraphEdge, CallGraphNode};
+
+/// Inline all [Call]s except those to functions in cycles on the call graph,
+/// and subject to a filter function that is given the [Call] node and the target
+/// [FuncDefn] node.
+///
+/// [Call]: hugr_core::ops::Call
+/// [FuncDefn]: hugr_core::ops::FuncDefn
+pub fn inline_acyclic<H: HugrMut>(
+    h: &mut H,
+    cg: CallGraph<H::Node>,
+    filt_func: impl Fn(H::Node, H::Node) -> bool,
+) {
+    let g = cg.graph();
+    let sccs = tarjan_scc(cg.graph());
+    let all_sccs: HashSet<_> = sccs.iter().flatten().collect::<HashSet<_>>();
+    if h.entrypoint() == h.module_root() {
+        // Can modify everywhere. Traverse post-order (callee before caller).
+        enum Status {
+            PushChildren,
+            Todo,
+            Done,
+        }
+        let mut status: HashMap<_, _> = g
+            .node_indices()
+            .map(|n| (n, Status::PushChildren))
+            .collect();
+        let mut stack: Vec<_> = h
+            .children(h.module_root())
+            .map(|n| cg.node_index(n).unwrap())
+            .collect();
+        while let Some(func) = stack.pop() {
+            let edges = cg
+                .graph()
+                .edges_directed(func, Direction::Outgoing)
+                .filter_map(|e| {
+                    assert_eq!(e.source(), func);
+                    let d = e.target();
+                    (!all_sccs.contains(&d)).then_some((g.edge_weight(e.id()).unwrap(), d))
+                });
+            match status.get(&func).unwrap() {
+                Status::Done => (),
+                Status::PushChildren => {
+                    stack.push(func);
+                    status.insert(func, Status::Todo);
+                    stack.extend(edges.map(|(_, tgt)| tgt));
+                }
+                Status::Todo => {
+                    // Callees have all been inlined.
+                    for (edge, callee) in edges {
+                        let tgt_func: H::Node = match g.node_weight(callee).unwrap() {
+                            CallGraphNode::FuncDecl(_) => continue,
+                            CallGraphNode::FuncDefn(n) => *n,
+                            CallGraphNode::NonFuncRoot => unreachable!("Call to non-func"),
+                        };
+                        if let CallGraphEdge::Call(n) = edge {
+                            if filt_func(*n, tgt_func) {
+                                h.apply_patch(InlineCall::new(tgt_func)).unwrap();
+                            }
+                        }
+                    }
+                    status.insert(func, Status::Done);
+                }
+            }
+        }
+    } else {
+        todo!() // Can only modify inside entrypoint. But, can keep inlining.
+    }
+}

--- a/hugr-passes/src/inline_funcs.rs
+++ b/hugr-passes/src/inline_funcs.rs
@@ -1,65 +1,78 @@
-use std::collections::HashSet;
+/// Pass to inline calls to selected functions in a Hugr.
+use std::collections::{HashSet, VecDeque};
 
-use hugr_core::hugr::{hugrmut::HugrMut, patch::inline_call::InlineCall};
-use petgraph::{Direction, algo::tarjan_scc, visit::EdgeRef};
+use hugr_core::hugr::hugrmut::HugrMut;
+use hugr_core::hugr::patch::inline_call::{InlineCall, InlineCallError};
+use petgraph::algo::tarjan_scc;
 
-use crate::call_graph::{CallGraph, CallGraphEdge, CallGraphNode};
+use crate::call_graph::{CallGraph, CallGraphNode};
 
-/// Inline all [Call]s except those to functions in cycles on the call graph,
-/// and subject to a filter function that is given the [Call] node and the target
-/// [FuncDefn] node.
+/// Error raised by [inline_acyclic]
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum InlineAllError<N> {
+    /// Raised to indicate a request to inline calls to a function that is part of an SCC
+    /// in the call graph.
+    #[error("Cannot inline calls to {0} as in a cycle {1:?}")]
+    FunctionOnCycle(N, Vec<N>),
+    /// An error inlining a call.
+    #[error(transparent)]
+    InlineCallError(#[from] InlineCallError),
+}
+
+/// Inline all [Call]s to the specified `target_funcs` subject to a filter function
+/// that is given the [Call] node and the target [FuncDefn] node. (Note the [Call]
+/// may be created as a result of inlining and so may not have existed in the input
+/// Hugr).
+///
+/// # Errors
+///
+/// [InlineAllError::FunctionOnCycle] if any element of `target_funcs` is in a cycle
+/// in the call graph
 ///
 /// [Call]: hugr_core::ops::Call
 /// [FuncDefn]: hugr_core::ops::FuncDefn
 pub fn inline_acyclic<H: HugrMut>(
     h: &mut H,
     cg: CallGraph<H::Node>,
+    target_funcs: HashSet<H::Node>, // If empty, inline ALL
     filt_func: impl Fn(H::Node, H::Node) -> bool,
-) {
+) -> Result<(), InlineAllError<H::Node>> {
     let g = cg.graph();
-    let sccs = tarjan_scc(cg.graph());
-    let all_sccs: HashSet<_> = sccs.iter().flatten().collect::<HashSet<_>>();
-    if h.entrypoint() == h.module_root() {
-        // Can modify everywhere. Traverse post-order (callee before caller).
-        let mut seen = HashSet::new();
-        let mut stack: Vec<_> = h
-            .children(h.module_root())
-            .map(|n| (cg.node_index(n).unwrap(), false))
-            .collect();
-        while let Some((func, children_done)) = stack.pop() {
-            let edges = cg
-                .graph()
-                .edges_directed(func, Direction::Outgoing)
-                .filter_map(|e| {
-                    assert_eq!(e.source(), func);
-                    let d = e.target();
-                    (!all_sccs.contains(&d)).then_some((g.edge_weight(e.id()).unwrap(), d))
-                });
-            if !children_done {
-                stack.push((func, true));
-                stack.extend(edges.map(|(_, tgt)| (tgt, false)));
-                // We know no tgt can push `func` because we have already filtered out cycles
-                continue
-            }
-            // Callees have all been processed.
-            if !seen.insert(func) { continue } // Caller has too!
-            for (edge, callee) in edges {
-                let tgt_func: H::Node = match g.node_weight(callee).unwrap() {
-                    CallGraphNode::FuncDecl(_) => continue,
-                    CallGraphNode::FuncDefn(n) => *n,
-                    CallGraphNode::NonFuncRoot => unreachable!("Call to non-func"),
-                };
-                if let CallGraphEdge::Call(n) = edge {
-                    // If we've processed `func` already, the calls will have become DFGs
-                    assert_eq!(h.static_source(*n), Some(tgt_func));
-                    if filt_func(*n, tgt_func) {
-                        h.apply_patch(InlineCall::new(tgt_func)).unwrap();
-                    }
+    let sccs = tarjan_scc(g)
+        .into_iter()
+        .map(|ns| {
+            ns.into_iter()
+                .map(|n| {
+                    let CallGraphNode::FuncDefn(fd) = g.node_weight(n).unwrap() else {
+                        panic!("Expected only FuncDefns in sccs")
+                    };
+                    *fd
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let all_sccs: HashSet<_> = sccs.iter().cloned().flatten().collect();
+    let target_funcs = if target_funcs.is_empty() {
+        h.children(h.module_root())
+            .filter(|n| !all_sccs.contains(n))
+            .collect()
+    } else if let Some(n) = target_funcs.intersection(&all_sccs).next() {
+        let scc = sccs.iter().find(|ns| ns.as_slice().contains(n)).unwrap();
+        return Err(InlineAllError::FunctionOnCycle(*n, scc.clone()));
+    } else {
+        target_funcs
+    };
+    let mut q = VecDeque::from([h.entrypoint()]);
+    while let Some(n) = q.pop_front() {
+        if h.get_optype(n).is_call() {
+            if let Some(t) = h.static_source(n) {
+                if target_funcs.contains(&t) && filt_func(n, t) {
+                    h.apply_patch(InlineCall::new(n)).unwrap();
                 }
             }
-            
         }
-    } else {
-        todo!() // Can only modify inside entrypoint. But, can keep inlining.
+        // If that was a call, `n` is now a DFG containing the function body, so explore inside
+        q.extend(h.children(n));
     }
+    Ok(())
 }

--- a/hugr-passes/src/inline_funcs.rs
+++ b/hugr-passes/src/inline_funcs.rs
@@ -42,8 +42,7 @@ pub fn inline_acyclic<H: HugrMut>(
 ) -> Result<(), InlineAllError<H::Node>> {
     let cg = CallGraph::new(&*h);
     let g = cg.graph();
-    let sccs = tarjan_scc(g);
-    let sccs = sccs
+    let sccs = tarjan_scc(g)
         .into_iter()
         .filter_map(|ns| {
             if let Ok(n) = ns.iter().exactly_one() {
@@ -64,7 +63,6 @@ pub fn inline_acyclic<H: HugrMut>(
         })
         .collect::<Vec<_>>();
     let all_sccs: HashSet<_> = sccs.iter().cloned().flatten().collect();
-    eprintln!("ALAN {all_sccs:?}");
     let target_funcs = if target_funcs.is_empty() {
         h.children(h.module_root())
             .filter(|n| !all_sccs.contains(n))
@@ -80,10 +78,6 @@ pub fn inline_acyclic<H: HugrMut>(
         if h.get_optype(n).is_call() {
             if let Some(t) = h.static_source(n) {
                 if target_funcs.contains(&t) && filt_func(&h, n, t) {
-                    eprintln!(
-                        "ALAN inlining call {n} to {t}=={}",
-                        h.get_optype(t).as_func_defn().unwrap().func_name()
-                    );
                     h.apply_patch(InlineCall::new(n)).unwrap();
                 }
             }
@@ -222,11 +216,11 @@ mod test {
                         else {
                             panic!()
                         };
-
-                        match h.get_optype(*fd) {
-                            hugr_core::ops::OpType::FuncDefn(fd) => fd.func_name().as_str(),
-                            o => panic!("Expected funcdefn, got {o}"),
-                        }
+                        h.get_optype(*fd)
+                            .as_func_defn()
+                            .unwrap()
+                            .func_name()
+                            .as_str()
                     })
                     .collect::<HashSet<_>>(),
                 HashSet::from_iter(tgts),

--- a/hugr-passes/src/inline_funcs.rs
+++ b/hugr-passes/src/inline_funcs.rs
@@ -11,6 +11,7 @@ use crate::call_graph::{CallGraph, CallGraphNode};
 
 /// Error raised by [inline_acyclic]
 #[derive(Clone, Debug, thiserror::Error, PartialEq)]
+#[non_exhaustive]
 pub enum InlineAllError<N> {
     /// Raised to indicate a request to inline calls to a node that is not a FuncDefn
     #[error("Can only inline calls to FuncDefns; {0} is a {1:?}")]

--- a/hugr-passes/src/inline_funcs.rs
+++ b/hugr-passes/src/inline_funcs.rs
@@ -200,6 +200,7 @@ mod test {
     #[rstest]
     #[case([], ["a", "b", "c", "d"], [("f", vec!["g"]), ("g", vec!["f", "x"]), ("c", vec![]), ("a", vec!["x"])])]
     #[case(["a", "c"], ["a", "c"], [("f", vec!["g", "d"]), ("g", vec!["f", "b"]), ("c", vec!["d"]), ("a", vec!["b"])])]
+    #[case(["b", "d"], ["b", "d"], [("f", vec!["g", "c"]), ("g", vec!("f", "a")), ("a", vec!["x"]), ("c", vec![])])]
     fn test_inline(
         #[case] req: impl IntoIterator<Item = &'static str>,
         #[case] check_not_called: impl IntoIterator<Item = &'static str>,

--- a/hugr-passes/src/lib.rs
+++ b/hugr-passes/src/lib.rs
@@ -11,6 +11,7 @@ mod dead_funcs;
 pub use dead_funcs::{RemoveDeadFuncsError, RemoveDeadFuncsPass, remove_dead_funcs};
 pub mod force_order;
 mod half_node;
+pub mod inline_funcs;
 pub mod linearize_array;
 pub use linearize_array::LinearizeArrayPass;
 pub mod lower;


### PR DESCRIPTION
Allows filtering via a callback.
* Note the final commit 27194cf7fbfd80f43671f079f7b6482221be66f5 removes a `target_funcs: HashSet<Node>` that I had before, as you can emulate this just by a callback `|_,_,tgt| mySet.contains(&tgt)`, and that saves a massive amount of code. See the LHS! However, maybe that code is worth having?
* The `#[non_exhaustive]` but empty error is gonna be annoying, I am tempted to remove it (and use Infallible) unless we decide the `target_funcs` is worth having
* No `ComposablePass` yet....it should be pretty easy to add (containing a Box/Arc of `dyn`)