### PR TITLE
fix(core): check used extension versions against resolved extensions

### DIFF
--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -559,16 +559,16 @@ pub enum ExtensionBreakingError {
 }
 /// If HUGR metadata contains a list of used extensions, under the key [`USED_EXTENSIONS_KEY`],
 /// and extension is resolved in the HUGR, check that the
-/// version of the extension in the metadata matches the resolved version (up to
-/// MAJOR.MINOR).
+/// version of the extension in the metadata matches the resolved version.
+/// Version compatibility is defined by [`compatible_versions`].
 fn check_breaking_extensions(hugr: impl crate::HugrView) -> Result<(), ExtensionBreakingError> {
     check_breaking_extensions_against_registry(&hugr, hugr.extensions())
 }
 
 /// If HUGR metadata contains a list of used extensions, under the key [`USED_EXTENSIONS_KEY`],
 /// and extension is registered in the given registry, check that the
-/// version of the extension in the metadata matches the registered version (up to
-/// MAJOR.MINOR).
+/// version of the extension in the metadata matches the registered version.
+/// Version compatibility is defined by [`compatible_versions`].
 fn check_breaking_extensions_against_registry(
     hugr: &impl crate::HugrView,
     registry: &ExtensionRegistry,

--- a/hugr-core/src/envelope/package_json.rs
+++ b/hugr-core/src/envelope/package_json.rs
@@ -15,7 +15,7 @@ use crate::{Extension, Hugr};
 pub(super) fn from_json_reader(
     reader: impl io::Read,
     extension_registry: &ExtensionRegistry,
-) -> Result<(Package, ExtensionRegistry), PackageEncodingError> {
+) -> Result<Package, PackageEncodingError> {
     let val: serde_json::Value = serde_json::from_reader(reader)?;
 
     let PackageDeser {
@@ -38,13 +38,10 @@ pub(super) fn from_json_reader(
         .try_for_each(|module| module.resolve_extension_defs(&combined_registry))
         .map_err(|err| WithGenerator::new(err, &modules))?;
 
-    Ok((
-        Package {
-            modules,
-            extensions: pkg_extensions,
-        },
-        combined_registry,
-    ))
+    Ok(Package {
+        modules,
+        extensions: pkg_extensions,
+    })
 }
 
 /// Write the Package in json format into an io writer.


### PR DESCRIPTION
Extension resolution computes the actually used extensions in the HUGR and places them inside the HUGR, this can be used to check for version mismatch rather than the registry used for loading


Reverts unnecessary registry returns from https://github.com/CQCL/hugr/commit/91bff6e7a93915696fc67e77870d32b8c877f61d