### PR TITLE
build: relax typing-extensions constraint

### DIFF
--- a/hugr-py/pyproject.toml
+++ b/hugr-py/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pydantic>=2.8,<2.12",
     "pydantic-extra-types>=2.9.0",
     "semver>=3.0.2",
-    "typing-extensions~=4.12",
+    "typing-extensions>=4",
     "pyzstd>=0.16.2,<0.18.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ requires-dist = [
     { name = "pyzstd", specifier = ">=0.16.2,<0.18.0" },
     { name = "semver", specifier = ">=3.0.2" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1.3,<9.0.0" },
-    { name = "typing-extensions", specifier = "~=4.12" },
+    { name = "typing-extensions", specifier = ">=4" },
 ]
 provides-extras = ["docs", "pytket"]
 


### PR DESCRIPTION
selene-core requires a later version, see https://github.com/CQCL/selene/blob/ef2cd14b27757b805872a5d42d3dbb3e20ce038d/selene-core/pyproject.toml#L11

The current constraint is too strict.