### PR TITLE
feat(py): Use SumValue serialization for tuples

### DIFF
--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -214,10 +214,10 @@ class Tuple(Sum):
             tag=0, typ=tys.Tuple(*(v.type_() for v in val_list)), vals=val_list
         )
 
-    # sops.TupleValue isn't an instance of sops.SumValue
-    # so mypy doesn't like the override of Sum._to_serial
-    def _to_serial(self) -> sops.TupleValue:  # type: ignore[override]
-        return sops.TupleValue(
+    def _to_serial(self) -> sops.SumValue:
+        return sops.SumValue(
+            tag=0,
+            typ=stys.SumType(root=self.type_()._to_serial()),
             vs=ser_it(self.vals),
         )
 

--- a/specification/schema/hugr_schema_live.json
+++ b/specification/schema/hugr_schema_live.json
@@ -1464,17 +1464,30 @@
             "description": "A Sum variant For any Sum type where this value meets the type of the variant indicated by the tag.",
             "properties": {
                 "v": {
-                    "const": "Sum",
                     "default": "Sum",
+                    "enum": [
+                        "Sum",
+                        "Tuple"
+                    ],
                     "title": "ValueTag",
                     "type": "string"
                 },
                 "tag": {
-                    "title": "Tag",
+                    "default": 0,
+                    "title": "VariantTag",
                     "type": "integer"
                 },
                 "typ": {
-                    "$ref": "#/$defs/SumType"
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/SumType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "SumType"
                 },
                 "vs": {
                     "items": {
@@ -1485,8 +1498,6 @@
                 }
             },
             "required": [
-                "tag",
-                "typ",
                 "vs"
             ],
             "title": "SumValue",
@@ -1615,30 +1626,6 @@
                 "params"
             ],
             "title": "TupleParam",
-            "type": "object"
-        },
-        "TupleValue": {
-            "additionalProperties": true,
-            "description": "A constant tuple value.",
-            "properties": {
-                "v": {
-                    "const": "Tuple",
-                    "default": "Tuple",
-                    "title": "ValueTag",
-                    "type": "string"
-                },
-                "vs": {
-                    "items": {
-                        "$ref": "#/$defs/Value"
-                    },
-                    "title": "Vs",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "vs"
-            ],
-            "title": "TupleValue",
             "type": "object"
         },
         "Type": {
@@ -1922,7 +1909,7 @@
                     "Extension": "#/$defs/CustomValue",
                     "Function": "#/$defs/FunctionValue",
                     "Sum": "#/$defs/SumValue",
-                    "Tuple": "#/$defs/TupleValue"
+                    "Tuple": "#/$defs/SumValue"
                 },
                 "propertyName": "v"
             },
@@ -1932,9 +1919,6 @@
                 },
                 {
                     "$ref": "#/$defs/FunctionValue"
-                },
-                {
-                    "$ref": "#/$defs/TupleValue"
                 },
                 {
                     "$ref": "#/$defs/SumValue"

--- a/specification/schema/hugr_schema_strict_live.json
+++ b/specification/schema/hugr_schema_strict_live.json
@@ -1464,17 +1464,30 @@
             "description": "A Sum variant For any Sum type where this value meets the type of the variant indicated by the tag.",
             "properties": {
                 "v": {
-                    "const": "Sum",
                     "default": "Sum",
+                    "enum": [
+                        "Sum",
+                        "Tuple"
+                    ],
                     "title": "ValueTag",
                     "type": "string"
                 },
                 "tag": {
-                    "title": "Tag",
+                    "default": 0,
+                    "title": "VariantTag",
                     "type": "integer"
                 },
                 "typ": {
-                    "$ref": "#/$defs/SumType"
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/SumType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "SumType"
                 },
                 "vs": {
                     "items": {
@@ -1485,8 +1498,6 @@
                 }
             },
             "required": [
-                "tag",
-                "typ",
                 "vs"
             ],
             "title": "SumValue",
@@ -1615,30 +1626,6 @@
                 "params"
             ],
             "title": "TupleParam",
-            "type": "object"
-        },
-        "TupleValue": {
-            "additionalProperties": false,
-            "description": "A constant tuple value.",
-            "properties": {
-                "v": {
-                    "const": "Tuple",
-                    "default": "Tuple",
-                    "title": "ValueTag",
-                    "type": "string"
-                },
-                "vs": {
-                    "items": {
-                        "$ref": "#/$defs/Value"
-                    },
-                    "title": "Vs",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "vs"
-            ],
-            "title": "TupleValue",
             "type": "object"
         },
         "Type": {
@@ -1922,7 +1909,7 @@
                     "Extension": "#/$defs/CustomValue",
                     "Function": "#/$defs/FunctionValue",
                     "Sum": "#/$defs/SumValue",
-                    "Tuple": "#/$defs/TupleValue"
+                    "Tuple": "#/$defs/SumValue"
                 },
                 "propertyName": "v"
             },
@@ -1932,9 +1919,6 @@
                 },
                 {
                     "$ref": "#/$defs/FunctionValue"
-                },
-                {
-                    "$ref": "#/$defs/TupleValue"
                 },
                 {
                     "$ref": "#/$defs/SumValue"

--- a/specification/schema/testing_hugr_schema_live.json
+++ b/specification/schema/testing_hugr_schema_live.json
@@ -1463,17 +1463,30 @@
             "description": "A Sum variant For any Sum type where this value meets the type of the variant indicated by the tag.",
             "properties": {
                 "v": {
-                    "const": "Sum",
                     "default": "Sum",
+                    "enum": [
+                        "Sum",
+                        "Tuple"
+                    ],
                     "title": "ValueTag",
                     "type": "string"
                 },
                 "tag": {
-                    "title": "Tag",
+                    "default": 0,
+                    "title": "VariantTag",
                     "type": "integer"
                 },
                 "typ": {
-                    "$ref": "#/$defs/SumType"
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/SumType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "SumType"
                 },
                 "vs": {
                     "items": {
@@ -1484,8 +1497,6 @@
                 }
             },
             "required": [
-                "tag",
-                "typ",
                 "vs"
             ],
             "title": "SumValue",
@@ -1693,30 +1704,6 @@
                 "params"
             ],
             "title": "TupleParam",
-            "type": "object"
-        },
-        "TupleValue": {
-            "additionalProperties": true,
-            "description": "A constant tuple value.",
-            "properties": {
-                "v": {
-                    "const": "Tuple",
-                    "default": "Tuple",
-                    "title": "ValueTag",
-                    "type": "string"
-                },
-                "vs": {
-                    "items": {
-                        "$ref": "#/$defs/Value"
-                    },
-                    "title": "Vs",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "vs"
-            ],
-            "title": "TupleValue",
             "type": "object"
         },
         "Type": {
@@ -2000,7 +1987,7 @@
                     "Extension": "#/$defs/CustomValue",
                     "Function": "#/$defs/FunctionValue",
                     "Sum": "#/$defs/SumValue",
-                    "Tuple": "#/$defs/TupleValue"
+                    "Tuple": "#/$defs/SumValue"
                 },
                 "propertyName": "v"
             },
@@ -2010,9 +1997,6 @@
                 },
                 {
                     "$ref": "#/$defs/FunctionValue"
-                },
-                {
-                    "$ref": "#/$defs/TupleValue"
                 },
                 {
                     "$ref": "#/$defs/SumValue"

--- a/specification/schema/testing_hugr_schema_strict_live.json
+++ b/specification/schema/testing_hugr_schema_strict_live.json
@@ -1463,17 +1463,30 @@
             "description": "A Sum variant For any Sum type where this value meets the type of the variant indicated by the tag.",
             "properties": {
                 "v": {
-                    "const": "Sum",
                     "default": "Sum",
+                    "enum": [
+                        "Sum",
+                        "Tuple"
+                    ],
                     "title": "ValueTag",
                     "type": "string"
                 },
                 "tag": {
-                    "title": "Tag",
+                    "default": 0,
+                    "title": "VariantTag",
                     "type": "integer"
                 },
                 "typ": {
-                    "$ref": "#/$defs/SumType"
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/SumType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "SumType"
                 },
                 "vs": {
                     "items": {
@@ -1484,8 +1497,6 @@
                 }
             },
             "required": [
-                "tag",
-                "typ",
                 "vs"
             ],
             "title": "SumValue",
@@ -1693,30 +1704,6 @@
                 "params"
             ],
             "title": "TupleParam",
-            "type": "object"
-        },
-        "TupleValue": {
-            "additionalProperties": false,
-            "description": "A constant tuple value.",
-            "properties": {
-                "v": {
-                    "const": "Tuple",
-                    "default": "Tuple",
-                    "title": "ValueTag",
-                    "type": "string"
-                },
-                "vs": {
-                    "items": {
-                        "$ref": "#/$defs/Value"
-                    },
-                    "title": "Vs",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "vs"
-            ],
-            "title": "TupleValue",
             "type": "object"
         },
         "Type": {
@@ -2000,7 +1987,7 @@
                     "Extension": "#/$defs/CustomValue",
                     "Function": "#/$defs/FunctionValue",
                     "Sum": "#/$defs/SumValue",
-                    "Tuple": "#/$defs/TupleValue"
+                    "Tuple": "#/$defs/SumValue"
                 },
                 "propertyName": "v"
             },
@@ -2010,9 +1997,6 @@
                 },
                 {
                     "$ref": "#/$defs/FunctionValue"
-                },
-                {
-                    "$ref": "#/$defs/TupleValue"
                 },
                 {
                     "$ref": "#/$defs/SumValue"


### PR DESCRIPTION
The python lib had a `_serialization.ops.TupleValue` struct for special cases of single-variant sums, that got encoded with an special tag.
The rust does not have the specialized varinat, and simply loads it as `SumValue`.

This PR removes the unnecessary special case from the python side, to simplify the serialization logic and help with the roundtrip checks.

The json schemas have been updated, but the change is non-breaking.