### PR TITLE
chore: Fix new rust lints

### DIFF
--- a/hugr-core/src/builder/build_traits.rs
+++ b/hugr-core/src/builder/build_traits.rs
@@ -657,7 +657,7 @@ pub trait Dataflow: Container {
 
     /// For the vector of `wires`, produce a `CircuitBuilder` where ops can be
     /// added using indices in to the vector.
-    fn as_circuit(&mut self, wires: impl IntoIterator<Item = Wire>) -> CircuitBuilder<Self> {
+    fn as_circuit(&mut self, wires: impl IntoIterator<Item = Wire>) -> CircuitBuilder<'_, Self> {
         CircuitBuilder::new(wires, self)
     }
 

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -840,7 +840,7 @@ pub(super) mod test {
             // But not with an external row variable
             let arg: TypeArg = TypeRV::new_row_var_use(0, TypeBound::Copyable).into();
             assert_eq!(
-                def.compute_signature(&[arg.clone()]),
+                def.compute_signature(std::slice::from_ref(&arg)),
                 Err(SignatureError::TypeArgMismatch(
                     TermTypeError::TypeMismatch {
                         type_: Box::new(TypeBound::Linear.into()),

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -438,7 +438,7 @@ pub trait HugrView: HugrInternals {
     ///
     /// For a more detailed representation, use the [`HugrView::dot_string`]
     /// format instead.
-    fn mermaid_format(&self) -> MermaidFormatter<Self> {
+    fn mermaid_format(&self) -> MermaidFormatter<'_, Self> {
         MermaidFormatter::new(self).with_entrypoint(self.entrypoint())
     }
 

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -1039,7 +1039,7 @@ mod test {
         // Now substitute a list of two types for that row-variable
         let row_var_arg = vec![usize_t().into(), bool_t().into()].into();
         check_term_type(&row_var_arg, &row_var_decl).unwrap();
-        let subst_arg = good_arg.substitute(&Substitution(&[row_var_arg.clone()]));
+        let subst_arg = good_arg.substitute(&Substitution(std::slice::from_ref(&row_var_arg)));
         check_term_type(&subst_arg, &outer_param).unwrap(); // invariance of substitution
         assert_eq!(
             subst_arg,

--- a/hugr-llvm/src/utils/fat.rs
+++ b/hugr-llvm/src/utils/fat.rs
@@ -341,7 +341,7 @@ impl<OT, H> NodeIndex for &FatNode<'_, OT, H> {
 /// TODO: Add the remaining [`HugrView`] equivalents that make sense.
 pub trait FatExt: HugrView {
     /// Try to create a specific [`FatNode`] for a given [Node].
-    fn try_fat<OT>(&self, node: Self::Node) -> Option<FatNode<OT, Self, Self::Node>>
+    fn try_fat<OT>(&self, node: Self::Node) -> Option<FatNode<'_, OT, Self, Self::Node>>
     where
         for<'a> &'a OpType: TryInto<&'a OT>,
     {
@@ -349,7 +349,7 @@ pub trait FatExt: HugrView {
     }
 
     /// Create a general [`FatNode`] for a given [Node].
-    fn fat_optype(&self, node: Self::Node) -> FatNode<OpType, Self, Self::Node> {
+    fn fat_optype(&self, node: Self::Node) -> FatNode<'_, OpType, Self, Self::Node> {
         FatNode::new_optype(self, node)
     }
 
@@ -360,8 +360,8 @@ pub trait FatExt: HugrView {
         &self,
         node: Self::Node,
     ) -> Option<(
-        FatNode<Input, Self, Self::Node>,
-        FatNode<Output, Self, Self::Node>,
+        FatNode<'_, Input, Self, Self::Node>,
+        FatNode<'_, Output, Self, Self::Node>,
     )> {
         self.fat_optype(node).get_io()
     }
@@ -370,17 +370,17 @@ pub trait FatExt: HugrView {
     fn fat_children(
         &self,
         node: Self::Node,
-    ) -> impl Iterator<Item = FatNode<OpType, Self, Self::Node>> {
+    ) -> impl Iterator<Item = FatNode<'_, OpType, Self, Self::Node>> {
         self.children(node).map(|x| self.fat_optype(x))
     }
 
     /// Try to create a specific [`FatNode`] for the root of a [`HugrView`].
-    fn fat_root(&self) -> Option<FatNode<Module, Self, Self::Node>> {
+    fn fat_root(&self) -> Option<FatNode<'_, Module, Self, Self::Node>> {
         self.try_fat(self.module_root())
     }
 
     /// Try to create a specific [`FatNode`] for the entrypoint of a [`HugrView`].
-    fn fat_entrypoint<OT>(&self) -> Option<FatNode<OT, Self, Self::Node>>
+    fn fat_entrypoint<OT>(&self) -> Option<FatNode<'_, OT, Self, Self::Node>>
     where
         for<'a> &'a OpType: TryInto<&'a OT>,
     {

--- a/hugr-model/src/v0/scope/symbol.rs
+++ b/hugr-model/src/v0/scope/symbol.rs
@@ -93,7 +93,7 @@ impl<'a> SymbolTable<'a> {
     /// # Panics
     ///
     /// Panics if there is no current scope.
-    pub fn insert(&mut self, name: &'a str, node: NodeId) -> Result<(), DuplicateSymbolError> {
+    pub fn insert(&mut self, name: &'a str, node: NodeId) -> Result<(), DuplicateSymbolError<'_>> {
         let scope_depth = self.scopes.len() as u16 - 1;
         let (symbol_index, shadowed) = self.symbols.insert_full(name, self.bindings.len());
 
@@ -129,7 +129,7 @@ impl<'a> SymbolTable<'a> {
     }
 
     /// Tries to resolve a symbol name in the current scope.
-    pub fn resolve(&self, name: &'a str) -> Result<NodeId, UnknownSymbolError> {
+    pub fn resolve(&self, name: &'a str) -> Result<NodeId, UnknownSymbolError<'_>> {
         let index = *self
             .symbols
             .get(name)


### PR DESCRIPTION
Fixes upcoming lint errors in `rust 1.89`.

These are mostly cases of making ambiguous lifetimes explicit in trait calls: [`mismatched-lifetime-syntaxes`](https://www.github.com/rust-lang/rust/issues/142501).