### PR TITLE
ci: Disable zstd for miri tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+
+
+[profile.default-miri]
+# Fail if tests take more than 5 mins.
+# Those tests should be skipped in `.github/workflows/unsondness.yml`.
+slow-timeout = { period = "60s", terminate-after = 5 }
+fail-fast = false

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -34,8 +34,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v0-miri
+
+      # Run miri unsoundness checks.
+      #
+      # The default "zstd" feature requires FFI to the zstd library encode/decode envelopes.
+      # As this is not supported in miri, we must disable it here.
       - name: Test with Miri
-        run: cargo miri test
+        run: cargo miri test --no-default-features
 
 
   create-issue:

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -40,9 +40,44 @@ jobs:
       #
       # The default "zstd" feature requires FFI to the zstd library encode/decode envelopes.
       # As this is not supported in miri, we must disable it here.
+      #
+      # We also skip tests that take over 5mins in CI.
       - name: Test with Miri
-        run: cargo miri nextest run --no-default-features
-
+        run: |
+          cargo miri nextest run --no-default-features -- \
+            --skip "builder::circuit::test::with_nonlinear_and_outputs" \
+            --skip "extension::op_def::test::check_ext_id_wellformed" \
+            --skip "extension::resolution::test::register_new_cyclic" \
+            --skip "extension::simple_op::test::check_ext_id_wellformed" \
+            --skip "extension::test::test_register_update" \
+            --skip "extension::type_def::test::test_instantiate_typedef" \
+            --skip "hugr::ident::test::proptest::arbitrary_identlist_valid" \
+            --skip "hugr::ident::test::test_idents" \
+            --skip "hugr::patch::replace::test::test_invalid" \
+            --skip "hugr::validate::test::check_ext_id_wellformed" \
+            --skip "ops::constant::test::test_json_const" \
+            --skip "ops::custom::test::resolve_missing" \
+            --skip "ops::custom::test::new_opaque_op" \
+            --skip "std_extensions::arithmetic::int_types::test::proptest::valid_signed_int" \
+            --skip "types::test::construct" \
+            --skip "types::test::transform" \
+            --skip "types::test::transform_copyable_to_linear" \
+            --skip "types::type_param::test::proptest::term_contains_itself" \
+            `# -------- hugr-model` \
+            --skip "v0::test::test_literal_text" \
+            `# -------- hugr-passes` \
+            --skip "dataflow::partial_value::test::bounded_lattice" \
+            --skip "dataflow::partial_value::test::lattice" \
+            --skip "dataflow::partial_value::test::lattice_associative" \
+            --skip "dataflow::partial_value::test::meet_join_self_noop" \
+            --skip "dataflow::partial_value::test::partial_value_type" \
+            --skip "dataflow::partial_value::test::partial_value_valid" \
+            --skip "merge_bbs::test::check_ext_id_wellformed" \
+            --skip "monomorphize::test::test_recursion_module" \
+            --skip "replace_types::test::dfg_conditional_case" \
+            --skip "replace_types::test::module_func_cfg_call" \
+            --skip "replace_types::test::op_to_call" \
+            #
 
   create-issue:
     uses: CQCL/hugrverse-actions/.github/workflows/create-issue.yml@main

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -31,16 +31,17 @@ jobs:
           rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
-      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@v2
         with:
-          prefix-key: v0-miri
+          tool: nextest
 
       # Run miri unsoundness checks.
       #
       # The default "zstd" feature requires FFI to the zstd library encode/decode envelopes.
       # As this is not supported in miri, we must disable it here.
       - name: Test with Miri
-        run: cargo miri test --no-default-features
+        run: cargo miri nextest run --no-default-features
 
 
   create-issue:

--- a/hugr-core/src/envelope/serde_with.rs
+++ b/hugr-core/src/envelope/serde_with.rs
@@ -573,6 +573,7 @@ mod test {
     #[case::text_hugr_legacy_hugr(TextHugr::default(), decode::<LegacyHugr>, true)]
     #[case::bin_pkg_legacy_hugr(BinaryPkg::default(), decode::<LegacyHugr>, true)]
     #[case::bin_hugr_legacy_hugr(BinaryHugr::default(), decode::<LegacyHugr>, true)]
+    #[cfg_attr(all(miri, feature = "zstd"), ignore)] // FFI calls (required to compress with zstd) are not supported in miri
     fn check_format_compatibility(
         #[case] encoder: impl serde::Serialize,
         #[case] decoder: fn(String) -> Result<(), serde_json::Error>,


### PR DESCRIPTION
Fixes #2457

Ci run: https://github.com/CQCL/hugr/actions/runs/16420064018/job/46395888590

drive-by: Use `nextest` for miri runs. This way we can use multiple threads for testing, and we also report each test duration in the log (so we know if any is particularly long and should be skipped).
    See https://nexte.st/docs/integrations/miri/#benefits
    
drive-by: Skip tests that take over 5mins to run (See linked CI run, most test take 10-20s).
  In general any test defining new extensions seems to be really slow. Things dealing with `Term::is_supertype` also seem slow.
  I don't know if that's because of miri, or because of Hugr...
<img width="724" height="88" alt="image" src="https://github.com/user-attachments/assets/6edcdd28-5f47-4c1c-adf7-6fc2f0fde485" />

With the improved parallelism and skipped tests the unsoundness test now takes <1h rather than 5h :)