### PR TITLE
chore: Ensure release-plz includes all breaking commits

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -53,6 +53,7 @@ commit_parsers = [
     { message = "^revert", group = "Reverted changes", skip = true },
     { message = "^ci", group = "CI", skip = true },
 ]
+protect_breaking_commits = true
 
 [[package]]
 name = "hugr"


### PR DESCRIPTION
Ensures that the generated changelog includes breaking changes even if they have a normally-ignored label (`chore` / `revert`)

https://release-plz.dev/docs/config#the-protect_breaking_commits-field