### PR TITLE
fix(py): Python builder for function declarations did not create static output port

### DIFF
--- a/hugr-py/src/hugr/build/function.py
+++ b/hugr-py/src/hugr/build/function.py
@@ -78,7 +78,9 @@ class Module(DefinitionBuilder[ops.Module]):
             >>> m.declare_function("f", sig)
             Node(1)
         """
-        return self.hugr.add_node(ops.FuncDecl(name, signature), self.hugr.entrypoint)
+        return self.hugr.add_node(
+            ops.FuncDecl(name, signature), self.hugr.entrypoint, num_outs=1
+        )
 
     def add_alias_defn(self, name: str, ty: Type) -> Node:
         """Add a type alias definition."""

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -311,6 +311,24 @@ def test_mono_function(direct_call: bool) -> None:
     validate(mod.hugr)
 
 
+def test_static_output() -> None:
+    mod = Module()
+
+    mod.declare_function(
+        "declared",
+        tys.PolyFuncType(
+            [],
+            tys.FunctionType.endo([]),
+        ),
+    )
+
+    func = mod.define_function("defined", [], [])
+    func.declare_outputs([])
+    func.set_outputs()
+
+    validate(mod.hugr)
+
+
 def test_function_dfg() -> None:
     d = Dfg(tys.Qubit)
 


### PR DESCRIPTION
The Python builder for function declarations did not create a static output port when the function declaration is not used. This caused the json to json roundtrip test to fail, since the json deserialisation does add the static output port.