### PR TITLE
chore: Enable `too_long_first_doc_paragraph` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ missing_docs = "warn"
 # Unstable check, may cause false positives.
 # https://github.com/rust-lang/rust-clippy/issues/5112
 debug_assert_with_mut_call = "warn"
+too_long_first_doc_paragraph = "warn"
 
 [workspace.dependencies]
 anyhow = "1.0.98"

--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -70,6 +70,7 @@ pub const GENERATOR_KEY: &str = "core.generator";
 pub const USED_EXTENSIONS_KEY: &str = "core.used_extensions";
 
 /// Get the name of the generator from the metadata of the HUGR modules.
+///
 /// If multiple modules have different generators, a comma-separated list is returned in
 /// module order.
 /// If no generator is found, `None` is returned.

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -1,6 +1,8 @@
 //! Utilities for resolving operations and types present in a HUGR, and updating
-//! the list of used extensions. The functionalities of this module can be
-//! called from the type methods [`crate::ops::OpType::used_extensions`] and
+//! the list of used extensions.
+//!
+//! The functionalities of this module can be called from the type methods
+//! [`crate::ops::OpType::used_extensions`] and
 //! [`crate::types::Signature::used_extensions`].
 //!
 //! When listing "used extensions" we only care about _definitional_ extension

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -778,6 +778,7 @@ impl<'a> Substitution<'a> {
 }
 
 /// A transformation that can be applied to a [Type] or [`TypeArg`].
+///
 /// More general in some ways than a Substitution: can fail with a
 /// [`Self::Err`],  may change [`TypeBound::Copyable`] to [`TypeBound::Linear`],
 /// and applies to arbitrary extension types rather than type variables.

--- a/hugr-core/src/types/signature.rs
+++ b/hugr-core/src/types/signature.rs
@@ -23,10 +23,13 @@ use {crate::proptest::RecursionDepth, proptest::prelude::*, proptest_derive::Arb
 
 #[derive(Clone, Debug, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(Arbitrary), proptest(params = "RecursionDepth"))]
-/// Describes the edges required to/from a node or inside a [`FuncDefn`] (when ROWVARS=[`NoRV`]);
-/// or (when ROWVARS=[`RowVariable`]) the type of a higher-order [`function value`] or the inputs/outputs from an `OpDef`
+/// Base type for listing inputs and output types.
 ///
-/// ROWVARS specifies whether it may contain [`RowVariable`]s or not.
+/// The exact semantics depend on the use case:
+/// - If `ROWVARS=`[`NoRV`], describes the edges required to/from a node or inside a [`FuncDefn`].
+/// - If `ROWVARS=`[`RowVariable`], describes the type of a higher-order [`function value`] or the inputs/outputs from an `OpDef`.
+///
+/// `ROWVARS` specifies whether the type lists may contain [`RowVariable`]s or not.
 ///
 /// [`function value`]: crate::ops::constant::Value::Function
 /// [`FuncDefn`]: crate::ops::FuncDefn

--- a/hugr-llvm/src/custom.rs
+++ b/hugr-llvm/src/custom.rs
@@ -142,8 +142,9 @@ impl<'a, H: HugrView<Node = Node> + 'a> CodegenExtsBuilder<'a, H> {
     }
 }
 
-/// The result of [`CodegenExtsBuilder::finish`]. Users are expected to
-/// deconstruct this type, and consume the fields independently.
+/// The result of [`CodegenExtsBuilder::finish`].
+///
+/// Users are expected to deconstruct this type, and consume the fields independently.
 /// We expect to add further collections at a later date, and so this type is
 /// marked `non_exhaustive`
 #[derive(Default)]

--- a/hugr-llvm/src/custom/extension_op.rs
+++ b/hugr-llvm/src/custom/extension_op.rs
@@ -16,7 +16,9 @@ use strum::IntoEnumIterator;
 use crate::emit::{EmitFuncContext, EmitOpArgs};
 
 /// A helper trait for describing the callback used for emitting [`ExtensionOp`]s,
-/// and for hanging documentation. We have the appropriate `Fn` as a supertrait,
+/// and for hanging documentation.
+///
+/// We have the appropriate `Fn` as a supertrait,
 /// and there is a blanket impl for that `Fn`. We do not intend users to impl
 /// this trait.
 ///

--- a/hugr-llvm/src/custom/load_constant.rs
+++ b/hugr-llvm/src/custom/load_constant.rs
@@ -9,7 +9,9 @@ use anyhow::{Result, anyhow, bail, ensure};
 use crate::emit::EmitFuncContext;
 
 /// A helper trait for describing the callback used for emitting [`CustomConst`]s,
-/// and for hanging documentation. We have the appropriate `Fn` as a supertrait,
+/// and for hanging documentation.
+///
+/// We have the appropriate `Fn` as a supertrait,
 /// and there is a blanket impl for that `Fn`. We do not intend users to impl
 /// this trait.
 ///

--- a/hugr-llvm/src/utils/fat.rs
+++ b/hugr-llvm/src/utils/fat.rs
@@ -14,7 +14,9 @@ use hugr_core::{
 use itertools::Itertools as _;
 
 /// A Fat Node is a [Node] along with a reference to the [`HugrView`] whence it
-/// originates. It carries a type `OT`, the [`OpType`] of that node. `OT` may be
+/// originates.
+///
+/// It carries a type `OT`, the [`OpType`] of that node. `OT` may be
 /// general, i.e. exactly [`OpType`], or specifec, e.g. [`FuncDefn`].
 ///
 /// We provide a [Deref<Target=OT>] impl, so it can be used in place of `OT`.

--- a/hugr-passes/src/dataflow.rs
+++ b/hugr-passes/src/dataflow.rs
@@ -53,6 +53,7 @@ impl<N> From<N> for ConstLocation<'_, N> {
 }
 
 /// Trait for loading [`PartialValue`]s from constant [Value]s in a Hugr.
+///
 /// Implementors will likely want to override either/both of [`Self::value_from_opaque`]
 /// and [`Self::value_from_const_hugr`]: the defaults
 /// are "correct" but maximally conservative (minimally informative).
@@ -73,8 +74,9 @@ pub trait ConstLoader<V> {
     }
 }
 
-/// Produces a [`PartialValue`] from a constant. Traverses [Sum](Value::Sum) constants
-/// to their leaves ([`Value::Extension`] and [`Value::Function`]),
+/// Produces a [`PartialValue`] from a constant.
+///
+/// Traverses [Sum](Value::Sum) constants to their leaves ([`Value::Extension`] and [`Value::Function`]),
 /// converts these using [`ConstLoader::value_from_opaque`] and [`ConstLoader::value_from_const_hugr`],
 /// and builds nested [`PartialValue::new_variant`] to represent the structure.
 pub fn partial_from_const<'a, V, CL: ConstLoader<V>>(

--- a/hugr-passes/src/dataflow/partial_value.rs
+++ b/hugr-passes/src/dataflow/partial_value.rs
@@ -169,6 +169,7 @@ impl<V: AbstractValue, N: PartialEq + PartialOrd> PartialSum<V, N> {
 }
 
 /// Trait implemented by value types into which [`PartialValue`]s can be converted,
+///
 /// so long as the PV has no [Top](PartialValue::Top), [Bottom](PartialValue::Bottom)
 /// or [`PartialSum`]s with more than one possible tag. See [`PartialSum::try_into_sum`]
 /// and [`PartialValue::try_into_concrete`].

--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -171,8 +171,9 @@ fn call<H: HugrView<Node = Node>>(
     Ok(Call::try_new(func_sig, type_args)?)
 }
 
-/// Options for how the replacement for an op is processed. May be specified by
-/// [ReplaceTypes::replace_op_with] and [ReplaceTypes::replace_parametrized_op_with].
+/// Options for how the replacement for an op is processed.
+///
+/// May be specified by [ReplaceTypes::replace_op_with] and [ReplaceTypes::replace_parametrized_op_with].
 /// Otherwise (the default), replacements are inserted as is (without further processing).
 #[derive(Clone, Default, PartialEq, Eq)] // More derives might inhibit future extension
 pub struct ReplacementOptions {

--- a/hugr-passes/src/replace_types/linearize.rs
+++ b/hugr-passes/src/replace_types/linearize.rs
@@ -15,7 +15,9 @@ use super::handlers::{copy_discard_array, linearize_value_array};
 use super::{NodeTemplate, ParametricType};
 
 /// Trait for things that know how to wire up linear outports to other than one
-/// target.  Used to restore Hugr validity when a [`ReplaceTypes`](super::ReplaceTypes)
+/// target.
+///
+/// Used to restore Hugr validity when a [`ReplaceTypes`](super::ReplaceTypes)
 /// results in types of such outports changing from [Copyable] to linear (i.e.
 /// [`hugr_core::types::TypeBound::Linear`]).
 ///


### PR DESCRIPTION
See [`clippy::too_long_first_doc_paragraph`](https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph).

>  <img width="730" height="614" alt="image" src="https://github.com/user-attachments/assets/ed6daacd-db92-4465-97b4-3de4fb569b77" />
