### PR TITLE
feat: Include copy_discard_array in DelegatingLinearizer::default

### DIFF
--- a/hugr-passes/src/linearize_array.rs
+++ b/hugr-passes/src/linearize_array.rs
@@ -10,7 +10,7 @@ use hugr_core::{
     std_extensions::collections::{
         array::{
             ARRAY_REPEAT_OP_ID, ARRAY_SCAN_OP_ID, Array, ArrayKind, ArrayOpDef, ArrayRepeatDef,
-            ArrayScanDef, ArrayValue, array_type_def, array_type_parametric,
+            ArrayScanDef, ArrayValue, array_type_parametric,
         },
         value_array::{self, VArrayFromArrayDef, VArrayToArrayDef, VArrayValue, ValueArray},
     },
@@ -21,9 +21,7 @@ use strum::IntoEnumIterator;
 
 use crate::{
     ComposablePass, ReplaceTypes,
-    replace_types::{
-        DelegatingLinearizer, NodeTemplate, ReplaceTypesError, handlers::copy_discard_array,
-    },
+    replace_types::{DelegatingLinearizer, NodeTemplate, ReplaceTypesError},
 };
 
 /// A HUGR -> HUGR pass that turns 'value_array`s into regular linear `array`s.
@@ -114,8 +112,6 @@ impl Default for LinearizeArrayPass {
                 ))
             },
         );
-        pass.linearizer()
-            .register_callback(array_type_def(), copy_discard_array);
         Self(pass)
     }
 }

--- a/hugr-passes/src/replace_types/linearize.rs
+++ b/hugr-passes/src/replace_types/linearize.rs
@@ -5,12 +5,14 @@ use hugr_core::builder::{
     HugrBuilder, inout_sig,
 };
 use hugr_core::extension::{SignatureError, TypeDef};
+use hugr_core::std_extensions::collections::array::array_type_def;
 use hugr_core::std_extensions::collections::value_array::value_array_type_def;
 use hugr_core::types::{CustomType, Signature, Type, TypeArg, TypeEnum, TypeRow};
 use hugr_core::{HugrView, IncomingPort, Node, Wire, hugr::hugrmut::HugrMut, ops::Tag};
 use itertools::Itertools;
 
-use super::{NodeTemplate, ParametricType, handlers::linearize_value_array};
+use super::handlers::{copy_discard_array, linearize_value_array};
+use super::{NodeTemplate, ParametricType};
 
 /// Trait for things that know how to wire up linear outports to other than one
 /// target.  Used to restore Hugr validity when a [`ReplaceTypes`](super::ReplaceTypes)
@@ -124,6 +126,7 @@ impl Default for DelegatingLinearizer {
     fn default() -> Self {
         let mut res = Self::new_empty();
         res.register_callback(value_array_type_def(), linearize_value_array);
+        res.register_callback(array_type_def(), copy_discard_array);
         res
     }
 }


### PR DESCRIPTION
…thus no need to add in linearize_array / LinearizeArrayPass