### PR TITLE
Revert "feat!: Add `insert_region` to HugrMut (#2463)"

### DIFF
--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -82,20 +82,10 @@ pub trait Container {
         self.add_child_node(constant.into()).into()
     }
 
-    /// Insert a HUGR's entrypoint region as a child of the container.
-    ///
-    /// To insert an arbitrary region of a HUGR, use [`Container::add_hugr_region`].
+    /// Insert a HUGR as a child of the container.
     fn add_hugr(&mut self, child: Hugr) -> InsertionResult {
-        let region = child.entrypoint();
-        self.add_hugr_region(child, region)
-    }
-
-    /// Insert a HUGR region as a child of the container.
-    ///
-    /// To insert the entrypoint region of a HUGR, use [`Container::add_hugr`].
-    fn add_hugr_region(&mut self, child: Hugr, region: Node) -> InsertionResult {
         let parent = self.container_node();
-        self.hugr_mut().insert_region(parent, child, region)
+        self.hugr_mut().insert_hugr(parent, child)
     }
 
     /// Insert a copy of a HUGR as a child of the container.
@@ -210,10 +200,6 @@ pub trait Dataflow: Container {
     /// Insert a hugr-defined op to the sibling graph, wiring up the
     /// `input_wires` to the incoming ports of the resulting root node.
     ///
-    /// Inserts everything from the entrypoint region of the HUGR.
-    /// See [`Dataflow::add_hugr_region_with_wires`] for a generic version that allows
-    /// inserting a region other than the entrypoint.
-    ///
     /// # Errors
     ///
     /// This function will return an error if there is an error when adding the
@@ -223,29 +209,9 @@ pub trait Dataflow: Container {
         hugr: Hugr,
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
-        let region = hugr.entrypoint();
-        self.add_hugr_region_with_wires(hugr, region, input_wires)
-    }
-
-    /// Insert a hugr-defined op to the sibling graph, wiring up the
-    /// `input_wires` to the incoming ports of the resulting root node.
-    ///
-    /// `region` must be a node in the `hugr`. See [`Dataflow::add_hugr_with_wires`]
-    /// for a helper that inserts the entrypoint region to the HUGR.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if there is an error when adding the
-    /// node.
-    fn add_hugr_region_with_wires(
-        &mut self,
-        hugr: Hugr,
-        region: Node,
-        input_wires: impl IntoIterator<Item = Wire>,
-    ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
-        let optype = hugr.get_optype(region).clone();
+        let optype = hugr.get_optype(hugr.entrypoint()).clone();
         let num_outputs = optype.value_output_count();
-        let node = self.add_hugr_region(hugr, region).inserted_entrypoint;
+        let node = self.add_hugr(hugr).inserted_entrypoint;
 
         wire_up_inputs(input_wires, node, self).map_err(|error| BuildError::OperationWiring {
             op: Box::new(optype),

--- a/hugr-core/src/hugr/views/impls.rs
+++ b/hugr-core/src/hugr/views/impls.rs
@@ -115,7 +115,6 @@ macro_rules! hugr_mut_methods {
                 fn disconnect(&mut self, node: Self::Node, port: impl Into<crate::Port>);
                 fn add_other_edge(&mut self, src: Self::Node, dst: Self::Node) -> (crate::OutgoingPort, crate::IncomingPort);
                 fn insert_hugr(&mut self, root: Self::Node, other: crate::Hugr) -> crate::hugr::hugrmut::InsertionResult<crate::Node, Self::Node>;
-                fn insert_region(&mut self, root: Self::Node, other: crate::Hugr, region: crate::Node) -> crate::hugr::hugrmut::InsertionResult<crate::Node, Self::Node>;
                 fn insert_from_view<Other: crate::hugr::HugrView>(&mut self, root: Self::Node, other: &Other) -> crate::hugr::hugrmut::InsertionResult<Other::Node, Self::Node>;
                 fn insert_subgraph<Other: crate::hugr::HugrView>(&mut self, root: Self::Node, other: &Other, subgraph: &crate::hugr::views::SiblingSubgraph<Other::Node>) -> std::collections::HashMap<Other::Node, Self::Node>;
                 fn use_extension(&mut self, extension: impl Into<std::sync::Arc<crate::extension::Extension>>);

--- a/hugr-core/src/hugr/views/rerooted.rs
+++ b/hugr-core/src/hugr/views/rerooted.rs
@@ -138,7 +138,6 @@ impl<H: HugrMut> HugrMut for Rerooted<H> {
                 fn disconnect(&mut self, node: Self::Node, port: impl Into<crate::Port>);
                 fn add_other_edge(&mut self, src: Self::Node, dst: Self::Node) -> (crate::OutgoingPort, crate::IncomingPort);
                 fn insert_hugr(&mut self, root: Self::Node, other: crate::Hugr) -> crate::hugr::hugrmut::InsertionResult<crate::Node, Self::Node>;
-                fn insert_region(&mut self, root: Self::Node, other: crate::Hugr, region: crate::Node) -> crate::hugr::hugrmut::InsertionResult<crate::Node, Self::Node>;
                 fn insert_from_view<Other: crate::hugr::HugrView>(&mut self, root: Self::Node, other: &Other) -> crate::hugr::hugrmut::InsertionResult<Other::Node, Self::Node>;
                 fn insert_subgraph<Other: crate::hugr::HugrView>(&mut self, root: Self::Node, other: &Other, subgraph: &crate::hugr::views::SiblingSubgraph<Other::Node>) -> std::collections::HashMap<Other::Node, Self::Node>;
                 fn use_extension(&mut self, extension: impl Into<std::sync::Arc<crate::extension::Extension>>);


### PR DESCRIPTION
This was merged to solve #2462 but thinking changed on that issue and we decided on #2464 which was implemented by #2467. I think therefore we can revert this and avoid adding the new HugrMut method (can easily be done via `set_entrypoint` / `with_entrypoint`)