### PR TITLE
chore!: Cleanup deprecated definitions

### DIFF
--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -34,12 +34,6 @@
 //! - Bit 7,6: Constant "01" to make some headers ascii-printable.
 //!
 
-#![allow(deprecated)]
-// TODO: Due to a bug in `derive_more`
-// (https://github.com/JelteF/derive_more/issues/419) we need to deactivate
-// deprecation warnings here. We can reactivate them once the bug is fixed by
-// https://github.com/JelteF/derive_more/pull/454.
-
 mod header;
 mod package_json;
 pub mod serde_with;
@@ -362,7 +356,6 @@ fn read_impl(
     registry: &ExtensionRegistry,
 ) -> Result<Package, EnvelopeError> {
     let package = match header.format {
-        #[allow(deprecated)]
         EnvelopeFormat::PackageJson => Ok(package_json::from_json_reader(payload, registry)?),
         EnvelopeFormat::Model | EnvelopeFormat::ModelWithExtensions => {
             decode_model(payload, registry, header.format)
@@ -467,7 +460,6 @@ fn write_impl<'h>(
     config: EnvelopeConfig,
 ) -> Result<(), EnvelopeError> {
     match config.format {
-        #[allow(deprecated)]
         EnvelopeFormat::PackageJson => package_json::to_json_writer(hugrs, extensions, writer)?,
         EnvelopeFormat::Model
         | EnvelopeFormat::ModelWithExtensions

--- a/hugr-core/src/envelope/serde_with.rs
+++ b/hugr-core/src/envelope/serde_with.rs
@@ -198,7 +198,7 @@ macro_rules! impl_serde_as_string_envelope {
                         //
                         // TODO: Remove this fallback in 0.21.0
                         let deserializer = serde::de::value::MapAccessDeserializer::new(map);
-                        #[allow(deprecated)]
+                        #[expect(deprecated)]
                         let mut hugr =
                             $crate::hugr::serialize::serde_deserialize_hugr(deserializer)
                                 .map_err(serde::de::Error::custom)?;
@@ -394,7 +394,7 @@ macro_rules! impl_serde_as_binary_envelope {
                         //
                         // TODO: Remove this fallback in a breaking change
                         let deserializer = serde::de::value::MapAccessDeserializer::new(map);
-                        #[allow(deprecated)]
+                        #[expect(deprecated)]
                         let mut hugr =
                             $crate::hugr::serialize::serde_deserialize_hugr(deserializer)
                                 .map_err(serde::de::Error::custom)?;

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -186,8 +186,7 @@ impl<N: HugrNode> ExtensionResolutionError<N> {
 }
 
 /// Errors that can occur when collecting extension requirements.
-// TODO: [Deprecated] Remove `From` implementation from here
-#[derive(Debug, Display, Clone, Error, From, PartialEq)]
+#[derive(Debug, Display, Clone, Error, PartialEq)]
 #[non_exhaustive]
 pub enum ExtensionCollectionError<N: HugrNode = Node> {
     /// An operation requires an extension that is not in the given registry.
@@ -220,7 +219,6 @@ pub enum ExtensionCollectionError<N: HugrNode = Node> {
         "Type {typ} contains custom types which have lost the reference to their defining extensions. Dropped extensions: {}",
         missing_extensions.join(", ")
     )]
-    #[from(ignore)]
     DroppedTypeExtensions {
         /// The type that is missing extensions.
         typ: String,

--- a/hugr-core/src/hugr/patch.rs
+++ b/hugr-core/src/hugr/patch.rs
@@ -40,7 +40,7 @@ pub trait PatchVerification {
     /// The nodes invalidated by the rewrite. Deprecated: implement
     /// [Self::invalidated_nodes] instead. The default returns the empty
     /// iterator; this should be fine as there are no external calls.
-    #[deprecated(note = "Use/implement invalidated_nodes instead")]
+    #[deprecated(note = "Use/implement invalidated_nodes instead", since = "0.20.2")]
     fn invalidation_set(&self) -> impl Iterator<Item = Self::Node> {
         std::iter::empty()
     }

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -15,7 +15,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 pub use self::petgraph::PetgraphWrapper;
-#[allow(deprecated)]
+#[expect(deprecated)]
 use self::render::{MermaidFormatter, RenderConfig};
 pub use nodes_iter::NodesIter;
 pub use rerooted::Rerooted;
@@ -399,8 +399,8 @@ pub trait HugrView: HugrInternals {
     ///
     /// For a more detailed representation, use the [`HugrView::dot_string`]
     /// format instead.
-    #[deprecated(note = "Use `mermaid_format` instead")]
-    #[allow(deprecated)]
+    #[deprecated(note = "Use `mermaid_format` instead", since = "0.20.2")]
+    #[expect(deprecated)]
     fn mermaid_string_with_config(&self, config: RenderConfig<Self::Node>) -> String;
 
     /// Return the mermaid representation of the underlying hierarchical graph
@@ -419,14 +419,14 @@ pub trait HugrView: HugrInternals {
     /// encouraged to provide an implementation of this method overriding the default
     /// and no longer rely on [HugrView::mermaid_string_with_config].
     fn mermaid_string_with_formatter(&self, formatter: MermaidFormatter<Self>) -> String {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let config = match RenderConfig::try_from(formatter) {
             Ok(config) => config,
             Err(e) => {
                 panic!("Unsupported format option: {e}");
             }
         };
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.mermaid_string_with_config(config)
     }
 
@@ -677,7 +677,7 @@ impl HugrView for Hugr {
         self.graph.all_neighbours(node.into_portgraph()).map_into()
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn mermaid_string_with_config(&self, config: RenderConfig) -> String {
         self.mermaid_string_with_formatter(MermaidFormatter::from_render_config(config, self))
     }

--- a/hugr-core/src/hugr/views/render.rs
+++ b/hugr-core/src/hugr/views/render.rs
@@ -17,7 +17,7 @@ use crate::{Hugr, HugrView, Node};
 /// Additional options are available in the [`MermaidFormatter`] struct.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-#[deprecated(note = "Use `MermaidFormatter` instead")]
+#[deprecated(note = "Use `MermaidFormatter` instead", since = "0.20.2")]
 pub struct RenderConfig<N = Node> {
     /// Show the node index in the graph nodes.
     pub node_indices: bool,
@@ -46,7 +46,7 @@ pub struct MermaidFormatter<'h, H: HugrInternals + ?Sized = Hugr> {
 
 impl<'h, H: HugrInternals + ?Sized> MermaidFormatter<'h, H> {
     /// Create a new [`MermaidFormatter`] from a [`RenderConfig`].
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     pub fn from_render_config(config: RenderConfig<H::Node>, hugr: &'h H) -> Self {
         let node_labels = if config.node_indices {
             NodeLabel::Numeric
@@ -155,7 +155,7 @@ pub enum UnsupportedRenderConfig {
     CustomNodeLabels,
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl<'h, H: HugrInternals + ?Sized> TryFrom<MermaidFormatter<'h, H>> for RenderConfig<H::Node> {
     type Error = UnsupportedRenderConfig;
 
@@ -235,7 +235,7 @@ pub enum NodeLabel<N: HugrNode = Node> {
     Custom(HashMap<N, String>),
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl<N> Default for RenderConfig<N> {
     fn default() -> Self {
         Self {
@@ -413,7 +413,7 @@ mod tests {
         let h = simple_dfg_hugr();
         let config: MermaidFormatter =
             MermaidFormatter::new(&h).with_node_labels(NodeLabel::Custom(HashMap::new()));
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         {
             assert!(RenderConfig::try_from(config).is_err());
         }

--- a/hugr-core/src/hugr/views/rerooted.rs
+++ b/hugr-core/src/hugr/views/rerooted.rs
@@ -100,7 +100,7 @@ impl<H: HugrView> HugrView for Rerooted<H> {
                 fn first_child(&self, node: Self::Node) -> Option<Self::Node>;
                 fn neighbours(&self, node: Self::Node, dir: crate::Direction) -> impl Iterator<Item = Self::Node> + Clone;
                 fn all_neighbours(&self, node: Self::Node) -> impl Iterator<Item = Self::Node> + Clone;
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 fn mermaid_string_with_config(&self, config: crate::hugr::views::render::RenderConfig<Self::Node>) -> String;
                 fn dot_string(&self) -> String;
                 fn static_source(&self, node: Self::Node) -> Option<Self::Node>;

--- a/hugr-llvm/src/extension/collections/stack_array.rs
+++ b/hugr-llvm/src/extension/collections/stack_array.rs
@@ -33,7 +33,10 @@ use crate::{
 
 /// A helper trait for customising the lowering of [hugr_core::std_extensions::collections::array]
 /// types, [hugr_core::ops::constant::CustomConst]s, and ops.
-#[deprecated(note = "Use `hugr_llvm::extension::collections::array` instead")]
+#[deprecated(
+    note = "Use `hugr_llvm::extension::collections::array` instead",
+    since = "0.20.0"
+)]
 pub trait ArrayCodegen: Clone {
     /// Return the llvm type of [hugr_core::std_extensions::collections::array::ARRAY_TYPENAME].
     fn array_type<'c>(
@@ -92,13 +95,19 @@ pub trait ArrayCodegen: Clone {
 
 /// A trivial implementation of [ArrayCodegen] which passes all methods
 /// through to their default implementations.
-#[deprecated(note = "Use `hugr_llvm::extension::collections::array` instead")]
+#[deprecated(
+    note = "Use `hugr_llvm::extension::collections::array` instead",
+    since = "0.20.0"
+)]
 #[derive(Default, Clone)]
 pub struct DefaultArrayCodegen;
 
 impl ArrayCodegen for DefaultArrayCodegen {}
 
-#[deprecated(note = "Use `hugr_llvm::extension::collections::array` instead")]
+#[deprecated(
+    note = "Use `hugr_llvm::extension::collections::array` instead",
+    since = "0.20.0"
+)]
 #[derive(Clone, Debug, Default)]
 pub struct ArrayCodegenExtension<CCG>(CCG);
 

--- a/hugr-passes/src/dead_code.rs
+++ b/hugr-passes/src/dead_code.rs
@@ -158,7 +158,6 @@ impl<H: HugrView> DeadCodeElimPass<H> {
         if let Some(res) = cache.get(&n) {
             return *res;
         }
-        #[allow(deprecated)]
         let res = match self.preserve_callback.as_ref()(h, n) {
             PreserveNode::MustKeep => true,
             PreserveNode::CanRemoveIgnoringChildren => false,

--- a/hugr-passes/src/non_local.rs
+++ b/hugr-passes/src/non_local.rs
@@ -47,10 +47,6 @@ pub fn nonlocal_edges<H: HugrView>(hugr: &H) -> impl Iterator<Item = (H::Node, I
     })
 }
 
-/// Legacy alias of [FindNonLocalEdgesError]
-#[deprecated(note = "Use FindNonLocalEdgesError")]
-pub type NonLocalEdgesError<N> = FindNonLocalEdgesError<N>;
-
 /// An error from [ensure_no_nonlocal_edges]
 #[derive(Clone, derive_more::Error, derive_more::Display, Debug, PartialEq, Eq)]
 #[non_exhaustive]

--- a/hugr-persistent/src/parents_view.rs
+++ b/hugr-persistent/src/parents_view.rs
@@ -200,7 +200,7 @@ impl HugrView for ParentsView<'_> {
         unimplemented!()
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn mermaid_string_with_config(&self, _config: render::RenderConfig<Self::Node>) -> String {
         unimplemented!()
     }

--- a/hugr-persistent/src/trait_impls.rs
+++ b/hugr-persistent/src/trait_impls.rs
@@ -238,7 +238,7 @@ impl<R> HugrView for PersistentHugr<R> {
             .flat_map(move |port| self.linked_ports(node, port).map(|(opp_node, _)| opp_node))
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn mermaid_string_with_config(&self, config: render::RenderConfig<Self::Node>) -> String {
         self.mermaid_string_with_formatter(MermaidFormatter::from_render_config(config, self))
     }


### PR DESCRIPTION
In preparation for the breaking release,

- Removes a couple deprecated methods/aliases. (I didn't modify things that are too breaking, like removing `HugrView::mermaid_string_with_config`.
- Adds `since` fields to `#[deprecated]` annotations missing it.
- Replaces `#[allow(deprecated)]`s with `#[expect(deprecated)]` where possible, so we remember to remove them later.

BREAKING CHANGE: Removed deprecated `From` implementation for `ExtensionCollectionError`
BREAKING CHANGE: Removed deprecated `NonLocalEdgesError` alias