### PR TITLE
chore(deps-rs): Bump portgraph to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,9 +2178,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portgraph"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3112e4b1e107ff15507baeb67417f2eacbb3de476f1175c2846b1305d9848b"
+checksum = "61fb905fbfbc9abf3bd37853bbd4b25d31dffd5631994f8df528f85455085657"
 dependencies = [
  "bitvec",
  "delegate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ wyhash = "0.6.0"
 # These public dependencies usually require breaking changes downstream, so we
 # try to be as permissive as possible.
 pyo3 = ">= 0.23.4, < 0.25"
-portgraph = { version = "0.15.0" }
+portgraph = { version = "0.15.1" }
 petgraph = { version = ">= 0.8.1, < 0.9", default-features = false }
 
 [profile.dev.package]

--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -79,7 +79,7 @@ impl<T: DeserializeOwned> Versioned<T> {
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 struct NodeSer {
     /// Node index of the parent.
-    parent: usize,
+    parent: Node,
     #[serde(flatten)]
     op: OpType,
 }
@@ -90,7 +90,7 @@ struct SerHugrLatest {
     /// For each node: (parent, `node_operation`)
     nodes: Vec<NodeSer>,
     /// for each edge: (src, `src_offset`, tgt, `tgt_offset`)
-    edges: Vec<[(usize, Option<u32>); 2]>,
+    edges: Vec<[(Node, Option<u32>); 2]>,
     /// for each node: (metadata)
     #[serde(default)]
     metadata: Option<Vec<Option<NodeMetadataMap>>>,
@@ -102,7 +102,7 @@ struct SerHugrLatest {
     /// For backwards compatibility, if `None` the entrypoint is set to the root
     /// of the node hierarchy.
     #[serde(default)]
-    entrypoint: Option<usize>,
+    entrypoint: Option<Node>,
 }
 
 /// Errors that can occur while serializing a HUGR.
@@ -201,7 +201,7 @@ impl TryFrom<&Hugr> for SerHugrLatest {
             let opt = hugr.get_optype(n);
             let new_node = node_rekey[&n].index();
             nodes[new_node] = Some(NodeSer {
-                parent: parent.index(),
+                parent,
                 op: opt.clone(),
             });
             metadata[new_node].clone_from(hugr.metadata.get(n.into_portgraph()));
@@ -211,14 +211,13 @@ impl TryFrom<&Hugr> for SerHugrLatest {
             .collect::<Option<Vec<_>>>()
             .expect("Could not reach one of the nodes");
 
-        let find_offset =
-            |node: Node, offset: usize, dir: Direction, hugr: &Hugr| -> (usize, Option<u32>) {
-                let op = hugr.get_optype(node);
-                let is_value_port = offset < op.value_port_count(dir);
-                let is_static_input = op.static_port(dir).is_some_and(|p| p.index() == offset);
-                let offset = (is_value_port || is_static_input).then_some(offset as u32);
-                (node_rekey[&node].index(), offset)
-            };
+        let find_offset = |node: Node, offset: usize, dir: Direction, hugr: &Hugr| {
+            let op = hugr.get_optype(node);
+            let is_value_port = offset < op.value_port_count(dir);
+            let is_static_input = op.static_port(dir).is_some_and(|p| p.index() == offset);
+            let offset = (is_value_port || is_static_input).then_some(offset as u32);
+            (node_rekey[&node], offset)
+        };
 
         let edges: Vec<_> = hugr
             .nodes()
@@ -242,7 +241,7 @@ impl TryFrom<&Hugr> for SerHugrLatest {
             edges,
             metadata: Some(metadata),
             encoder,
-            entrypoint: Some(node_rekey[&hugr.entrypoint()].index()),
+            entrypoint: Some(node_rekey[&hugr.entrypoint()]),
         })
     }
 }
@@ -265,8 +264,7 @@ impl TryFrom<SerHugrLatest> for Hugr {
             op: root_type,
             ..
         } = nodes.next().unwrap();
-        if root_parent != 0 {
-            let root_parent = portgraph::NodeIndex::new(root_parent).into();
+        if root_parent.index() != 0 {
             return Err(HUGRSerializationError::FirstNodeNotRoot(root_parent));
         }
         // if there are any unconnected ports or copy nodes the capacity will be
@@ -277,12 +275,11 @@ impl TryFrom<SerHugrLatest> for Hugr {
         // encoded file did not have a module at the root), we need a function
         // to map the node indices.
         let padding_nodes = hugr.entrypoint.index();
-        let hugr_node = |node: usize| -> Node {
-            portgraph::NodeIndex::new(node.index() + padding_nodes).into()
-        };
+        let hugr_node =
+            |node: Node| -> Node { portgraph::NodeIndex::new(node.index() + padding_nodes).into() };
 
         for node_ser in nodes {
-            hugr.add_node_with_parent(hugr_node(node_ser.parent), node_ser.op);
+            hugr.add_node_with_parent(node_ser.parent, node_ser.op);
         }
 
         if let Some(entrypoint) = entrypoint {
@@ -292,7 +289,7 @@ impl TryFrom<SerHugrLatest> for Hugr {
         if let Some(metadata) = metadata {
             for (node_idx, metadata) in metadata.into_iter().enumerate() {
                 if let Some(metadata) = metadata {
-                    let node = hugr_node(node_idx);
+                    let node = hugr_node(portgraph::NodeIndex::new(node_idx).into());
                     hugr.metadata[node.into_portgraph()] = Some(metadata);
                 }
             }

--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -279,7 +279,7 @@ impl TryFrom<SerHugrLatest> for Hugr {
             |node: Node| -> Node { portgraph::NodeIndex::new(node.index() + padding_nodes).into() };
 
         for node_ser in nodes {
-            hugr.add_node_with_parent(node_ser.parent, node_ser.op);
+            hugr.add_node_with_parent(hugr_node(node_ser.parent), node_ser.op);
         }
 
         if let Some(entrypoint) = entrypoint {

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -607,7 +607,7 @@ fn roundtrip_polyfunctype_varlen(#[case] poly_func_type: PolyFuncTypeRV) {
 #[case(ops::CallIndirect { signature : Signature::new_endo(vec![bool_t()]) })]
 fn roundtrip_optype(#[case] optype: impl Into<OpType> + std::fmt::Debug) {
     check_testing_roundtrip(NodeSer {
-        parent: 0,
+        parent: portgraph::NodeIndex::new(0).into(),
         op: optype.into(),
     });
 }
@@ -636,7 +636,10 @@ mod proptest {
         type Parameters = ();
         type Strategy = BoxedStrategy<Self>;
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            ((0..i32::MAX as usize), any::<OpType>())
+            (
+                (0..i32::MAX as usize).prop_map(|x| portgraph::NodeIndex::new(x).into()),
+                any::<OpType>(),
+            )
                 .prop_map(|(parent, op)| {
                     if let OpType::ExtensionOp(ext_op) = op {
                         let opaque: OpaqueOp = ext_op.into();

--- a/hugr-persistent/src/state_space.rs
+++ b/hugr-persistent/src/state_space.rs
@@ -35,7 +35,7 @@ pub type CommitId = relrc::NodeId;
 #[derive(
     Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,
 )]
-pub struct PatchNode(pub CommitId, #[serde(with = "serialize_node")] pub Node);
+pub struct PatchNode(pub CommitId, pub Node);
 
 impl PatchNode {
     /// Get the commit ID of the commit that owns this node.
@@ -54,22 +54,6 @@ impl std::fmt::Debug for PatchNode {
 impl std::fmt::Display for PatchNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")
-    }
-}
-
-/// Helper for to serialize and deserialize nodes as their usize index.
-mod serialize_node {
-    use hugr_core::{Node, NodeIndex};
-    use serde::{Deserialize, Serialize};
-    use serde::{Deserializer, Serializer};
-
-    pub fn serialize<S: Serializer>(v: &Node, s: S) -> Result<S::Ok, S::Error> {
-        v.index().serialize(s)
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Node, D::Error> {
-        let index = usize::deserialize(d)?;
-        Ok(Node::from(portgraph::NodeIndex::new(index)))
     }
 }
 


### PR DESCRIPTION
We reverted the serialisation changes in portgraph and yanked the `15.0` release. We can thus revert the serialisation patches of https://github.com/CQCL/hugr/pull/2455.

~There are some breaking tests that I do not yet understand. Will look into these next.~

EDIT: all tests have been fixed.
