### PR TITLE
ci: Enable crates.io trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,6 +13,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    environment: crate-release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,8 +33,11 @@ jobs:
           # otherwise release-plz fails due to uncommitted changes.
           directory: ${{ runner.temp }}/llvm
 
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.HUGRBOT_PAT }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
See https://crates.io/docs/trusted-publishing.

I enabled it for the hugr crates.