### PR TITLE
DRAFT: hugr-llvm: make default function linkage to private

### DIFF
--- a/hugr-llvm/src/emit.rs
+++ b/hugr-llvm/src/emit.rs
@@ -134,7 +134,7 @@ impl<'c, 'a, H> EmitModuleContext<'c, 'a, H> {
             .ok_or(anyhow!("function has type params"))?;
         let llvm_func_ty = self.llvm_func_type(func_ty)?;
         let name = self.name_func(name, node);
-        self.get_func_impl(name, llvm_func_ty, None)
+        self.get_func_impl(name, llvm_func_ty, Some(Linkage::Private))
     }
 
     /// Adds or gets the [`FunctionValue`] in the [Module] corresponding to the given [`FuncDefn`].


### PR DESCRIPTION
This PR is related to [this deadcode issue](https://github.com/quantinuum-dev/eldarion/issues/360) found in eldarion.

In hugr-llvm, the previous implementation defaults all the llvm functions except for extern functions to have `None` linkage, and as a result, after the optimization passes in eldarion, there are some deadcode functions not being eliminated (without specifying linkage for the functions, llvm defaults them to external, and it won't eliminate those external functions even when they are not being used).

The proposed solution is to set the default linkage for llvm functions to be `Private`, enabling llvm to remove those deadcode functions.