### PR TITLE
ci: Add openID permissions to release-plz publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,6 +14,8 @@ jobs:
     name: Release-plz
     runs-on: ubuntu-latest
     environment: crate-release
+    permissions:
+      id-token: write     # Required for OIDC token exchange
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Missed this requirement -.-

Error: https://github.com/CQCL/hugr/actions/runs/16500206533/job/46656393076#step:5:13
```
Error: Please ensure the 'id-token' permission is set to 'write' in your workflow. For more information, see: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
```

