### PR TITLE
feat!: Add `insert_region` to HugrMut

### DIFF
--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -192,7 +192,8 @@ pub trait HugrMut: HugrMutInternals {
     ///
     /// # Panics
     ///
-    /// If the root node is not in the graph.
+    /// - If the root node is not in the graph.
+    /// - If the `region` node is not in `other`.
     fn insert_region(
         &mut self,
         root: Self::Node,

--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -262,15 +262,17 @@ pub trait HugrMut: HugrMutInternals {
         ExtensionRegistry: Extend<Reg>;
 }
 
-/// Records the result of inserting a Hugr or view
-/// via [`HugrMut::insert_hugr`] or [`HugrMut::insert_from_view`].
+/// Records the result of inserting a Hugr or view via [`HugrMut::insert_hugr`],
+/// [`HugrMut::insert_from_view`], or [`HugrMut::insert_region`].
 ///
-/// Contains a map from the nodes in the source HUGR to the nodes in the
-/// target HUGR, using their respective `Node` types.
+/// Contains a map from the nodes in the source HUGR to the nodes in the target
+/// HUGR, using their respective `Node` types.
 pub struct InsertionResult<SourceN = Node, TargetN = Node> {
-    /// The node, after insertion, that was the entrypoint of the inserted Hugr.
+    /// The node, after insertion, that was the root of the inserted Hugr.
     ///
-    /// That is, the value in [`InsertionResult::node_map`] under the key that was the [`HugrView::entrypoint`].
+    /// That is, the value in [`InsertionResult::node_map`] under the key that
+    /// was the the `region` passed to [`HugrMut::insert_region`] or the
+    /// [`HugrView::entrypoint`] in the other cases.
     pub inserted_entrypoint: TargetN,
     /// Map from nodes in the Hugr/view that was inserted, to their new
     /// positions in the Hugr into which said was inserted.

--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -183,7 +183,22 @@ pub trait HugrMut: HugrMutInternals {
     /// # Panics
     ///
     /// If the root node is not in the graph.
-    fn insert_hugr(&mut self, root: Self::Node, other: Hugr) -> InsertionResult<Node, Self::Node>;
+    fn insert_hugr(&mut self, root: Self::Node, other: Hugr) -> InsertionResult<Node, Self::Node> {
+        let region = other.entrypoint();
+        Self::insert_region(self, root, other, region)
+    }
+
+    /// Insert a sub-region of another hugr into this one, under a given parent node.
+    ///
+    /// # Panics
+    ///
+    /// If the root node is not in the graph.
+    fn insert_region(
+        &mut self,
+        root: Self::Node,
+        other: Hugr,
+        region: Node,
+    ) -> InsertionResult<Node, Self::Node>;
 
     /// Copy another hugr into this one, under a given parent node.
     ///
@@ -394,17 +409,14 @@ impl HugrMut for Hugr {
         (src_port, dst_port)
     }
 
-    fn insert_hugr(
+    fn insert_region(
         &mut self,
         root: Self::Node,
         mut other: Hugr,
+        region: Node,
     ) -> InsertionResult<Node, Self::Node> {
-        let node_map = insert_hugr_internal(self, &other, other.entry_descendants(), |&n| {
-            if n == other.entrypoint() {
-                Some(root)
-            } else {
-                None
-            }
+        let node_map = insert_hugr_internal(self, &other, other.descendants(region), |&n| {
+            if n == region { Some(root) } else { None }
         });
         // Merge the extension sets.
         self.extensions.extend(other.extensions());
@@ -420,7 +432,7 @@ impl HugrMut for Hugr {
             self.metadata.set(new_node_pg, meta);
         }
         InsertionResult {
-            inserted_entrypoint: node_map[&other.entrypoint()],
+            inserted_entrypoint: node_map[&region],
             node_map,
         }
     }

--- a/hugr-core/src/hugr/views/impls.rs
+++ b/hugr-core/src/hugr/views/impls.rs
@@ -115,6 +115,7 @@ macro_rules! hugr_mut_methods {
                 fn disconnect(&mut self, node: Self::Node, port: impl Into<crate::Port>);
                 fn add_other_edge(&mut self, src: Self::Node, dst: Self::Node) -> (crate::OutgoingPort, crate::IncomingPort);
                 fn insert_hugr(&mut self, root: Self::Node, other: crate::Hugr) -> crate::hugr::hugrmut::InsertionResult<crate::Node, Self::Node>;
+                fn insert_region(&mut self, root: Self::Node, other: crate::Hugr, region: crate::Node) -> crate::hugr::hugrmut::InsertionResult<crate::Node, Self::Node>;
                 fn insert_from_view<Other: crate::hugr::HugrView>(&mut self, root: Self::Node, other: &Other) -> crate::hugr::hugrmut::InsertionResult<Other::Node, Self::Node>;
                 fn insert_subgraph<Other: crate::hugr::HugrView>(&mut self, root: Self::Node, other: &Other, subgraph: &crate::hugr::views::SiblingSubgraph<Other::Node>) -> std::collections::HashMap<Other::Node, Self::Node>;
                 fn use_extension(&mut self, extension: impl Into<std::sync::Arc<crate::extension::Extension>>);

--- a/hugr-core/src/hugr/views/rerooted.rs
+++ b/hugr-core/src/hugr/views/rerooted.rs
@@ -138,6 +138,7 @@ impl<H: HugrMut> HugrMut for Rerooted<H> {
                 fn disconnect(&mut self, node: Self::Node, port: impl Into<crate::Port>);
                 fn add_other_edge(&mut self, src: Self::Node, dst: Self::Node) -> (crate::OutgoingPort, crate::IncomingPort);
                 fn insert_hugr(&mut self, root: Self::Node, other: crate::Hugr) -> crate::hugr::hugrmut::InsertionResult<crate::Node, Self::Node>;
+                fn insert_region(&mut self, root: Self::Node, other: crate::Hugr, region: crate::Node) -> crate::hugr::hugrmut::InsertionResult<crate::Node, Self::Node>;
                 fn insert_from_view<Other: crate::hugr::HugrView>(&mut self, root: Self::Node, other: &Other) -> crate::hugr::hugrmut::InsertionResult<Other::Node, Self::Node>;
                 fn insert_subgraph<Other: crate::hugr::HugrView>(&mut self, root: Self::Node, other: &Other, subgraph: &crate::hugr::views::SiblingSubgraph<Other::Node>) -> std::collections::HashMap<Other::Node, Self::Node>;
                 fn use_extension(&mut self, extension: impl Into<std::sync::Arc<crate::extension::Extension>>);


### PR DESCRIPTION
Required for #2462, as we will no longer be able to insert a conditional using `insert_hugr`.

BREAKING CHANGE: Added new `insert_region` method to `HugrMut`