### PR TITLE
feat: Deprecate HugrInputArgs::get_hugr

### DIFF
--- a/hugr-cli/src/hugr_io.rs
+++ b/hugr-cli/src/hugr_io.rs
@@ -72,6 +72,7 @@ impl HugrInputArgs {
     /// [`HugrInputArgs::hugr_json`] flag is used.
     ///
     /// For most cases, [`HugrInputArgs::get_package`] should be called instead.
+    #[deprecated(note = "Use `HugrInputArgs::get_package` instead.", since = "0.22.2")]
     pub fn get_hugr(&mut self) -> Result<Hugr, CliError> {
         let extensions = self.load_extensions()?;
         let mut buffer = BufReader::new(&mut self.input);

--- a/hugr-cli/src/mermaid.rs
+++ b/hugr-cli/src/mermaid.rs
@@ -57,6 +57,7 @@ impl MermaidArgs {
 
     /// Write the mermaid diagram for a legacy HUGR json.
     pub fn run_print_hugr(&mut self) -> Result<()> {
+        #[allow(deprecated)]
         let hugr = self.input_args.get_hugr()?;
 
         if self.validate {

--- a/hugr-cli/src/validate.rs
+++ b/hugr-cli/src/validate.rs
@@ -28,6 +28,7 @@ impl ValArgs {
     /// Run the HUGR cli and validate against an extension registry.
     pub fn run(&mut self) -> Result<()> {
         if self.input_args.hugr_json {
+            #[allow(deprecated)]
             let hugr = self.input_args.get_hugr()?;
             let generator = hugr::envelope::get_generator(&[&hugr]);
 


### PR DESCRIPTION
`get_hugr` is a backwards-compatibility call that loads the old (non-envelope) json hugr files.