### PR TITLE
ci: Fix release-plz changelog header

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -22,6 +22,11 @@ pr_labels = ["release"]
 release_always = false
 
 [changelog]
+
+header = """# Changelog
+
+"""
+
 sort_commits = "oldest"
 
 # Allowed conventional commit types


### PR DESCRIPTION
The default seems to have changed to 
```toml
header = """# Changelog

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## [Unreleased]

"""
```