### PR TITLE
fix: Ensure SumTypes have the same json encoding in -rs and -py

### DIFF
--- a/hugr-core/src/ops/constant.rs
+++ b/hugr-core/src/ops/constant.rs
@@ -9,6 +9,7 @@ use std::hash::{Hash, Hasher};
 use super::{NamedOp, OpName, OpTrait, StaticTag};
 use super::{OpTag, OpType};
 use crate::envelope::serde_with::AsStringEnvelope;
+use crate::types::serialize::SerSimpleType;
 use crate::types::{CustomType, EdgeKind, Signature, SumType, SumTypeError, Type, TypeRow};
 use crate::{Hugr, HugrView};
 
@@ -107,14 +108,14 @@ impl AsRef<Value> for Const {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct SerialSum {
     #[serde(default)]
     tag: usize,
     #[serde(rename = "vs")]
     values: Vec<Value>,
     #[serde(default, rename = "typ")]
-    sum_type: Option<SumType>,
+    sum_type: Option<SerSimpleType>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -170,7 +171,7 @@ impl TryFrom<SerialSum> for Sum {
             sum_type,
         } = value;
 
-        let sum_type = if let Some(sum_type) = sum_type {
+        let sum_type = if let Some(SerSimpleType::Sum(sum_type)) = sum_type {
             sum_type
         } else {
             if tag != 0 {
@@ -192,7 +193,7 @@ impl From<Sum> for SerialSum {
         Self {
             tag: value.tag,
             values: value.values,
-            sum_type: Some(value.sum_type),
+            sum_type: Some(SerSimpleType::Sum(value.sum_type)),
         }
     }
 }

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -4,7 +4,7 @@ mod check;
 pub mod custom;
 mod poly_func;
 mod row_var;
-mod serialize;
+pub(crate) mod serialize;
 mod signature;
 pub mod type_param;
 pub mod type_row;

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -14,7 +14,7 @@ use crate::types::{Term, Type};
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 #[serde(tag = "t")]
-pub(super) enum SerSimpleType {
+pub(crate) enum SerSimpleType {
     Q,
     I,
     G(Box<FuncValueType>),


### PR DESCRIPTION
Fixes #2454

drive-by: Compare encoded const values as JSON dicts instead of strings in the python roundtrip tests, so they ignore field order.