### PR TITLE
feat!: Add NodeType trait as hugr base trait

### DIFF
--- a/hugr-core/src/hugr/internal.rs
+++ b/hugr-core/src/hugr/internal.rs
@@ -15,21 +15,27 @@ use super::views::{panic_invalid_node, panic_invalid_non_entrypoint};
 use super::{NodeMetadataMap, OpType};
 use crate::ops::handle::NodeHandle;
 
+/// Base trait specifying the node type associated with Hugr implementations.
+///
+/// Base trait of [`HugrInternals`], and thus by transitivity of [`HugrView`],
+/// [`HugrMut`](crate::hugr::HugrMut) etc.
+pub trait NodeType {
+    /// The type of nodes in the Hugr.
+    type Node: HugrNode;
+}
+
 /// Trait for accessing the internals of a Hugr(View).
 ///
 /// Specifically, this trait provides access to the underlying portgraph
 /// view.
-pub trait HugrInternals {
+pub trait HugrInternals: NodeType {
     /// The portgraph graph structure returned by [`HugrInternals::region_portgraph`].
     type RegionPortgraph<'p>: LinkView<LinkEndpoint: Eq, PortOffsetBase = u32> + Clone + 'p
     where
         Self: 'p;
 
-    /// The type of nodes in the Hugr.
-    type Node: Copy + Ord + std::fmt::Debug + std::fmt::Display + std::hash::Hash;
-
-    /// A mapping between HUGR nodes and portgraph nodes in the graph returned by
-    /// [`HugrInternals::region_portgraph`].
+    /// A mapping between HUGR nodes and portgraph nodes in the graph returned
+    /// by [`HugrInternals::region_portgraph`].
     type RegionPortgraphNodes: PortgraphNodeMap<Self::Node>;
 
     /// Returns a flat portgraph view of a region in the HUGR, and a mapping between
@@ -107,13 +113,15 @@ impl<N: HugrNode> PortgraphNodeMap<N> for std::collections::HashMap<N, Node> {
     }
 }
 
+impl NodeType for Hugr {
+    type Node = Node;
+}
+
 impl HugrInternals for Hugr {
     type RegionPortgraph<'p>
         = &'p MultiPortGraph<u32, u32, u32>
     where
         Self: 'p;
-
-    type Node = Node;
 
     type RegionPortgraphNodes = DefaultPGNodeMap;
 

--- a/hugr-core/src/hugr/patch.rs
+++ b/hugr-core/src/hugr/patch.rs
@@ -13,6 +13,7 @@ pub mod simple_replace;
 
 use crate::HugrView;
 use crate::core::HugrNode;
+use crate::hugr::internal::NodeType;
 use itertools::Itertools;
 pub use port_types::{BoundaryPort, HostPort, ReplacementPort};
 pub use simple_replace::{SimpleReplacement, SimpleReplacementError};
@@ -68,7 +69,7 @@ pub trait PatchVerification {
 ///
 /// For patches that work on any `H: HugrMut`, prefer implementing [`PatchHugrMut`] instead. This
 /// will automatically implement this trait.
-pub trait Patch<H: HugrView>: PatchVerification<Node = H::Node> {
+pub trait Patch<H: NodeType>: PatchVerification<Node = H::Node> {
     /// The type returned on successful application of the rewrite.
     type Outcome;
 

--- a/hugr-core/src/hugr/views/impls.rs
+++ b/hugr-core/src/hugr/views/impls.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Cow, rc::Rc, sync::Arc};
 
 use super::HugrView;
-use crate::hugr::internal::{HugrInternals, HugrMutInternals};
+use crate::hugr::internal::{HugrInternals, HugrMutInternals, NodeType};
 use crate::hugr::{HugrMut, hugrmut::InsertForestResult};
 
 macro_rules! hugr_internal_methods {
@@ -125,13 +125,14 @@ macro_rules! hugr_mut_methods {
 pub(crate) use hugr_mut_methods;
 
 // -------- Immutable borrow
+impl<T: HugrView> NodeType for &T {
+    type Node = T::Node;
+}
 impl<T: HugrView> HugrInternals for &T {
     type RegionPortgraph<'p>
         = T::RegionPortgraph<'p>
     where
         Self: 'p;
-
-    type Node = T::Node;
 
     type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
@@ -142,13 +143,14 @@ impl<T: HugrView> HugrView for &T {
 }
 
 // -------- Mutable borrow
+impl<T: HugrView> NodeType for &mut T {
+    type Node = T::Node;
+}
 impl<T: HugrView> HugrInternals for &mut T {
     type RegionPortgraph<'p>
         = T::RegionPortgraph<'p>
     where
         Self: 'p;
-
-    type Node = T::Node;
 
     type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
@@ -165,13 +167,14 @@ impl<T: HugrMut> HugrMut for &mut T {
 }
 
 // -------- Rc
+impl<T: HugrView> NodeType for Rc<T> {
+    type Node = T::Node;
+}
 impl<T: HugrView> HugrInternals for Rc<T> {
     type RegionPortgraph<'p>
         = T::RegionPortgraph<'p>
     where
         Self: 'p;
-
-    type Node = T::Node;
 
     type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
@@ -182,13 +185,14 @@ impl<T: HugrView> HugrView for Rc<T> {
 }
 
 // -------- Arc
+impl<T: HugrView> NodeType for Arc<T> {
+    type Node = T::Node;
+}
 impl<T: HugrView> HugrInternals for Arc<T> {
     type RegionPortgraph<'p>
         = T::RegionPortgraph<'p>
     where
         Self: 'p;
-
-    type Node = T::Node;
 
     type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
@@ -199,13 +203,14 @@ impl<T: HugrView> HugrView for Arc<T> {
 }
 
 // -------- Box
+impl<T: HugrView> NodeType for Box<T> {
+    type Node = T::Node;
+}
 impl<T: HugrView> HugrInternals for Box<T> {
     type RegionPortgraph<'p>
         = T::RegionPortgraph<'p>
     where
         Self: 'p;
-
-    type Node = T::Node;
 
     type RegionPortgraphNodes = T::RegionPortgraphNodes;
 
@@ -222,13 +227,14 @@ impl<T: HugrMut> HugrMut for Box<T> {
 }
 
 // -------- Cow
+impl<T: HugrView + ToOwned> NodeType for Cow<'_, T> {
+    type Node = T::Node;
+}
 impl<T: HugrView + ToOwned> HugrInternals for Cow<'_, T> {
     type RegionPortgraph<'p>
         = T::RegionPortgraph<'p>
     where
         Self: 'p;
-
-    type Node = T::Node;
 
     type RegionPortgraphNodes = T::RegionPortgraphNodes;
 

--- a/hugr-core/src/hugr/views/rerooted.rs
+++ b/hugr-core/src/hugr/views/rerooted.rs
@@ -1,7 +1,7 @@
 //! A HUGR wrapper with a modified entrypoint node, returned by
 //! [`HugrView::with_entrypoint`] and [`HugrMut::with_entrypoint_mut`].
 
-use crate::hugr::internal::{HugrInternals, HugrMutInternals};
+use crate::hugr::internal::{HugrInternals, HugrMutInternals, NodeType};
 use crate::hugr::{HugrMut, hugrmut::InsertForestResult};
 
 use super::{HugrView, panic_invalid_node};
@@ -35,13 +35,15 @@ impl<H: HugrView> Rerooted<H> {
     }
 }
 
+impl<H: HugrView> NodeType for Rerooted<H> {
+    type Node = H::Node;
+}
+
 impl<H: HugrView> HugrInternals for Rerooted<H> {
     type RegionPortgraph<'p>
         = H::RegionPortgraph<'p>
     where
         Self: 'p;
-
-    type Node = H::Node;
 
     type RegionPortgraphNodes = H::RegionPortgraphNodes;
 

--- a/hugr-passes/src/dead_code.rs
+++ b/hugr-passes/src/dead_code.rs
@@ -1,6 +1,6 @@
 //! Pass for removing dead code, i.e. that computes values that are then discarded
 
-use hugr_core::hugr::internal::HugrInternals;
+use hugr_core::hugr::internal::NodeType;
 use hugr_core::{HugrView, hugr::hugrmut::HugrMut, ops::OpType};
 use std::convert::Infallible;
 use std::fmt::{Debug, Formatter};
@@ -52,7 +52,7 @@ impl<H: HugrView> Debug for DeadCodeElimPass<H> {
 
 /// Callback that identifies nodes that must be preserved even if their
 /// results are not used. For example, (the default) [`PreserveNode::default_for`].
-pub type PreserveCallback<H> = dyn Fn(&H, <H as HugrInternals>::Node) -> PreserveNode;
+pub type PreserveCallback<H> = dyn Fn(&H, <H as NodeType>::Node) -> PreserveNode;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 /// Signal that a node must be preserved even when its result is not used

--- a/hugr-persistent/src/parents_view.rs
+++ b/hugr-persistent/src/parents_view.rs
@@ -5,7 +5,7 @@ use hugr_core::{
     extension::ExtensionRegistry,
     hugr::{
         self,
-        internal::HugrInternals,
+        internal::{HugrInternals, NodeType},
         views::{ExtractionResult, render},
     },
     ops::OpType,
@@ -35,13 +35,15 @@ impl<'a> ParentsView<'a> {
     }
 }
 
+impl NodeType for ParentsView<'_> {
+    type Node = PatchNode;
+}
+
 impl HugrInternals for ParentsView<'_> {
     type RegionPortgraph<'p>
         = portgraph::MultiPortGraph<u32, u32, u32>
     where
         Self: 'p;
-
-    type Node = PatchNode;
 
     type RegionPortgraphNodes = HashMap<PatchNode, Node>;
 

--- a/hugr-persistent/src/trait_impls.rs
+++ b/hugr-persistent/src/trait_impls.rs
@@ -7,7 +7,7 @@ use hugr_core::{
     extension::ExtensionRegistry,
     hugr::{
         self, Patch, SimpleReplacementError,
-        internal::HugrInternals,
+        internal::{HugrInternals, NodeType},
         views::{
             ExtractionResult,
             render::{self, MermaidFormatter, NodeLabel},
@@ -37,13 +37,15 @@ impl Patch<PersistentHugr> for PersistentReplacement {
     }
 }
 
+impl<R> NodeType for PersistentHugr<R> {
+    type Node = PatchNode;
+}
+
 impl<R> HugrInternals for PersistentHugr<R> {
     type RegionPortgraph<'p>
         = portgraph::MultiPortGraph<u32, u32, u32>
     where
         Self: 'p;
-
-    type Node = PatchNode;
 
     type RegionPortgraphNodes = HashMap<PatchNode, Node>;
 


### PR DESCRIPTION
This is a small change but "pretty breaking". Some bullet points
- I am usually against fragmenting the API into more traits. My main issue is that it makes API discovery and intellisense worse. In this case, as it is a super trait of many common traits, you rarely need to actually import this new trait directly, so the fragmentation is less of a concern.
- I do think that the break up makes sense here: having an assoicated Node type is a much weaker constraint than implementing `HugrInternals` (which e.g. requires a view into an underlying portgraph)
- Seyon is "not against" it, and no-one else has expressed strong opinions
- Users won't notice this breaking change, unless they implemented `HugrInternals` themselves or explicitly refer to the `<Self as HugrInternals>::Node` type in macros or type aliases (in which case they'd probably get the side benefit of being able to loosen their type bounds).

BREAKING CHANGE: The HugrInternals::Node associated type was moved to the dedicated trait NodeType.
